### PR TITLE
[codex] Fix localized OG image rewrites

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -50,12 +50,18 @@ function createAppRewrites() {
   const llmDestination = "/llms.mdx/:path*";
   const ogSource = ["/:path*.png", "/:path*.og", "/:path*/image.png"];
   const ogDestination = "/og/:path*";
+  const ogRouteRewrites = [
+    {
+      source: "/:locale/og/:path*/image.png",
+      destination: "/:locale/og/:path*/image.png",
+    },
+    {
+      source: "/og/:path*/image.png",
+      destination: "/og/:path*/image.png",
+    },
+  ];
 
-  return [
-    // PostHog requires the specific static and array rewrites to come before the
-    // catch-all analytics rewrite so asset cache headers are preserved.
-    ...createPostHogProxyRewrites(env.POSTHOG_PROXY_HOST),
-    ...agentDiscoveryRewrites,
+  const seoAssetRewrites = [
     ...llmSource.map((source) => ({
       source,
       destination: llmDestination,
@@ -65,6 +71,20 @@ function createAppRewrites() {
       destination: ogDestination,
     })),
   ];
+
+  return {
+    // PostHog requires the specific static and array rewrites to come before the
+    // catch-all analytics rewrite so asset cache headers are preserved.
+    afterFiles: [
+      ...createPostHogProxyRewrites(env.POSTHOG_PROXY_HOST),
+      ...agentDiscoveryRewrites,
+      // Keep canonical OG image routes out of the broad extension rewrites.
+      // After a pass-through match, Next checks the localized dynamic route
+      // before continuing through the remaining `afterFiles` entries.
+      ...ogRouteRewrites,
+      ...seoAssetRewrites,
+    ],
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix localized canonical OG image URLs so routes like `/id/og/subject/high-school/10/chemistry/green-chemistry/principles/image.png` resolve to the localized dynamic OG route instead of being swallowed by the broad SEO asset `.png` rewrite.

## Root Cause

`next.config.ts` returned a flat rewrite array. Next.js applies that array after filesystem checks and before dynamic routes, so the broad `/:path*.png` SEO asset rewrite matched canonical OG image URLs before `/[locale]/og/[...slug]` could handle them. That rewrote the request to `/og/id/og/...`, which produced the fallback OG card.

## Change

- Move app rewrites into `afterFiles` so route matching follows Next.js' documented rewrite ordering.
- Add pass-through OG route rewrites before the broad SEO asset rewrites.
- Preserve PostHog proxy, agent discovery, LLMS, `.md`/`.mdx`, `.png`, `.og`, and `image.png` shortcut behavior.

## Verification

- `pnpm --filter www exec vitest run lib/utils/__tests__/metadata.test.ts`
- `pnpm --filter www typecheck`
- `pnpm exec ultracite check apps/www/next.config.ts`
- `pnpm lint`
- `pnpm --filter www build`
- Local production checks on `next start`:
  - `/id/og/subject/high-school/10/chemistry/green-chemistry/principles/image.png` returns `200 image/png` with the content-specific `Prinsip Kimia Hijau` OG image.
  - `/.well-known/llms.txt`, `/.well-known/llms-full.txt`, agent skill discovery routes, page `.md`, and page `llms.txt` return expected 200 responses.
  - `/_nakafa/static/array.js` returns `200 text/javascript` through the PostHog proxy.