### PR TITLE
Fix content list indentation and answer references

### DIFF
--- a/packages/contents/exercises/high-school/snbt/general-reasoning/try-out/2026/set-7/18/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/snbt/general-reasoning/try-out/2026/set-7/18/_answer/en.mdx
@@ -22,4 +22,4 @@ Since both result in the same method, the valid conclusion is that snakes **have
 - **Has a method of reproduction that is not the same**: *False*. Both reproduce by laying eggs.
 - **Has the same characteristics**: *False*. "Characteristics" is too broad (could be physical, habitat, etc.), while the similarity is only mentioned in the reproduction method.
 - **Has the same eggs**: *False*. The text does not discuss the physical appearance of the eggs.
-- **Has the same way of laying eggs**: *Less Precise*. The phrase used in the text is "method of reproduction", not the technical "way of laying eggs" (the process). Option C is more precise according to the text.
+- **Has the same way of laying eggs**: *Less Precise*. The phrase used in the text is "method of reproduction", not the technical "way of laying eggs" (the process). The more precise conclusion is that snakes **have the same method of reproduction as poultry**.

--- a/packages/contents/exercises/high-school/snbt/general-reasoning/try-out/2026/set-7/18/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/snbt/general-reasoning/try-out/2026/set-7/18/_answer/id.mdx
@@ -22,4 +22,4 @@ Karena keduanya bermuara pada metode yang sama, maka simpulan yang valid adalah 
 - **Memiliki cara berkembang biak yang tidak sama**: *Salah*. Keduanya sama-sama bertelur.
 - **Memiliki ciri-ciri yang sama**: *Salah*. "Ciri-ciri" terlalu luas (bisa fisik, habitat, dll), sedangkan kesamaan hanya disebutkan pada cara berkembang biak.
 - **Memiliki telur yang sama**: *Salah*. Teks tidak membahas fisik telurnya.
-- **Memiliki cara bertelur yang sama**: *Kurang Tepat*. Frasa yang digunakan dalam teks adalah "cara berkembang biak", bukan teknis "cara bertelur" (proses keluarnya). Pilihan C lebih presisi sesuai teks.
+- **Memiliki cara bertelur yang sama**: *Kurang Tepat*. Frasa yang digunakan dalam teks adalah "cara berkembang biak", bukan teknis "cara bertelur" (proses keluarnya). Simpulan yang lebih presisi adalah ular **memiliki cara berkembang biak yang sama dengan unggas**.

--- a/packages/contents/exercises/high-school/snbt/indonesian-language/try-out/2026/set-1/11/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/snbt/indonesian-language/try-out/2026/set-1/11/_answer/en.mdx
@@ -10,4 +10,4 @@ This sentence contains two main invitations:
 1.  "Tinggalkan apa pun yang sedang Anda lakukan" (Leave whatever you are doing): This implies an invitation to pause briefly from activities, routines, or work that is consuming attention.
 2.  "Saksikanlah" (Watch it - in the context of sunset): This implies an invitation to enjoy that moment of natural beauty (twilight/sunset).
 
-When these two meanings are combined, the sentence implies an invitation from the author for the reader to **enjoy the beauty of the sunset** (*menikmati keindahan senja*) and **leave work for a moment** (*meninggalkan sejenak pekerjaan*) to rest. Option A is the most complete in covering both aspects of this meaning.
+When these two meanings are combined, the sentence implies an invitation from the author for the reader to **enjoy the beauty of the sunset** (*menikmati keindahan senja*) and **leave work for a moment** (*meninggalkan sejenak pekerjaan*) to rest. This meaning most completely covers both aspects of the invitation in the sentence.

--- a/packages/contents/exercises/high-school/snbt/indonesian-language/try-out/2026/set-1/11/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/snbt/indonesian-language/try-out/2026/set-1/11/_answer/id.mdx
@@ -10,4 +10,4 @@ Kalimat ini mengandung dua ajakan utama:
 1.  "Tinggalkan apa pun yang sedang Anda lakukan": Ini menyiratkan ajakan untuk berhenti sejenak dari aktivitas, rutinitas, atau pekerjaan yang sedang menyita perhatian.
 2.  "Saksikanlah" (dalam konteks saat matahari terbenam): Ini menyiratkan ajakan untuk menikmati momen keindahan alam tersebut (senja).
 
-Jika kedua makna ini digabungkan, kalimat tersebut menyiratkan ajakan dari penulis agar pembaca **menikmati keindahan senja** dan **meninggalkan sejenak pekerjaan** untuk beristirahat. Pilihan A adalah yang paling lengkap mencakup kedua aspek makna ini.
+Jika kedua makna ini digabungkan, kalimat tersebut menyiratkan ajakan dari penulis agar pembaca **menikmati keindahan senja** dan **meninggalkan sejenak pekerjaan** untuk beristirahat. Makna ini paling lengkap mencakup kedua aspek ajakan pada kalimat tersebut.

--- a/packages/contents/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-4/5/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-4/5/_answer/en.mdx
@@ -4,85 +4,48 @@ export const metadata = {
   date: "11/26/2025",
 };
 
-Let's analyze each statement one by one based on the given graph.
-
-**<InlineMath math="1" />. Checking the Y-Axis Intercept (Statement <InlineMath math="1" />)**
-
-From the image, the intersection point with the <InlineMath math="y" />-axis appears to be at <InlineMath math="(0, -1)" /> and another point at the top.
-
-Let's find the equation first. The vertex of the parabola is at <InlineMath math="(4, 1)" />.
+Start by determining the equation of the parabola from the graph. The vertex is at <InlineMath math="(4, 1)" />.
 
 The general form of a horizontal parabola equation with vertex <InlineMath math="(x_p, y_p)" /> is <InlineMath math="x = a(y - y_p)^2 + x_p" />.
 
 Substitute <InlineMath math="x_p = 4" /> and <InlineMath math="y_p = 1" />:
 
-<MathContainer>
-  <BlockMath math="x = a(y - 1)^2 + 4" />
-</MathContainer>
+<BlockMath math="x = a(y - 1)^2 + 4" />
 
 The curve passes through the point <InlineMath math="(0, -1)" />. We substitute this point to find the value of <InlineMath math="a" />.
 
-<MathContainer>
-  <BlockMath math="0 = a(-1 - 1)^2 + 4" />
-  <BlockMath math="0 = a(-2)^2 + 4" />
-  <BlockMath math="0 = 4a + 4" />
-  <BlockMath math="4a = -4" />
-  <BlockMath math="a = -1" />
-</MathContainer>
+<BlockMath math="\begin{aligned}
+0 &= a(-1 - 1)^2 + 4 \\
+0 &= 4a + 4 \\
+a &= -1
+\end{aligned}" />
 
 So, the equation of the curve is <InlineMath math="x = -(y - 1)^2 + 4" />.
 
-Now we find the intersection points with the <InlineMath math="y" />-axis (when <InlineMath math="x = 0" />):
+This means statement <InlineMath math="(2)" /> is **true**, because it gives the same equation in function notation, <InlineMath math="f(y) = -(y - 1)^2 + 4" />.
 
-<MathContainer>
-  <BlockMath math="0 = -(y - 1)^2 + 4" />
-  <BlockMath math="(y - 1)^2 = 4" />
-  <BlockMath math="y - 1 = \pm 2" />
-</MathContainer>
+For the <InlineMath math="y" />-axis intersections, set <InlineMath math="x = 0" />.
 
-Solution <InlineMath math="1" />: <InlineMath math="y - 1 = 2 \Rightarrow y = 3" />. The intersection point is <InlineMath math="(0, 3)" />.
+<BlockMath math="\begin{aligned}
+0 &= -(y - 1)^2 + 4 \\
+(y - 1)^2 &= 4 \\
+y - 1 &= \pm 2
+\end{aligned}" />
 
-Solution <InlineMath math="2" />: <InlineMath math="y - 1 = -2 \Rightarrow y = -1" />. The intersection point is <InlineMath math="(0, -1)" />.
+From <InlineMath math="y - 1 = \pm 2" />, we get <InlineMath math="y = 3" /> or <InlineMath math="y = -1" />. The intersection points are <InlineMath math="(0, 3)" /> and <InlineMath math="(0, -1)" />.
 
-Statement <InlineMath math="(1)" /> states <InlineMath math="(0, 2)" />, which is **FALSE**.
+So statement <InlineMath math="(1)" /> is **false**, because the graph intersects the <InlineMath math="y" />-axis at <InlineMath math="(0, 3)" /> and <InlineMath math="(0, -1)" />, not at <InlineMath math="(0, 2)" />.
 
-**<InlineMath math="2" />. Checking the Curve Equation (Statement <InlineMath math="2" />)**
+Next, the <InlineMath math="x" />-axis intersection occurs when <InlineMath math="y = 0" />.
 
-From the calculation above, we have obtained the equation of the curve is:
+<BlockMath math="\begin{aligned}
+x &= -(0 - 1)^2 + 4 \\
+x &= -1 + 4 \\
+x &= 3
+\end{aligned}" />
 
-<MathContainer>
-  <BlockMath math="x = -(y - 1)^2 + 4" />
-</MathContainer>
+The intersection point with the <InlineMath math="x" />-axis is <InlineMath math="(3, 0)" />, so statement <InlineMath math="(3)" /> is **false** because it states <InlineMath math="(1, 0)" />.
 
-In function notation <InlineMath math="f(y)" />, this is written as <InlineMath math="f(y) = -(y - 1)^2 + 4" />.
+Finally, the vertex is <InlineMath math="(4, 1)" />, so its abscissa, or <InlineMath math="x" /> value, is <InlineMath math="4" />. Therefore statement <InlineMath math="(4)" /> is **true**.
 
-Statement <InlineMath math="(2)" /> is **TRUE**.
-
-**<InlineMath math="3" />. Checking the X-Axis Intercept (Statement <InlineMath math="3" />)**
-
-The intersection point with the <InlineMath math="x" />-axis occurs when <InlineMath math="y = 0" />.
-
-<MathContainer>
-  <BlockMath math="x = -(0 - 1)^2 + 4" />
-  <BlockMath math="x = -(-1)^2 + 4" />
-  <BlockMath math="x = -1 + 4" />
-  <BlockMath math="x = 3" />
-</MathContainer>
-
-So, the intersection point with the <InlineMath math="x" />-axis is <InlineMath math="(3, 0)" />.
-
-Statement <InlineMath math="(3)" /> states <InlineMath math="(1, 0)" />, which is **FALSE**.
-
-**<InlineMath math="4" />. Checking the Vertex (Statement <InlineMath math="4" />)**
-
-From the graph, it is clearly visible that the vertex is <InlineMath math="(4, 1)" />.
-
-The abscissa (<InlineMath math="x" /> value) of the vertex is <InlineMath math="4" />.
-
-Statement <InlineMath math="(4)" /> is **TRUE**.
-
-**Conclusion:**
-
-The correct statements are (<InlineMath math="2" />) and (<InlineMath math="4" />).
-
-Thus, the answer is **C**.
+Therefore, the correct statements are <InlineMath math="(2)" /> and <InlineMath math="(4)" />.

--- a/packages/contents/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-4/5/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-4/5/_answer/id.mdx
@@ -4,85 +4,48 @@ export const metadata = {
   date: "11/26/2025",
 };
 
-Mari kita analisis setiap pernyataan satu per satu berdasarkan grafik yang diberikan.
-
-**<InlineMath math="1" />. Pengecekan Titik Potong Sumbu Y (Pernyataan <InlineMath math="1" />)**
-
-Dari gambar, titik potong dengan sumbu <InlineMath math="y" /> terlihat berada di <InlineMath math="(0, -1)" /> dan satu titik lagi di bagian atas.
-
-Mari kita cari persamaannya terlebih dahulu. Titik puncak parabola tersebut berada di <InlineMath math="(4, 1)" />.
+Kita mulai dari persamaan parabolanya. Dari grafik, titik puncak parabola berada di <InlineMath math="(4, 1)" />.
 
 Bentuk umum persamaan parabola horizontal dengan puncak <InlineMath math="(x_p, y_p)" /> adalah <InlineMath math="x = a(y - y_p)^2 + x_p" />.
 
 Substitusikan <InlineMath math="x_p = 4" /> dan <InlineMath math="y_p = 1" />:
 
-<MathContainer>
-  <BlockMath math="x = a(y - 1)^2 + 4" />
-</MathContainer>
+<BlockMath math="x = a(y - 1)^2 + 4" />
 
 Kurva melalui titik <InlineMath math="(0, -1)" />. Kita substitusikan titik ini untuk mencari nilai <InlineMath math="a" />.
 
-<MathContainer>
-  <BlockMath math="0 = a(-1 - 1)^2 + 4" />
-  <BlockMath math="0 = a(-2)^2 + 4" />
-  <BlockMath math="0 = 4a + 4" />
-  <BlockMath math="4a = -4" />
-  <BlockMath math="a = -1" />
-</MathContainer>
+<BlockMath math="\begin{aligned}
+0 &= a(-1 - 1)^2 + 4 \\
+0 &= 4a + 4 \\
+a &= -1
+\end{aligned}" />
 
 Jadi, persamaan kurvanya adalah <InlineMath math="x = -(y - 1)^2 + 4" />.
 
-Sekarang kita cari titik potong dengan sumbu <InlineMath math="y" /> (saat <InlineMath math="x = 0" />):
+Artinya, pernyataan <InlineMath math="(2)" /> **benar**, karena persamaan yang diberikan sama, yaitu <InlineMath math="f(y) = -(y - 1)^2 + 4" />.
 
-<MathContainer>
-  <BlockMath math="0 = -(y - 1)^2 + 4" />
-  <BlockMath math="(y - 1)^2 = 4" />
-  <BlockMath math="y - 1 = \pm 2" />
-</MathContainer>
+Untuk titik potong dengan sumbu <InlineMath math="y" />, gunakan <InlineMath math="x = 0" />.
 
-Solusi <InlineMath math="1" />: <InlineMath math="y - 1 = 2 \Rightarrow y = 3" />. Titik potongnya <InlineMath math="(0, 3)" />.
+<BlockMath math="\begin{aligned}
+0 &= -(y - 1)^2 + 4 \\
+(y - 1)^2 &= 4 \\
+y - 1 &= \pm 2
+\end{aligned}" />
 
-Solusi <InlineMath math="2" />: <InlineMath math="y - 1 = -2 \Rightarrow y = -1" />. Titik potongnya <InlineMath math="(0, -1)" />.
+Dari <InlineMath math="y - 1 = \pm 2" />, diperoleh <InlineMath math="y = 3" /> atau <InlineMath math="y = -1" />. Titik potongnya adalah <InlineMath math="(0, 3)" /> dan <InlineMath math="(0, -1)" />.
 
-Pernyataan <InlineMath math="(1)" /> menyebutkan <InlineMath math="(0, 2)" />, yang mana **SALAH**.
+Jadi, pernyataan <InlineMath math="(1)" /> **salah**, karena titik potong dengan sumbu <InlineMath math="y" /> adalah <InlineMath math="(0, 3)" /> dan <InlineMath math="(0, -1)" />, bukan <InlineMath math="(0, 2)" />.
 
-**<InlineMath math="2" />. Pengecekan Persamaan Kurva (Pernyataan <InlineMath math="2" />)**
+Berikutnya, titik potong dengan sumbu <InlineMath math="x" /> terjadi saat <InlineMath math="y = 0" />.
 
-Dari perhitungan di atas, kita sudah mendapatkan persamaan kurvanya adalah:
+<BlockMath math="\begin{aligned}
+x &= -(0 - 1)^2 + 4 \\
+x &= -1 + 4 \\
+x &= 3
+\end{aligned}" />
 
-<MathContainer>
-  <BlockMath math="x = -(y - 1)^2 + 4" />
-</MathContainer>
+Titik potong dengan sumbu <InlineMath math="x" /> adalah <InlineMath math="(3, 0)" />, sehingga pernyataan <InlineMath math="(3)" /> **salah** karena menyebutkan <InlineMath math="(1, 0)" />.
 
-Dalam notasi fungsi <InlineMath math="f(y)" />, ini ditulis sebagai <InlineMath math="f(y) = -(y - 1)^2 + 4" />.
+Terakhir, titik puncak grafik adalah <InlineMath math="(4, 1)" />. Absisnya, yaitu nilai <InlineMath math="x" /> dari titik puncak, adalah <InlineMath math="4" />. Maka, pernyataan <InlineMath math="(4)" /> **benar**.
 
-Pernyataan <InlineMath math="(2)" /> **BENAR**.
-
-**<InlineMath math="3" />. Pengecekan Titik Potong Sumbu X (Pernyataan <InlineMath math="3" />)**
-
-Titik potong dengan sumbu <InlineMath math="x" /> terjadi saat <InlineMath math="y = 0" />.
-
-<MathContainer>
-  <BlockMath math="x = -(0 - 1)^2 + 4" />
-  <BlockMath math="x = -(-1)^2 + 4" />
-  <BlockMath math="x = -1 + 4" />
-  <BlockMath math="x = 3" />
-</MathContainer>
-
-Jadi, titik potong dengan sumbu <InlineMath math="x" /> adalah <InlineMath math="(3, 0)" />.
-
-Pernyataan <InlineMath math="(3)" /> menyebutkan <InlineMath math="(1, 0)" />, yang mana **SALAH**.
-
-**<InlineMath math="4" />. Pengecekan Titik Puncak (Pernyataan <InlineMath math="4" />)**
-
-Dari grafik, terlihat jelas titik puncaknya adalah <InlineMath math="(4, 1)" />.
-
-Absis (nilai <InlineMath math="x" />) dari titik puncak adalah <InlineMath math="4" />.
-
-Pernyataan <InlineMath math="(4)" /> **BENAR**.
-
-**Kesimpulan:**
-
-Pernyataan yang benar adalah (<InlineMath math="2" />) dan (<InlineMath math="4" />).
-
-Maka, jawabannya adalah **C**.
+Jadi, pernyataan yang benar adalah <InlineMath math="(2)" /> dan <InlineMath math="(4)" />.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/21/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/21/_answer/en.mdx
@@ -34,5 +34,4 @@ Therefore, to prove that the tangent line at <InlineMath math="A" /> is perpendi
 
 This is the vector representation to prove that the tangent line of the circle at point <InlineMath math="A" /> is perpendicular to the radius <InlineMath math="OA" />
 
-The most appropriate answer is C.
-
+So, the appropriate vector representation is to show that the dot product of the position vector of point <InlineMath math="A" /> and the direction vector of the tangent line at point <InlineMath math="A" /> is zero.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/21/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/21/_answer/id.mdx
@@ -34,5 +34,4 @@ Jadi, untuk membuktikan bahwa garis singgung di <InlineMath math="A" /> tegak lu
 
 Ini adalah representasi vektor untuk membuktikan bahwa garis singgung lingkaran di titik <InlineMath math="A" /> tegak lurus terhadap radius <InlineMath math="OA" />
 
-Pilihan jawaban yang paling tepat adalah C.
-
+Jadi, representasi vektor yang tepat adalah menunjukkan bahwa hasil kali titik vektor posisi titik <InlineMath math="A" /> dan vektor arah garis singgung di titik <InlineMath math="A" /> bernilai nol.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/24/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/24/_answer/en.mdx
@@ -50,5 +50,4 @@ In the notation of the standard normal distribution CDF, <InlineMath math="P(Z \
 
 Therefore, <InlineMath math="P(-1 \leq Z \leq 1) = P(Z \leq 1) - P(Z < -1)" />
 
-The most appropriate answer is A.
-
+Therefore, the probability that a newborn baby's weight is between <InlineMath math="2{,}750 \text{ grams}" /> and <InlineMath math="3{,}650 \text{ grams}" /> is represented by <InlineMath math="P(Z < 1) - P(Z < -1)" />.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/24/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/24/_answer/id.mdx
@@ -50,5 +50,4 @@ Dalam notasi fungsi distribusi kumulatif standar (CDF) distribusi normal, <Inlin
 
 Jadi, <InlineMath math="P(-1 \leq Z \leq 1) = P(Z \leq 1) - P(Z < -1)" />
 
-Pilihan jawaban yang paling tepat adalah A.
-
+Jadi, peluang bayi memiliki berat antara <InlineMath math="2.750 \text{ gram}" /> dan <InlineMath math="3.650 \text{ gram}" /> dinyatakan sebagai <InlineMath math="P(Z < 1) - P(Z < -1)" />.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/_answer/en.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/_answer/en.mdx
@@ -53,6 +53,4 @@ Convert to general form
 
 <BlockMath math="x - y + 8 = 0 \quad \text{or} \quad x - y = 0" />
 
-The most appropriate answer is C: <InlineMath math="x - y + 8 = 0" />
-
-
+Of these two equations, the one available in the choices is <InlineMath math="x - y + 8 = 0" />.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/_answer/id.mdx
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/_answer/id.mdx
@@ -53,6 +53,4 @@ Ubah ke bentuk umum
 
 <BlockMath math="x - y + 8 = 0 \quad \text{atau} \quad x - y = 0" />
 
-Pilihan jawaban yang paling tepat adalah C: <InlineMath math="x - y + 8 = 0" />
-
-
+Dari dua persamaan ini, yang tersedia pada pilihan adalah <InlineMath math="x - y + 8 = 0" />.

--- a/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/choices.ts
+++ b/packages/contents/exercises/high-school/tka/mathematics/try-out/2026/set-1/25/choices.ts
@@ -3,7 +3,7 @@ import type { ExercisesChoices } from "@repo/contents/_types/exercises/choices";
 const choices: ExercisesChoices = {
   id: [
     {
-      label: "$$x - y = 0$$",
+      label: "$$x - y + 4 = 0$$",
       value: false,
     },
     {
@@ -25,7 +25,7 @@ const choices: ExercisesChoices = {
   ],
   en: [
     {
-      label: "$$x - y = 0$$",
+      label: "$$x - y + 4 = 0$$",
       value: false,
     },
     {

--- a/packages/contents/subject/high-school/10/mathematics/statistics/percentile-data-group/en.mdx
+++ b/packages/contents/subject/high-school/10/mathematics/statistics/percentile-data-group/en.mdx
@@ -80,7 +80,7 @@ We want to find the value of the <InlineMath math="85" />th Percentile (<InlineM
 
 2.  **Determine the Class of <InlineMath math="P_{85}" />:**
 
-Look at the <InlineMath math="F_k" /> column. Where is the <InlineMath math="34" />th data point? The <InlineMath math="81\text{-}90" /> class has <InlineMath math="F_k = 30" /> (not enough). The <InlineMath math="91\text{-}100" /> class has <InlineMath math="F_k = 40" /> (data points <InlineMath math="31" /> through <InlineMath math="40" /> are here). So, the <InlineMath math="P_{85}" /> class is <InlineMath math="91\text{-}100" />.
+    Look at the <InlineMath math="F_k" /> column. Where is the <InlineMath math="34" />th data point? The <InlineMath math="81\text{-}90" /> class has <InlineMath math="F_k = 30" /> (not enough). The <InlineMath math="91\text{-}100" /> class has <InlineMath math="F_k = 40" /> (data points <InlineMath math="31" /> through <InlineMath math="40" /> are here). So, the <InlineMath math="P_{85}" /> class is <InlineMath math="91\text{-}100" />.
 
 3.  **Gather Ingredients for the Formula:**
 
@@ -116,7 +116,7 @@ Try calculating the value of the <InlineMath math="20" />th Percentile (<InlineM
 
 2.  **Class of <InlineMath math="P_{20}" />:**
 
-Look at <InlineMath math="F_k" />. The <InlineMath math="8" />th data point is in the <InlineMath math="71\text{-}80" /> class (because the previous class's <InlineMath math="F_k" /> is <InlineMath math="4" />, and this class's <InlineMath math="F_k" /> is <InlineMath math="14" />).
+    Look at <InlineMath math="F_k" />. The <InlineMath math="8" />th data point is in the <InlineMath math="71\text{-}80" /> class (because the previous class's <InlineMath math="F_k" /> is <InlineMath math="4" />, and this class's <InlineMath math="F_k" /> is <InlineMath math="14" />).
 
 3.  **Formula Ingredients:**
 

--- a/packages/contents/subject/high-school/10/mathematics/statistics/percentile-data-group/id.mdx
+++ b/packages/contents/subject/high-school/10/mathematics/statistics/percentile-data-group/id.mdx
@@ -84,7 +84,7 @@ Kita mau cari nilai Persentil ke-<InlineMath math="85" /> (<InlineMath math="P_{
 
 2.  **Tentukan Kelas <InlineMath math="P_{85}" />:**
 
-Lihat kolom <InlineMath math="F_k" />. Data ke-<InlineMath math="34" /> ada di mana? Kelas <InlineMath math="81\text{-}90" /> memiliki <InlineMath math="F_k = 30" /> (belum cukup). Kelas <InlineMath math="91\text{-}100" /> memiliki <InlineMath math="F_k = 40" /> (data ke-<InlineMath math="31" /> sampai ke-<InlineMath math="40" /> ada di sini). Jadi, kelas <InlineMath math="P_{85}" /> adalah <InlineMath math="91\text{-}100" />.
+    Lihat kolom <InlineMath math="F_k" />. Data ke-<InlineMath math="34" /> ada di mana? Kelas <InlineMath math="81\text{-}90" /> memiliki <InlineMath math="F_k = 30" /> (belum cukup). Kelas <InlineMath math="91\text{-}100" /> memiliki <InlineMath math="F_k = 40" /> (data ke-<InlineMath math="31" /> sampai ke-<InlineMath math="40" /> ada di sini). Jadi, kelas <InlineMath math="P_{85}" /> adalah <InlineMath math="91\text{-}100" />.
 
 3.  **Kumpulkan Bahan untuk Rumus:**
 
@@ -120,7 +120,7 @@ Coba kamu hitung nilai Persentil ke-<InlineMath math="20" /> (<InlineMath math="
 
 2.  **Kelas <InlineMath math="P_{20}" />:**
 
-Lihat <InlineMath math="F_k" />. Data ke-<InlineMath math="8" /> ada di kelas <InlineMath math="71\text{-}80" /> (karena <InlineMath math="F_k" /> kelas sebelumnya <InlineMath math="4" />, dan <InlineMath math="F_k" /> kelas ini <InlineMath math="14" />).
+    Lihat <InlineMath math="F_k" />. Data ke-<InlineMath math="8" /> ada di kelas <InlineMath math="71\text{-}80" /> (karena <InlineMath math="F_k" /> kelas sebelumnya <InlineMath math="4" />, dan <InlineMath math="F_k" /> kelas ini <InlineMath math="14" />).
 
 3.  **Bahan Rumus:**
 

--- a/packages/contents/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle/en.mdx
+++ b/packages/contents/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle/en.mdx
@@ -323,7 +323,7 @@ Let's prove the relationship between central angle and inscribed angle by constr
 
 1. **Inscribed Angle Subtending a Diameter**
 
-Every inscribed angle that subtends a diameter of a circle measures <InlineMath math="90^\circ" /> (right angle).
+   Every inscribed angle that subtends a diameter of a circle measures <InlineMath math="90^\circ" /> (right angle).
 
    <LineEquation
      title="Inscribed Angle Subtending a Diameter"

--- a/packages/contents/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle/id.mdx
+++ b/packages/contents/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle/id.mdx
@@ -323,7 +323,7 @@ Mari kita buktikan hubungan antara sudut pusat dan sudut keliling dengan membuat
 
 1. **Sudut Keliling yang Menghadap Diameter**
 
-Setiap sudut keliling yang menghadap diameter lingkaran besarnya <InlineMath math="90^\circ" /> (sudut siku-siku).
+   Setiap sudut keliling yang menghadap diameter lingkaran besarnya <InlineMath math="90^\circ" /> (sudut siku-siku).
 
    <LineEquation
      title="Sudut Keliling Menghadap Diameter"

--- a/packages/contents/subject/high-school/12/mathematics/circle-arc-sector/central-angle-on-sector/en.mdx
+++ b/packages/contents/subject/high-school/12/mathematics/circle-arc-sector/central-angle-on-sector/en.mdx
@@ -353,17 +353,17 @@ This theorem forms the basis for all calculations involving relationships betwee
 
 Determining the central angle measure can be done through various known information about the sector:
 
-**<InlineMath math="1" />. From sector area and radius:**
+1. **From sector area and radius:**
 
-<BlockMath math="\alpha = \frac{360^\circ \times L}{\pi r^2}" />
+   <BlockMath math="\alpha = \frac{360^\circ \times L}{\pi r^2}" />
 
-**<InlineMath math="2" />. From arc length and radius:**
+2. **From arc length and radius:**
 
-<BlockMath math="\alpha = \frac{180^\circ \times s}{\pi r}" />
+   <BlockMath math="\alpha = \frac{180^\circ \times s}{\pi r}" />
 
-**<InlineMath math="3" />. From equal circle division:**
+3. **From equal circle division:**
 
-<BlockMath math="\alpha = \frac{360^\circ}{n}" />
+   <BlockMath math="\alpha = \frac{360^\circ}{n}" />
 
 where:
 - <InlineMath math="\alpha" /> = central angle (in degrees)

--- a/packages/contents/subject/high-school/12/mathematics/circle-arc-sector/central-angle-on-sector/id.mdx
+++ b/packages/contents/subject/high-school/12/mathematics/circle-arc-sector/central-angle-on-sector/id.mdx
@@ -353,17 +353,17 @@ Teorema ini menjadi dasar dalam semua perhitungan yang melibatkan hubungan antar
 
 Menentukan besar sudut pusat dapat dilakukan melalui berbagai informasi yang diketahui tentang juring:
 
-**<InlineMath math="1" />. Dari luas juring dan jari-jari:**
+1. **Dari luas juring dan jari-jari:**
 
-<BlockMath math="\alpha = \frac{360^\circ \times L}{\pi r^2}" />
+   <BlockMath math="\alpha = \frac{360^\circ \times L}{\pi r^2}" />
 
-**<InlineMath math="2" />. Dari panjang busur dan jari-jari:**
+2. **Dari panjang busur dan jari-jari:**
 
-<BlockMath math="\alpha = \frac{180^\circ \times s}{\pi r}" />
+   <BlockMath math="\alpha = \frac{180^\circ \times s}{\pi r}" />
 
-**<InlineMath math="3" />. Dari pembagian lingkaran sama rata:**
+3. **Dari pembagian lingkaran sama rata:**
 
-<BlockMath math="\alpha = \frac{360^\circ}{n}" />
+   <BlockMath math="\alpha = \frac{360^\circ}{n}" />
 
 dimana:
 - <InlineMath math="\alpha" /> = sudut pusat (dalam derajat)


### PR DESCRIPTION
## Summary
- Fix MDX list-continuation indentation in contents lessons so nested prose/components stay in the intended list context.
- Convert inline-math pseudo-list answer explanations into clearer prose or real list structure where confirmed.
- Replace confirmed answer-option letter references with content-based final answers after checking each question and choices context.
- Correct one TKA math distractor so the choices file has only one mathematically valid true option.

## Verification
- `pnpm format`
- `pnpm --filter @repo/contents typecheck`
- `pnpm --filter @repo/contents exec vitest run --coverage.enabled=false`
- `pnpm lint`
- `git diff --check`
- `rg` scans for exact option-letter answer references returned no matches

## Notes
- Left option-by-option analysis labels and real content labels such as `Class C/D`, statements `A/B`, and variables `A/B/C` unchanged.