### PR TITLE
Add SEO utilities, docs, and tests

### DIFF
--- a/.agents/skills/nakafa-content/SKILL.md
+++ b/.agents/skills/nakafa-content/SKILL.md
@@ -18,6 +18,7 @@ Use this file as the routing map. Load only the references needed for the curren
 ## Reference Map
 
 - New or edited subject lessons: read `references/source-workflow.md`, `references/writing-quality.md`, and `references/math-formatting.md`.
+- SEO, metadata, search discovery, and crawlability checks: read `references/seo.md`.
 - MDX component contracts and import examples: read `references/mdx-components.md`.
 - Visual content, custom TSX, R3F, Three.js, layout, and colors: read `references/visualization.md`.
 - Exercises, choices, answer explanations, and self-checks: read `references/exercise-patterns.md` and use `templates/exercise-template.md` when scaffolding.
@@ -27,6 +28,7 @@ Use this file as the routing map. Load only the references needed for the curren
 
 - Lessons stand alone for direct visits. Define terms, symbols, abbreviations, and prerequisites on first use in each locale.
 - Localized content uses natural teacher voice for that locale; Indonesian lessons should feel like a teacher speaking to students, not formal textbook prose.
+- SEO must support the lesson, not distort it: keep titles, descriptions, headings, and visible content accurate, helpful, and natural for students.
 - Use concrete examples or comparisons only when they immediately clarify the concept. Avoid meta-labels before comparisons; phrase them naturally.
 - Do not add activities, Mermaid diagrams, visuals, or closing sections unless they improve understanding.
 - Prefer show-over-tell visuals: avoid oversized explanatory scene titles or dense overlays when the model, interaction, and short captions can carry the concept.

--- a/.agents/skills/nakafa-content/references/seo.md
+++ b/.agents/skills/nakafa-content/references/seo.md
@@ -1,0 +1,40 @@
+# SEO and Discovery
+
+Use this reference when work touches content metadata, search snippets, sitemap discovery, crawlability, structured data, social previews, or AI/discovery surfaces.
+
+## Principles
+
+- Write for students first. Search metadata should summarize the actual learning value, not force keywords into the lesson.
+- Keep each page useful from a direct search visit: define context early, answer the likely learning intent, and avoid generic filler.
+- Do not keyword-stuff titles, descriptions, headings, alt text, or visible prose.
+- Do not create shallow pages only to target search queries. Prefer one complete, teachable page over many thin pages.
+- AI-assisted content is acceptable only after checking facts, math, sources, grammar, locale quality, and student usefulness.
+
+## Metadata
+
+- Subject and article MDX must provide a specific `title`, natural `description`, `authors`, and valid `date`.
+- Descriptions should say what the student will learn or what the article explains. Avoid reusable copy such as "complete material" when the file already has a better specific summary.
+- Keep `id` and `en` metadata natural for their locale. Translate intent, not word order.
+- Exercise question and answer files do not need per-file descriptions; route metadata may describe the exam, material, set, and question count.
+- Metadata must match the visible content. Do not promise examples, visuals, sources, or solutions that are not present.
+
+## Visuals and Media
+
+- If an image, chart, canvas, or interactive visual carries learning content, provide meaningful visible context and an accessible name or alt text.
+- Keep essential explanations in DOM-visible text, not only inside canvas pixels.
+- Decorative visuals should not receive keyword-heavy alt text.
+- Captions and surrounding prose should explain what students should notice, not describe internal implementation.
+
+## Sources and Claims
+
+- Articles and current factual claims need visible references when the claim is not common classroom knowledge.
+- Keep references close enough for readers to verify the claim. Do not invent citations.
+- When adapting source material, write original explanations in Nakafa's teacher voice and preserve the verifiable facts.
+
+## System Paths
+
+- Route metadata: `apps/www/lib/utils/seo/`.
+- Page metadata and structured data: `apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/`.
+- Sitemap discovery: `apps/www/lib/sitemap/`.
+- JSON-LD components: `packages/seo/json-ld/`.
+- Content metadata schema and readers: `packages/contents/_types/content.ts` and `packages/contents/_lib/metadata.ts`.

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/[slug]/page.tsx
@@ -32,6 +32,8 @@ import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
 import { fetchArticleMetadataContext } from "@/lib/utils/pages/article";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 import type { SEOContext } from "@/lib/utils/seo/types";
 import { getStaticParams } from "@/lib/utils/system";
@@ -69,12 +71,11 @@ export async function generateMetadata({
   }
 
   const path = `/${locale}${filePath}`;
-  const alternates = {
-    canonical: path,
+  const alternates = createLocalizedAlternates(path, {
     types: {
       "text/markdown": `${path}.md`,
     },
-  };
+  });
   const { metadata } = content;
 
   // Evidence: Use ICU-based SEO generator for type-safe, locale-aware metadata
@@ -261,13 +262,12 @@ async function CachedArticleShell({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={headings.map((heading, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${FilePath}${heading.href}`,
-          position: index + 1,
-          name: heading.label,
-          item: `https://nakafa.com/${locale}${FilePath}${heading.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("articles"), path: "/articles" },
+          { name: tArticles(category), path: `/articles/${category}` },
+          { name: metadata.title, path: FilePath },
+        ])}
       />
       <ArticleJsonLd
         author={metadata.authors.map((author: { name: string }) => ({

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/page.tsx
@@ -22,6 +22,8 @@ import { RefContent } from "@/components/shared/ref-content";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { getStaticParams } from "@/lib/utils/system";
 
 async function getResolvedParams(
@@ -70,9 +72,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: {
-      canonical: path,
-    },
+    alternates: createLocalizedAlternates(path),
     ...socialMetadata,
   };
 }
@@ -129,18 +129,19 @@ async function PageArticles({
   header: React.ReactNode;
 }) {
   const articles = await getCategoryArticles(category, locale);
-  const t = await getTranslations({ locale, namespace: "Articles" });
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Articles" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
 
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={articles.map((article, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${FilePath}/${article.slug}`,
-          position: index + 1,
-          name: article.title,
-          item: `https://nakafa.com/${locale}${FilePath}/${article.slug}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("articles"), path: "/articles" },
+          { name: t(category), path: FilePath },
+        ])}
       />
       <CollectionPageJsonLd
         description={t("description")}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/articles/page.tsx
@@ -1,8 +1,91 @@
-import { notFound } from "next/navigation";
+import { BookOpen02Icon } from "@hugeicons/core-free-icons";
+import {
+  getCategoryIcon,
+  getCategoryPath,
+} from "@repo/contents/_lib/articles/category";
+import { ArticleCategorySchema } from "@repo/contents/_types/articles/category";
+import { BreadcrumbJsonLd } from "@repo/seo/json-ld/breadcrumb";
+import type { Metadata } from "next";
+import type { Locale } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import { use } from "react";
+import { HeaderContent } from "@/components/shared/header-content";
+import { LayoutContent } from "@/components/shared/layout-content";
+import { SubjectItem, SubjectList } from "@/components/shared/subject-list";
+import { getLocaleOrThrow } from "@/lib/i18n/params";
+import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
-export default function Page() {
-  // Return 404 for empty articles index page
-  // This prevents soft 404s and tells Google this page doesn't exist
-  // Source: https://developers.google.com/search/docs/crawling-indexing/soft-404s
-  notFound();
+export async function generateMetadata({
+  params,
+}: {
+  params: PageProps<"/[locale]/articles">["params"];
+}): Promise<Metadata> {
+  const locale = getLocaleOrThrow((await params).locale);
+  const [tCommon, tArticles] = await Promise.all([
+    getTranslations({ locale, namespace: "Common" }),
+    getTranslations({ locale, namespace: "Articles" }),
+  ]);
+
+  const path = `/${locale}/articles`;
+  const title = tCommon("articles");
+  const description = tArticles("description");
+  const socialMetadata = getSocialMetadata({
+    title,
+    description,
+    locale,
+    path,
+    image: getOgUrl(locale, "/articles"),
+  });
+
+  return {
+    title,
+    description,
+    alternates: createLocalizedAlternates(path),
+    ...socialMetadata,
+  };
+}
+
+export default function Page(props: PageProps<"/[locale]/articles">) {
+  const { locale: rawLocale } = use(props.params);
+  const locale = getLocaleOrThrow(rawLocale);
+
+  return <PageContent locale={locale} />;
+}
+
+async function PageContent({ locale }: { locale: Locale }) {
+  const categories = ArticleCategorySchema.options;
+  const [tCommon, tArticles] = await Promise.all([
+    getTranslations({ locale, namespace: "Common" }),
+    getTranslations({ locale, namespace: "Articles" }),
+  ]);
+
+  return (
+    <>
+      <BreadcrumbJsonLd
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("articles"), path: "/articles" },
+        ])}
+      />
+      <HeaderContent
+        description={tArticles("description")}
+        icon={BookOpen02Icon}
+        title={tCommon("articles")}
+      />
+      <LayoutContent>
+        <SubjectList>
+          {categories.map((category) => (
+            <SubjectItem
+              href={getCategoryPath(category)}
+              icon={getCategoryIcon(category)}
+              key={category}
+              label={tArticles(category)}
+            />
+          ))}
+        </SubjectList>
+      </LayoutContent>
+    </>
+  );
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/group.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/group.tsx
@@ -1,3 +1,5 @@
+import { getExercisesPath } from "@repo/contents/_lib/exercises/route";
+import type { ExercisesCategory } from "@repo/contents/_types/exercises/category";
 import type { ExercisesMaterial } from "@repo/contents/_types/exercises/material";
 import type { ExercisesType } from "@repo/contents/_types/exercises/type";
 import { slugify } from "@repo/design-system/lib/utils";
@@ -18,32 +20,38 @@ import {
 } from "@/components/shared/layout-material";
 import { RefContent } from "@/components/shared/ref-content";
 import { getGithubUrl } from "@/lib/utils/github";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 /** Renders the year-group overview variant for one exercises route. */
 export async function YearGroupPage({
+  category,
   data,
   locale,
   material,
   type,
 }: {
+  category: ExercisesCategory;
   data: Extract<ExerciseRouteData, { kind: "year-group" }>;
   locale: Locale;
   material: ExercisesMaterial;
   type: ExercisesType;
 }) {
-  const t = await getTranslations({ locale, namespace: "Exercises" });
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Exercises" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
+  const typePath = getExercisesPath(category, type);
   const headingId = slugify(data.currentMaterial.title);
 
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={data.currentMaterial.items.map((item, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${item.href}`,
-          position: index + 1,
-          name: item.title,
-          item: `https://nakafa.com/${locale}${item.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t(type), path: typePath },
+          { name: t(material), path: data.materialPath },
+          { name: data.currentMaterial.title, path: data.pagePath },
+        ])}
       />
       <CollectionPageJsonLd
         description={data.currentMaterial.description ?? t(type)}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/page.tsx
@@ -174,6 +174,7 @@ export default async function Page({
           category={category}
           data={data}
           locale={locale}
+          material={material}
           type={type}
         />
       );
@@ -183,12 +184,14 @@ export default async function Page({
           category={category}
           data={data}
           locale={locale}
+          material={material}
           type={type}
         />
       );
     case "year-group":
       return (
         <YearGroupPage
+          category={category}
           data={data}
           locale={locale}
           material={material}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/page.tsx
@@ -15,6 +15,7 @@ import { YearGroupPage } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/exer
 import { ExerciseSetPage } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/set";
 import { SingleExercisePage } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/single";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
 import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 import type { SEOContext } from "@/lib/utils/seo/types";
 import { getStaticParams } from "@/lib/utils/system";
@@ -114,12 +115,11 @@ export async function generateMetadata({
     },
     description,
     keywords,
-    alternates: {
-      canonical: urlPath,
+    alternates: createLocalizedAlternates(urlPath, {
       types: {
         "text/markdown": `${urlPath}.md`,
       },
-    },
+    }),
     ...socialMetadata,
   };
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/set.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/set.tsx
@@ -1,6 +1,8 @@
+import { getExercisesPath } from "@repo/contents/_lib/exercises/route";
 import { getExercisesPagination } from "@repo/contents/_lib/exercises/slug";
 import { formatContentDateISO } from "@repo/contents/_shared/date";
 import type { ExercisesCategory } from "@repo/contents/_types/exercises/category";
+import type { ExercisesMaterial } from "@repo/contents/_types/exercises/material";
 import type { ExercisesType } from "@repo/contents/_types/exercises/type";
 import type { ParsedHeading } from "@repo/contents/_types/toc";
 import { slugify } from "@repo/design-system/lib/utils";
@@ -25,20 +27,27 @@ import {
   LayoutMaterialToc,
 } from "@/components/shared/layout-material";
 import { getOgUrl } from "@/lib/utils/metadata";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 /** Renders the exercise-set variant for one learn route. */
 export async function ExerciseSetPage({
   category,
   data,
   locale,
+  material,
   type,
 }: {
   category: ExercisesCategory;
   data: Extract<ExerciseRouteData, { kind: "set" }>;
   locale: Locale;
+  material: ExercisesMaterial;
   type: ExercisesType;
 }) {
-  const t = await getTranslations({ locale, namespace: "Exercises" });
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Exercises" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
+  const typePath = getExercisesPath(category, type);
   const pagination = getExercisesPagination(data.pagePath, data.materials);
   const headings: ParsedHeading[] = data.exercises.map((exercise) => ({
     label: t("number-count", { count: exercise.number }),
@@ -54,13 +63,13 @@ export async function ExerciseSetPage({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={headings.map((heading, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${data.pagePath}${heading.href}`,
-          position: index + 1,
-          name: heading.label,
-          item: `https://nakafa.com/${locale}${data.pagePath}${heading.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t(type), path: typePath },
+          { name: t(material), path: data.materialPath },
+          { name: data.currentMaterial.title, path: data.currentMaterial.href },
+          { name: data.currentMaterialItem.title, path: data.pagePath },
+        ])}
       />
       <LearningResourceJsonLd
         author={FOUNDER}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/single.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/[...slug]/single.tsx
@@ -1,6 +1,8 @@
+import { getExercisesPath } from "@repo/contents/_lib/exercises/route";
 import { getExerciseNumberPagination } from "@repo/contents/_lib/exercises/slug";
 import { formatContentDateISO } from "@repo/contents/_shared/date";
 import type { ExercisesCategory } from "@repo/contents/_types/exercises/category";
+import type { ExercisesMaterial } from "@repo/contents/_types/exercises/material";
 import type { ExercisesType } from "@repo/contents/_types/exercises/type";
 import { slugify } from "@repo/design-system/lib/utils";
 import { ArticleJsonLd } from "@repo/seo/json-ld/article";
@@ -24,20 +26,27 @@ import {
   LayoutMaterialToc,
 } from "@/components/shared/layout-material";
 import { getOgUrl } from "@/lib/utils/metadata";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 /** Renders the standalone single-exercise variant for one learn route. */
 export async function SingleExercisePage({
   category,
   data,
   locale,
+  material,
   type,
 }: {
   category: ExercisesCategory;
   data: Extract<ExerciseRouteData, { kind: "single" }>;
   locale: Locale;
+  material: ExercisesMaterial;
   type: ExercisesType;
 }) {
-  const t = await getTranslations({ locale, namespace: "Exercises" });
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Exercises" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
+  const typePath = getExercisesPath(category, type);
   const exerciseLabel = t("number-count", { count: data.exercise.number });
   const exerciseId = slugify(exerciseLabel);
   const description = `${t("exercises")} - ${data.exercise.question.metadata.title} - ${data.currentMaterialItem.title}`;
@@ -55,22 +64,17 @@ export async function SingleExercisePage({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={[
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t(type), path: typePath },
+          { name: t(material), path: data.materialPath },
+          { name: data.currentMaterial.title, path: data.currentMaterial.href },
+          { name: data.currentMaterialItem.title, path: data.setPath },
           {
-            "@type": "ListItem",
-            "@id": `https://nakafa.com/${locale}${data.setPath}`,
-            position: 1,
-            name: data.currentMaterialItem.title,
-            item: `https://nakafa.com/${locale}${data.setPath}`,
-          },
-          {
-            "@type": "ListItem",
-            "@id": `https://nakafa.com/${locale}${data.exerciseFilePath}`,
-            position: 2,
             name: data.exercise.question.metadata.title,
-            item: `https://nakafa.com/${locale}${data.exerciseFilePath}`,
+            path: data.exerciseFilePath,
           },
-        ]}
+        ])}
       />
       <LearningResourceJsonLd
         author={FOUNDER}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/[material]/page.tsx
@@ -36,6 +36,8 @@ import { RefContent } from "@/components/shared/ref-content";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { createSEODescription } from "@/lib/utils/seo/descriptions";
 import { createSEOTitle } from "@/lib/utils/seo/titles";
 import { getStaticParams } from "@/lib/utils/system";
@@ -104,9 +106,7 @@ export async function generateMetadata({
       absolute: title,
     },
     description,
-    alternates: {
-      canonical: urlPath,
-    },
+    alternates: createLocalizedAlternates(urlPath),
     ...socialMetadata,
   };
 }
@@ -161,9 +161,10 @@ async function PageContent({
   const typePath = getExercisesPath(category, type);
   const FilePath = getMaterialPath(category, type, material);
 
-  const [materials, t] = await Promise.all([
+  const [materials, t, tCommon] = await Promise.all([
     getMaterials(FilePath, locale),
     getTranslations({ locale, namespace: "Exercises" }),
+    getTranslations({ locale, namespace: "Common" }),
   ]);
 
   const chapters: ParsedHeading[] = materials.map((mat) => ({
@@ -175,13 +176,11 @@ async function PageContent({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={materials.map((mat, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${mat.href}`,
-          position: index + 1,
-          name: mat.title,
-          item: `https://nakafa.com/${locale}${mat.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t(type), path: typePath },
+          { name: t(material), path: FilePath },
+        ])}
       />
       <CollectionPageJsonLd
         description={t(type)}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/exercises/[category]/[type]/page.tsx
@@ -23,6 +23,8 @@ import { SubjectItem, SubjectList } from "@/components/shared/subject-list";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { createSEODescription } from "@/lib/utils/seo/descriptions";
 import { createSEOTitle } from "@/lib/utils/seo/titles";
 import { getStaticParams } from "@/lib/utils/system";
@@ -85,9 +87,7 @@ export async function generateMetadata({
       absolute: title,
     },
     description,
-    alternates: {
-      canonical: path,
-    },
+    alternates: createLocalizedAlternates(path),
     ...socialMetadata,
   };
 }
@@ -131,18 +131,18 @@ async function PageContent({
   const FilePath = getExercisesPath(category, type);
 
   const subjects = getSubjects(category, type);
-  const t = await getTranslations({ locale, namespace: "Exercises" });
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Exercises" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
 
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={subjects.map((subject, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${subject.href}`,
-          position: index + 1,
-          name: t(subject.label),
-          item: `https://nakafa.com/${locale}${subject.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t(type), path: FilePath },
+        ])}
       />
       <HeaderContent
         description={t("type-description")}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -2,6 +2,7 @@ import { AllahIcon } from "@hugeicons/core-free-icons";
 import { getAllSurah, getSurahName } from "@repo/contents/_lib/quran";
 import { cn, slugify } from "@repo/design-system/lib/utils";
 import { BookJsonLd } from "@repo/seo/json-ld/book";
+import { BreadcrumbJsonLd } from "@repo/seo/json-ld/breadcrumb";
 import { Effect } from "effect";
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
@@ -32,6 +33,8 @@ import {
   fetchSurahMetadataContext,
   getQuranPagination,
 } from "@/lib/utils/pages/quran";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 import type { SEOContext } from "@/lib/utils/seo/types";
 
@@ -43,16 +46,15 @@ export async function generateMetadata({
   const { locale: rawLocale, surah } = await params;
   const locale = getLocaleOrThrow(rawLocale);
 
-  const t = await getTranslations("Holy");
+  const t = await getTranslations({ locale, namespace: "Holy" });
 
   const path = `/${locale}/quran/${surah}`;
 
-  const alternates = {
-    canonical: path,
+  const alternates = createLocalizedAlternates(path, {
     types: {
       "text/markdown": `${path}.md`,
     },
-  };
+  });
   const surahNumber = Number(surah);
 
   if (Number.isNaN(surahNumber)) {
@@ -153,7 +155,10 @@ async function CachedSurahShell({
 
   cacheLife("max");
 
-  const t = await getTranslations("Holy");
+  const [t, tCommon] = await Promise.all([
+    getTranslations({ locale, namespace: "Holy" }),
+    getTranslations({ locale, namespace: "Common" }),
+  ]);
 
   const surahNumber = Number(surah);
 
@@ -216,6 +221,13 @@ async function CachedSurahShell({
 
   return (
     <>
+      <BreadcrumbJsonLd
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t("quran"), path: "/quran" },
+          { name: title, path: `/quran/${surah}` },
+        ])}
+      />
       <BookJsonLd
         author={{ "@type": "Person", name: "Allah" }}
         description={translation}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/page.tsx
@@ -12,6 +12,8 @@ import { LayoutContent } from "@/components/shared/layout-content";
 import { RefContent } from "@/components/shared/ref-content";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 export async function generateMetadata({
   params,
@@ -24,12 +26,11 @@ export async function generateMetadata({
 
   const path = `/${locale}/quran`;
 
-  const alternates = {
-    canonical: path,
+  const alternates = createLocalizedAlternates(path, {
     types: {
       "text/markdown": `${path}.md`,
     },
-  };
+  });
   const title = t("quran");
   const description = t("quran-description");
   const socialMetadata = getSocialMetadata({
@@ -60,19 +61,17 @@ export default function Page(props: PageProps<"/[locale]/quran">) {
 
 function PageContent({ locale }: { locale: Locale }) {
   const t = useTranslations("Holy");
+  const tCommon = useTranslations("Common");
 
   const surahs = getAllSurah();
 
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={surahs.map((surah, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}/quran/${surah.number}`,
-          position: index + 1,
-          name: getSurahName({ locale, name: surah.name }),
-          item: `https://nakafa.com/${locale}/quran/${surah.number}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t("quran"), path: "/quran" },
+        ])}
       />
       <HeaderContent
         description={t("quran-description")}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/[...slug]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/[...slug]/page.tsx
@@ -356,7 +356,6 @@ async function CachedSubjectShell({
         breadcrumbItems={createBreadcrumbItems(locale, [
           { name: tCommon("home"), path: "" },
           { name: tCommon("subject"), path: "/subject" },
-          { name: tSubject(category), path: `/subject/${category}` },
           {
             name: tSubject(getGradeNonNumeric(grade) ?? "grade", { grade }),
             path: getGradePath(category, grade),

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/[...slug]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import { importContentModule } from "@repo/contents/_lib/module";
 import { parseSubjectCategory } from "@repo/contents/_lib/subject/category";
 import {
   getGradeNonNumeric,
+  getGradePath,
   parseGrade,
 } from "@repo/contents/_lib/subject/grade";
 import {
@@ -51,6 +52,8 @@ import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
 import { getContentMetadataContext } from "@/lib/utils/pages/subject";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 import type { SEOContext } from "@/lib/utils/seo/types";
 import { getStaticParams } from "@/lib/utils/system";
@@ -103,12 +106,11 @@ export async function generateMetadata({
     notFound();
   }
 
-  const alternates = {
-    canonical: path,
+  const alternates = createLocalizedAlternates(path, {
     types: {
       "text/markdown": `${path}.md`,
     },
-  };
+  });
   // Evidence: Use ICU-based SEO generator for type-safe, locale-aware metadata
   // Source: https://developers.google.com/search/docs/appearance/title-link
   const seoContext: SEOContext = {
@@ -351,13 +353,17 @@ async function CachedSubjectShell({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={headings.map((heading, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${FilePath}${heading.href}`,
-          position: index + 1,
-          name: heading.label,
-          item: `https://nakafa.com/${locale}${FilePath}${heading.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("subject"), path: "/subject" },
+          { name: tSubject(category), path: `/subject/${category}` },
+          {
+            name: tSubject(getGradeNonNumeric(grade) ?? "grade", { grade }),
+            path: getGradePath(category, grade),
+          },
+          { name: tSubject(material), path: materialPath },
+          { name: metadata.title, path: FilePath },
+        ])}
       />
       <ArticleJsonLd
         author={metadata.authors.map((author: { name: string }) => ({

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/[material]/page.tsx
@@ -41,6 +41,8 @@ import { RefContent } from "@/components/shared/ref-content";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { createSEODescription } from "@/lib/utils/seo/descriptions";
 import { createSEOTitle } from "@/lib/utils/seo/titles";
 import { getStaticParams } from "@/lib/utils/system";
@@ -111,9 +113,7 @@ export async function generateMetadata({
       absolute: title,
     },
     description,
-    alternates: {
-      canonical: urlPath,
-    },
+    alternates: createLocalizedAlternates(urlPath),
     ...socialMetadata,
   };
 }
@@ -168,9 +168,10 @@ async function PageContent({
   const gradePath = getGradePath(category, grade);
   const FilePath = getMaterialPath(category, grade, material);
 
-  const [materials, t] = await Promise.all([
+  const [materials, t, tCommon] = await Promise.all([
     getMaterials(FilePath, locale),
     getTranslations({ locale, namespace: "Subject" }),
+    getTranslations({ locale, namespace: "Common" }),
   ]);
 
   const chapters: ParsedHeading[] = materials.map((mat) => ({
@@ -182,13 +183,15 @@ async function PageContent({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={materials.map((mat, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${mat.href}`,
-          position: index + 1,
-          name: mat.title,
-          item: `https://nakafa.com/${locale}${mat.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("subject"), path: "/subject" },
+          {
+            name: t(getGradeNonNumeric(grade) ?? "grade", { grade }),
+            path: gradePath,
+          },
+          { name: t(material), path: FilePath },
+        ])}
       />
       <CollectionPageJsonLd
         description={t(getGradeNonNumeric(grade) ?? "grade", { grade })}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/[category]/[grade]/page.tsx
@@ -26,6 +26,8 @@ import { SubjectItem, SubjectList } from "@/components/shared/subject-list";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 import { createSEOTitle } from "@/lib/utils/seo/titles";
 import { getStaticParams } from "@/lib/utils/system";
 
@@ -91,9 +93,7 @@ export async function generateMetadata({
       absolute: title,
     },
     description,
-    alternates: {
-      canonical: path,
-    },
+    alternates: createLocalizedAlternates(path),
     ...socialMetadata,
   };
 }
@@ -145,13 +145,14 @@ async function PageContent({
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={subjects.map((subject, index) => ({
-          "@type": "ListItem",
-          "@id": `https://nakafa.com/${locale}${subject.href}`,
-          position: index + 1,
-          name: tSubject(subject.label),
-          item: `https://nakafa.com/${locale}${subject.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("subject"), path: "/subject" },
+          {
+            name: tSubject(getGradeNonNumeric(grade) ?? "grade", { grade }),
+            path: FilePath,
+          },
+        ])}
       />
       <HeaderContent
         description={tSubject("grade-description")}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/subject/page.tsx
@@ -16,6 +16,8 @@ import { HeaderContent } from "@/components/shared/header-content";
 import { LayoutContent } from "@/components/shared/layout-content";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 export async function generateMetadata({
   params,
@@ -42,9 +44,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: {
-      canonical: path,
-    },
+    alternates: createLocalizedAlternates(path),
     ...socialMetadata,
   };
 }
@@ -77,15 +77,10 @@ async function PageContent({ locale }: { locale: Locale }) {
   return (
     <>
       <BreadcrumbJsonLd
-        breadcrumbItems={allGrades.map((grade, index) => ({
-          "@type": "ListItem" as const,
-          "@id": `https://nakafa.com/${locale}${grade.href}`,
-          position: index + 1,
-          name: tSubject(getGradeNonNumeric(grade.grade) ?? "grade", {
-            grade: grade.grade,
-          }),
-          item: `https://nakafa.com/${locale}${grade.href}`,
-        }))}
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: tCommon("subject"), path: "/subject" },
+        ])}
       />
       <HeaderContent
         description={tSubject("subject-description")}

--- a/apps/www/app/[locale]/(app)/(shared)/try-out/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/page.tsx
@@ -6,6 +6,9 @@ import { getTranslations } from "next-intl/server";
 import { use } from "react";
 import { TryoutHubPage } from "@/components/tryout/hub-page";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
+import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
 
 export async function generateMetadata({
   params,
@@ -22,21 +25,19 @@ export async function generateMetadata({
   const path = `/${locale}/try-out`;
   const title = tCommon("try-out");
   const description = tTryouts("description");
+  const socialMetadata = getSocialMetadata({
+    title,
+    description,
+    locale,
+    path,
+    image: getOgUrl(locale, "/try-out"),
+  });
 
   return {
     title,
     description,
-    alternates: {
-      canonical: path,
-    },
-    openGraph: {
-      title,
-      description,
-      url: path,
-      siteName: "Nakafa",
-      locale,
-      type: "website",
-    },
+    alternates: createLocalizedAlternates(path),
+    ...socialMetadata,
   };
 }
 
@@ -56,20 +57,10 @@ function PageBreadcrumb({ locale }: { locale: Locale }) {
 
   return (
     <BreadcrumbJsonLd
-      breadcrumbItems={[
-        {
-          "@type": "ListItem",
-          position: 1,
-          name: tCommon("home"),
-          item: `https://nakafa.com/${locale}`,
-        },
-        {
-          "@type": "ListItem",
-          position: 2,
-          name: tCommon("try-out"),
-          item: `https://nakafa.com/${locale}/try-out`,
-        },
-      ]}
+      breadcrumbItems={createBreadcrumbItems(locale, [
+        { name: tCommon("home"), path: "" },
+        { name: tCommon("try-out"), path: "/try-out" },
+      ])}
     />
   );
 }

--- a/apps/www/lib/utils/seo/alternates.test.ts
+++ b/apps/www/lib/utils/seo/alternates.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
+
+describe("createLocalizedAlternates", () => {
+  it("builds canonical, locale, default, and markdown alternates", () => {
+    const result = createLocalizedAlternates("/id/articles/politics/example", {
+      types: {
+        "text/markdown": "/id/articles/politics/example.md",
+      },
+    });
+
+    expect(result).toEqual({
+      canonical: "/id/articles/politics/example",
+      languages: {
+        en: "/en/articles/politics/example",
+        id: "/id/articles/politics/example",
+        "x-default": "/en/articles/politics/example",
+      },
+      types: {
+        "text/markdown": "/id/articles/politics/example.md",
+      },
+    });
+  });
+
+  it("normalizes paths without a leading slash", () => {
+    const result = createLocalizedAlternates(
+      "en/subject/high-school/11/mathematics"
+    );
+
+    expect(result).toEqual({
+      canonical: "/en/subject/high-school/11/mathematics",
+      languages: {
+        en: "/en/subject/high-school/11/mathematics",
+        id: "/id/subject/high-school/11/mathematics",
+        "x-default": "/en/subject/high-school/11/mathematics",
+      },
+    });
+  });
+
+  it("handles locale root paths", () => {
+    const result = createLocalizedAlternates("/id");
+
+    expect(result).toEqual({
+      canonical: "/id",
+      languages: {
+        en: "/en",
+        id: "/id",
+        "x-default": "/en",
+      },
+    });
+  });
+
+  it("keeps unlocalized paths as the shared route path", () => {
+    const result = createLocalizedAlternates("/robots.txt");
+
+    expect(result).toEqual({
+      canonical: "/robots.txt",
+      languages: {
+        en: "/en/robots.txt",
+        id: "/id/robots.txt",
+        "x-default": "/en/robots.txt",
+      },
+    });
+  });
+});

--- a/apps/www/lib/utils/seo/alternates.ts
+++ b/apps/www/lib/utils/seo/alternates.ts
@@ -1,0 +1,44 @@
+import { routing } from "@repo/internationalization/src/routing";
+
+interface LocalizedAlternatesOptions {
+  types?: Record<string, string>;
+}
+
+/** Removes an existing locale prefix before building language alternates. */
+function getPathWithoutLocale(canonical: string) {
+  for (const locale of routing.locales) {
+    const prefix = `/${locale}`;
+
+    if (canonical === prefix) {
+      return "";
+    }
+
+    if (canonical.startsWith(`${prefix}/`)) {
+      return canonical.slice(prefix.length);
+    }
+  }
+
+  return canonical;
+}
+
+/** Builds canonical, hreflang, x-default, and optional typed alternates. */
+export function createLocalizedAlternates(
+  path: string,
+  options: LocalizedAlternatesOptions = {}
+) {
+  const canonical = path.startsWith("/") ? path : `/${path}`;
+  const pathWithoutLocale = getPathWithoutLocale(canonical);
+  const languages = Object.fromEntries(
+    routing.locales.map((locale) => [locale, `/${locale}${pathWithoutLocale}`])
+  );
+  const typeAlternates = options.types ? { types: options.types } : {};
+
+  return {
+    canonical,
+    languages: {
+      ...languages,
+      "x-default": `/${routing.defaultLocale}${pathWithoutLocale}`,
+    },
+    ...typeAlternates,
+  };
+}

--- a/apps/www/lib/utils/seo/breadcrumbs.test.ts
+++ b/apps/www/lib/utils/seo/breadcrumbs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
+
+describe("createBreadcrumbItems", () => {
+  it("builds localized BreadcrumbList items from page hierarchy entries", () => {
+    const result = createBreadcrumbItems("id", [
+      { name: "Beranda", path: "" },
+      { name: "Mata pelajaran", path: "/subject" },
+      { name: "SMA", path: "/subject/high-school/11" },
+      {
+        name: "Grafik Fungsi Trigonometri",
+        path: "/subject/high-school/11/mathematics/function-modeling/trigonometric-function-graph",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Beranda",
+        item: "https://nakafa.com/id",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Mata pelajaran",
+        item: "https://nakafa.com/id/subject",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "SMA",
+        item: "https://nakafa.com/id/subject/high-school/11",
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: "Grafik Fungsi Trigonometri",
+        item: "https://nakafa.com/id/subject/high-school/11/mathematics/function-modeling/trigonometric-function-graph",
+      },
+    ]);
+  });
+
+  it("normalizes paths that do not include a leading slash", () => {
+    const result = createBreadcrumbItems("en", [
+      { name: "Home", path: "/" },
+      { name: "Articles", path: "articles" },
+    ]);
+
+    expect(result).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://nakafa.com/en",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Articles",
+        item: "https://nakafa.com/en/articles",
+      },
+    ]);
+  });
+});

--- a/apps/www/lib/utils/seo/breadcrumbs.ts
+++ b/apps/www/lib/utils/seo/breadcrumbs.ts
@@ -1,0 +1,39 @@
+import { MAIN_DOMAIN } from "@repo/next-config/domains";
+import type { Locale } from "next-intl";
+
+const SITE_ORIGIN = `https://${MAIN_DOMAIN}`;
+
+interface BreadcrumbEntry {
+  name: string;
+  path: string;
+}
+
+/** Normalizes an app path before joining it with the locale prefix. */
+function normalizeBreadcrumbPath(path: string) {
+  if (path === "" || path === "/") {
+    return "";
+  }
+
+  if (path.startsWith("/")) {
+    return path;
+  }
+
+  return `/${path}`;
+}
+
+/** Builds Schema.org ListItem entries for a visible page hierarchy. */
+export function createBreadcrumbItems(
+  locale: Locale,
+  entries: BreadcrumbEntry[]
+) {
+  return entries.map((entry, index) => {
+    const path = normalizeBreadcrumbPath(entry.path);
+
+    return {
+      "@type": "ListItem" as const,
+      position: index + 1,
+      name: entry.name,
+      item: `${SITE_ORIGIN}/${locale}${path}`,
+    };
+  });
+}

--- a/apps/www/lib/utils/seo/descriptions.test.ts
+++ b/apps/www/lib/utils/seo/descriptions.test.ts
@@ -15,6 +15,11 @@ describe("createSEODescription", () => {
       expect(result).toBe("First part. Second part");
     });
 
+    it("does not duplicate punctuation between sentence parts", () => {
+      const result = createSEODescription(["First part.", "Second part"]);
+      expect(result).toBe("First part. Second part");
+    });
+
     it("joins three or more parts", () => {
       const result = createSEODescription(["A", "B", "C"]);
       expect(result).toBe("A. B. C");

--- a/apps/www/lib/utils/seo/descriptions.ts
+++ b/apps/www/lib/utils/seo/descriptions.ts
@@ -28,6 +28,8 @@
  * @param options.maxLength - Maximum length (default: 160)
  * @returns Optimized description string, clean without ellipsis
  */
+const SENTENCE_END_REGEX = /[.!?]$/;
+
 export function createSEODescription(
   parts: (string | null | undefined)[],
   options: { maxLength?: number } = {}
@@ -43,8 +45,15 @@ export function createSEODescription(
     return "";
   }
 
-  // Join all parts with ". " separator
-  const joined = validParts.join(". ");
+  // Join all parts with sentence spacing without duplicating punctuation.
+  const joined = validParts.reduce((description, part) => {
+    if (!description) {
+      return part;
+    }
+
+    const separator = SENTENCE_END_REGEX.test(description) ? " " : ". ";
+    return `${description}${separator}${part}`;
+  }, "");
 
   // If under maxLength, return as-is
   if (joined.length <= maxLength) {

--- a/apps/www/lib/utils/seo/generator.test.ts
+++ b/apps/www/lib/utils/seo/generator.test.ts
@@ -1,0 +1,547 @@
+import type { Surah } from "@repo/contents/_types/quran";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateSEOMetadata } from "@/lib/utils/seo/generator";
+
+const { mockCacheLife, mockGetTranslations } = vi.hoisted(() => ({
+  mockCacheLife: vi.fn(),
+  mockGetTranslations: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  cacheLife: mockCacheLife,
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+}));
+
+type TranslationEntry =
+  | string
+  | ((values: Record<string, number | string>) => string);
+
+/** Reads one ICU-like mock value as display text. */
+function getValue(values: Record<string, number | string>, key: string) {
+  return String(values[key] ?? "");
+}
+
+const translations = {
+  Articles: {
+    politics: "Politics",
+  },
+  Exercises: {
+    "quantitative-knowledge": "Quantitative Knowledge",
+    snbt: "SNBT",
+  },
+  Metadata: {
+    title: "Nakafa",
+  },
+  SEO: {
+    "article.description": (values) =>
+      `Generated article description for ${getValue(values, "title")}.`,
+    "article.keywords": (values) =>
+      `${getValue(values, "title")}, ${getValue(values, "category")}, article`,
+    "article.title": (values) =>
+      `${getValue(values, "title")} - ${getValue(values, "category")} | Nakafa`,
+    "exercise.description": (values) =>
+      `Take ${getValue(values, "material")} ${getValue(values, "exam")} exercise with ${getValue(values, "questionCount")} questions and detailed solutions.`,
+    "exercise.keywords": (values) =>
+      `${getValue(values, "material")}, ${getValue(values, "exam")}, exercise`,
+    "exercise.title": (values) =>
+      `Question ${getValue(values, "number")}/${getValue(values, "questionCount")}: ${getValue(values, "material")} (${getValue(values, "exam")}) | Nakafa`,
+    "quran.description": (values) =>
+      `Read Surah ${getValue(values, "name")} with ${getValue(values, "numberOfVerses")} verses.`,
+    "quran.keywords": (values) =>
+      `${getValue(values, "name")}, ${getValue(values, "translation")}, ${getValue(values, "revelation")}`,
+    "quran.title": (values) =>
+      `Surah ${getValue(values, "number")}. ${getValue(values, "name")} - ${getValue(values, "translation")} | Nakafa`,
+    "subject.description": (values) =>
+      `Generated subject description for ${getValue(values, "title")} in ${getValue(values, "material")} for ${getValue(values, "grade")}.`,
+    "subject.keywords": (values) =>
+      `${getValue(values, "title")}, ${getValue(values, "material")}, ${getValue(values, "grade")}`,
+    "subject.title": (values) =>
+      `${getValue(values, "title")}: ${getValue(values, "material")} (${getValue(values, "grade")}) | Nakafa`,
+  },
+  Subject: {
+    bachelor: "Bachelor",
+    grade: (values) => `Grade ${getValue(values, "grade")}`,
+    mathematics: "Mathematics",
+  },
+} satisfies Record<string, Record<string, TranslationEntry>>;
+
+const translationMap: Record<
+  string,
+  Record<string, TranslationEntry>
+> = translations;
+
+/** Returns the mocked translator for the requested namespace. */
+function getTranslator(namespace: string) {
+  const dictionary = translationMap[namespace] ?? {};
+
+  return (key: string, values: Record<string, number | string> = {}) => {
+    const entry = dictionary[key];
+
+    if (typeof entry === "function") {
+      return entry(values);
+    }
+
+    return entry ?? key;
+  };
+}
+
+const surah = {
+  name: {
+    long: "الفاتحة",
+    short: "Al-Fatihah",
+    translation: {
+      en: "The Opening",
+      id: "Pembukaan",
+    },
+    transliteration: {
+      en: "Al-Fatihah",
+      id: "Al-Fatihah",
+    },
+  },
+  number: 1,
+  numberOfVerses: 7,
+  preBismillah: null,
+  revelation: {
+    arab: "مكة",
+    en: "Meccan",
+    id: "Makkiyah",
+  },
+  sequence: 5,
+  verses: [],
+} satisfies Surah;
+
+beforeEach(() => {
+  mockCacheLife.mockClear();
+  mockGetTranslations.mockReset();
+  mockGetTranslations.mockImplementation(({ namespace }) =>
+    Promise.resolve(getTranslator(namespace))
+  );
+});
+
+describe("generateSEOMetadata", () => {
+  it("uses subject MDX description before generated fallback copy", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {
+          title: "Trigonometric Function Graph",
+          description: "Hand-written subject summary for students.",
+        },
+      },
+      "en"
+    );
+
+    expect(result.description).toBe(
+      "Hand-written subject summary for students."
+    );
+    expect(result.title).toBe(
+      "Trigonometric Function Graph: Mathematics (Grade 11) | Nakafa"
+    );
+    expect(result.keywords).toEqual([
+      "Trigonometric Function Graph",
+      "Mathematics",
+      "Grade 11",
+    ]);
+  });
+
+  it("uses generated subject description when MDX description is missing", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "university",
+        grade: "bachelor",
+        material: "mathematics",
+        data: {
+          title: "Linear Algebra",
+          description: "   ",
+        },
+      },
+      "en"
+    );
+
+    expect(result.description).toBe(
+      "Generated subject description for Linear Algebra in Mathematics for Bachelor."
+    );
+  });
+
+  it("uses subject metadata when title is missing", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {
+          title: "   ",
+          subject: "Function Modeling",
+        },
+      },
+      "en"
+    );
+
+    expect(result.title).toBe(
+      "Function Modeling: Mathematics (Grade 11) | Nakafa"
+    );
+  });
+
+  it("uses the site title when content title and subject are missing", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {},
+      },
+      "en"
+    );
+
+    expect(result.title).toBe("Nakafa: Mathematics (Grade 11) | Nakafa");
+  });
+
+  it("uses article MDX description before generated fallback copy", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "article",
+        category: "politics",
+        data: {
+          title: "Regional Elections",
+          description: "Hand-written article summary.",
+        },
+      },
+      "en"
+    );
+
+    expect(result.description).toBe("Hand-written article summary.");
+    expect(result.title).toBe("Regional Elections - Politics | Nakafa");
+  });
+
+  it("uses generated article description when MDX description is missing", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "article",
+        category: "politics",
+        data: {
+          title: "Regional Elections",
+        },
+      },
+      "en"
+    );
+
+    expect(result.description).toBe(
+      "Generated article description for Regional Elections."
+    );
+  });
+
+  it("keeps exercise metadata tied to exam, material, and question count", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        number: 9,
+        questionCount: 20,
+        data: {
+          title: "Question 9",
+        },
+      },
+      "en"
+    );
+
+    expect(result.title).toBe(
+      "Question 9/20: Quantitative Knowledge (SNBT) | Nakafa"
+    );
+    expect(result.description).toBe(
+      "Take Quantitative Knowledge SNBT exercise with 20 questions and detailed solutions."
+    );
+  });
+
+  it("uses exercise defaults when optional route data is absent", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        group: "Try Out",
+        set: "Set 1",
+        data: {
+          title: "Practice Set",
+        },
+      },
+      "en"
+    );
+
+    expect(result.title).toBe(
+      "Question 0/0: Quantitative Knowledge (SNBT) | Nakafa"
+    );
+    expect(result.description).toBe(
+      "Take Quantitative Knowledge SNBT exercise with 0 questions and detailed solutions."
+    );
+  });
+
+  it("generates Quran metadata from the surah payload", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "quran",
+        surah,
+      },
+      "en"
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - The Opening | Nakafa");
+    expect(result.description).toBe("Read Surah Al-Fatihah with 7 verses.");
+  });
+
+  it("falls back to English Quran labels when locale labels are empty", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "quran",
+        surah: {
+          ...surah,
+          name: {
+            ...surah.name,
+            translation: {
+              en: "The Opening",
+              id: "",
+            },
+            transliteration: {
+              en: "Al-Fatihah",
+              id: "",
+            },
+          },
+          revelation: {
+            arab: "مكة",
+            en: "Meccan",
+            id: "",
+          },
+        },
+      },
+      "id"
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - The Opening | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "The Opening", "Meccan"]);
+  });
+
+  it("falls back to the short Quran name when translated names are empty", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "quran",
+        surah: {
+          ...surah,
+          name: {
+            ...surah.name,
+            translation: {
+              en: "",
+              id: "",
+            },
+            transliteration: {
+              en: "",
+              id: "",
+            },
+          },
+          revelation: {
+            arab: "مكة",
+            en: "",
+            id: "",
+          },
+        },
+      },
+      "id"
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - Al-Fatihah | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "Al-Fatihah", ""]);
+  });
+
+  it("keeps Quran metadata stable when all display names are empty", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "quran",
+        surah: {
+          ...surah,
+          name: {
+            ...surah.name,
+            short: "",
+            translation: {
+              en: "",
+              id: "",
+            },
+          },
+        },
+      },
+      "id"
+    );
+
+    expect(result.title).toBe("Surah 1.  -  | Nakafa");
+  });
+
+  it("falls back to legacy metadata builders when translations fail", async () => {
+    mockGetTranslations.mockRejectedValueOnce(
+      new Error("missing translations")
+    );
+
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {
+          title: "Trigonometric Function Graph",
+          description: "Graph lesson fallback.",
+        },
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "Trigonometric Function Graph - mathematics - Nakafa",
+      description: "Graph lesson fallback. Trigonometric Function Graph",
+      keywords: [],
+    });
+  });
+
+  it("falls back when Metadata translations fail for the ultimate title fallback", async () => {
+    mockGetTranslations.mockImplementation(({ namespace }) => {
+      if (namespace === "Metadata") {
+        return Promise.reject(new Error("missing Metadata translations"));
+      }
+
+      return Promise.resolve(getTranslator(namespace));
+    });
+
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {},
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "mathematics - Nakafa",
+      description: "",
+      keywords: [],
+    });
+  });
+
+  it("falls back when Subject translations fail", async () => {
+    mockGetTranslations.mockImplementation(({ namespace }) => {
+      if (namespace === "Subject") {
+        return Promise.reject(new Error("missing Subject translations"));
+      }
+
+      return Promise.resolve(getTranslator(namespace));
+    });
+
+    const result = await generateSEOMetadata(
+      {
+        type: "subject",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {
+          title: "Trigonometric Function Graph",
+          description: "Graph lesson fallback.",
+        },
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "Trigonometric Function Graph - mathematics - Nakafa",
+      description: "Graph lesson fallback. Trigonometric Function Graph",
+      keywords: [],
+    });
+  });
+
+  it("falls back to Quran metadata when Quran translations fail", async () => {
+    mockGetTranslations.mockRejectedValueOnce(
+      new Error("missing translations")
+    );
+
+    const result = await generateSEOMetadata(
+      {
+        type: "quran",
+        surah,
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "The Opening - Nakafa",
+      description: "The Opening",
+      keywords: [],
+    });
+  });
+
+  it("falls back to exercise metadata when exercise translations fail", async () => {
+    mockGetTranslations.mockImplementation(({ namespace }) => {
+      if (namespace === "Exercises") {
+        return Promise.reject(new Error("missing Exercises translations"));
+      }
+
+      return Promise.resolve(getTranslator(namespace));
+    });
+
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        data: {
+          title: "Question 9",
+          description: "Exercise fallback.",
+        },
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "Question 9 - quantitative-knowledge - Nakafa",
+      description: "Exercise fallback. Question 9",
+      keywords: [],
+    });
+  });
+
+  it("falls back to article metadata when article translations fail", async () => {
+    mockGetTranslations.mockImplementation(({ namespace }) => {
+      if (namespace === "Articles") {
+        return Promise.reject(new Error("missing Articles translations"));
+      }
+
+      return Promise.resolve(getTranslator(namespace));
+    });
+
+    const result = await generateSEOMetadata(
+      {
+        type: "article",
+        category: "politics",
+        data: {
+          title: "Regional Elections",
+          description: "Article fallback.",
+        },
+      },
+      "en"
+    );
+
+    expect(result).toStrictEqual({
+      title: "Regional Elections - politics - Nakafa",
+      description: "Article fallback. Regional Elections",
+      keywords: [],
+    });
+  });
+});

--- a/apps/www/lib/utils/seo/generator.ts
+++ b/apps/www/lib/utils/seo/generator.ts
@@ -146,6 +146,17 @@ const translateArticleCategory = Effect.fn("SEO.translateArticleCategory")(
     })
 );
 
+/** Returns the hand-written content description when it is present. */
+function getContentDescription(data: ContentSEOData) {
+  const description = data.description?.trim();
+
+  if (!description) {
+    return null;
+  }
+
+  return description;
+}
+
 /**
  * Generates SEO metadata for subject content.
  */
@@ -172,12 +183,14 @@ const generateSubjectMetadata = Effect.fn("SEO.generateSubjectMetadata")(
           material: materialDisplayName,
           grade: gradeDisplay,
         }),
-        description: t("subject.description", {
-          title: effectiveTitle,
-          chapter: chapterValue,
-          material: materialDisplayName,
-          grade: gradeDisplay,
-        }),
+        description:
+          getContentDescription(data) ??
+          t("subject.description", {
+            title: effectiveTitle,
+            chapter: chapterValue,
+            material: materialDisplayName,
+            grade: gradeDisplay,
+          }),
         keywords: t("subject.keywords", {
           title: effectiveTitle,
           chapter: chapterValue,
@@ -264,10 +277,12 @@ const generateArticleMetadata = Effect.fn("SEO.generateArticleMetadata")(
           title: effectiveTitle,
           category: categoryDisplayName,
         }),
-        description: t("article.description", {
-          title: effectiveTitle,
-          category: categoryDisplayName,
-        }),
+        description:
+          getContentDescription(data) ??
+          t("article.description", {
+            title: effectiveTitle,
+            category: categoryDisplayName,
+          }),
         keywords: t("article.keywords", {
           title: effectiveTitle,
           category: categoryDisplayName,
@@ -334,23 +349,19 @@ export async function generateSEOMetadata(
   const { type } = context;
 
   const effect = Effect.gen(function* () {
-    switch (type) {
-      case "subject": {
-        return yield* generateSubjectMetadata(context, locale);
-      }
-      case "exercise": {
-        return yield* generateExerciseMetadata(context, locale);
-      }
-      case "article": {
-        return yield* generateArticleMetadata(context, locale);
-      }
-      case "quran": {
-        return yield* generateQuranMetadata(context, locale);
-      }
-      default: {
-        return yield* Effect.sync(() => generateFallbackMetadata(context));
-      }
+    if (type === "subject") {
+      return yield* generateSubjectMetadata(context, locale);
     }
+
+    if (type === "exercise") {
+      return yield* generateExerciseMetadata(context, locale);
+    }
+
+    if (type === "article") {
+      return yield* generateArticleMetadata(context, locale);
+    }
+
+    return yield* generateQuranMetadata(context, locale);
   });
 
   return Effect.runPromise(

--- a/packages/contents/_lib/__tests__/metadata.test.ts
+++ b/packages/contents/_lib/__tests__/metadata.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
 import {
   extractMetadata,
   getContentMetadata,
@@ -43,6 +45,38 @@ export const metadata = {
 
 # ${title}
 `;
+
+const localeFileNames = new Set(["en.mdx", "id.mdx"]);
+const seoContentRoots = ["articles", "subject"] as const;
+
+/** Returns the package root whether Vitest runs from the workspace or repo root. */
+function getContentsRoot() {
+  if (process.cwd().endsWith("packages/contents")) {
+    return process.cwd();
+  }
+
+  return path.join(process.cwd(), "packages/contents");
+}
+
+/** Collects localized MDX files below a content directory. */
+function collectLocalizedMdxFiles(directory: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectLocalizedMdxFiles(entryPath));
+      continue;
+    }
+
+    if (entry.isFile() && localeFileNames.has(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
 
 beforeEach(() => {
   mockReadFile.mockResolvedValue(createRawMetadata("Default"));
@@ -108,6 +142,60 @@ export const metadata = {
 `);
 
     expect(Option.isNone(result)).toBe(true);
+  });
+});
+
+describe("content SEO metadata", () => {
+  it("keeps subject and article metadata complete and unique", () => {
+    const contentsRoot = getContentsRoot();
+    const descriptions = new Map<string, string>();
+    const failures: string[] = [];
+
+    for (const root of seoContentRoots) {
+      const files = collectLocalizedMdxFiles(path.join(contentsRoot, root));
+
+      for (const file of files) {
+        const raw = readFileSync(file, "utf8");
+        const metadata = extractMetadata(raw);
+        const label = path.relative(contentsRoot, file);
+
+        if (Option.isNone(metadata)) {
+          failures.push(`${label} metadata cannot be parsed`);
+          continue;
+        }
+
+        const { title, description, authors } = metadata.value;
+        const trimmedTitle = title.trim();
+        const trimmedDescription = description?.trim();
+
+        if (!trimmedTitle) {
+          failures.push(`${label} title is empty`);
+        }
+
+        if (!trimmedDescription) {
+          failures.push(`${label} description is empty`);
+        }
+
+        if (authors.length === 0) {
+          failures.push(`${label} authors are empty`);
+        }
+
+        if (!trimmedDescription) {
+          continue;
+        }
+
+        const duplicate = descriptions.get(trimmedDescription);
+
+        if (duplicate) {
+          failures.push(`${label} repeats description from ${duplicate}`);
+          continue;
+        }
+
+        descriptions.set(trimmedDescription, label);
+      }
+    }
+
+    expect(failures).toEqual([]);
   });
 });
 

--- a/packages/design-system/components/ui/command.tsx
+++ b/packages/design-system/components/ui/command.tsx
@@ -44,7 +44,7 @@ function CommandDialog({
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
+        <DialogTitle render={<span />}>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent className="overflow-hidden p-0" showCloseButton={false}>

--- a/packages/design-system/lib/button.ts
+++ b/packages/design-system/lib/button.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex shrink-0 cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Introduce createLocalizedAlternates and createBreadcrumbItems and wire them into article, exercise, and subject pages. Add SEO guidance reference and unit tests, plus small generator and description helpers.