### PR TITLE
Add reasoning to math steps and enhance discrete math operations

### DIFF
--- a/apps/cas/cas/discrete.py
+++ b/apps/cas/cas/discrete.py
@@ -1,10 +1,12 @@
 """Discrete math CAS operations backed by SymPy."""
 
+import math
+
 import sympy as sp
 
 from cas import parse
 from cas.format import expression_text, item, result, step
-from cas.schema import MathExpression, MathRequest, MathResult
+from cas.schema import MathExpression, MathItem, MathRequest, MathResult, MathStep
 
 EQUALS = expression_text("equals", "=")
 
@@ -14,17 +16,21 @@ def run(request: MathRequest) -> MathResult:
     operation = request.operation
 
     if operation == "gcd":
-        values = [_integer(value) for value in request.values]
+        values = _integer_values(request.values)
+        primary = _function_expression("gcd", values)
         output = sp.gcd_list(values)
         steps = _gcd_steps(values, output)
     elif operation == "lcm":
-        values = [_integer(value) for value in request.values]
+        values = _integer_values(request.values)
+        primary = _function_expression("lcm", values)
         output = sp.lcm_list(values)
-        steps = _operation_steps("lcm", values, output)
+        steps = _lcm_steps(values, output)
     elif operation == "prime_factorization":
         value = _integer(request.n)
+        if value == 0:
+            raise ValueError("Prime factorization requires a nonzero integer.")
+
         # `factorint` returns the prime-power dictionary shape used below.
-        # https://docs.sympy.org/latest/modules/ntheory.html#sympy.ntheory.factor_.factorint
         factors = sp.factorint(value)
         factorization = _factorization_expression(factors)
 
@@ -36,7 +42,7 @@ def run(request: MathRequest) -> MathResult:
             secondary=factorization,
             items=[
                 item("factor", _factor_expression(prime, power))
-                for prime, power in factors.items()
+                for prime, power in _ordered_factors(factors)
             ],
             steps=[
                 step(
@@ -44,55 +50,40 @@ def run(request: MathRequest) -> MathResult:
                     primary=value,
                     relation=EQUALS,
                     secondary=factorization,
+                    reason=_prime_factorization_reason(value, factors),
                 )
             ],
             stepStatus="complete",
         )
     elif operation == "is_prime":
         value = _integer(request.n)
+        primary = value
         # SymPy's primality API gives a deterministic boolean for exact integers.
-        # https://docs.sympy.org/latest/modules/ntheory.html#sympy.ntheory.primetest.isprime
         output = sp.isprime(value)
-        steps = [
-            step(
-                "is_prime",
-                primary=value,
-                relation=expression_text("is", "\\text{is}"),
-                secondary=expression_text(
-                    "prime" if output else "not prime",
-                    "\\text{prime}" if output else "\\text{not prime}",
-                ),
-            )
-        ]
+        steps = [_is_prime_step(value, output)]
     elif operation == "modular":
         value = _integer(request.n)
         modulus = _nonzero_integer(request.modulus)
         primary = _modular_expression(value, modulus)
         output = value % modulus
-        steps = [step("modular", primary=primary, relation=EQUALS, secondary=output)]
+        steps = _modular_steps(value, modulus, output)
     elif operation == "permutation":
         n, k = _bounded_count(request.n, request.k, "Permutation")
         primary = _permutation_expression(n, k)
         output = sp.factorial(n) / sp.factorial(n - k)
-        steps = [
-            step("permutation", primary=primary, relation=EQUALS, secondary=output)
-        ]
+        steps = _permutation_steps(n, k, output)
     elif operation == "combination":
         n, k = _bounded_count(request.n, request.k, "Combination")
         primary = _combination_expression(n, k)
         output = sp.binomial(n, k)
-        steps = [
-            step("combination", primary=primary, relation=EQUALS, secondary=output)
-        ]
+        steps = _combination_steps(n, k, output)
     else:
         raise ValueError(f"Unsupported discrete operation: {operation}")
 
     return result(
         request,
         status="verified",
-        primary=(
-            steps[-1].primary if steps else request.values or request.n or operation
-        ),
+        primary=primary,
         secondary=output,
         reason="The discrete math operation was checked exactly.",
         steps=steps,
@@ -107,6 +98,14 @@ def _integer(value: str | None) -> int:
         raise ValueError("Discrete operands must be integers.")
 
     return int(parsed)
+
+
+def _integer_values(values: list[str]) -> list[int]:
+    """Parse a non-empty list of exact integer operands."""
+    if not values:
+        raise ValueError("Discrete value operations require at least one integer.")
+
+    return [_integer(value) for value in values]
 
 
 def _nonzero_integer(value: str | None) -> int:
@@ -130,7 +129,7 @@ def _bounded_count(
     return n, k
 
 
-def _operation_steps(name: str, values: list[int], output: object) -> list:
+def _operation_steps(name: str, values: list[int], output: object) -> list[MathStep]:
     """Create one function-style step for exact integer-list operations."""
     return [
         step(
@@ -138,6 +137,9 @@ def _operation_steps(name: str, values: list[int], output: object) -> list:
             primary=_function_expression(name, values),
             relation=EQUALS,
             secondary=output,
+            reason=(
+                f"Reduce the integer list using the associative {name} operation."
+            ),
         )
     ]
 
@@ -159,14 +161,22 @@ def _factorization_expression(factors: dict[int, int]) -> MathExpression:
 
     pieces = [
         f"{prime}^{power}" if power > 1 else str(prime)
-        for prime, power in factors.items()
+        for prime, power in _ordered_factors(factors)
     ]
     latex_pieces = [
         f"{prime}^{{{power}}}" if power > 1 else str(prime)
-        for prime, power in factors.items()
+        for prime, power in _ordered_factors(factors)
     ]
 
     return expression_text("*".join(pieces), " \\cdot ".join(latex_pieces))
+
+
+def _ordered_factors(factors: dict[int, int]) -> list[tuple[int, int]]:
+    """Keep the sign unit first, then render prime factors in ascending order."""
+    return sorted(
+        ((int(prime), int(power)) for prime, power in factors.items()),
+        key=lambda factor: (factor[0] != -1, abs(factor[0])),
+    )
 
 
 def _factor_expression(prime: int, power: int) -> MathExpression:
@@ -201,12 +211,249 @@ def _permutation_expression(n: object, k: object) -> MathExpression:
     )
 
 
-def _gcd_steps(values: list[int], output: object) -> list:
+def _combination_formula_expression(n: int, k: int) -> MathExpression:
+    """Render the factorial form of n choose k after substituting values."""
+    remaining = n - k
+
+    return expression_text(
+        f"{n}!/({k}!*{remaining}!)",
+        f"\\frac{{{n}!}}{{{k}! \\cdot {remaining}!}}",
+    )
+
+
+def _permutation_formula_expression(n: int, k: int) -> MathExpression:
+    """Render the factorial form of n permute k after substituting values."""
+    remaining = n - k
+
+    return expression_text(
+        f"{n}!/{remaining}!",
+        f"\\frac{{{n}!}}{{{remaining}!}}",
+    )
+
+
+def _combination_steps(n: int, k: int, output: object) -> list[MathStep]:
+    """Create formula-substitution steps for combinations."""
+    formula = _combination_formula_expression(n, k)
+
+    return [
+        step(
+            "combination",
+            primary=_combination_expression(n, k),
+            relation=EQUALS,
+            secondary=formula,
+            reason=(
+                "Use the combination formula because order does not matter."
+            ),
+        ),
+        step(
+            "evaluate",
+            primary=formula,
+            relation=EQUALS,
+            secondary=output,
+            reason="Evaluate the factorials and simplify exactly.",
+        ),
+    ]
+
+
+def _permutation_steps(n: int, k: int, output: object) -> list[MathStep]:
+    """Create formula-substitution steps for permutations."""
+    formula = _permutation_formula_expression(n, k)
+
+    return [
+        step(
+            "permutation",
+            primary=_permutation_expression(n, k),
+            relation=EQUALS,
+            secondary=formula,
+            reason="Use the permutation formula because order matters.",
+        ),
+        step(
+            "evaluate",
+            primary=formula,
+            relation=EQUALS,
+            secondary=output,
+            reason="Evaluate the factorials and simplify exactly.",
+        ),
+    ]
+
+
+def _modular_steps(value: int, modulus: int, output: object) -> list[MathStep]:
+    """Create a modular arithmetic step with the division algorithm context."""
+    quotient, remainder = divmod(value, modulus)
+    division = expression_text(
+        f"{value} = {quotient}*{modulus} + {remainder}",
+        f"{value} = {quotient} \\cdot {modulus} + {remainder}",
+    )
+
+    return [
+        step(
+            "modular",
+            primary=_modular_expression(value, modulus),
+            relation=EQUALS,
+            secondary=output,
+            items=[item("division", division)],
+            reason=(
+                "Use the division algorithm; the remainder is the value modulo "
+                "the modulus."
+            ),
+        )
+    ]
+
+
+def _is_prime_step(value: int, output: bool) -> MathStep:
+    """Create a primality step with the exact reason for the conclusion."""
+    step_items: list[MathItem] = []
+
+    if value < 2:
+        reason = "Prime numbers are integers greater than 1."
+    elif output and value <= 3:
+        reason = f"{value} has exactly two positive divisors: 1 and {value}."
+    elif output:
+        checked_divisors = list(sp.primerange(2, math.isqrt(value) + 1))
+        if checked_divisors:
+            rendered_divisors = ", ".join(str(divisor) for divisor in checked_divisors)
+            step_items.append(
+                item(
+                    "checked_divisors",
+                    expression_text(rendered_divisors, rendered_divisors),
+                )
+            )
+        reason = (
+            f"No prime divisor up to sqrt({value}) divides {value}, so it is prime."
+        )
+    else:
+        divisor = _smallest_prime_factor(value)
+        if divisor is None:
+            reason = "Prime numbers are integers greater than 1."
+        else:
+            step_items.append(item("divisor", divisor))
+            reason = f"{divisor} divides {value}, so {value} is not prime."
+
+    return step(
+        "is_prime",
+        primary=value,
+        relation=expression_text("is", "\\text{is}"),
+        secondary=expression_text(
+            "prime" if output else "not prime",
+            "\\text{prime}" if output else "\\text{not prime}",
+        ),
+        items=step_items,
+        reason=reason,
+    )
+
+
+def _smallest_prime_factor(value: int) -> int | None:
+    """Return the smallest prime factor for a composite integer when available."""
+    if abs(value) < 2:
+        return None
+
+    factors = _ordered_factors(sp.factorint(abs(value)))
+    return next((prime for prime, _power in factors if prime > 1), None)
+
+
+def _lcm_steps(values: list[int], output: object) -> list[MathStep]:
+    """Create lcm evidence, using the gcd identity for two integers."""
+    if len(values) != 2:
+        return _operation_steps("lcm", values, output)
+
+    left, right = values
+    primary = _function_expression("lcm", values)
+
+    if left == 0 and right == 0:
+        return [
+            step(
+                "lcm",
+                primary=primary,
+                relation=EQUALS,
+                secondary=output,
+                reason=(
+                    "Both inputs are zero, so the least common multiple is 0 "
+                    "in this exact integer convention."
+                ),
+            )
+        ]
+
+    gcd_value = sp.gcd(abs(left), abs(right))
+
+    return [
+        step(
+            "lcm",
+            primary=primary,
+            relation=EQUALS,
+            secondary=output,
+            items=[
+                item("gcd", gcd_value),
+                item("identity", _lcm_identity_expression(left, right)),
+            ],
+            reason=(
+                "Use the identity lcm(a, b) = |a*b| / gcd(a, b) for two "
+                "integers."
+            ),
+        )
+    ]
+
+
+def _lcm_identity_expression(left: int, right: int) -> MathExpression:
+    """Render the two-integer lcm identity with substituted inputs."""
+    return expression_text(
+        f"|{left}*{right}|/gcd({left}, {right})",
+        (
+            "\\frac{"
+            f"\\left|{left} \\cdot {right}\\right|"
+            "}{"
+            f"\\gcd\\left({left}, {right}\\right)"
+            "}"
+        ),
+    )
+
+
+def _prime_factorization_reason(value: int, factors: dict[int, int]) -> str:
+    """Return the student-facing reason for one prime factorization step."""
+    if value == 1:
+        return "1 has no prime factors, so the empty product is 1."
+
+    if value == -1:
+        return "-1 is the sign unit and has no positive prime factors."
+
+    if -1 in factors:
+        return (
+            "Separate the negative sign, then combine equal positive prime "
+            "factors as powers."
+        )
+
+    return "Break the integer into prime factors and combine repeated primes as powers."
+
+
+def _gcd_steps(values: list[int], output: object) -> list[MathStep]:
     """Create Euclidean algorithm steps for two positive integers."""
     if len(values) != 2:
         return _operation_steps("gcd", values, output)
 
     left, right = sorted((abs(values[0]), abs(values[1])), reverse=True)
+    primary = _function_expression("gcd", values)
+
+    if left == 0:
+        return [
+            step(
+                "gcd",
+                primary=primary,
+                relation=EQUALS,
+                secondary=output,
+                reason="The gcd of two zeros is 0 in this exact integer convention.",
+            )
+        ]
+
+    if right == 0:
+        return [
+            step(
+                "gcd",
+                primary=primary,
+                relation=EQUALS,
+                secondary=output,
+                reason="The gcd of an integer and 0 is the integer's absolute value.",
+            )
+        ]
+
     steps = []
 
     while right != 0:
@@ -218,6 +465,10 @@ def _gcd_steps(values: list[int], output: object) -> list:
                     f"{left} = {quotient}*{right} + {remainder}",
                     f"{left} = {quotient} \\cdot {right} + {remainder}",
                 ),
+                reason=(
+                    "Use Euclidean division; replacing the larger number by "
+                    "the remainder preserves the gcd."
+                ),
             )
         )
         left, right = right, remainder
@@ -225,12 +476,10 @@ def _gcd_steps(values: list[int], output: object) -> list:
     steps.append(
         step(
             "gcd",
-            primary=expression_text(
-                f"gcd({values[0]}, {values[1]})",
-                f"\\gcd\\left({values[0]}, {values[1]}\\right)",
-            ),
+            primary=primary,
             relation=EQUALS,
             secondary=output,
+            reason="When the remainder is 0, the last nonzero divisor is the gcd.",
         )
     )
 

--- a/apps/cas/cas/format.py
+++ b/apps/cas/cas/format.py
@@ -47,6 +47,7 @@ def step(
     relation: MathExpression | None = None,
     secondary: object | None = None,
     items: Sequence[MathItem] | None = None,
+    reason: str | None = None,
 ) -> MathStep:
     """Build one deterministic math evidence step."""
     return MathStep(
@@ -55,6 +56,7 @@ def step(
         relation=relation,
         secondary=math_expression(secondary) if secondary is not None else None,
         items=list(items or []),
+        reason=reason,
     )
 
 

--- a/apps/cas/cas/schema.py
+++ b/apps/cas/cas/schema.py
@@ -81,6 +81,7 @@ class MathStep(BaseModel):
     relation: MathExpression | None = None
     secondary: MathExpression | None = None
     items: list[MathItem] = Field(default_factory=list)
+    reason: str | None = None
 
 
 class MathResult(BaseModel):

--- a/apps/cas/tests/discrete_test.py
+++ b/apps/cas/tests/discrete_test.py
@@ -51,6 +51,44 @@ def test_discrete_steps_preserve_operation_context(
     assert result.steps[0].primary.latex == expected_latex
 
 
+@pytest.mark.parametrize(
+    "math_request",
+    [
+        MathRequest(kind="math", k="2", n="5", operation="combination"),
+        MathRequest(kind="math", operation="gcd", values=["18", "24"]),
+        MathRequest(kind="math", n="21", operation="is_prime"),
+        MathRequest(kind="math", operation="lcm", values=["6", "8"]),
+        MathRequest(kind="math", modulus="5", n="17", operation="modular"),
+        MathRequest(kind="math", k="2", n="5", operation="permutation"),
+        MathRequest(kind="math", n="84", operation="prime_factorization"),
+    ],
+)
+def test_discrete_steps_include_reasons(math_request: MathRequest) -> None:
+    result = run(math_request)
+
+    assert result.steps
+    assert all(step.reason for step in result.steps)
+
+
+def test_combination_and_permutation_show_formula_substitution() -> None:
+    combination = run(MathRequest(kind="math", k="2", n="5", operation="combination"))
+    permutation = run(MathRequest(kind="math", k="2", n="5", operation="permutation"))
+
+    assert [step.action for step in combination.steps] == ["combination", "evaluate"]
+    assert combination.steps[0].secondary
+    assert combination.steps[0].secondary.expression == "5!/(2!*3!)"
+    assert [step.action for step in permutation.steps] == ["permutation", "evaluate"]
+    assert permutation.steps[0].secondary
+    assert permutation.steps[0].secondary.expression == "5!/3!"
+
+
+def test_modular_step_keeps_division_algorithm_context() -> None:
+    result = run(MathRequest(kind="math", modulus="30", n="84", operation="modular"))
+
+    assert result.steps[0].items[0].label == "division"
+    assert result.steps[0].items[0].value == "84 = 2*30 + 24"
+
+
 def test_prime_factorization() -> None:
     result = run(MathRequest(kind="math", n="84", operation="prime_factorization"))
 
@@ -67,6 +105,18 @@ def test_prime_factorization_of_one() -> None:
     assert result.secondary
     assert result.secondary.expression == "1"
     assert result.secondary.latex == "1"
+
+
+def test_prime_factorization_keeps_negative_sign_first() -> None:
+    result = run(MathRequest(kind="math", n="-12", operation="prime_factorization"))
+
+    assert result.secondary
+    assert result.secondary.expression == "-1*2^2*3"
+
+
+def test_prime_factorization_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="nonzero integer"):
+        run(MathRequest(kind="math", n="0", operation="prime_factorization"))
 
 
 def test_gcd_with_more_than_two_values_uses_function_notation() -> None:
@@ -94,6 +144,11 @@ def test_discrete_operands_reject_non_integers(math_request: MathRequest) -> Non
 def test_modular_rejects_zero_modulus() -> None:
     with pytest.raises(ValueError, match="Modulus must be nonzero"):
         run(MathRequest(kind="math", modulus="0", n="84", operation="modular"))
+
+
+def test_discrete_value_operations_require_values() -> None:
+    with pytest.raises(ValueError, match="at least one integer"):
+        run(MathRequest(kind="math", operation="gcd"))
 
 
 @pytest.mark.parametrize(

--- a/packages/math/schema/result.test.ts
+++ b/packages/math/schema/result.test.ts
@@ -37,6 +37,7 @@ describe("MathResultSchema", () => {
               expression: "equals",
               latex: "=",
             },
+            reason: "Evaluate the exact arithmetic expression.",
             secondary: {
               expression: "4",
               latex: "4",
@@ -48,6 +49,11 @@ describe("MathResultSchema", () => {
     ).toMatchObject({
       kind: "evaluate",
       status: "verified",
+      steps: [
+        expect.objectContaining({
+          reason: "Evaluate the exact arithmetic expression.",
+        }),
+      ],
     });
   });
 });

--- a/packages/math/schema/shared.ts
+++ b/packages/math/schema/shared.ts
@@ -101,6 +101,13 @@ export const MathStepSchema = Schema.Struct({
   items: Schema.Array(MathItemSchema).pipe(Schema.mutable),
   primary: MathExpressionSchema,
   relation: Schema.optional(MathExpressionSchema),
+  reason: Schema.optional(
+    Schema.NullOr(
+      Schema.String.annotations({
+        description: "Student-facing reason why this step is valid.",
+      })
+    )
+  ),
   secondary: Schema.optional(MathExpressionSchema),
 })
   .pipe(Schema.mutable)


### PR DESCRIPTION
- Introduced a `reason` field in `MathStep` for student-facing explanations.
- Updated discrete math operations to include reasoning in steps for gcd, lcm, prime factorization, and modular arithmetic.
- Enhanced tests to verify the presence of reasoning in results.
- Improved error handling for prime factorization with zero and ensured proper value requirements for operations.

## Description

Briefly describe your changes and what they accomplish.

## Type

- Bug fix
- New feature
- Breaking change
- Documentation
- Refactoring
- Performance

## Testing

- Tests pass: `pnpm test`
- No new lint errors: `pnpm lint`
- Relevant workspace type checks pass, for example `pnpm --filter www typecheck`
- Manual testing (desktop/mobile)
- Contribution terms reviewed: `LICENSE`, `CONTENT_LICENSE.md`, and `TRADEMARKS.md`

## Related Issues

Closes #

## Additional Context

Any other information reviewers should know.
