### PR TITLE
Integrate PostHog product analytics

### DIFF
--- a/apps/email/package.json
+++ b/apps/email/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "email build --dir ../../packages/email/templates",
+    "build": "env -u npm_config_npm_globalconfig -u npm_config_verify_deps_before_run -u npm_config__jsr_registry -u npm_config_recursive email build --dir ../../packages/email/templates",
     "dev": "email dev --port 3004 --dir ../../packages/email/templates",
     "export": "email export --dir ../../packages/email/templates",
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/apps/www/app/api/chat/persistence.test.ts
+++ b/apps/www/app/api/chat/persistence.test.ts
@@ -1,0 +1,222 @@
+import type { MyUIMessage } from "@repo/ai/types/message";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadMessages, saveOrCreateChat } from "@/app/api/chat/persistence";
+
+const mocks = vi.hoisted(() => ({
+  compressMessages: vi.fn(),
+  fetchMutation: vi.fn(),
+  fetchQuery: vi.fn(),
+  mapDBMessagesToUIMessages: vi.fn(),
+  mapUIMessagePartsToDBParts: vi.fn(),
+}));
+
+vi.mock("@repo/ai/lib/utils", () => ({
+  compressMessages: mocks.compressMessages,
+}));
+
+vi.mock("convex/nextjs", () => ({
+  fetchMutation: mocks.fetchMutation,
+  fetchQuery: mocks.fetchQuery,
+}));
+
+vi.mock("@repo/backend/convex/chats/messageParts/uiToDb", () => ({
+  mapUIMessagePartsToDBParts: mocks.mapUIMessagePartsToDBParts,
+}));
+
+vi.mock("@repo/backend/convex/chats/utils", () => ({
+  mapDBMessagesToUIMessages: mocks.mapDBMessagesToUIMessages,
+}));
+
+const message = {
+  id: "message-1",
+  parts: [],
+  role: "user",
+} satisfies MyUIMessage;
+
+/** Returns one typed chat ID through the public persistence path. */
+async function createTypedChatId() {
+  mocks.fetchMutation.mockResolvedValueOnce({ chatId: "chat_existing" });
+
+  const chatId = await saveOrCreateChat({
+    chatId: undefined,
+    message,
+    modelId: "gpt-5-nano",
+    token: "session-token",
+  });
+
+  vi.clearAllMocks();
+  mocks.mapUIMessagePartsToDBParts.mockReturnValue([]);
+
+  return chatId;
+}
+
+describe("app/api/chat/persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.compressMessages.mockImplementation((messages) => ({
+      messages,
+      tokens: 0,
+    }));
+    mocks.mapDBMessagesToUIMessages.mockImplementation((messages) => messages);
+    mocks.mapUIMessagePartsToDBParts.mockReturnValue([]);
+  });
+
+  it("passes the selected model when creating a chat with the first user message", async () => {
+    mocks.fetchMutation.mockResolvedValue({ chatId: "chat_new" });
+
+    const chatId = await saveOrCreateChat({
+      chatId: undefined,
+      message,
+      modelId: "gpt-5-nano",
+      token: "session-token",
+    });
+
+    expect(chatId).toBe("chat_new");
+    expect(mocks.fetchMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        message: {
+          identifier: "message-1",
+          modelId: "gpt-5-nano",
+          role: "user",
+        },
+        parts: [],
+        type: "study",
+      },
+      { token: "session-token" }
+    );
+  });
+
+  it("passes the selected model when saving a message to an existing chat", async () => {
+    const chatId = await createTypedChatId();
+    mocks.fetchQuery.mockResolvedValue(null);
+
+    const result = await saveOrCreateChat({
+      chatId,
+      message,
+      modelId: "gpt-5-nano",
+      token: "session-token",
+    });
+
+    expect(result).toBe(chatId);
+    expect(mocks.fetchMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        message: {
+          chatId,
+          identifier: "message-1",
+          modelId: "gpt-5-nano",
+          role: "user",
+        },
+        parts: [],
+      },
+      { token: "session-token" }
+    );
+  });
+
+  it("deletes an existing message rewrite batch before saving the replacement", async () => {
+    const chatId = await createTypedChatId();
+    mocks.fetchQuery.mockResolvedValue({ creationTime: 123 });
+    mocks.fetchMutation
+      .mockResolvedValueOnce({ hasMore: true })
+      .mockResolvedValueOnce({ hasMore: false })
+      .mockResolvedValueOnce({});
+
+    await saveOrCreateChat({
+      chatId,
+      message,
+      modelId: "gpt-5-nano",
+      token: "session-token",
+    });
+
+    expect(mocks.fetchMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      {
+        chatId,
+        fromCreationTime: 123,
+      },
+      { token: "session-token" }
+    );
+    expect(mocks.fetchMutation).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      {
+        chatId,
+        fromCreationTime: 123,
+      },
+      { token: "session-token" }
+    );
+    expect(mocks.fetchMutation).toHaveBeenNthCalledWith(
+      3,
+      expect.anything(),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          chatId,
+          modelId: "gpt-5-nano",
+        }),
+      }),
+      { token: "session-token" }
+    );
+  });
+
+  it("loads paginated messages until the page stream is done", async () => {
+    const chatId = await createTypedChatId();
+    const newerMessage = { ...message, id: "newer" };
+    const olderMessage = { ...message, id: "older" };
+    mocks.fetchQuery
+      .mockResolvedValueOnce({
+        continueCursor: "cursor-1",
+        isDone: false,
+        page: [newerMessage],
+      })
+      .mockResolvedValueOnce({
+        continueCursor: "",
+        isDone: true,
+        page: [olderMessage],
+      });
+
+    const messages = await loadMessages({ chatId, token: "session-token" });
+
+    expect(messages).toEqual([olderMessage, newerMessage]);
+    expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      {
+        chatId,
+        paginationOpts: {
+          cursor: null,
+          numItems: expect.any(Number),
+        },
+      },
+      { token: "session-token" }
+    );
+    expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      {
+        chatId,
+        paginationOpts: {
+          cursor: "cursor-1",
+          numItems: expect.any(Number),
+        },
+      },
+      { token: "session-token" }
+    );
+  });
+
+  it("stops loading when compression trims the retained transcript", async () => {
+    const chatId = await createTypedChatId();
+    mocks.fetchQuery.mockResolvedValue({
+      continueCursor: "cursor-1",
+      isDone: false,
+      page: [message],
+    });
+    mocks.compressMessages.mockReturnValue({ messages: [], tokens: 0 });
+
+    const messages = await loadMessages({ chatId, token: "session-token" });
+
+    expect(messages).toEqual([]);
+    expect(mocks.fetchQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/www/app/api/chat/persistence.ts
+++ b/apps/www/app/api/chat/persistence.ts
@@ -1,3 +1,4 @@
+import type { ModelId } from "@repo/ai/config/models";
 import { compressMessages } from "@repo/ai/lib/utils";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { api as convexApi } from "@repo/backend/convex/_generated/api";
@@ -23,10 +24,12 @@ interface ChatMessagesPage {
 export async function saveOrCreateChat({
   chatId,
   message,
+  modelId,
   token,
 }: {
   chatId: Id<"chats"> | undefined;
   message: MyUIMessage;
+  modelId: ModelId;
   token: string;
 }): Promise<Id<"chats">> {
   const dbParts = mapUIMessagePartsToDBParts({ messageParts: message.parts });
@@ -65,6 +68,7 @@ export async function saveOrCreateChat({
           chatId,
           role: message.role,
           identifier: message.id,
+          modelId,
         },
         parts: dbParts,
       },
@@ -80,6 +84,7 @@ export async function saveOrCreateChat({
       message: {
         role: message.role,
         identifier: message.id,
+        modelId,
       },
       parts: dbParts,
     },

--- a/apps/www/app/api/chat/route.ts
+++ b/apps/www/app/api/chat/route.ts
@@ -42,7 +42,6 @@ import {
   smoothStream,
   stepCountIs,
   streamText,
-  type Tool,
 } from "ai";
 import { fetchAction, fetchMutation } from "convex/nextjs";
 import { getTranslations } from "next-intl/server";
@@ -375,8 +374,11 @@ export async function POST(req: Request) {
             return null;
           }
 
-          const tool: Tool =
-            availableTools[toolCall.toolName as keyof typeof availableTools];
+          const tool = availableTools[toolCall.toolName];
+          if (!tool) {
+            sessionLogger.warn("Tool is unavailable, not attempting repair");
+            return null;
+          }
 
           const { output: repairedArgs } = await generateText({
             model: model.languageModel(defaultModel),

--- a/apps/www/app/api/chat/route.ts
+++ b/apps/www/app/api/chat/route.ts
@@ -201,7 +201,12 @@ export async function POST(req: Request) {
     );
   }
 
-  const chatId = await saveOrCreateChat({ chatId: id, message, token });
+  const chatId = await saveOrCreateChat({
+    chatId: id,
+    message,
+    modelId: selectedModel,
+    token,
+  });
   const messages = await loadMessages({ chatId, token });
   const isFirstMessage = messages.length === 1;
 

--- a/apps/www/lib/context/use-user.test.ts
+++ b/apps/www/lib/context/use-user.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const PROVIDER_ERROR = /useUser must be used within a UserContextProvider/;
+const SIGNED_UP_AT = "2026-04-02T12:00:00.000Z";
+const SIGNED_UP_AT_MS = Date.parse(SIGNED_UP_AT);
 
 vi.mock("@repo/analytics/posthog", () => ({
   analytics: {
@@ -69,7 +71,12 @@ describe("lib/context/use-user", () => {
     mocks.getProperty.mockReturnValue(undefined);
     mocks.useQueryWithStatus.mockReturnValue({
       data: {
-        appUser: { _id: "user_123" },
+        appUser: {
+          _id: "user_123",
+          _creationTime: SIGNED_UP_AT_MS,
+          plan: "pro",
+          role: "teacher",
+        },
         authUser: { email: "nabil@nakafa.com", name: "Nabil" },
       },
       isPending: false,
@@ -81,10 +88,18 @@ describe("lib/context/use-user", () => {
       );
     });
 
-    expect(mocks.identify).toHaveBeenCalledWith("user_123", {
-      email: "nabil@nakafa.com",
-      name: "Nabil",
-    });
+    expect(mocks.identify).toHaveBeenCalledWith(
+      "user_123",
+      {
+        email: "nabil@nakafa.com",
+        name: "Nabil",
+        plan: "pro",
+        role: "teacher",
+      },
+      {
+        signed_up_at: SIGNED_UP_AT,
+      }
+    );
     expect(mocks.setPersonProperties).not.toHaveBeenCalled();
     expect(mocks.reset).not.toHaveBeenCalled();
 
@@ -102,7 +117,11 @@ describe("lib/context/use-user", () => {
     mocks.getProperty.mockReturnValue(undefined);
     mocks.useQueryWithStatus.mockReturnValue({
       data: {
-        appUser: { _id: "user_123" },
+        appUser: {
+          _id: "user_123",
+          _creationTime: SIGNED_UP_AT_MS,
+          plan: "pro",
+        },
         authUser: { email: null, name: "Nabil" },
       },
       isPending: false,
@@ -132,7 +151,11 @@ describe("lib/context/use-user", () => {
     mocks.getProperty.mockReturnValue("user_123");
     mocks.useQueryWithStatus.mockReturnValue({
       data: {
-        appUser: { _id: "user_123" },
+        appUser: {
+          _id: "user_123",
+          _creationTime: SIGNED_UP_AT_MS,
+          plan: "free",
+        },
         authUser: { email: "nabil@nakafa.com", name: "Nabil" },
       },
       isPending: false,
@@ -145,10 +168,16 @@ describe("lib/context/use-user", () => {
     });
 
     expect(mocks.identify).not.toHaveBeenCalled();
-    expect(mocks.setPersonProperties).toHaveBeenCalledWith({
-      email: "nabil@nakafa.com",
-      name: "Nabil",
-    });
+    expect(mocks.setPersonProperties).toHaveBeenCalledWith(
+      {
+        email: "nabil@nakafa.com",
+        name: "Nabil",
+        plan: "free",
+      },
+      {
+        signed_up_at: SIGNED_UP_AT,
+      }
+    );
     expect(mocks.reset).not.toHaveBeenCalled();
 
     act(() => {
@@ -212,7 +241,11 @@ describe("lib/context/use-user", () => {
 
     mocks.useQueryWithStatus.mockReturnValue({
       data: {
-        appUser: { _id: "user_123" },
+        appUser: {
+          _id: "user_123",
+          _creationTime: SIGNED_UP_AT_MS,
+          plan: "free",
+        },
         authUser: { email: "nabil@nakafa.com", name: "Nabil" },
       },
       isPending: false,

--- a/apps/www/lib/context/use-user.tsx
+++ b/apps/www/lib/context/use-user.tsx
@@ -33,9 +33,15 @@ export function UserContextProvider({
 }) {
   const { data: user, isPending } = useQueryWithStatus(api.auth.getCurrentUser);
   const currentUser = user ?? null;
+  const appUser = currentUser?.appUser ?? null;
   const userId = currentUser?.appUser._id ?? null;
   const userEmail = currentUser?.authUser.email ?? null;
   const userName = currentUser?.authUser.name ?? null;
+  const userPlan = appUser?.plan ?? null;
+  const userRole = appUser?.role ?? null;
+  const signedUpAt = appUser
+    ? new Date(appUser._creationTime).toISOString()
+    : null;
 
   useEffect(() => {
     if (isPending) {
@@ -52,22 +58,33 @@ export function UserContextProvider({
       return;
     }
 
-    if (userEmail === null || userName === null) {
+    if (
+      userEmail === null ||
+      userName === null ||
+      userPlan === null ||
+      signedUpAt === null
+    ) {
       return;
     }
 
+    const roleProperties = userRole ? { role: userRole } : {};
     const personProperties = {
       email: userEmail,
       name: userName,
+      plan: userPlan,
+      ...roleProperties,
+    };
+    const setOnceProperties = {
+      signed_up_at: signedUpAt,
     };
 
     if (trackedUserId !== userId) {
-      analytics.identify(userId, personProperties);
+      analytics.identify(userId, personProperties, setOnceProperties);
       return;
     }
 
-    analytics.setPersonProperties(personProperties);
-  }, [isPending, userEmail, userId, userName]);
+    analytics.setPersonProperties(personProperties, setOnceProperties);
+  }, [isPending, signedUpAt, userEmail, userId, userName, userPlan, userRole]);
 
   return (
     <UserContext.Provider value={{ user: currentUser, isPending }}>

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type * as analytics_capture from "../analytics/capture.js";
+import type * as analytics_events from "../analytics/events.js";
 import type * as assessments_helpers_access from "../assessments/helpers/access.js";
 import type * as assessments_helpers_attempts from "../assessments/helpers/attempts.js";
 import type * as assessments_helpers_authoring from "../assessments/helpers/authoring.js";
@@ -171,6 +173,7 @@ import type * as lib_validators_vv from "../lib/validators/vv.js";
 import type * as notifications_mutations from "../notifications/mutations.js";
 import type * as notifications_queries from "../notifications/queries.js";
 import type * as polyfills from "../polyfills.js";
+import type * as posthog from "../posthog.js";
 import type * as routes_constants from "../routes/constants.js";
 import type * as routes_middleware_requestId from "../routes/middleware/requestId.js";
 import type * as routes_polar from "../routes/polar.js";
@@ -186,11 +189,13 @@ import type * as subscriptions_queries from "../subscriptions/queries.js";
 import type * as subscriptions_utils from "../subscriptions/utils.js";
 import type * as triggers_chats_chats from "../triggers/chats/chats.js";
 import type * as triggers_chats_cleanup from "../triggers/chats/cleanup.js";
+import type * as triggers_chats_messages from "../triggers/chats/messages.js";
 import type * as triggers_comments_cleanup from "../triggers/comments/cleanup.js";
 import type * as triggers_comments_commentVotes from "../triggers/comments/commentVotes.js";
 import type * as triggers_comments_comments from "../triggers/comments/comments.js";
 import type * as triggers_contents_exerciseAnswers from "../triggers/contents/exerciseAnswers.js";
 import type * as triggers_contents_exerciseAttempts from "../triggers/contents/exerciseAttempts.js";
+import type * as triggers_contents_views from "../triggers/contents/views.js";
 import type * as triggers_forums_postReactions from "../triggers/forums/postReactions.js";
 import type * as triggers_forums_posts from "../triggers/forums/posts.js";
 import type * as triggers_forums_reactions from "../triggers/forums/reactions.js";
@@ -211,6 +216,7 @@ import type * as triggers_schools_members from "../triggers/schools/members.js";
 import type * as triggers_schools_schools from "../triggers/schools/schools.js";
 import type * as triggers_subscriptions_subscriptions from "../triggers/subscriptions/subscriptions.js";
 import type * as triggers_tryouts_leaderboard from "../triggers/tryouts/leaderboard.js";
+import type * as triggers_tryouts_tryoutAttempts from "../triggers/tryouts/tryoutAttempts.js";
 import type * as tryoutAccess_helpers_campaignProducts from "../tryoutAccess/helpers/campaignProducts.js";
 import type * as tryoutAccess_helpers_codes from "../tryoutAccess/helpers/codes.js";
 import type * as tryoutAccess_helpers_entitlements from "../tryoutAccess/helpers/entitlements.js";
@@ -289,6 +295,8 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "analytics/capture": typeof analytics_capture;
+  "analytics/events": typeof analytics_events;
   "assessments/helpers/access": typeof assessments_helpers_access;
   "assessments/helpers/attempts": typeof assessments_helpers_attempts;
   "assessments/helpers/authoring": typeof assessments_helpers_authoring;
@@ -452,6 +460,7 @@ declare const fullApi: ApiFromModules<{
   "notifications/mutations": typeof notifications_mutations;
   "notifications/queries": typeof notifications_queries;
   polyfills: typeof polyfills;
+  posthog: typeof posthog;
   "routes/constants": typeof routes_constants;
   "routes/middleware/requestId": typeof routes_middleware_requestId;
   "routes/polar": typeof routes_polar;
@@ -467,11 +476,13 @@ declare const fullApi: ApiFromModules<{
   "subscriptions/utils": typeof subscriptions_utils;
   "triggers/chats/chats": typeof triggers_chats_chats;
   "triggers/chats/cleanup": typeof triggers_chats_cleanup;
+  "triggers/chats/messages": typeof triggers_chats_messages;
   "triggers/comments/cleanup": typeof triggers_comments_cleanup;
   "triggers/comments/commentVotes": typeof triggers_comments_commentVotes;
   "triggers/comments/comments": typeof triggers_comments_comments;
   "triggers/contents/exerciseAnswers": typeof triggers_contents_exerciseAnswers;
   "triggers/contents/exerciseAttempts": typeof triggers_contents_exerciseAttempts;
+  "triggers/contents/views": typeof triggers_contents_views;
   "triggers/forums/postReactions": typeof triggers_forums_postReactions;
   "triggers/forums/posts": typeof triggers_forums_posts;
   "triggers/forums/reactions": typeof triggers_forums_reactions;
@@ -492,6 +503,7 @@ declare const fullApi: ApiFromModules<{
   "triggers/schools/schools": typeof triggers_schools_schools;
   "triggers/subscriptions/subscriptions": typeof triggers_subscriptions_subscriptions;
   "triggers/tryouts/leaderboard": typeof triggers_tryouts_leaderboard;
+  "triggers/tryouts/tryoutAttempts": typeof triggers_tryouts_tryoutAttempts;
   "tryoutAccess/helpers/campaignProducts": typeof tryoutAccess_helpers_campaignProducts;
   "tryoutAccess/helpers/codes": typeof tryoutAccess_helpers_codes;
   "tryoutAccess/helpers/entitlements": typeof tryoutAccess_helpers_entitlements;
@@ -597,6 +609,7 @@ export declare const components: {
   irtScalePublicationQueueWorkpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"irtScalePublicationQueueWorkpool">;
   tryoutLeaderboardWorkpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"tryoutLeaderboardWorkpool">;
   resend: import("@convex-dev/resend/_generated/component.js").ComponentApi<"resend">;
+  posthog: import("@posthog/convex/_generated/component.js").ComponentApi<"posthog">;
   tryoutLeaderboard: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"tryoutLeaderboard">;
   globalLeaderboard: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"globalLeaderboard">;
   forumPostsBySequence: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"forumPostsBySequence">;

--- a/packages/backend/convex/analytics/capture.test.ts
+++ b/packages/backend/convex/analytics/capture.test.ts
@@ -1,0 +1,209 @@
+import posthogTest from "@posthog/convex/test";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
+import { productAnalyticsEventValidator } from "@repo/backend/convex/analytics/events";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { validate } from "convex-helpers/validators";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
+const posthogHost =
+  process.env.POSTHOG_HOST?.trim() || "https://eu.i.posthog.com";
+
+describe("analytics/capture", () => {
+  it("keeps the product analytics contract on approved event names", () => {
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "user signed up",
+        properties: { plan: "free" },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "content viewed",
+        properties: {
+          content_type: "article",
+          is_new_view: true,
+          locale: "id",
+          slug: "articles/example",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "exercise attempt started",
+        properties: {
+          mode: "practice",
+          origin: "standalone",
+          scope: "set",
+          slug: "exercises/example",
+          total_exercises: 10,
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "exercise attempt completed",
+        properties: {
+          answered_count: 10,
+          correct_answers: 8,
+          mode: "practice",
+          origin: "standalone",
+          score_percentage: 80,
+          scope: "set",
+          slug: "exercises/example",
+          total_exercises: 10,
+          total_time: 120,
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "tryout attempt started",
+        properties: {
+          attempt_number: 1,
+          locale: "id",
+          product: "snbt",
+          score_status: "official",
+          tryout_slug: "snbt-2026",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "tryout attempt completed",
+        properties: {
+          attempt_number: 1,
+          locale: "id",
+          product: "snbt",
+          raw_score_percentage: 75,
+          score_status: "official",
+          theta: 0.4,
+          total_correct: 15,
+          total_questions: 20,
+          tryout_slug: "snbt-2026",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "chat message sent",
+        properties: {
+          chat_type: "study",
+          model_id: "gpt-5-nano",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "chat response completed",
+        properties: {
+          chat_type: "study",
+          credits: 1,
+          input_tokens: 10,
+          model_id: "gpt-5-nano",
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "checkout started",
+        properties: {
+          product_count: 1,
+          product_id: "product-pro",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "subscription started",
+        properties: {
+          product_id: "product-pro",
+          status: "active",
+          subscription_id: "sub-pro",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "subscription canceled",
+        properties: {
+          product_id: "product-pro",
+          status: "canceled",
+          subscription_id: "sub-pro",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "plan changed",
+        properties: {
+          new_plan: "pro",
+          previous_plan: "free",
+          subscription_id: "sub-pro",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validate(productAnalyticsEventValidator, {
+        name: "pageview",
+        properties: {},
+      })
+    ).toBe(false);
+  });
+
+  it("schedules the PostHog component capture action with the product payload", async () => {
+    const t = convexTest(schema, convexModules);
+    posthogTest.register(t);
+
+    const scheduledJobs = await t.mutation(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        authId: "analytics-user-auth",
+        credits: 10,
+        creditsResetAt: NOW,
+        email: "analytics@example.com",
+        name: "Analytics User",
+        plan: "free",
+      });
+
+      await captureProductEvent(ctx, {
+        distinctId: userId,
+        event: {
+          name: "content viewed",
+          properties: {
+            content_type: "article",
+            is_new_view: true,
+            locale: "id",
+            slug: "articles/example",
+          },
+        },
+        timestamp: new Date(NOW),
+      });
+
+      return await ctx.db.system.query("_scheduled_functions").collect();
+    });
+
+    expect(scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            disableGeoip: true,
+            event: "content viewed",
+            host: posthogHost,
+            properties: JSON.stringify({
+              content_type: "article",
+              is_new_view: true,
+              locale: "id",
+              slug: "articles/example",
+            }),
+            timestamp: NOW,
+          }),
+        ],
+        name: expect.stringContaining("capture"),
+      }),
+    ]);
+  });
+});

--- a/packages/backend/convex/analytics/capture.test.ts
+++ b/packages/backend/convex/analytics/capture.test.ts
@@ -5,13 +5,21 @@ import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { validate } from "convex-helpers/validators";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
 const posthogHost =
   process.env.POSTHOG_HOST?.trim() || "https://eu.i.posthog.com";
 
 describe("analytics/capture", () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date(NOW));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps the product analytics contract on approved event names", () => {
     expect(
       validate(productAnalyticsEventValidator, {

--- a/packages/backend/convex/analytics/capture.ts
+++ b/packages/backend/convex/analytics/capture.ts
@@ -1,0 +1,30 @@
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
+import { posthog } from "@repo/backend/convex/posthog";
+
+type ProductAnalyticsCtx = Pick<MutationCtx, "scheduler">;
+
+/**
+ * Capture one backend product event through the official PostHog Convex component.
+ */
+export async function captureProductEvent(
+  ctx: ProductAnalyticsCtx,
+  {
+    distinctId,
+    event,
+    timestamp,
+  }: {
+    distinctId: Id<"users">;
+    event: ProductAnalyticsEvent;
+    timestamp?: Date;
+  }
+) {
+  await posthog.capture(ctx, {
+    distinctId,
+    disableGeoip: true,
+    event: event.name,
+    properties: event.properties,
+    timestamp,
+  });
+}

--- a/packages/backend/convex/analytics/events.ts
+++ b/packages/backend/convex/analytics/events.ts
@@ -1,0 +1,144 @@
+import {
+  chatTypeValidator,
+  modelIdValidator,
+} from "@repo/backend/convex/chats/schema";
+import {
+  exerciseAttemptModeValidator,
+  exerciseAttemptOriginValidator,
+  exerciseAttemptScopeValidator,
+} from "@repo/backend/convex/exercises/schema";
+import {
+  contentTypeValidator,
+  localeValidator,
+} from "@repo/backend/convex/lib/validators/contents";
+import { tryoutProductValidator } from "@repo/backend/convex/tryouts/products";
+import {
+  tryoutAccessKindValidator,
+  tryoutScoreStatusValidator,
+} from "@repo/backend/convex/tryouts/schema";
+import { userPlanValidator } from "@repo/backend/convex/users/schema";
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+
+const optionalNumber = v.optional(v.number());
+
+export const productAnalyticsEventValidator = v.union(
+  v.object({
+    name: v.literal("user signed up"),
+    properties: v.object({
+      plan: userPlanValidator,
+    }),
+  }),
+  v.object({
+    name: v.literal("content viewed"),
+    properties: v.object({
+      content_type: contentTypeValidator,
+      is_new_view: v.boolean(),
+      locale: localeValidator,
+      slug: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("exercise attempt started"),
+    properties: v.object({
+      exercise_number: optionalNumber,
+      mode: exerciseAttemptModeValidator,
+      origin: exerciseAttemptOriginValidator,
+      scope: exerciseAttemptScopeValidator,
+      slug: v.string(),
+      total_exercises: v.number(),
+    }),
+  }),
+  v.object({
+    name: v.literal("exercise attempt completed"),
+    properties: v.object({
+      answered_count: v.number(),
+      correct_answers: v.number(),
+      mode: exerciseAttemptModeValidator,
+      origin: exerciseAttemptOriginValidator,
+      score_percentage: v.number(),
+      scope: exerciseAttemptScopeValidator,
+      slug: v.string(),
+      total_exercises: v.number(),
+      total_time: v.number(),
+    }),
+  }),
+  v.object({
+    name: v.literal("tryout attempt started"),
+    properties: v.object({
+      access_kind: v.optional(tryoutAccessKindValidator),
+      attempt_number: v.number(),
+      locale: localeValidator,
+      product: tryoutProductValidator,
+      score_status: tryoutScoreStatusValidator,
+      tryout_slug: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("tryout attempt completed"),
+    properties: v.object({
+      attempt_number: v.number(),
+      locale: localeValidator,
+      product: tryoutProductValidator,
+      raw_score_percentage: v.number(),
+      score_status: tryoutScoreStatusValidator,
+      theta: v.number(),
+      total_correct: v.number(),
+      total_questions: v.number(),
+      tryout_slug: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("chat message sent"),
+    properties: v.object({
+      chat_type: chatTypeValidator,
+      model_id: modelIdValidator,
+    }),
+  }),
+  v.object({
+    name: v.literal("chat response completed"),
+    properties: v.object({
+      chat_type: chatTypeValidator,
+      credits: optionalNumber,
+      input_tokens: optionalNumber,
+      model_id: modelIdValidator,
+      output_tokens: optionalNumber,
+      total_tokens: optionalNumber,
+    }),
+  }),
+  v.object({
+    name: v.literal("checkout started"),
+    properties: v.object({
+      product_count: v.number(),
+      product_id: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("subscription started"),
+    properties: v.object({
+      product_id: v.string(),
+      status: v.string(),
+      subscription_id: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("subscription canceled"),
+    properties: v.object({
+      product_id: v.string(),
+      status: v.string(),
+      subscription_id: v.string(),
+    }),
+  }),
+  v.object({
+    name: v.literal("plan changed"),
+    properties: v.object({
+      new_plan: userPlanValidator,
+      previous_plan: userPlanValidator,
+      subscription_id: v.string(),
+    }),
+  })
+);
+
+export type ProductAnalyticsEvent = Infer<
+  typeof productAnalyticsEventValidator
+>;

--- a/packages/backend/convex/analytics/triggers.test.ts
+++ b/packages/backend/convex/analytics/triggers.test.ts
@@ -1,0 +1,145 @@
+import { api } from "@repo/backend/convex/_generated/api";
+import {
+  createConvexTestWithBetterAuth,
+  seedAuthenticatedUser,
+} from "@repo/backend/convex/test.helpers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
+
+describe("analytics/triggers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("captures signed-in content views after the engaged view write", async () => {
+    vi.setSystemTime(new Date(NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const identity = await seedAuthenticatedUser(ctx, { now: NOW });
+
+      await ctx.db.insert("articleContents", {
+        articleSlug: "analytics",
+        body: "content",
+        category: "politics",
+        contentHash: "hash",
+        date: NOW,
+        locale: "id",
+        slug: "articles/politics/analytics",
+        syncedAt: NOW,
+        title: "Analytics",
+      });
+
+      return identity;
+    });
+
+    await t
+      .withIdentity({
+        subject: identity.authUserId,
+        sessionId: identity.sessionId,
+      })
+      .mutation(api.contents.mutations.views.recordContentView, {
+        contentRef: {
+          slug: "articles/politics/analytics",
+          type: "article",
+        },
+        deviceId: "device-1",
+        locale: "id",
+      });
+
+    const scheduledJobs = await t.query(
+      async (ctx) => await ctx.db.system.query("_scheduled_functions").collect()
+    );
+
+    expect(scheduledJobs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          args: [
+            expect.objectContaining({
+              distinctId: identity.userId,
+              event: "content viewed",
+              properties: JSON.stringify({
+                content_type: "article",
+                is_new_view: true,
+                locale: "id",
+                slug: "articles/politics/analytics",
+              }),
+            }),
+          ],
+        }),
+      ])
+    );
+  });
+
+  it("captures exercise start and completion from the attempt lifecycle", async () => {
+    vi.setSystemTime(new Date(NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(
+      async (ctx) => await seedAuthenticatedUser(ctx, { now: NOW })
+    );
+    const client = t.withIdentity({
+      subject: identity.authUserId,
+      sessionId: identity.sessionId,
+    });
+
+    const attemptId = await client.mutation(
+      api.exercises.mutations.startAttempt,
+      {
+        mode: "practice",
+        scope: "set",
+        slug: "exercises/high-school/snbt/set-1",
+        timeLimit: 600,
+        totalExercises: 10,
+      }
+    );
+
+    await client.mutation(api.exercises.mutations.completeAttempt, {
+      attemptId,
+    });
+
+    const scheduledJobs = await t.query(
+      async (ctx) => await ctx.db.system.query("_scheduled_functions").collect()
+    );
+
+    expect(scheduledJobs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          args: [
+            expect.objectContaining({
+              distinctId: identity.userId,
+              event: "exercise attempt started",
+              properties: JSON.stringify({
+                mode: "practice",
+                origin: "standalone",
+                scope: "set",
+                slug: "exercises/high-school/snbt/set-1",
+                total_exercises: 10,
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          args: [
+            expect.objectContaining({
+              distinctId: identity.userId,
+              event: "exercise attempt completed",
+              properties: JSON.stringify({
+                answered_count: 0,
+                correct_answers: 0,
+                mode: "practice",
+                origin: "standalone",
+                score_percentage: 0,
+                scope: "set",
+                slug: "exercises/high-school/snbt/set-1",
+                total_exercises: 10,
+                total_time: 0,
+              }),
+            }),
+          ],
+        }),
+      ])
+    );
+  });
+});

--- a/packages/backend/convex/auth/client.ts
+++ b/packages/backend/convex/auth/client.ts
@@ -1,12 +1,14 @@
 import { type AuthFunctions, createClient } from "@convex-dev/better-auth";
 import { components, internal } from "@repo/backend/convex/_generated/api";
 import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import authSchema from "@repo/backend/convex/betterAuth/schema";
 import {
   DEFAULT_USER_CREDITS,
   DEFAULT_USER_PLAN,
 } from "@repo/backend/convex/credits/constants";
 import { getCurrentCreditResetTimestamp } from "@repo/backend/convex/credits/helpers/state";
+import { posthog } from "@repo/backend/convex/posthog";
 
 const authFunctions: AuthFunctions = internal.auth;
 
@@ -21,6 +23,8 @@ export const authComponent = createClient<DataModel, typeof authSchema>(
     triggers: {
       user: {
         onCreate: async (ctx, authUser) => {
+          const now = Date.now();
+          const signedUpAt = new Date(now).toISOString();
           const userId = await ctx.db.insert("users", {
             email: authUser.email,
             authId: authUser._id,
@@ -30,7 +34,7 @@ export const authComponent = createClient<DataModel, typeof authSchema>(
             credits: DEFAULT_USER_CREDITS,
             creditsResetAt: getCurrentCreditResetTimestamp(
               DEFAULT_USER_PLAN,
-              Date.now()
+              now
             ),
           });
 
@@ -39,13 +43,39 @@ export const authComponent = createClient<DataModel, typeof authSchema>(
             userId,
             emailEnabled: true,
             emailDigest: "weekly",
-            updatedAt: Date.now(),
+            updatedAt: now,
           });
 
           await ctx.db.insert("notificationCounts", {
             userId,
             unreadCount: 0,
-            updatedAt: Date.now(),
+            updatedAt: now,
+          });
+
+          await posthog.identify(ctx, {
+            distinctId: userId,
+            disableGeoip: true,
+            properties: {
+              $set: {
+                email: authUser.email,
+                name: authUser.name,
+                plan: DEFAULT_USER_PLAN,
+              },
+              $set_once: {
+                signed_up_at: signedUpAt,
+              },
+            },
+          });
+
+          await captureProductEvent(ctx, {
+            distinctId: userId,
+            event: {
+              name: "user signed up",
+              properties: {
+                plan: DEFAULT_USER_PLAN,
+              },
+            },
+            timestamp: new Date(now),
           });
 
           await ctx.runMutation(components.betterAuth.mutations.setUserId, {

--- a/packages/backend/convex/chats/mutations.test.ts
+++ b/packages/backend/convex/chats/mutations.test.ts
@@ -1,5 +1,10 @@
-import { internal } from "@repo/backend/convex/_generated/api";
+import posthogTest from "@posthog/convex/test";
+import { api, internal } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";
+import {
+  createConvexTestWithBetterAuth,
+  seedAuthenticatedUser,
+} from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +18,7 @@ describe("chats/mutations", () => {
 
   it("records a reset grant before the usage transaction when credits roll into a new window", async () => {
     const t = convexTest(schema, convexModules);
+    posthogTest.register(t);
 
     const { chatId, userId } = await t.mutation(async (ctx) => {
       const userId = await ctx.db.insert("users", {
@@ -53,6 +59,9 @@ describe("chats/mutations", () => {
 
     const savedState = await t.query(async (ctx) => ({
       creditTransactions: await ctx.db.query("creditTransactions").collect(),
+      scheduledJobs: await ctx.db.system
+        .query("_scheduled_functions")
+        .collect(),
       user: await ctx.db.get("users", userId),
     }));
 
@@ -81,6 +90,71 @@ describe("chats/mutations", () => {
           totalTokens: 30,
           modelId: "gpt-5-nano",
         }),
+      }),
+    ]);
+    expect(savedState.scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            disableGeoip: true,
+            distinctId: userId,
+            event: "chat response completed",
+            host: "https://eu.i.posthog.com",
+            properties: JSON.stringify({
+              chat_type: "study",
+              credits: 1,
+              input_tokens: 10,
+              model_id: "gpt-5-nano",
+              output_tokens: 20,
+              total_tokens: 30,
+            }),
+          }),
+        ],
+        name: expect.stringContaining("capture"),
+      }),
+    ]);
+  });
+
+  it("captures a user chat message with the selected model", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(
+      async (ctx) => await seedAuthenticatedUser(ctx, { now: NOW })
+    );
+
+    const result = await t
+      .withIdentity({
+        subject: identity.authUserId,
+        sessionId: identity.sessionId,
+      })
+      .mutation(api.chats.mutations.createChatWithMessage, {
+        type: "study",
+        message: {
+          role: "user",
+          identifier: "user-1",
+          modelId: "gpt-5-nano",
+        },
+        parts: [],
+      });
+
+    const scheduledJobs = await t.query(
+      async (ctx) => await ctx.db.system.query("_scheduled_functions").collect()
+    );
+
+    expect(result.chatId).toBeDefined();
+    expect(scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            disableGeoip: true,
+            distinctId: identity.userId,
+            event: "chat message sent",
+            properties: JSON.stringify({
+              chat_type: "study",
+              model_id: "gpt-5-nano",
+            }),
+          }),
+        ],
+        name: expect.stringContaining("capture"),
       }),
     ]);
   });

--- a/packages/backend/convex/chats/mutations.ts
+++ b/packages/backend/convex/chats/mutations.ts
@@ -189,6 +189,7 @@ export const createChatWithMessage = mutation({
       chatId,
       role: args.message.role,
       identifier: args.message.identifier,
+      modelId: args.message.modelId,
     });
 
     const partIds = await insertParts(ctx, messageId, args.parts);

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -2,6 +2,7 @@ import aggregate from "@convex-dev/aggregate/convex.config.js";
 import resend from "@convex-dev/resend/convex.config.js";
 import workflow from "@convex-dev/workflow/convex.config.js";
 import workpool from "@convex-dev/workpool/convex.config.js";
+import posthog from "@posthog/convex/convex.config.js";
 import betterAuth from "@repo/backend/convex/betterAuth/convex.config";
 import { defineApp } from "convex/server";
 
@@ -12,6 +13,7 @@ app.use(workpool, { name: "irtCalibrationSyncWorkpool" });
 app.use(workpool, { name: "irtScalePublicationQueueWorkpool" });
 app.use(workpool, { name: "tryoutLeaderboardWorkpool" });
 app.use(resend);
+app.use(posthog);
 
 // Aggregates for tryout leaderboard rankings
 app.use(aggregate, { name: "tryoutLeaderboard" });

--- a/packages/backend/convex/customers/actions/public.ts
+++ b/packages/backend/convex/customers/actions/public.ts
@@ -1,4 +1,5 @@
 import { action } from "@repo/backend/convex/_generated/server";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import {
   createPolarCheckoutSession,
   createPolarCustomerPortalSession,
@@ -62,7 +63,15 @@ function requireAllowedCheckoutProducts(productIds: string[]) {
     });
   }
 
-  return productIds;
+  const primaryProductId = productIds.at(0);
+  if (!primaryProductId) {
+    throw new ConvexError({
+      code: "INVALID_PRODUCT_SELECTION",
+      message: "Checkout requires at least one allowed product.",
+    });
+  }
+
+  return { primaryProductId, productIds };
 }
 
 /**
@@ -78,13 +87,27 @@ export const generateCheckoutLink = action({
   handler: async (ctx, args) => {
     const { appUser } = await requireAuthForAction(ctx);
     const customer = await requireCustomer(ctx, appUser._id);
-    const productIds = requireAllowedCheckoutProducts(args.productIds);
+    const { primaryProductId, productIds } = requireAllowedCheckoutProducts(
+      args.productIds
+    );
     const successUrl = requireAllowedSuccessUrl(args.successUrl);
 
     const checkout = await createPolarCheckoutSession({
       customerId: customer.id,
       productIds,
       successUrl,
+    });
+
+    await captureProductEvent(ctx, {
+      distinctId: appUser._id,
+      event: {
+        name: "checkout started",
+        properties: {
+          product_count: productIds.length,
+          product_id: primaryProductId,
+        },
+      },
+      timestamp: new Date(),
     });
 
     return { url: checkout.url };

--- a/packages/backend/convex/functions.ts
+++ b/packages/backend/convex/functions.ts
@@ -9,10 +9,12 @@ import {
 } from "@repo/backend/convex/_generated/server";
 // Trigger handlers - direct imports only (no barrel files)
 import { chatsHandler } from "@repo/backend/convex/triggers/chats/chats";
+import { messagesHandler } from "@repo/backend/convex/triggers/chats/messages";
 import { commentsHandler } from "@repo/backend/convex/triggers/comments/comments";
 import { commentVotesHandler } from "@repo/backend/convex/triggers/comments/commentVotes";
 import { exerciseAnswersHandler } from "@repo/backend/convex/triggers/contents/exerciseAnswers";
 import { exerciseAttemptsHandler } from "@repo/backend/convex/triggers/contents/exerciseAttempts";
+import { contentViewsHandler } from "@repo/backend/convex/triggers/contents/views";
 import { postReactionsHandler } from "@repo/backend/convex/triggers/forums/postReactions";
 import { forumPostsHandler } from "@repo/backend/convex/triggers/forums/posts";
 import { forumReactionsHandler } from "@repo/backend/convex/triggers/forums/reactions";
@@ -29,6 +31,7 @@ import {
   globalLeaderboardTrigger,
   tryoutLeaderboardTrigger,
 } from "@repo/backend/convex/triggers/tryouts/leaderboard";
+import { tryoutAttemptsHandler } from "@repo/backend/convex/triggers/tryouts/tryoutAttempts";
 import {
   customCtx,
   customMutation,
@@ -44,7 +47,6 @@ export const internalMutation = customMutation(
 );
 
 // No-op triggers: tables modified by triggers but don't need custom logic
-triggers.register("messages", noopHandler);
 triggers.register("parts", noopHandler);
 triggers.register("schoolInviteCodes", noopHandler);
 triggers.register("schoolClassInviteCodes", noopHandler);
@@ -60,7 +62,6 @@ triggers.register("schoolClassMaterialAttachments", noopHandler);
 triggers.register("schoolClassMaterialViews", noopHandler);
 triggers.register("contentAudios", noopHandler);
 triggers.register("audioGenerationQueue", noopHandler);
-triggers.register("contentViews", noopHandler);
 triggers.register("contentViewAnalyticsQueue", noopHandler);
 triggers.register("contentAnalyticsPartitions", noopHandler);
 triggers.register("articlePopularity", noopHandler);
@@ -77,6 +78,8 @@ triggers.register("users", noopHandler);
 triggers.register("subscriptions", subscriptionsHandler);
 
 // Active triggers with custom logic
+triggers.register("messages", messagesHandler);
+triggers.register("contentViews", contentViewsHandler);
 triggers.register("exerciseAttempts", exerciseAttemptsHandler);
 triggers.register("exerciseAnswers", exerciseAnswersHandler);
 triggers.register("comments", commentsHandler);
@@ -94,3 +97,4 @@ triggers.register("schoolClassMaterialGroups", materialGroupsHandler);
 
 triggers.register("tryoutLeaderboardEntries", tryoutLeaderboardTrigger);
 triggers.register("userTryoutStats", globalLeaderboardTrigger);
+triggers.register("tryoutAttempts", tryoutAttemptsHandler);

--- a/packages/backend/convex/posthog.ts
+++ b/packages/backend/convex/posthog.ts
@@ -1,0 +1,13 @@
+import { PostHog } from "@posthog/convex";
+import { components } from "@repo/backend/convex/_generated/api";
+
+// Convex runs outside Next rewrites, so this must be an absolute ingest or proxy origin.
+const posthogHost =
+  process.env.POSTHOG_HOST?.trim() || "https://eu.i.posthog.com";
+
+/**
+ * Official PostHog Convex component client for backend product analytics.
+ */
+export const posthog = new PostHog(components.posthog, {
+  host: posthogHost,
+});

--- a/packages/backend/convex/test.helpers.ts
+++ b/packages/backend/convex/test.helpers.ts
@@ -1,3 +1,4 @@
+import posthogTest from "@posthog/convex/test";
 import { components } from "@repo/backend/convex/_generated/api";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -31,6 +32,7 @@ export function createConvexTestWithBetterAuth() {
     aggregateSchema,
     aggregateModules
   );
+  posthogTest.register(t);
   return t;
 }
 

--- a/packages/backend/convex/triggers/chats/messages.ts
+++ b/packages/backend/convex/triggers/chats/messages.ts
@@ -1,0 +1,58 @@
+import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
+import type { GenericMutationCtx } from "convex/server";
+import type { Change } from "convex-helpers/server/triggers";
+
+/**
+ * Captures chat product events after user and assistant messages are persisted.
+ */
+export async function messagesHandler(
+  ctx: GenericMutationCtx<DataModel>,
+  change: Change<DataModel, "messages">
+) {
+  const message = change.newDoc;
+
+  if (change.operation !== "insert" || !message) {
+    return;
+  }
+
+  const chat = await ctx.db.get(message.chatId);
+  if (!chat) {
+    return;
+  }
+
+  if (message.role === "user") {
+    await captureProductEvent(ctx, {
+      distinctId: chat.userId,
+      event: {
+        name: "chat message sent",
+        properties: {
+          chat_type: chat.type,
+          model_id: message.modelId,
+        },
+      },
+      timestamp: new Date(message._creationTime),
+    });
+    return;
+  }
+
+  if (message.role !== "assistant") {
+    return;
+  }
+
+  await captureProductEvent(ctx, {
+    distinctId: chat.userId,
+    event: {
+      name: "chat response completed",
+      properties: {
+        chat_type: chat.type,
+        credits: message.credits,
+        input_tokens: message.inputTokens,
+        model_id: message.modelId,
+        output_tokens: message.outputTokens,
+        total_tokens: message.totalTokens,
+      },
+    },
+    timestamp: new Date(message._creationTime),
+  });
+}

--- a/packages/backend/convex/triggers/contents/exerciseAttempts.ts
+++ b/packages/backend/convex/triggers/contents/exerciseAttempts.ts
@@ -1,5 +1,6 @@
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import { irtCalibrationSyncWorkpool } from "@repo/backend/convex/irt/workpool";
 import type { GenericMutationCtx } from "convex/server";
 import type { Change } from "convex-helpers/server/triggers";
@@ -15,6 +16,52 @@ export async function exerciseAttemptsHandler(
   const newAttempt = change.newDoc;
   const oldAttempt = change.oldDoc;
   const attemptId = newAttempt?._id ?? oldAttempt?._id;
+
+  if (change.operation === "insert" && newAttempt) {
+    await captureProductEvent(ctx, {
+      distinctId: newAttempt.userId,
+      event: {
+        name: "exercise attempt started",
+        properties: {
+          exercise_number: newAttempt.exerciseNumber,
+          mode: newAttempt.mode,
+          origin: newAttempt.origin,
+          scope: newAttempt.scope,
+          slug: newAttempt.slug,
+          total_exercises: newAttempt.totalExercises,
+        },
+      },
+      timestamp: new Date(newAttempt.startedAt),
+    });
+  }
+
+  if (
+    change.operation === "update" &&
+    oldAttempt?.status !== "completed" &&
+    newAttempt?.status === "completed"
+  ) {
+    await captureProductEvent(ctx, {
+      distinctId: newAttempt.userId,
+      event: {
+        name: "exercise attempt completed",
+        properties: {
+          answered_count: newAttempt.answeredCount,
+          correct_answers: newAttempt.correctAnswers,
+          mode: newAttempt.mode,
+          origin: newAttempt.origin,
+          score_percentage: newAttempt.scorePercentage,
+          scope: newAttempt.scope,
+          slug: newAttempt.slug,
+          total_exercises: newAttempt.totalExercises,
+          total_time: newAttempt.totalTime,
+        },
+      },
+      timestamp:
+        newAttempt.completedAt === null
+          ? undefined
+          : new Date(newAttempt.completedAt),
+    });
+  }
 
   if (!attemptId) {
     return;

--- a/packages/backend/convex/triggers/contents/views.ts
+++ b/packages/backend/convex/triggers/contents/views.ts
@@ -1,0 +1,32 @@
+import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
+import type { GenericMutationCtx } from "convex/server";
+import type { Change } from "convex-helpers/server/triggers";
+
+/**
+ * Captures signed-in content views after the durable engagement row is written.
+ */
+export async function contentViewsHandler(
+  ctx: GenericMutationCtx<DataModel>,
+  change: Change<DataModel, "contentViews">
+) {
+  const view = change.newDoc;
+
+  if (!view?.userId) {
+    return;
+  }
+
+  await captureProductEvent(ctx, {
+    distinctId: view.userId,
+    event: {
+      name: "content viewed",
+      properties: {
+        content_type: view.contentRef.type,
+        is_new_view: change.operation === "insert",
+        locale: view.locale,
+        slug: view.slug,
+      },
+    },
+    timestamp: new Date(view.lastViewedAt),
+  });
+}

--- a/packages/backend/convex/triggers/helpers/subscriptions.test.ts
+++ b/packages/backend/convex/triggers/helpers/subscriptions.test.ts
@@ -1,3 +1,4 @@
+import posthogTest from "@posthog/convex/test";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { getStoredCreditResetTimestamp } from "@repo/backend/convex/credits/helpers/state";
@@ -10,6 +11,13 @@ import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 18, 0, 0);
+
+/** Builds a Convex test instance with the PostHog component registered. */
+function createSubscriptionTestConvex() {
+  const t = convexTest(schema, convexModules);
+  posthogTest.register(t);
+  return t;
+}
 
 /** Inserts one minimal app user row for subscription-trigger tests. */
 async function insertUser(
@@ -114,7 +122,7 @@ describe("triggers/helpers/subscriptions", () => {
   it("returns without side effects when the customer is missing", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       await insertSubscription(ctx, {
@@ -142,7 +150,7 @@ describe("triggers/helpers/subscriptions", () => {
   it("returns without side effects when the customer user is missing", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       const userId = await insertUser(ctx, "missing-user");
@@ -173,7 +181,7 @@ describe("triggers/helpers/subscriptions", () => {
   it("returns early when the derived plan is unchanged", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       const userId = await insertUser(ctx, "no-op", {
@@ -211,7 +219,7 @@ describe("triggers/helpers/subscriptions", () => {
   it("upgrades a free user to pro and records a purchase transaction", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       const userId = await insertUser(ctx, "upgrade", {
@@ -232,6 +240,9 @@ describe("triggers/helpers/subscriptions", () => {
 
       return {
         creditTransactions: await ctx.db.query("creditTransactions").collect(),
+        scheduledJobs: await ctx.db.system
+          .query("_scheduled_functions")
+          .collect(),
         storedResetAt: await getStoredCreditResetTimestamp(ctx.db, "pro"),
         user: await ctx.db.get("users", userId),
       };
@@ -255,13 +266,41 @@ describe("triggers/helpers/subscriptions", () => {
         }),
       }),
     ]);
+    expect(result.scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            distinctId: result.user?._id,
+            event: "subscription started",
+            properties: JSON.stringify({
+              product_id: products.pro.id,
+              status: "active",
+              subscription_id: "sub-upgrade",
+            }),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            distinctId: result.user?._id,
+            event: "plan changed",
+            properties: JSON.stringify({
+              new_plan: "pro",
+              previous_plan: "free",
+              subscription_id: "sub-upgrade",
+            }),
+          }),
+        ],
+      }),
+    ]);
     expect(result.storedResetAt).toBe(Date.UTC(2026, 3, 1, 0, 0, 0));
   });
 
   it("downgrades a pro user to free and records the reset grant transaction", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       const userId = await insertUser(ctx, "downgrade", {
@@ -282,6 +321,9 @@ describe("triggers/helpers/subscriptions", () => {
 
       return {
         creditTransactions: await ctx.db.query("creditTransactions").collect(),
+        scheduledJobs: await ctx.db.system
+          .query("_scheduled_functions")
+          .collect(),
         storedResetAt: await getStoredCreditResetTimestamp(ctx.db, "free"),
         user: await ctx.db.get("users", userId),
       };
@@ -305,13 +347,41 @@ describe("triggers/helpers/subscriptions", () => {
         }),
       }),
     ]);
+    expect(result.scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            distinctId: result.user?._id,
+            event: "subscription canceled",
+            properties: JSON.stringify({
+              product_id: "free-plan",
+              status: "active",
+              subscription_id: "sub-downgrade",
+            }),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            distinctId: result.user?._id,
+            event: "plan changed",
+            properties: JSON.stringify({
+              new_plan: "free",
+              previous_plan: "pro",
+              subscription_id: "sub-downgrade",
+            }),
+          }),
+        ],
+      }),
+    ]);
     expect(result.storedResetAt).toBe(Date.UTC(2026, 3, 2, 0, 0, 0));
   });
 
   it("picks the highest plan across overlapping active subscriptions", async () => {
     vi.setSystemTime(new Date(NOW));
 
-    const t = convexTest(schema, convexModules);
+    const t = createSubscriptionTestConvex();
 
     const result = await t.mutation(async (ctx) => {
       const userId = await insertUser(ctx, "highest-plan", {

--- a/packages/backend/convex/triggers/helpers/subscriptions.test.ts
+++ b/packages/backend/convex/triggers/helpers/subscriptions.test.ts
@@ -297,7 +297,7 @@ describe("triggers/helpers/subscriptions", () => {
     expect(result.storedResetAt).toBe(Date.UTC(2026, 3, 1, 0, 0, 0));
   });
 
-  it("downgrades a pro user to free and records the reset grant transaction", async () => {
+  it("downgrades a pro user without recording a cancellation for an active subscription", async () => {
     vi.setSystemTime(new Date(NOW));
 
     const t = createSubscriptionTestConvex();
@@ -352,11 +352,64 @@ describe("triggers/helpers/subscriptions", () => {
         args: [
           expect.objectContaining({
             distinctId: result.user?._id,
+            event: "plan changed",
+            properties: JSON.stringify({
+              new_plan: "free",
+              previous_plan: "pro",
+              subscription_id: "sub-downgrade",
+            }),
+          }),
+        ],
+      }),
+    ]);
+    expect(result.storedResetAt).toBe(Date.UTC(2026, 3, 2, 0, 0, 0));
+  });
+
+  it("records a cancellation only when a canceled subscription downgrades the user", async () => {
+    vi.setSystemTime(new Date(NOW));
+
+    const t = createSubscriptionTestConvex();
+
+    const result = await t.mutation(async (ctx) => {
+      const userId = await insertUser(ctx, "canceled-downgrade", {
+        credits: 120,
+        creditsResetAt: Date.UTC(2026, 3, 1, 0, 0, 0),
+        plan: "pro",
+      });
+
+      await insertCustomer(ctx, userId, "polar-canceled-downgrade");
+      await insertSubscription(ctx, {
+        customerId: "polar-canceled-downgrade",
+        productId: products.pro.id,
+        status: "canceled",
+        subscriptionId: "sub-canceled-downgrade",
+      });
+
+      await runSyncCustomerPlanBySubscriptionId(ctx, "sub-canceled-downgrade");
+
+      return {
+        scheduledJobs: await ctx.db.system
+          .query("_scheduled_functions")
+          .collect(),
+        user: await ctx.db.get("users", userId),
+      };
+    });
+
+    expect(result.user).toMatchObject({
+      credits: 10,
+      plan: "free",
+      creditsResetAt: Date.UTC(2026, 3, 2, 0, 0, 0),
+    });
+    expect(result.scheduledJobs).toEqual([
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            distinctId: result.user?._id,
             event: "subscription canceled",
             properties: JSON.stringify({
-              product_id: "free-plan",
-              status: "active",
-              subscription_id: "sub-downgrade",
+              product_id: products.pro.id,
+              status: "canceled",
+              subscription_id: "sub-canceled-downgrade",
             }),
           }),
         ],
@@ -369,13 +422,12 @@ describe("triggers/helpers/subscriptions", () => {
             properties: JSON.stringify({
               new_plan: "free",
               previous_plan: "pro",
-              subscription_id: "sub-downgrade",
+              subscription_id: "sub-canceled-downgrade",
             }),
           }),
         ],
       }),
     ]);
-    expect(result.storedResetAt).toBe(Date.UTC(2026, 3, 2, 0, 0, 0));
   });
 
   it("picks the highest plan across overlapping active subscriptions", async () => {

--- a/packages/backend/convex/triggers/helpers/subscriptions.ts
+++ b/packages/backend/convex/triggers/helpers/subscriptions.ts
@@ -1,4 +1,5 @@
 import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import { getPlanCreditConfig } from "@repo/backend/convex/credits/constants";
 import { resolveCurrentCreditResetTimestamp } from "@repo/backend/convex/credits/helpers/state";
 import { listCanonicalActiveTryoutSubscriptions } from "@repo/backend/convex/tryoutAccess/helpers/subscriptions";
@@ -34,9 +35,10 @@ async function applyPlanChange(
   user: DataModel["users"]["document"],
   newPlan: UserPlan,
   now: number,
-  subscriptionId: string
+  subscription: DataModel["subscriptions"]["document"]
 ) {
   const previousPlan = user.plan;
+  const timestamp = new Date(now);
   const newCreditConfig = getPlanCreditConfig(newPlan);
   const nextResetTimestamp = await resolveCurrentCreditResetTimestamp(
     ctx.db,
@@ -62,16 +64,42 @@ async function applyPlanChange(
         reason: "plan-upgrade",
         "previous-plan": previousPlan,
         "new-plan": newPlan,
-        "subscription-id": subscriptionId,
+        "subscription-id": subscription.id,
       },
     });
 
     logger.info("User upgraded with credits", {
       userId: user._id,
-      subscriptionId,
+      subscriptionId: subscription.id,
       creditsGranted: newCreditConfig.amount,
       previousPlan,
       newPlan,
+    });
+
+    await captureProductEvent(ctx, {
+      distinctId: user._id,
+      event: {
+        name: "subscription started",
+        properties: {
+          product_id: subscription.productId,
+          status: subscription.status,
+          subscription_id: subscription.id,
+        },
+      },
+      timestamp,
+    });
+
+    await captureProductEvent(ctx, {
+      distinctId: user._id,
+      event: {
+        name: "plan changed",
+        properties: {
+          new_plan: newPlan,
+          previous_plan: previousPlan,
+          subscription_id: subscription.id,
+        },
+      },
+      timestamp,
     });
 
     return;
@@ -92,16 +120,42 @@ async function applyPlanChange(
       reason: "plan-downgrade",
       "previous-plan": previousPlan,
       "new-plan": newPlan,
-      "subscription-id": subscriptionId,
+      "subscription-id": subscription.id,
     },
   });
 
   logger.info("User downgraded, credits adjusted", {
     userId: user._id,
-    subscriptionId,
+    subscriptionId: subscription.id,
     newCredits: newCreditConfig.amount,
     previousPlan,
     newPlan,
+  });
+
+  await captureProductEvent(ctx, {
+    distinctId: user._id,
+    event: {
+      name: "subscription canceled",
+      properties: {
+        product_id: subscription.productId,
+        status: subscription.status,
+        subscription_id: subscription.id,
+      },
+    },
+    timestamp,
+  });
+
+  await captureProductEvent(ctx, {
+    distinctId: user._id,
+    event: {
+      name: "plan changed",
+      properties: {
+        new_plan: newPlan,
+        previous_plan: previousPlan,
+        subscription_id: subscription.id,
+      },
+    },
+    timestamp,
   });
 }
 
@@ -144,15 +198,24 @@ export async function syncCustomerPlan(
     }
   );
 
-  const newPlan = activeSubscriptions.reduce<UserPlan>(
-    (highestPlan, row) =>
-      getHigherPlan(highestPlan, getPlanFromProductId(row.productId)),
-    "free"
-  );
+  let newPlan: UserPlan = "free";
+  let planChangeSubscription = subscription;
+
+  for (const row of activeSubscriptions) {
+    const rowPlan = getPlanFromProductId(row.productId);
+    const highestPlan = getHigherPlan(newPlan, rowPlan);
+
+    if (highestPlan === newPlan) {
+      continue;
+    }
+
+    newPlan = highestPlan;
+    planChangeSubscription = row;
+  }
 
   if (newPlan === user.plan) {
     return;
   }
 
-  await applyPlanChange(ctx, user, newPlan, now, subscription.id);
+  await applyPlanChange(ctx, user, newPlan, now, planChangeSubscription);
 }

--- a/packages/backend/convex/triggers/helpers/subscriptions.ts
+++ b/packages/backend/convex/triggers/helpers/subscriptions.ts
@@ -132,18 +132,20 @@ async function applyPlanChange(
     newPlan,
   });
 
-  await captureProductEvent(ctx, {
-    distinctId: user._id,
-    event: {
-      name: "subscription canceled",
-      properties: {
-        product_id: subscription.productId,
-        status: subscription.status,
-        subscription_id: subscription.id,
+  if (subscription.status === "canceled") {
+    await captureProductEvent(ctx, {
+      distinctId: user._id,
+      event: {
+        name: "subscription canceled",
+        properties: {
+          product_id: subscription.productId,
+          status: subscription.status,
+          subscription_id: subscription.id,
+        },
       },
-    },
-    timestamp,
-  });
+      timestamp,
+    });
+  }
 
   await captureProductEvent(ctx, {
     distinctId: user._id,

--- a/packages/backend/convex/triggers/tryouts/tryoutAttempts.ts
+++ b/packages/backend/convex/triggers/tryouts/tryoutAttempts.ts
@@ -1,0 +1,73 @@
+import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
+import { computeTryoutRawScorePercentage } from "@repo/backend/convex/tryouts/helpers/metrics";
+import type { GenericMutationCtx } from "convex/server";
+import type { Change } from "convex-helpers/server/triggers";
+
+/**
+ * Captures tryout attempt lifecycle events after start and completion writes.
+ */
+export async function tryoutAttemptsHandler(
+  ctx: GenericMutationCtx<DataModel>,
+  change: Change<DataModel, "tryoutAttempts">
+) {
+  const attempt = change.newDoc;
+
+  if (!attempt) {
+    return;
+  }
+
+  const tryout = await ctx.db.get(attempt.tryoutId);
+  if (!tryout) {
+    return;
+  }
+
+  if (change.operation === "insert") {
+    await captureProductEvent(ctx, {
+      distinctId: attempt.userId,
+      event: {
+        name: "tryout attempt started",
+        properties: {
+          access_kind: attempt.accessKind,
+          attempt_number: attempt.attemptNumber,
+          locale: tryout.locale,
+          product: tryout.product,
+          score_status: attempt.scoreStatus,
+          tryout_slug: tryout.slug,
+        },
+      },
+      timestamp: new Date(attempt.startedAt),
+    });
+    return;
+  }
+
+  const oldAttempt = change.oldDoc;
+  const completedNow =
+    change.operation === "update" &&
+    oldAttempt?.status !== "completed" &&
+    attempt.status === "completed";
+
+  if (!completedNow) {
+    return;
+  }
+
+  await captureProductEvent(ctx, {
+    distinctId: attempt.userId,
+    event: {
+      name: "tryout attempt completed",
+      properties: {
+        attempt_number: attempt.attemptNumber,
+        locale: tryout.locale,
+        product: tryout.product,
+        raw_score_percentage: computeTryoutRawScorePercentage(attempt),
+        score_status: attempt.scoreStatus,
+        theta: attempt.theta,
+        total_correct: attempt.totalCorrect,
+        total_questions: attempt.totalQuestions,
+        tryout_slug: tryout.slug,
+      },
+    },
+    timestamp:
+      attempt.completedAt === null ? undefined : new Date(attempt.completedAt),
+  });
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,6 +51,7 @@
     "@convex-dev/workflow": "^0.3.12",
     "@convex-dev/workpool": "^0.4.6",
     "@polar-sh/sdk": "^0.47.1",
+    "@posthog/convex": "0.2.22",
     "@repo/ai": "workspace:*",
     "@repo/utilities": "workspace:*",
     "@t3-oss/env-nextjs": "^0.13.11",

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const convexTestTimeout = 15_000;
 const convexSerialTestPattern = "convex/**/*.serial.test.ts";
 const defaultExcludes = ["**/node_modules/**", "coverage/**"];
 
@@ -23,6 +24,7 @@ const config = defineConfig({
           include: ["convex/**/*.test.ts"],
           exclude: [convexSerialTestPattern, ...defaultExcludes],
           environment: "edge-runtime",
+          testTimeout: convexTestTimeout,
         },
       },
       {
@@ -40,6 +42,7 @@ const config = defineConfig({
           include: [convexSerialTestPattern],
           exclude: defaultExcludes,
           environment: "edge-runtime",
+          testTimeout: convexTestTimeout,
         },
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: link:../../packages/utilities
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
-        version: 0.13.11(typescript@6.0.3)(zod@4.3.6)
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       better-auth:
         specifier: ~1.6.9
         version: 1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3))
@@ -550,7 +550,7 @@ importers:
         version: 0.2.1(convex@1.37.0(react@19.2.5))
       '@convex-dev/better-auth':
         specifier: ^0.12.2
-        version: 0.12.2(@standard-schema/spec@1.1.0)(better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)))(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)
+        version: 0.12.2(@standard-schema/spec@1.1.0)(better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)))(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)
       '@convex-dev/resend':
         specifier: ^0.2.3
         version: 0.2.3(@react-email/render@2.0.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(convex-helpers@0.1.115(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)(zod@4.4.3))(convex@1.37.0(react@19.2.5))(react@19.2.5)
@@ -563,6 +563,9 @@ importers:
       '@polar-sh/sdk':
         specifier: ^0.47.1
         version: 0.47.1
+      '@posthog/convex':
+        specifier: 0.2.22
+        version: 0.2.22(convex@1.37.0(react@19.2.5))(rxjs@7.8.2)
       '@repo/ai':
         specifier: workspace:*
         version: link:../ai
@@ -577,7 +580,7 @@ importers:
         version: 6.0.174(zod@4.4.3)
       better-auth:
         specifier: ~1.6.9
-        version: 1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3))
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -4370,6 +4373,11 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@posthog/convex@0.2.22':
+    resolution: {integrity: sha512-iZO/Nk9sFtXa6o5IL0US0cH9yLPpAVSlu5D1CmzximnPIYYKAwPq+ZCvFv8nF+MzFuRfL6VjUrfA1quhdRirOA==}
+    peerDependencies:
+      convex: ^1.31.7
 
   '@posthog/core@1.28.2':
     resolution: {integrity: sha512-Dii3pxDheG1WioztvV/MqHQMnb16jSFrl2HkDR1T5yf5/R7lPqJCFYt+eXkEdp/oAv/PD+1joyG6Ap/2quFmtQ==}
@@ -14085,7 +14093,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@4.4.3)
       jose: 6.1.3
       kysely: 0.28.14
       nanostores: 1.1.1
@@ -14379,6 +14387,24 @@ snapshots:
   '@convex-dev/aggregate@0.2.1(convex@1.37.0(react@19.2.5))':
     dependencies:
       convex: 1.37.0(react@19.2.5)
+
+  '@convex-dev/better-auth@0.12.2(@standard-schema/spec@1.1.0)(better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)))(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)':
+    dependencies:
+      '@better-fetch/fetch': 1.1.21
+      better-auth: 1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3))
+      common-tags: 1.8.2
+      convex: 1.37.0(react@19.2.5)
+      convex-helpers: 0.1.115(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)(zod@4.4.2)
+      jose: 6.1.3
+      react: 19.2.5
+      remeda: 2.33.1
+      semver: 7.7.4
+      type-fest: 5.4.0
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@standard-schema/spec'
+      - hono
+      - typescript
 
   '@convex-dev/better-auth@0.12.2(@standard-schema/spec@1.1.0)(better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)))(convex@1.37.0(react@19.2.5))(hono@4.12.16)(react@19.2.5)(typescript@6.0.3)':
     dependencies:
@@ -16664,6 +16690,14 @@ snapshots:
   '@poppinss/exception@1.2.3':
     optional: true
 
+  '@posthog/convex@0.2.22(convex@1.37.0(react@19.2.5))(rxjs@7.8.2)':
+    dependencies:
+      '@posthog/core': 1.28.2
+      convex: 1.37.0(react@19.2.5)
+      posthog-node: 5.33.2(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - rxjs
+
   '@posthog/core@1.28.2':
     dependencies:
       '@posthog/types': 1.372.8
@@ -18568,22 +18602,10 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(zod@4.3.6)':
-    optionalDependencies:
-      typescript: 6.0.3
-      zod: 4.3.6
-
   '@t3-oss/env-core@0.13.11(typescript@6.0.3)(zod@4.4.3)':
     optionalDependencies:
       typescript: 6.0.3
       zod: 4.4.3
-
-  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(zod@4.3.6)':
-    dependencies:
-      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(zod@4.3.6)
-    optionalDependencies:
-      typescript: 6.0.3
-      zod: 4.3.6
 
   '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
@@ -19849,6 +19871,36 @@ snapshots:
 
   baseline-browser-mapping@2.10.8: {}
 
+  better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)):
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(kysely@0.28.14)
+      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.3.5(zod@4.4.3)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.14
+      nanostores: 1.1.1
+      zod: 4.3.6
+    optionalDependencies:
+      mongodb: 7.1.0
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      vitest: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.12.7(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.4))
+      vue: 3.5.30(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
   better-auth@1.6.9(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.1.1)
@@ -19887,6 +19939,15 @@ snapshots:
       set-cookie-parser: 3.0.1
     optionalDependencies:
       zod: 4.3.6
+
+  better-call@1.3.5(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.0.1
+    optionalDependencies:
+      zod: 4.4.3
 
   better-path-resolve@1.0.0:
     dependencies:


### PR DESCRIPTION
Memoize folder scans, static-param candidates, and sitemap content
route sets, and cache exercise material fetches used by pagefind. Export
clearFolderChildNamesCache, clearStaticParamCaches, and
clearSitemapRouteCache
for tests and long-lived tools. Add getExerciseSetPathsFromSlugs to
derive
exercise set paths from already-loaded MDX slugs.