### PR TITLE
Tune animations and 3D geometry defaults

### DIFF
--- a/packages/contents/subject/high-school/10/mathematics/sequence-series/sequence-concept/animation-table.tsx
+++ b/packages/contents/subject/high-school/10/mathematics/sequence-series/sequence-concept/animation-table.tsx
@@ -12,7 +12,14 @@ import {
   CardTitle,
 } from "@repo/design-system/components/ui/card";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
-import { AnimatePresence, LayoutGroup, motion } from "motion/react";
+import {
+  AnimatePresence,
+  domMax,
+  LayoutGroup,
+  LazyMotion,
+  MotionConfig,
+} from "motion/react";
+import * as m from "motion/react-m";
 import {
   useCallback,
   useDeferredValue,
@@ -59,6 +66,16 @@ interface ChairItem {
   y: number;
 }
 
+/**
+ * Renders the table-chair sequence animation used by the sequence concept page.
+ *
+ * `LazyMotion` with `domMax` keeps layout animation support explicit, while
+ * `MotionConfig reducedMotion="user"` follows the user's OS preference.
+ *
+ * @see https://motion.dev/docs/react-reduce-bundle-size
+ * @see https://motion.dev/docs/react-accessibility
+ * @see https://motion.dev/docs/react-layout-animations
+ */
 export default function TableChairsAnimation({
   labels = {
     title: "Table and Chair Sequence Pattern",
@@ -68,22 +85,19 @@ export default function TableChairsAnimation({
 }: TableChairsProps) {
   const [tableCount, setTableCount] = useState(1);
   const [speed, setSpeed] = useState(1);
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const deferredPlaying = useDeferredValue(isPlaying);
-  const deferredTableCount = useDeferredValue(tableCount);
-
-  const isMobile = useMediaQuery("(max-width: 640px)");
+  const [isPlaying, setIsPlaying] = useState(true);
 
   const { ref, entry } = useIntersection({
     threshold: 0.1,
   });
 
-  useEffect(() => {
-    if (entry) {
-      setIsPlaying(entry.isIntersecting);
-    }
-  }, [entry]);
+  const isInView = entry?.isIntersecting ?? false;
+  // Viewport visibility gates work without overriding the user's Play/Pause intent.
+  const isAnimating = isPlaying && isInView;
+  const deferredAnimating = useDeferredValue(isAnimating);
+  const deferredTableCount = useDeferredValue(tableCount);
+
+  const isMobile = useMediaQuery("(max-width: 640px)");
 
   const maxTables = isMobile ? MAX_TABLES_MOBILE : MAX_TABLES_DESKTOP;
 
@@ -94,27 +108,27 @@ export default function TableChairsAnimation({
   );
 
   useEffect(() => {
-    let interval: NodeJS.Timeout;
-
     // Stop playing when maximum table count is reached
     if (deferredTableCount >= maxTables) {
       setIsPlaying(false);
       return;
     }
 
-    if (deferredPlaying) {
-      interval = setInterval(() => {
-        setTableCount((prev) => {
-          if (prev < maxTables) {
-            return prev + 1;
-          }
-          return prev;
-        });
-      }, ANIMATION_INTERVAL_MS / speed);
+    if (!deferredAnimating) {
+      return;
     }
 
+    const interval = setInterval(() => {
+      setTableCount((prev) => {
+        if (prev < maxTables) {
+          return prev + 1;
+        }
+        return prev;
+      });
+    }, ANIMATION_INTERVAL_MS / speed);
+
     return () => clearInterval(interval);
-  }, [deferredPlaying, deferredTableCount, maxTables, speed]);
+  }, [deferredAnimating, deferredTableCount, maxTables, speed]);
 
   const resetAnimation = useCallback(() => {
     setTableCount(1);
@@ -126,9 +140,10 @@ export default function TableChairsAnimation({
       // If at max table count and trying to play, restart from beginning
       setTableCount(1);
       setIsPlaying(true);
-    } else {
-      setIsPlaying(!isPlaying);
+      return;
     }
+
+    setIsPlaying(!isPlaying);
   }, [isPlaying, tableCount, maxTables]);
 
   // Constants for sizing and spacing
@@ -237,7 +252,7 @@ export default function TableChairsAnimation({
   }, [deferredTableCount]);
 
   return (
-    <Card className="content-auto-card">
+    <Card className="content-auto-card" ref={ref}>
       <CardHeader>
         <CardTitle>{labels.title}</CardTitle>
         <CardDescription>
@@ -246,10 +261,7 @@ export default function TableChairsAnimation({
       </CardHeader>
 
       <CardContent>
-        <div
-          className="relative aspect-square w-full overflow-hidden rounded-lg border border-cyan-100 bg-cyan-50 p-4 sm:aspect-video dark:border-cyan-900 dark:bg-cyan-950"
-          ref={ref}
-        >
+        <div className="relative aspect-square w-full overflow-hidden rounded-lg border border-cyan-100 bg-cyan-50 p-4 sm:aspect-video dark:border-cyan-900 dark:bg-cyan-950">
           <div className="flex h-full flex-col items-center justify-center gap-8">
             {/* Table and chairs visualization */}
             <div className="relative flex w-full items-center justify-center">
@@ -262,61 +274,65 @@ export default function TableChairsAnimation({
                   height: tableHeight,
                 }}
               >
-                <LayoutGroup>
-                  {/* Tables */}
-                  <AnimatePresence mode="popLayout">
-                    {arrangement.tables.map((table) => (
-                      <motion.div
-                        animate={{ opacity: 1, scale: 1 }}
-                        className="absolute rounded-md bg-teal-300 shadow-sm transition-colors hover:bg-teal-400 dark:bg-teal-500"
-                        exit={{ opacity: 0, scale: 0 }}
-                        initial={{ opacity: 0, scale: 0 }}
-                        key={`table-${table.id}`}
-                        layout
-                        style={{
-                          left: table.x,
-                          top: table.y,
-                          width: table.width,
-                          height: table.height,
-                          zIndex: Z_INDEX_TABLE,
-                        }}
-                        transition={{
-                          type: "spring",
-                          stiffness: 500,
-                          damping: 30,
-                          delay: (table.id - 1) * STAGGER_DELAY, // Stagger effect
-                        }}
-                      />
-                    ))}
-                  </AnimatePresence>
+                <MotionConfig reducedMotion="user">
+                  <LazyMotion features={domMax} strict>
+                    <LayoutGroup>
+                      {/* Tables */}
+                      <AnimatePresence mode="popLayout">
+                        {arrangement.tables.map((table) => (
+                          <m.div
+                            animate={{ opacity: 1, scale: 1 }}
+                            className="absolute rounded-md bg-teal-300 shadow-sm transition-colors hover:bg-teal-400 dark:bg-teal-500"
+                            exit={{ opacity: 0, scale: 0 }}
+                            initial={{ opacity: 0, scale: 0 }}
+                            key={`table-${table.id}`}
+                            layout
+                            style={{
+                              left: table.x,
+                              top: table.y,
+                              width: table.width,
+                              height: table.height,
+                              zIndex: Z_INDEX_TABLE,
+                            }}
+                            transition={{
+                              type: "spring",
+                              stiffness: 500,
+                              damping: 30,
+                              delay: (table.id - 1) * STAGGER_DELAY, // Stagger effect
+                            }}
+                          />
+                        ))}
+                      </AnimatePresence>
 
-                  {/* Chairs */}
-                  <AnimatePresence mode="popLayout">
-                    {arrangement.chairs.map((chair) => (
-                      <motion.div
-                        animate={{ opacity: 1, scale: 1 }}
-                        className="absolute rounded-full bg-cyan-300 shadow-sm transition-colors hover:bg-cyan-400 dark:bg-cyan-500"
-                        exit={{ opacity: 0, scale: 0 }}
-                        initial={{ opacity: 0, scale: 0 }}
-                        key={`chair-${chair.id}`}
-                        layout
-                        style={{
-                          left: chair.x,
-                          top: chair.y,
-                          width: CHAIR_SIZE,
-                          height: CHAIR_SIZE,
-                          zIndex: Z_INDEX_CHAIR,
-                        }}
-                        transition={{
-                          type: "spring",
-                          stiffness: 500,
-                          damping: 30,
-                          delay: chair.id * STAGGER_DELAY, // Stagger effect
-                        }}
-                      />
-                    ))}
-                  </AnimatePresence>
-                </LayoutGroup>
+                      {/* Chairs */}
+                      <AnimatePresence mode="popLayout">
+                        {arrangement.chairs.map((chair) => (
+                          <m.div
+                            animate={{ opacity: 1, scale: 1 }}
+                            className="absolute rounded-full bg-cyan-300 shadow-sm transition-colors hover:bg-cyan-400 dark:bg-cyan-500"
+                            exit={{ opacity: 0, scale: 0 }}
+                            initial={{ opacity: 0, scale: 0 }}
+                            key={`chair-${chair.id}`}
+                            layout
+                            style={{
+                              left: chair.x,
+                              top: chair.y,
+                              width: CHAIR_SIZE,
+                              height: CHAIR_SIZE,
+                              zIndex: Z_INDEX_CHAIR,
+                            }}
+                            transition={{
+                              type: "spring",
+                              stiffness: 500,
+                              damping: 30,
+                              delay: chair.id * STAGGER_DELAY, // Stagger effect
+                            }}
+                          />
+                        ))}
+                      </AnimatePresence>
+                    </LayoutGroup>
+                  </LazyMotion>
+                </MotionConfig>
               </div>
             </div>
           </div>

--- a/packages/design-system/components/contents/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/animation-bacterial.tsx
@@ -12,7 +12,14 @@ import {
   CardTitle,
 } from "@repo/design-system/components/ui/card";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
-import { AnimatePresence, LayoutGroup, motion } from "motion/react";
+import {
+  AnimatePresence,
+  domMax,
+  LayoutGroup,
+  LazyMotion,
+  MotionConfig,
+} from "motion/react";
+import * as m from "motion/react-m";
 import {
   useCallback,
   useDeferredValue,
@@ -82,6 +89,16 @@ interface BacterialGrowthProps {
   timeUnit?: string;
 }
 
+/**
+ * Renders a bounded bacterial-growth animation for exponential-growth lessons.
+ *
+ * `LazyMotion` with `domMax` keeps the layout/popLayout feature bundle explicit,
+ * while `MotionConfig reducedMotion="user"` follows the user's OS preference.
+ *
+ * @see https://motion.dev/docs/react-reduce-bundle-size
+ * @see https://motion.dev/docs/react-accessibility
+ * @see https://motion.dev/docs/react-animate-presence#poplayout
+ */
 export function BacterialGrowth({
   ratio = 2,
   initialCount = 1,
@@ -98,22 +115,18 @@ export function BacterialGrowth({
 }: BacterialGrowthProps) {
   const [generation, setGeneration] = useState(0);
   const [speed, setSpeed] = useState(1);
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const deferredPlaying = useDeferredValue(isPlaying);
-  const deferredGeneration = useDeferredValue(generation);
+  const [isPlaying, setIsPlaying] = useState(true);
 
   const { ref, entry } = useIntersection({
     threshold: 0.1,
   });
 
-  useEffect(() => {
-    if (entry) {
-      setIsPlaying(entry.isIntersecting);
-    }
-  }, [entry]);
-
-  // Start playing when component comes into view
+  const isInView = entry?.isIntersecting ?? false;
+  // Viewport visibility gates work without overriding the user's Play/Pause intent.
+  const isAnimating = isPlaying && isInView;
+  const deferredAnimating = useDeferredValue(isAnimating);
+  const deferredGeneration = useDeferredValue(generation);
+  const pulseRepeat = deferredAnimating ? Number.POSITIVE_INFINITY : 0;
 
   // Calculate current bacteria count based on the selected formula type
   const bacteriaCount = useMemo(() => {
@@ -159,27 +172,27 @@ export function BacterialGrowth({
   );
 
   useEffect(() => {
-    let interval: NodeJS.Timeout;
-
     // Stop playing when maximum generation is reached
     if (deferredGeneration >= maxGenerations) {
       setIsPlaying(false);
       return;
     }
 
-    if (deferredPlaying) {
-      interval = setInterval(() => {
-        setGeneration((prev) => {
-          if (prev < maxGenerations) {
-            return prev + 1;
-          }
-          return prev;
-        });
-      }, SPEED_INTERVAL / speed);
+    if (!deferredAnimating) {
+      return;
     }
 
+    const interval = setInterval(() => {
+      setGeneration((prev) => {
+        if (prev < maxGenerations) {
+          return prev + 1;
+        }
+        return prev;
+      });
+    }, SPEED_INTERVAL / speed);
+
     return () => clearInterval(interval);
-  }, [deferredPlaying, deferredGeneration, maxGenerations, speed]);
+  }, [deferredAnimating, deferredGeneration, maxGenerations, speed]);
 
   const resetAnimation = useCallback(() => {
     setGeneration(0);
@@ -191,9 +204,10 @@ export function BacterialGrowth({
       // If at max generation and trying to play, restart from beginning
       setGeneration(0);
       setIsPlaying(true);
-    } else {
-      setIsPlaying(!isPlaying);
+      return;
     }
+
+    setIsPlaying(!isPlaying);
   }, [isPlaying, generation, maxGenerations]);
 
   // Generate time buttons
@@ -220,7 +234,7 @@ export function BacterialGrowth({
   );
 
   return (
-    <Card className="content-auto-card">
+    <Card className="content-auto-card" ref={ref}>
       <CardHeader>
         <CardTitle>{labels.title}</CardTitle>
         <CardDescription>
@@ -229,54 +243,57 @@ export function BacterialGrowth({
       </CardHeader>
 
       <CardContent>
-        <div
-          className="relative aspect-square w-full overflow-hidden rounded-lg border border-cyan-100 bg-cyan-50 sm:aspect-video dark:border-cyan-900 dark:bg-cyan-950"
-          ref={ref}
-        >
+        <div className="relative aspect-square w-full overflow-hidden rounded-lg border border-cyan-100 bg-cyan-50 sm:aspect-video dark:border-cyan-900 dark:bg-cyan-950">
           <div
-            className="grid h-full w-full gap-0.5 p-2 sm:px-0"
+            className="relative grid h-full w-full gap-0.5 p-2 sm:px-0"
             style={{
               gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
             }}
           >
-            <LayoutGroup>
-              <AnimatePresence mode="popLayout">
-                {bacteria.map((id) => (
-                  <motion.div
-                    animate={{
-                      scale: 1,
-                      opacity: 1,
-                    }}
-                    className="relative flex items-center justify-center"
-                    exit={{ scale: 0, opacity: 0 }}
-                    initial={{ scale: 0, opacity: 0 }}
-                    key={id}
-                    layout
-                    transition={{
-                      type: "spring",
-                      stiffness: 500,
-                      damping: 30,
-                      delay: id * STAGGER_DELAY, // Stagger effect
-                    }}
-                  >
-                    <motion.div
-                      animate={{
-                        scale: [1, SCALE_INCREASE, 1],
-                      }}
-                      className="aspect-square h-full max-h-5 w-full max-w-5 rounded-full bg-cyan-300 transition-colors hover:bg-cyan-400 sm:max-h-8 sm:max-w-8 dark:bg-cyan-500"
-                      transition={{
-                        duration: 1,
-                        repeat: Number.POSITIVE_INFINITY,
-                        repeatType: "reverse",
-                      }}
-                      whileHover={{
-                        scale: SCALE_INCREASE,
-                      }}
-                    />
-                  </motion.div>
-                ))}
-              </AnimatePresence>
-            </LayoutGroup>
+            <MotionConfig reducedMotion="user">
+              <LazyMotion features={domMax} strict>
+                <LayoutGroup>
+                  <AnimatePresence mode="popLayout">
+                    {bacteria.map((id) => (
+                      <m.div
+                        animate={{
+                          scale: 1,
+                          opacity: 1,
+                        }}
+                        className="relative flex items-center justify-center"
+                        exit={{ scale: 0, opacity: 0 }}
+                        initial={{ scale: 0, opacity: 0 }}
+                        key={id}
+                        layout
+                        transition={{
+                          type: "spring",
+                          stiffness: 500,
+                          damping: 30,
+                          delay: id * STAGGER_DELAY, // Stagger effect
+                        }}
+                      >
+                        <m.div
+                          animate={{
+                            scale: deferredAnimating
+                              ? [1, SCALE_INCREASE, 1]
+                              : 1,
+                          }}
+                          className="aspect-square h-full max-h-5 w-full max-w-5 rounded-full bg-cyan-300 transition-colors hover:bg-cyan-400 sm:max-h-8 sm:max-w-8 dark:bg-cyan-500"
+                          transition={{
+                            duration: 1,
+                            repeat: pulseRepeat,
+                            repeatType: "reverse",
+                          }}
+                          whileHover={{
+                            scale: SCALE_INCREASE,
+                          }}
+                        />
+                      </m.div>
+                    ))}
+                  </AnimatePresence>
+                </LayoutGroup>
+              </LazyMotion>
+            </MotionConfig>
           </div>
         </div>
       </CardContent>

--- a/packages/design-system/components/contents/inequality.tsx
+++ b/packages/design-system/components/contents/inequality.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 // CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
 // https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";

--- a/packages/design-system/components/contents/inequality.tsx
+++ b/packages/design-system/components/contents/inequality.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+// CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
+// https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";
 import { Inequality as Inequality3D } from "@repo/design-system/components/three/inequality";
 import {

--- a/packages/design-system/components/contents/line-equation.tsx
+++ b/packages/design-system/components/contents/line-equation.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 // CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
 // https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";

--- a/packages/design-system/components/contents/line-equation.tsx
+++ b/packages/design-system/components/contents/line-equation.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+// CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
+// https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";
 import { LineEquation as LineEquation3D } from "@repo/design-system/components/three/line-equation";
 import {

--- a/packages/design-system/components/contents/vector-3d.tsx
+++ b/packages/design-system/components/contents/vector-3d.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 // CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
 // https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";

--- a/packages/design-system/components/contents/vector-3d.tsx
+++ b/packages/design-system/components/contents/vector-3d.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+// CoordinateSystem renders a dynamic WebGL canvas with SSR disabled.
+// https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr
 import { CoordinateSystem } from "@repo/design-system/components/three/coordinate-system";
 import { Vector } from "@repo/design-system/components/three/vector";
 import {

--- a/packages/design-system/components/three/arrow-helper.tsx
+++ b/packages/design-system/components/three/arrow-helper.tsx
@@ -1,33 +1,35 @@
 "use client";
 
 import { Line, Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { COLORS } from "@repo/design-system/lib/color";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import {
   Color,
   ConeGeometry,
-  type Group,
   MeshBasicMaterial,
   Quaternion,
   Vector3,
 } from "three";
 import { FONT_PATH, MONO_FONT_PATH } from "./_data";
+import { GRAPH_ARROW_SEGMENTS } from "./quality";
 
-const ARROW_SEGMENTS = 16;
 const ARROW_SEGMENT_OFFSET = 0.2;
 
 // Shared geometry and material caches
 const coneGeometryCache = new Map<string, ConeGeometry>();
 const materialCache = new Map<string, MeshBasicMaterial>();
 
+/**
+ * Reuses cone geometry per arrow size to avoid repeated GPU resource work.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedConeGeometry(size: number): ConeGeometry {
   const key = `cone-${size}`;
   if (!coneGeometryCache.has(key)) {
-    // Reduced segments from 32 to 16 for better performance
     coneGeometryCache.set(
       key,
-      new ConeGeometry(size / 2, size, ARROW_SEGMENTS, 1)
+      new ConeGeometry(size / 2, size, GRAPH_ARROW_SEGMENTS, 1)
     );
   }
   const geometry = coneGeometryCache.get(key);
@@ -37,6 +39,11 @@ function getSharedConeGeometry(size: number): ConeGeometry {
   return geometry;
 }
 
+/**
+ * Reuses arrow materials by color so repeated vectors do not recompile materials.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedMaterial(color: string | Color): MeshBasicMaterial {
   const colorKey = color instanceof Color ? color.getHexString() : color;
   if (!materialCache.has(colorKey)) {
@@ -77,6 +84,9 @@ interface Props {
   [key: string]: unknown;
 }
 
+/**
+ * Renders a labeled 3D arrow with shared cone geometry and stable vector math.
+ */
 export function ArrowHelper({
   from = [0, 0, 0],
   to,
@@ -89,8 +99,6 @@ export function ArrowHelper({
   useMonoFont = true,
   ...props
 }: Props) {
-  const groupRef = useRef<Group>(null);
-
   // Memoize vector calculations
   const vectors = useMemo(() => {
     const fromVec = new Vector3(...from);
@@ -177,15 +185,8 @@ export function ArrowHelper({
     [useMonoFont]
   );
 
-  // Enable frustum culling for the entire group
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
-
   return (
-    <group ref={groupRef} {...props}>
+    <group frustumCulled {...props}>
       {/* Shaft of the arrow */}
       <Line
         color={color}

--- a/packages/design-system/components/three/axes.tsx
+++ b/packages/design-system/components/three/axes.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { Line, Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { COLORS } from "@repo/design-system/lib/color";
-import { type ComponentProps, useMemo, useRef } from "react";
-import { type Group, MeshBasicMaterial, Vector3 } from "three";
+import { type ComponentProps, useMemo } from "react";
+import { MeshBasicMaterial, Vector3 } from "three";
 import { FONT_PATH, MONO_FONT_PATH } from "./_data";
 
 // Shared materials cache for text components
 const textMaterialCache = new Map<string, MeshBasicMaterial>();
 
+/**
+ * Reuses text materials per axis color across repeated coordinate systems.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getTextMaterial(color: string): MeshBasicMaterial {
   if (!textMaterialCache.has(color)) {
     textMaterialCache.set(
@@ -24,6 +28,9 @@ function getTextMaterial(color: string): MeshBasicMaterial {
   return material;
 }
 
+/**
+ * Renders the shared X/Y/Z axes and labels for educational 3D scenes.
+ */
 export function Axes({
   size = 10,
   showLabels = true,
@@ -40,8 +47,6 @@ export function Axes({
   labelOffset?: number;
   font?: "mono" | "sans";
 } & ComponentProps<"group">) {
-  const groupRef = useRef<Group>(null);
-
   // Create points for each axis (now extending in both positive and negative directions)
   const xPoints = useMemo(
     () => [new Vector3(-size, 0, 0), new Vector3(size, 0, 0)],
@@ -64,21 +69,14 @@ export function Axes({
   const labelPositions = useMemo(() => {
     const offset = size + labelOffset;
     return {
-      xPos: [offset, 0, 0] as [number, number, number],
-      xNeg: [-offset, 0, 0] as [number, number, number],
-      yPos: [0, offset, 0] as [number, number, number],
-      yNeg: [0, -offset, 0] as [number, number, number],
-      zPos: [0, 0, offset] as [number, number, number],
-      zNeg: [0, 0, -offset] as [number, number, number],
+      xPos: new Vector3(offset, 0, 0),
+      xNeg: new Vector3(-offset, 0, 0),
+      yPos: new Vector3(0, offset, 0),
+      yNeg: new Vector3(0, -offset, 0),
+      zPos: new Vector3(0, 0, offset),
+      zNeg: new Vector3(0, 0, -offset),
     };
   }, [size, labelOffset]);
-
-  // Enable frustum culling for the entire group
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
 
   // Get shared materials for text
   const redMaterial = getTextMaterial(COLORS.RED);
@@ -86,7 +84,7 @@ export function Axes({
   const blueMaterial = getTextMaterial(COLORS.BLUE);
 
   return (
-    <group ref={groupRef} {...props}>
+    <group frustumCulled {...props}>
       {/* Axis lines with frustum culling */}
       <Line color={COLORS.RED} frustumCulled lineWidth={2} points={xPoints} />
       <Line color={COLORS.GREEN} frustumCulled lineWidth={2} points={yPoints} />

--- a/packages/design-system/components/three/inequality.tsx
+++ b/packages/design-system/components/three/inequality.tsx
@@ -1,20 +1,19 @@
 "use client";
 
-import { Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
+import { Line, Text } from "@react-three/drei";
 import { COLORS } from "@repo/design-system/lib/color";
 import { isMobileDevice } from "@repo/design-system/lib/device";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import {
   BufferAttribute,
   BufferGeometry,
   Color,
   DoubleSide,
   Float32BufferAttribute,
-  type Group,
   MeshBasicMaterial,
 } from "three";
 import { FONT_PATH, MONO_FONT_PATH } from "./_data";
+import { GRAPH_BOUNDARY_SEGMENTS } from "./quality";
 
 // Performance tuning constants
 const MIN_CORES_FOR_HIGH_RES = 8;
@@ -37,8 +36,6 @@ const SATISFIED_CORNERS_THRESHOLD_HIGH = 3;
 const SATISFIED_CORNERS_THRESHOLD_LOW = 2;
 const RESOLUTION_THRESHOLD_FOR_CORNERS = 80;
 
-// Boundary line constants
-const MAX_LINE_RESOLUTION = 50;
 const EPSILON = 1e-10;
 const VERTICAL_CONNECTOR_DENSITY_FACTOR = 4;
 
@@ -88,7 +85,9 @@ interface Props {
   zRange?: [number, number];
 }
 
-// Performance optimization: Adaptive resolution based on device capabilities
+/**
+ * Adapts inequality mesh resolution to the device budget while honoring callers.
+ */
 function getAdaptiveResolution(requestedResolution: number): number {
   // Check device capabilities
   const isMobile = isMobileDevice();
@@ -103,6 +102,9 @@ function getAdaptiveResolution(requestedResolution: number): number {
   return Math.min(requestedResolution, MAX_RES_MEDIUM_CORE);
 }
 
+/**
+ * Renders 2D or 3D inequality regions with a wide boundary guide line.
+ */
 export function Inequality({
   boundaryFunction,
   is2D = false,
@@ -120,7 +122,6 @@ export function Inequality({
   useMonoFont = true,
 }: Props) {
   const fontPath = useMonoFont ? MONO_FONT_PATH : FONT_PATH;
-  const groupRef = useRef<Group>(null);
 
   // Adaptive resolution for performance
   const adaptiveResolution = getAdaptiveResolution(resolution);
@@ -345,13 +346,16 @@ export function Inequality({
 
   // Generate boundary lines for rendering - optimized
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This is a complex function, but it's necessary for the inequality visualization
-  const boundarySegmentsGeometry = useMemo(() => {
+  const boundaryPoints = useMemo(() => {
     if (!((boundaryFunction || boundaryLine2D) && showBoundary)) {
       return;
     }
 
-    const vertices: number[] = [];
-    const lineResolution = Math.min(adaptiveResolution, MAX_LINE_RESOLUTION); // Lower resolution for lines
+    const points: Point[] = [];
+    const lineResolution = Math.min(
+      adaptiveResolution,
+      GRAPH_BOUNDARY_SEGMENTS
+    );
     const xStep = (xRange[1] - xRange[0]) / lineResolution;
     const yStep = (yRange[1] - yRange[0]) / lineResolution;
 
@@ -371,9 +375,9 @@ export function Inequality({
             const prevY = (-a * prevX - c) / b;
             if (prevY >= yRange[0] && prevY <= yRange[1]) {
               // Bottom edge
-              vertices.push(prevX, prevY, zRange[0], x, y, zRange[0]);
+              points.push([prevX, prevY, zRange[0]], [x, y, zRange[0]]);
               // Top edge
-              vertices.push(prevX, prevY, zRange[1], x, y, zRange[1]);
+              points.push([prevX, prevY, zRange[1]], [x, y, zRange[1]]);
             }
           }
         }
@@ -382,12 +386,15 @@ export function Inequality({
         for (
           let i = 0;
           i <= lineResolution;
-          i += Math.floor(lineResolution / VERTICAL_CONNECTOR_DENSITY_FACTOR)
+          i += Math.max(
+            1,
+            Math.floor(lineResolution / VERTICAL_CONNECTOR_DENSITY_FACTOR)
+          )
         ) {
           const x = xRange[0] + i * xStep;
           const y = (-a * x - c) / b;
           if (y >= yRange[0] && y <= yRange[1]) {
-            vertices.push(x, y, zRange[0], x, y, zRange[1]);
+            points.push([x, y, zRange[0]], [x, y, zRange[1]]);
           }
         }
       } else if (Math.abs(a) > EPSILON) {
@@ -400,15 +407,15 @@ export function Inequality({
             const prevY = yRange[0] + (iy - 1) * yStep;
             const prevX = (-b * prevY - c) / a;
             if (prevX >= xRange[0] && prevX <= xRange[1]) {
-              vertices.push(prevX, prevY, zRange[0], x, y, zRange[0]);
-              vertices.push(prevX, prevY, zRange[1], x, y, zRange[1]);
+              points.push([prevX, prevY, zRange[0]], [x, y, zRange[0]]);
+              points.push([prevX, prevY, zRange[1]], [x, y, zRange[1]]);
             }
           }
         }
       }
     } else if (boundaryFunction) {
       // For 3D inequalities - create a wireframe grid
-      const gridStep = Math.floor(lineResolution / 10);
+      const gridStep = Math.max(1, Math.floor(lineResolution / 10));
 
       // Lines along x-axis
       for (let iy = 0; iy <= lineResolution; iy += gridStep) {
@@ -425,7 +432,7 @@ export function Inequality({
             prevZ >= zRange[0] &&
             prevZ <= zRange[1]
           ) {
-            vertices.push(prevX, y, prevZ, x, y, z);
+            points.push([prevX, y, prevZ], [x, y, z]);
           }
         }
       }
@@ -445,22 +452,17 @@ export function Inequality({
             prevZ >= zRange[0] &&
             prevZ <= zRange[1]
           ) {
-            vertices.push(x, prevY, prevZ, x, y, z);
+            points.push([x, prevY, prevZ], [x, y, z]);
           }
         }
       }
     }
 
-    if (vertices.length === 0) {
+    if (points.length === 0) {
       return;
     }
 
-    const geom = new BufferGeometry();
-    geom.setAttribute(
-      "position",
-      new Float32BufferAttribute(vertices, COMPONENTS_PER_VERTEX)
-    );
-    return geom;
+    return points;
   }, [
     showBoundary,
     adaptiveResolution,
@@ -475,26 +477,20 @@ export function Inequality({
   // Default boundary color is the same as the region color but more opaque
   const finalBoundaryColor = boundaryColor || color;
 
-  // Use frustum culling
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
-
   return (
-    <group ref={groupRef}>
+    <group frustumCulled>
       {/* Render the shaded region */}
       <mesh frustumCulled geometry={geometry} material={material} />
 
-      {/* Render the boundary as one lineSegments for better performance */}
-      {!!showBoundary && !!boundarySegmentsGeometry && (
-        <lineSegments frustumCulled geometry={boundarySegmentsGeometry}>
-          <lineBasicMaterial
-            color={finalBoundaryColor}
-            linewidth={boundaryLineWidth}
-          />
-        </lineSegments>
+      {/* Drei Line uses Line2, unlike LineBasicMaterial linewidth in WebGL. */}
+      {!!showBoundary && !!boundaryPoints && (
+        <Line
+          color={finalBoundaryColor}
+          frustumCulled
+          lineWidth={boundaryLineWidth}
+          points={boundaryPoints}
+          segments
+        />
       )}
 
       {/* Render label if provided */}

--- a/packages/design-system/components/three/line-equation.tsx
+++ b/packages/design-system/components/three/line-equation.tsx
@@ -1,24 +1,25 @@
 "use client";
 
 import { Instance, Instances, Line, Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { randomColor } from "@repo/design-system/lib/color";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import {
   CatmullRomCurve3,
   Color,
   ConeGeometry,
-  type Group,
   MeshBasicMaterial,
   Quaternion,
   SphereGeometry,
   Vector3,
 } from "three";
 import { FONT_PATH, MONO_FONT_PATH } from "./_data";
+import {
+  GRAPH_ARROW_SEGMENTS,
+  GRAPH_POINT_SEGMENTS,
+  getCurveDivisions,
+} from "./quality";
 
 const SPHERE_GEOMETRY_RADIUS = 0.1;
-const SPHERE_GEOMETRY_SEGMENTS = 8;
-const CONE_GEOMETRY_SEGMENTS = 16;
 const CONE_GEOMETRY_HEIGHT_SEGMENTS = 1;
 const DEFAULT_ARROW_SIZE = 0.5;
 const DEFAULT_FONT_SIZE = 0.5;
@@ -28,28 +29,36 @@ let sharedSphereGeometry: SphereGeometry | null = null;
 const sharedConeGeometries = new Map<string, ConeGeometry>();
 const sharedMaterials = new Map<string, MeshBasicMaterial>();
 
+/**
+ * Reuses point marker geometry across all rendered line equations.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedSphereGeometry(): SphereGeometry {
   if (!sharedSphereGeometry) {
-    // Reduced segments for better performance
     sharedSphereGeometry = new SphereGeometry(
       SPHERE_GEOMETRY_RADIUS,
-      SPHERE_GEOMETRY_SEGMENTS,
-      SPHERE_GEOMETRY_SEGMENTS
+      GRAPH_POINT_SEGMENTS,
+      GRAPH_POINT_SEGMENTS
     );
   }
   return sharedSphereGeometry;
 }
 
+/**
+ * Reuses arrowhead geometry per size for line equation direction markers.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedConeGeometry(size: number): ConeGeometry {
   const key = `cone-${size}`;
   if (!sharedConeGeometries.has(key)) {
-    // Reduced segments for better performance
     sharedConeGeometries.set(
       key,
       new ConeGeometry(
         size / 2,
         size,
-        CONE_GEOMETRY_SEGMENTS,
+        GRAPH_ARROW_SEGMENTS,
         CONE_GEOMETRY_HEIGHT_SEGMENTS
       )
     );
@@ -61,6 +70,11 @@ function getSharedConeGeometry(size: number): ConeGeometry {
   return geometry;
 }
 
+/**
+ * Reuses line equation materials by color to avoid repeated material setup.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedMaterial(color: string | Color): MeshBasicMaterial {
   const colorKey = color instanceof Color ? color.getHexString() : color;
   if (!sharedMaterials.has(colorKey)) {
@@ -127,19 +141,20 @@ export interface Props {
   useMonoFont?: boolean;
 }
 
+/**
+ * Renders a 3D line or curve with optional point markers, labels, and arrowheads.
+ */
 export function LineEquation({
   points,
   color = randomColor(["YELLOW", "GREEN", "BLUE"]),
   lineWidth = 2,
   showPoints = true,
   smooth = true,
-  curvePoints = 30, // Reduced default from 50 for better performance
+  curvePoints,
   labels = [],
   useMonoFont = true,
   cone,
 }: Props) {
-  const groupRef = useRef<Group>(null);
-
   const vectorPoints = useMemo(
     () => points.map((point) => new Vector3(point.x, point.y, point.z)),
     [points]
@@ -154,15 +169,12 @@ export function LineEquation({
       return vectorPoints;
     }
 
-    let basePoints: Vector3[];
+    let basePoints = [...vectorPoints];
 
-    if (smooth) {
-      // Use CatmullRomCurve3 for smooth curves
+    if (smooth && vectorPoints.length > 2) {
       const curve = new CatmullRomCurve3(vectorPoints);
-      basePoints = curve.getPoints(curvePoints);
-    } else {
-      // For non-smooth lines, use the original points directly
-      basePoints = [...vectorPoints];
+      const divisions = getCurveDivisions(vectorPoints.length, curvePoints);
+      basePoints = curve.getPoints(divisions);
     }
 
     // Adjust line end points to account for the cone size to prevent overlap
@@ -275,44 +287,35 @@ export function LineEquation({
     return cones.length > 0 ? cones : null;
   }, [cone, vectorPoints, arrowSize]);
 
-  // Enable frustum culling for the entire group
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
-
   // Pre-calculate label data to avoid recreating in render
   const labelData = useMemo(
     () =>
-      labels
-        .map((label, idx) => {
-          const mid = Math.floor(vectorPoints.length / 2);
-          const index = label.at ?? mid;
-          const base = vectorPoints[index];
-          if (!base) {
-            return null;
-          }
-          const [ox = 0, oy = 0, oz = 0] = label.offset || [0, 0, 0];
-          const pos: [number, number, number] = [
-            base.x + ox,
-            base.y + oy,
-            base.z + oz,
-          ];
-          return {
+      labels.flatMap((label, idx) => {
+        const mid = Math.floor(vectorPoints.length / 2);
+        const index = label.at ?? mid;
+        const base = vectorPoints[index];
+        if (!base) {
+          return [];
+        }
+
+        const [ox = 0, oy = 0, oz = 0] = label.offset || [0, 0, 0];
+        const position = new Vector3(base.x + ox, base.y + oy, base.z + oz);
+
+        return [
+          {
             key: `label-${idx}`,
-            position: pos,
+            position,
             color: label.color ?? color,
             fontSize: label.fontSize ?? DEFAULT_FONT_SIZE,
             text: label.text,
-          };
-        })
-        .filter(Boolean),
+          },
+        ];
+      }),
     [labels, vectorPoints, color]
   );
 
   return (
-    <group ref={groupRef}>
+    <group frustumCulled>
       {/* Draw a line connecting the provided points */}
       <Line
         color={color}
@@ -354,27 +357,22 @@ export function LineEquation({
       </Instances>
 
       {/* Render custom labels at specified indices */}
-      {labelData.map((data) => {
-        if (!data) {
-          return null;
-        }
-        return (
-          <Text
-            anchorX="center"
-            anchorY="middle"
-            color={data.color}
-            font={fontPath}
-            fontSize={data.fontSize}
-            frustumCulled={false}
-            key={data.key}
-            material-depthTest={false}
-            position={data.position}
-            renderOrder={10}
-          >
-            {data.text}
-          </Text>
-        );
-      })}
+      {labelData.map((data) => (
+        <Text
+          anchorX="center"
+          anchorY="middle"
+          color={data.color}
+          font={fontPath}
+          fontSize={data.fontSize}
+          frustumCulled={false}
+          key={data.key}
+          material-depthTest={false}
+          position={data.position}
+          renderOrder={10}
+        >
+          {data.text}
+        </Text>
+      ))}
     </group>
   );
 }

--- a/packages/design-system/components/three/origin.tsx
+++ b/packages/design-system/components/three/origin.tsx
@@ -1,8 +1,10 @@
 import type { ComponentProps } from "react";
 import { ORIGIN_COLOR } from "./_data";
+import { GRAPH_POINT_SEGMENTS } from "./quality";
 
-const SPHERE_GEOMETRY_SEGMENTS = 16;
-
+/**
+ * Renders the origin marker shared by coordinate-system based 3D content.
+ */
 export function Origin({
   size = 0.2,
   color = ORIGIN_COLOR.LIGHT,
@@ -14,7 +16,7 @@ export function Origin({
   return (
     <mesh {...props}>
       <sphereGeometry
-        args={[size, SPHERE_GEOMETRY_SEGMENTS, SPHERE_GEOMETRY_SEGMENTS]}
+        args={[size, GRAPH_POINT_SEGMENTS, GRAPH_POINT_SEGMENTS]}
       />
       <meshBasicMaterial color={color} />
     </mesh>

--- a/packages/design-system/components/three/quality.ts
+++ b/packages/design-system/components/three/quality.ts
@@ -1,0 +1,79 @@
+import { Vector3 } from "three";
+
+const DEFAULT_CURVE_DIVISIONS = 64;
+
+/**
+ * Smooth full circles without making every graph primitive expensive.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
+export const GRAPH_FULL_CIRCLE_SEGMENTS = 96;
+
+/**
+ * Smooth small educational angle arcs while keeping point counts predictable.
+ *
+ * @see https://threejs.org/docs/pages/Curve.html#getPoints
+ */
+export const GRAPH_ANGLE_ARC_SEGMENTS = 48;
+
+/**
+ * Keeps small point markers round enough at high DPR without heavy meshes.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
+export const GRAPH_POINT_SEGMENTS = 16;
+
+/**
+ * Keeps arrowheads visibly round without doubling geometry cost.
+ *
+ * @see https://threejs.org/docs/pages/ConeGeometry.html
+ */
+export const GRAPH_ARROW_SEGMENTS = 24;
+
+/**
+ * Caps generated boundary guide density for inequality surfaces.
+ *
+ * @see https://threejs.org/docs/pages/Line2.html
+ */
+export const GRAPH_BOUNDARY_SEGMENTS = 96;
+
+/**
+ * Samples sparse curves smoothly and keeps dense content near its source detail.
+ *
+ * `Curve.getPoints(divisions)` returns `divisions + 1` points, so dense
+ * content should not be doubled unless a caller explicitly asks for it.
+ *
+ * @see https://threejs.org/docs/pages/Curve.html#getPoints
+ */
+export function getCurveDivisions(
+  pointCount: number,
+  requestedDivisions?: number
+) {
+  if (requestedDivisions !== undefined) {
+    return Math.max(1, requestedDivisions);
+  }
+
+  if (pointCount < 2) {
+    return 0;
+  }
+
+  return Math.max(DEFAULT_CURVE_DIVISIONS, pointCount - 1);
+}
+
+/**
+ * Creates XY-plane arc points with shared graph quality defaults.
+ *
+ * @see https://threejs.org/docs/pages/Vector3.html
+ */
+export function createArcPoints(
+  radius: number,
+  radians: number,
+  segments: number
+) {
+  const safeSegments = Math.max(1, segments);
+
+  return Array.from({ length: safeSegments + 1 }, (_, index) => {
+    const angle = (index / safeSegments) * radians;
+    return new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+  });
+}

--- a/packages/design-system/components/three/triangle.tsx
+++ b/packages/design-system/components/three/triangle.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { Instance, Instances, Line, Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { COLORS } from "@repo/design-system/lib/color";
 import { useTheme } from "next-themes";
-import { useMemo, useRef } from "react";
-import { type Group, MeshBasicMaterial, SphereGeometry, Vector3 } from "three";
+import { useMemo } from "react";
+import { MeshBasicMaterial, SphereGeometry, Vector3 } from "three";
 import { FONT_PATH, MONO_FONT_PATH, ORIGIN_COLOR } from "./_data";
-
-// Pre-calculate common values
-const SPHERE_SEGMENTS = 8; // Reduced from 16
-const ARC_SEGMENTS = 20; // Reduced from 30
+import {
+  createArcPoints,
+  GRAPH_ANGLE_ARC_SEGMENTS,
+  GRAPH_POINT_SEGMENTS,
+} from "./quality";
 
 // Angle and Quadrant constants
 const DEGREES_IN_HALF_CIRCLE = 180;
@@ -60,17 +60,27 @@ interface Props {
 let sharedSphereGeometry: SphereGeometry | null = null;
 const sharedMaterials: Map<string, MeshBasicMaterial> = new Map();
 
+/**
+ * Reuses vertex marker geometry across triangle visualizations.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedSphereGeometry() {
   if (!sharedSphereGeometry) {
     sharedSphereGeometry = new SphereGeometry(
       1,
-      SPHERE_SEGMENTS,
-      SPHERE_SEGMENTS
+      GRAPH_POINT_SEGMENTS,
+      GRAPH_POINT_SEGMENTS
     );
   }
   return sharedSphereGeometry;
 }
 
+/**
+ * Reuses triangle materials by color for repeated side and point rendering.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedMaterial(color: string) {
   if (!sharedMaterials.has(color)) {
     sharedMaterials.set(color, new MeshBasicMaterial({ color }));
@@ -82,6 +92,9 @@ function getSharedMaterial(color: string) {
   return material;
 }
 
+/**
+ * Renders a trigonometric triangle with smooth angle arcs and reusable markers.
+ */
 export function Triangle({
   angle = 45,
   size = 1,
@@ -94,7 +107,6 @@ export function Triangle({
   ...props
 }: Props) {
   const { resolvedTheme } = useTheme();
-  const groupRef = useRef<Group>(null);
 
   // Convert angle to radians and calculate the points
   const angleInRadians = angle * DEGREES_TO_RADIANS;
@@ -141,17 +153,10 @@ export function Triangle({
     ];
   }, [adjacent, opposite]);
 
-  // Memoize the angle arc points with fewer segments for performance
-  const triangleArcPoints = useMemo(() => {
-    const pts: Vector3[] = [];
-    for (let i = 0; i <= ARC_SEGMENTS; i += 1) {
-      const a = (i / ARC_SEGMENTS) * angleInRadians;
-      pts.push(
-        new Vector3(Math.cos(a) * arcRadius, Math.sin(a) * arcRadius, 0)
-      );
-    }
-    return pts;
-  }, [angleInRadians, arcRadius]);
+  const triangleArcPoints = useMemo(
+    () => createArcPoints(arcRadius, angleInRadians, GRAPH_ANGLE_ARC_SEGMENTS),
+    [angleInRadians, arcRadius]
+  );
 
   // Vertices for instancing with semantic labels
   const triangleVertices = useMemo(() => {
@@ -256,13 +261,6 @@ export function Triangle({
     }
   }, [quadrant, opposite, adjacent]);
 
-  // Use frustum culling
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
-
   // Line colors and semantic keys for triangle sides
   const sideConfig = [
     { color: COLORS.CYAN, key: "adjacent" },
@@ -271,7 +269,7 @@ export function Triangle({
   ];
 
   return (
-    <group ref={groupRef} {...props}>
+    <group frustumCulled {...props}>
       {/* Draw the triangle sides - optimized with single color array access */}
       {triangleSideLines.map((pts, i) => (
         <Line

--- a/packages/design-system/components/three/unit-circle.tsx
+++ b/packages/design-system/components/three/unit-circle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Line, Text } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { COLORS } from "@repo/design-system/lib/color";
 import {
   getCos,
@@ -11,9 +10,15 @@ import {
 } from "@repo/design-system/lib/math";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
-import { useMemo, useRef } from "react";
-import { type Group, MeshBasicMaterial, SphereGeometry, Vector3 } from "three";
+import { useMemo } from "react";
+import { MeshBasicMaterial, SphereGeometry, Vector3 } from "three";
 import { FONT_PATH, MONO_FONT_PATH, ORIGIN_COLOR } from "./_data";
+import {
+  createArcPoints,
+  GRAPH_ANGLE_ARC_SEGMENTS,
+  GRAPH_FULL_CIRCLE_SEGMENTS,
+  GRAPH_POINT_SEGMENTS,
+} from "./quality";
 
 interface Props {
   /** Angle in degrees */
@@ -36,10 +41,6 @@ interface Props {
   [key: string]: unknown;
 }
 
-// Optimized settings for performance
-const UNIT_CIRCLE_SEGMENTS = 48; // Reduced from 64
-const UNIT_ARC_SEGMENTS = 16; // Reduced from 24
-const SPHERE_SEGMENTS = 8; // Low poly sphere
 const SPHERE_RADIUS = 0.05;
 const ARC_RADIUS = 0.3;
 const LABEL_FONT_SIZE = 0.12;
@@ -56,32 +57,40 @@ const SQRT_3 = Math.sqrt(THREE);
 const TWO = 2;
 const FOUR = 4;
 const ONE = 1;
+const FULL_CIRCLE_RADIANS = Math.PI * 2;
 
-// Pre-calculate static circle points once
-const STATIC_CIRCLE_POINTS: Vector3[] = (() => {
-  const pts: Vector3[] = [];
-  for (let i = 0; i <= UNIT_CIRCLE_SEGMENTS; i += 1) {
-    const a = (i / UNIT_CIRCLE_SEGMENTS) * Math.PI * 2;
-    pts.push(new Vector3(Math.cos(a), Math.sin(a), 0));
-  }
-  return pts;
-})();
+// Pre-calculate static circle points once.
+const STATIC_CIRCLE_POINTS = createArcPoints(
+  1,
+  FULL_CIRCLE_RADIANS,
+  GRAPH_FULL_CIRCLE_SEGMENTS
+);
 
 // Shared geometry instances
 let sharedSphereGeometry: SphereGeometry | null = null;
 const sharedMaterials: Map<string, MeshBasicMaterial> = new Map();
 
+/**
+ * Reuses point marker geometry across unit-circle renders.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedSphereGeometry() {
   if (!sharedSphereGeometry) {
     sharedSphereGeometry = new SphereGeometry(
       SPHERE_RADIUS,
-      SPHERE_SEGMENTS,
-      SPHERE_SEGMENTS
+      GRAPH_POINT_SEGMENTS,
+      GRAPH_POINT_SEGMENTS
     );
   }
   return sharedSphereGeometry;
 }
 
+/**
+ * Reuses unit-circle materials by color for labels and point markers.
+ *
+ * @see https://r3f.docs.pmnd.rs/advanced/scaling-performance#re-using-geometries-and-materials
+ */
 function getSharedMaterial(color: string) {
   if (!sharedMaterials.has(color)) {
     sharedMaterials.set(color, new MeshBasicMaterial({ color }));
@@ -93,6 +102,9 @@ function getSharedMaterial(color: string) {
   return material;
 }
 
+/**
+ * Renders the interactive unit-circle scene with smooth circle and angle arcs.
+ */
 export function UnitCircle({
   angle = 45,
   showLabels = true,
@@ -104,7 +116,6 @@ export function UnitCircle({
 }: Props) {
   const t = useTranslations("Common");
   const { resolvedTheme } = useTheme();
-  const groupRef = useRef<Group>(null);
 
   const angleInRadians = getRadians(angle);
   const sin = getSin(angle);
@@ -114,17 +125,10 @@ export function UnitCircle({
   // Use precomputed circle outline points (static)
   const circlePoints = STATIC_CIRCLE_POINTS;
 
-  // Memoize angle arc points with reduced segments
-  const arcPoints = useMemo(() => {
-    const pts: Vector3[] = [];
-    for (let i = 0; i <= UNIT_ARC_SEGMENTS; i += 1) {
-      const a = (i / UNIT_ARC_SEGMENTS) * angleInRadians;
-      pts.push(
-        new Vector3(Math.cos(a) * ARC_RADIUS, Math.sin(a) * ARC_RADIUS, 0)
-      );
-    }
-    return pts;
-  }, [angleInRadians]);
+  const arcPoints = useMemo(
+    () => createArcPoints(ARC_RADIUS, angleInRadians, GRAPH_ANGLE_ARC_SEGMENTS),
+    [angleInRadians]
+  );
 
   // Format values according to display mode - memoize the function
   const formatValue = useMemo(() => {
@@ -211,19 +215,12 @@ export function UnitCircle({
     [origin, pointPosition, cosPoint]
   );
 
-  // Use frustum culling
-  useFrame(() => {
-    if (groupRef.current) {
-      groupRef.current.frustumCulled = true;
-    }
-  });
-
   // Get shared geometry and material
   const sphereGeometry = getSharedSphereGeometry();
   const sphereMaterial = getSharedMaterial(circleColor);
 
   return (
-    <group ref={groupRef} {...props}>
+    <group frustumCulled {...props}>
       {/* Unit Circle (XY plane) */}
       <group rotation={[0, 0, 0]}>
         {/* Circle outline */}


### PR DESCRIPTION
Use LazyMotion/domMax and MotionConfig to load motion features and respect OS reduced-motion. Gate playback by viewport intersection while preserving user Play/Pause intent and use deferred values for smoother updates. Add packages/design-system/components/three/quality.ts to centralize segment/division defaults and replace magic geometry segment counts, plus reuse shared geometries/materials and add client directives and documentation comments for 3D components
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nakafaai/nakafa.com/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
