### PR TITLE
Fix try-out content read model

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/body.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/body.tsx
@@ -123,10 +123,6 @@ export async function TryoutPartBody({
 
   const exercises = await getTryoutExercises(locale, contentPart.setSlug);
 
-  if (exercises.length === 0) {
-    notFound();
-  }
-
   const material = parseExercisesMaterial(contentPart.material);
   const partIcon = Option.isSome(material)
     ? getMaterialIcon(material.value)

--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/data.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/data.ts
@@ -4,7 +4,15 @@ import { fetchQuery } from "convex/nextjs";
 import { cacheLife } from "next/cache";
 import type { Locale } from "next-intl";
 
-/** Loads the public tryout details for one part route inside a cacheable scope. */
+/**
+ * Loads the public tryout details for one part route from the Convex read model.
+ *
+ * Convex content sync can publish this read model after a web deployment, so the
+ * cache stays short-lived instead of letting a temporary miss become a
+ * persistent prerendered 404.
+ *
+ * Docs: https://nextjs.org/docs/app/api-reference/functions/cacheLife#preset-cache-profiles
+ */
 export async function getTryoutPartData(
   locale: Locale,
   product: TryoutProduct,
@@ -13,7 +21,7 @@ export async function getTryoutPartData(
 ) {
   "use cache";
 
-  cacheLife("max");
+  cacheLife("seconds");
 
   const details = await fetchQuery(
     api.tryouts.queries.tryouts.getTryoutDetails,
@@ -41,11 +49,19 @@ export async function getTryoutPartData(
   };
 }
 
-/** Loads one synced tryout exercise set from the Convex content read model. */
+/**
+ * Loads one synced tryout exercise set from the Convex content read model.
+ *
+ * The rendered choices must stay close to the live Convex answer sheet used by
+ * the client runtime because answer submission maps visible choices to option
+ * keys by order.
+ *
+ * Docs: https://docs.convex.dev/client/react#fetching-data
+ */
 export async function getTryoutExercises(locale: Locale, setSlug: string) {
   "use cache";
 
-  cacheLife("max");
+  cacheLife("seconds");
 
   const exercises = await fetchQuery(
     api.exercises.queries.getRenderableRowsBySlug,

--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/data.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[product]/[slug]/part/[partKey]/data.ts
@@ -1,20 +1,10 @@
 import { api } from "@repo/backend/convex/_generated/api";
 import type { TryoutProduct } from "@repo/backend/convex/tryouts/products";
-import { getRenderableExercisesContent } from "@repo/contents/_lib/exercises/renderable";
 import { fetchQuery } from "convex/nextjs";
-import { Effect } from "effect";
 import { cacheLife } from "next/cache";
 import type { Locale } from "next-intl";
 
-/**
- * Loads the public tryout details for one part route from the Convex read model.
- *
- * Convex content sync can publish this read model after a web deployment, so the
- * cache must stay short-lived instead of allowing a temporary miss to become a
- * persistent prerendered 404.
- *
- * Docs: https://nextjs.org/docs/app/api-reference/functions/cacheLife#prerendering-behavior
- */
+/** Loads the public tryout details for one part route inside a cacheable scope. */
 export async function getTryoutPartData(
   locale: Locale,
   product: TryoutProduct,
@@ -23,7 +13,7 @@ export async function getTryoutPartData(
 ) {
   "use cache";
 
-  cacheLife("seconds");
+  cacheLife("max");
 
   const details = await fetchQuery(
     api.tryouts.queries.tryouts.getTryoutDetails,
@@ -51,13 +41,23 @@ export async function getTryoutPartData(
   };
 }
 
-/** Loads one tryout exercise set as serializable exercise rows. */
+/** Loads one synced tryout exercise set from the Convex content read model. */
 export async function getTryoutExercises(locale: Locale, setSlug: string) {
   "use cache";
 
   cacheLife("max");
 
-  return await Effect.runPromise(
-    getRenderableExercisesContent(locale, setSlug)
+  const exercises = await fetchQuery(
+    api.exercises.queries.getRenderableRowsBySlug,
+    {
+      locale,
+      slug: setSlug,
+    }
   );
+
+  if (!exercises) {
+    throw new Error(`Synced exercise set is missing for tryout: ${setSlug}`);
+  }
+
+  return exercises;
 }

--- a/apps/www/components/exercise/entry.tsx
+++ b/apps/www/components/exercise/entry.tsx
@@ -6,6 +6,8 @@ import { QuestionAnalytics } from "@/components/exercise/item/analytics";
 import { ExerciseArticle } from "@/components/exercise/item/article";
 import { importContentModuleOrNull } from "@/lib/content/module";
 
+type ExerciseEntryData = Pick<ExerciseWithoutDefaults, "choices" | "number">;
+
 /** Loads the compiled question module for one exercise entry. */
 async function QuestionContent({
   exerciseNumber,
@@ -62,7 +64,7 @@ function ExerciseEntryBody({
   setPath,
   srLabel,
 }: {
-  exercise: ExerciseWithoutDefaults;
+  exercise: ExerciseEntryData;
   id: string;
   locale: Locale;
   setPath: string;
@@ -101,7 +103,7 @@ export function ExerciseEntry({
   setPath,
   srLabel,
 }: {
-  exercise: ExerciseWithoutDefaults;
+  exercise: ExerciseEntryData;
   locale: Locale;
   setPath: string;
   srLabel: string;
@@ -126,7 +128,7 @@ export function ExerciseTrackedEntry({
   setPath,
   srLabel,
 }: {
-  exercise: ExerciseWithoutDefaults;
+  exercise: ExerciseEntryData;
   locale: Locale;
   setPath: string;
   srLabel: string;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -170,6 +170,8 @@ import type * as exercises_answerScoring_spec from "../exercises/answerScoring/s
 import type * as exercises_helpers from "../exercises/helpers.js";
 import type * as exercises_mutations from "../exercises/mutations.js";
 import type * as exercises_queries from "../exercises/queries.js";
+import type * as exercises_renderable_impl from "../exercises/renderable/impl.js";
+import type * as exercises_renderable_spec from "../exercises/renderable/spec.js";
 import type * as exercises_utils from "../exercises/utils.js";
 import type * as functions from "../functions.js";
 import type * as http from "../http.js";
@@ -508,6 +510,8 @@ declare const fullApi: ApiFromModules<{
   "exercises/helpers": typeof exercises_helpers;
   "exercises/mutations": typeof exercises_mutations;
   "exercises/queries": typeof exercises_queries;
+  "exercises/renderable/impl": typeof exercises_renderable_impl;
+  "exercises/renderable/spec": typeof exercises_renderable_spec;
   "exercises/utils": typeof exercises_utils;
   functions: typeof functions;
   http: typeof http;

--- a/packages/backend/convex/exercises/queries.test.ts
+++ b/packages/backend/convex/exercises/queries.test.ts
@@ -1,0 +1,201 @@
+import { api } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { CONTENT_SYNC_BATCH_LIMITS } from "@repo/backend/convex/contentSync/constants";
+import { exerciseSetIntegrityErrorCode } from "@repo/backend/convex/exercises/renderable/spec";
+import { SUPPORTED_CONTENT_LOCALES } from "@repo/backend/convex/lib/validators/contents";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+const NOW = Date.parse("2026-01-01T00:00:00.000Z");
+const exerciseSetSlug =
+  "exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-1";
+const testLocale = SUPPORTED_CONTENT_LOCALES[1];
+
+/**
+ * Inserts one synced exercise set for query tests.
+ */
+async function insertExerciseSet(ctx: MutationCtx, questionCount: number) {
+  return await ctx.db.insert("exerciseSets", {
+    category: "high-school",
+    exerciseType: "try-out",
+    locale: testLocale,
+    material: "quantitative-knowledge",
+    questionCount,
+    setName: "set-1",
+    slug: exerciseSetSlug,
+    syncedAt: NOW,
+    title: "Set 1",
+    type: "snbt",
+  });
+}
+
+/**
+ * Inserts one synced exercise question under a set.
+ */
+async function insertExerciseQuestion(
+  ctx: MutationCtx,
+  setId: Awaited<ReturnType<typeof insertExerciseSet>>,
+  number: number
+) {
+  return await ctx.db.insert("exerciseQuestions", {
+    answerBody: `Answer ${number}`,
+    category: "high-school",
+    contentHash: `hash-${number}`,
+    date: NOW,
+    exerciseType: "try-out",
+    locale: testLocale,
+    material: "quantitative-knowledge",
+    number,
+    questionBody: `Question ${number}`,
+    setId,
+    setName: "set-1",
+    slug: `${exerciseSetSlug}/${number}`,
+    syncedAt: NOW,
+    title: `Question ${number}`,
+    type: "snbt",
+  });
+}
+
+/**
+ * Inserts one synced choice row under a question.
+ */
+async function insertExerciseChoice(
+  ctx: MutationCtx,
+  questionId: Awaited<ReturnType<typeof insertExerciseQuestion>>,
+  order: number
+) {
+  await ctx.db.insert("exerciseChoices", {
+    isCorrect: order === 0,
+    label: `Choice ${order + 1}`,
+    locale: testLocale,
+    optionKey: String.fromCharCode(65 + order),
+    order,
+    questionId,
+  });
+}
+
+/**
+ * Loads renderable rows for the shared fixture set.
+ */
+function queryRenderableRows(t: ReturnType<typeof convexTest>) {
+  return t.query(api.exercises.queries.getRenderableRowsBySlug, {
+    locale: testLocale,
+    slug: exerciseSetSlug,
+  });
+}
+
+/**
+ * Asserts one structured synced-content integrity failure.
+ */
+async function expectIntegrityError(
+  promise: ReturnType<typeof queryRenderableRows>,
+  message: string
+) {
+  await expect(promise).rejects.toMatchObject({
+    data: {
+      code: exerciseSetIntegrityErrorCode,
+      message,
+    },
+  });
+}
+
+describe("exercises/queries", () => {
+  it("loads renderable exercise rows from indexed synced content rows", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.mutation(async (ctx) => {
+      const setId = await insertExerciseSet(ctx, 2);
+      const firstQuestionId = await insertExerciseQuestion(ctx, setId, 1);
+      const secondQuestionId = await insertExerciseQuestion(ctx, setId, 2);
+
+      await insertExerciseChoice(ctx, firstQuestionId, 1);
+      await insertExerciseChoice(ctx, firstQuestionId, 0);
+      await insertExerciseChoice(ctx, secondQuestionId, 0);
+    });
+
+    const result = await queryRenderableRows(t);
+
+    expect(result).toEqual([
+      {
+        choices: {
+          id: [
+            { label: "Choice 1", value: true },
+            { label: "Choice 2", value: false },
+          ],
+          en: [],
+        },
+        number: 1,
+      },
+      {
+        choices: {
+          id: [{ label: "Choice 1", value: true }],
+          en: [],
+        },
+        number: 2,
+      },
+    ]);
+  });
+
+  it("returns null when the synced exercise set does not exist", async () => {
+    const t = convexTest(schema, convexModules);
+
+    const result = await queryRenderableRows(t);
+
+    expect(result).toBeNull();
+  });
+
+  it("fails when question rows do not match the declared count", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.mutation(async (ctx) => {
+      await insertExerciseSet(ctx, 2);
+    });
+
+    await expectIntegrityError(
+      queryRenderableRows(t),
+      "Exercise set question count does not match synced question rows."
+    );
+  });
+
+  it("fails when question numbers are not contiguous", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.mutation(async (ctx) => {
+      const setId = await insertExerciseSet(ctx, 2);
+      const firstQuestionId = await insertExerciseQuestion(ctx, setId, 1);
+      const thirdQuestionId = await insertExerciseQuestion(ctx, setId, 3);
+
+      await insertExerciseChoice(ctx, firstQuestionId, 0);
+      await insertExerciseChoice(ctx, thirdQuestionId, 0);
+    });
+
+    await expectIntegrityError(
+      queryRenderableRows(t),
+      "Exercise set questions must use contiguous 1-based numbers."
+    );
+  });
+
+  it("fails when a question has more choices than content sync allows", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.mutation(async (ctx) => {
+      const setId = await insertExerciseSet(ctx, 1);
+      const questionId = await insertExerciseQuestion(ctx, setId, 1);
+
+      for (
+        let order = 0;
+        order <= CONTENT_SYNC_BATCH_LIMITS.exerciseChoices;
+        order++
+      ) {
+        await insertExerciseChoice(ctx, questionId, order);
+      }
+    });
+
+    await expectIntegrityError(
+      queryRenderableRows(t),
+      "Exercise question has more synced choices than the content-sync choice limit."
+    );
+  });
+});

--- a/packages/backend/convex/exercises/queries.ts
+++ b/packages/backend/convex/exercises/queries.ts
@@ -1,6 +1,14 @@
 import { query } from "@repo/backend/convex/_generated/server";
+import {
+  getQuestionAnswerSheetBySlugImpl,
+  getRenderableRowsBySlugImpl,
+} from "@repo/backend/convex/exercises/renderable/impl";
+import {
+  questionAnswerSheetReturnValidator,
+  renderableRowsBySlugArgsValidator,
+  renderableRowsBySlugReturnValidator,
+} from "@repo/backend/convex/exercises/renderable/spec";
 import { requireAuth } from "@repo/backend/convex/lib/helpers/auth";
-import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
 import { vv } from "@repo/backend/convex/lib/validators/vv";
 import { v } from "convex/values";
 import { getManyFrom } from "convex-helpers/server/relationships";
@@ -10,19 +18,6 @@ const attemptWithAnswersValidator = v.object({
   attempt: vv.doc("exerciseAttempts"),
   answers: v.array(vv.doc("exerciseAnswers")),
 });
-
-const questionAnswerSheetValidator = v.array(
-  v.object({
-    exerciseNumber: v.number(),
-    questionId: vv.id("exerciseQuestions"),
-    options: v.array(
-      v.object({
-        optionKey: v.string(),
-        order: v.number(),
-      })
-    ),
-  })
-);
 
 /**
  * Get the latest attempt for a specific exercise/set.
@@ -75,56 +70,23 @@ export const getLatestAttemptBySlug = query({
  * server-authoritative answer scoring without trusting client correctness flags.
  */
 export const getQuestionAnswerSheetBySlug = query({
-  args: {
-    locale: localeValidator,
-    slug: v.string(),
-  },
-  returns: questionAnswerSheetValidator,
+  args: renderableRowsBySlugArgsValidator,
+  returns: questionAnswerSheetReturnValidator,
   handler: async (ctx, args) => {
     await requireAuth(ctx);
 
-    const set = await ctx.db
-      .query("exerciseSets")
-      .withIndex("by_locale_and_slug", (q) =>
-        q.eq("locale", args.locale).eq("slug", args.slug)
-      )
-      .first();
-
-    if (!set) {
-      return [];
-    }
-
-    const questions = await getManyFrom(
-      ctx.db,
-      "exerciseQuestions",
-      "by_setId",
-      set._id
-    );
-    const orderedQuestions = [...questions].sort((a, b) => a.number - b.number);
-
-    const answerSheet = await Promise.all(
-      orderedQuestions.map(async (question) => {
-        const choices = await getManyFrom(
-          ctx.db,
-          "exerciseChoices",
-          "by_questionId_and_locale",
-          question._id,
-          "questionId"
-        );
-
-        return {
-          exerciseNumber: question.number,
-          questionId: question._id,
-          options: choices
-            .map((choice) => ({
-              optionKey: choice.optionKey,
-              order: choice.order,
-            }))
-            .sort((a, b) => a.order - b.order),
-        };
-      })
-    );
-
-    return answerSheet;
+    return await getQuestionAnswerSheetBySlugImpl(ctx, args);
   },
+});
+
+/**
+ * Load renderable exercise rows from the synced Convex content read model.
+ *
+ * This query owns runtime try-out set membership. The page still imports exact
+ * compiled MDX modules by number for the visible question and answer bodies.
+ */
+export const getRenderableRowsBySlug = query({
+  args: renderableRowsBySlugArgsValidator,
+  returns: renderableRowsBySlugReturnValidator,
+  handler: getRenderableRowsBySlugImpl,
 });

--- a/packages/backend/convex/exercises/renderable/impl.ts
+++ b/packages/backend/convex/exercises/renderable/impl.ts
@@ -1,0 +1,192 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { CONTENT_SYNC_BATCH_LIMITS } from "@repo/backend/convex/contentSync/constants";
+import { exerciseSetIntegrityErrorCode } from "@repo/backend/convex/exercises/renderable/spec";
+import type { Locale } from "@repo/backend/convex/lib/validators/contents";
+import { ConvexError } from "convex/values";
+
+/**
+ * Throws a structured Convex integrity error for synced exercise data.
+ */
+function throwExerciseSetIntegrityError(message: string) {
+  throw new ConvexError({
+    code: exerciseSetIntegrityErrorCode,
+    message,
+  });
+}
+
+/**
+ * Loads one synced exercise set by its public content slug.
+ */
+async function getExerciseSet(
+  ctx: QueryCtx,
+  args: {
+    locale: Locale;
+    slug: string;
+  }
+) {
+  return await ctx.db
+    .query("exerciseSets")
+    .withIndex("by_locale_and_slug", (q) =>
+      q.eq("locale", args.locale).eq("slug", args.slug)
+    )
+    .first();
+}
+
+/**
+ * Loads, sorts, and validates the bounded question rows for a synced set.
+ */
+async function getOrderedQuestions(ctx: QueryCtx, set: Doc<"exerciseSets">) {
+  const questions = await ctx.db
+    .query("exerciseQuestions")
+    .withIndex("by_setId", (q) => q.eq("setId", set._id))
+    .take(set.questionCount + 1);
+
+  if (questions.length > set.questionCount) {
+    throwExerciseSetIntegrityError(
+      "Exercise set has more synced questions than its declared question count."
+    );
+  }
+
+  if (questions.length !== set.questionCount) {
+    throwExerciseSetIntegrityError(
+      "Exercise set question count does not match synced question rows."
+    );
+  }
+
+  const orderedQuestions = [...questions].sort((a, b) => a.number - b.number);
+  const hasContiguousNumbers = orderedQuestions.every(
+    (question, index) => question.number === index + 1
+  );
+
+  if (!hasContiguousNumbers) {
+    throwExerciseSetIntegrityError(
+      "Exercise set questions must use contiguous 1-based numbers."
+    );
+  }
+
+  return orderedQuestions;
+}
+
+/**
+ * Loads, sorts, and validates bounded choice rows for one synced question.
+ */
+async function getOrderedChoices(
+  ctx: QueryCtx,
+  question: Doc<"exerciseQuestions">,
+  locale: Locale
+) {
+  const choices = await ctx.db
+    .query("exerciseChoices")
+    .withIndex("by_questionId_and_locale", (q) =>
+      q.eq("questionId", question._id).eq("locale", locale)
+    )
+    .take(CONTENT_SYNC_BATCH_LIMITS.exerciseChoices + 1);
+
+  if (choices.length > CONTENT_SYNC_BATCH_LIMITS.exerciseChoices) {
+    throwExerciseSetIntegrityError(
+      "Exercise question has more synced choices than the content-sync choice limit."
+    );
+  }
+
+  if (choices.length === 0) {
+    throwExerciseSetIntegrityError(
+      "Exercise question is missing synced choices."
+    );
+  }
+
+  return [...choices].sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Builds the locale-keyed choices shape expected by the shared exercise UI.
+ */
+function buildRenderableChoices(
+  locale: Locale,
+  choices: Array<{ isCorrect: boolean; label: string }>
+) {
+  const renderableChoices = choices.map((choice) => ({
+    label: choice.label,
+    value: choice.isCorrect,
+  }));
+
+  if (locale === "id") {
+    return {
+      en: [],
+      id: renderableChoices,
+    };
+  }
+
+  return {
+    en: renderableChoices,
+    id: [],
+  };
+}
+
+/**
+ * Loads renderable exercise rows from the synced Convex content read model.
+ */
+export async function getRenderableRowsBySlugImpl(
+  ctx: QueryCtx,
+  args: {
+    locale: Locale;
+    slug: string;
+  }
+) {
+  const set = await getExerciseSet(ctx, args);
+
+  if (!set) {
+    return null;
+  }
+
+  const orderedQuestions = await getOrderedQuestions(ctx, set);
+
+  return await Promise.all(
+    orderedQuestions.map(async (question) => {
+      const orderedChoices = await getOrderedChoices(
+        ctx,
+        question,
+        args.locale
+      );
+
+      return {
+        choices: buildRenderableChoices(args.locale, orderedChoices),
+        number: question.number,
+      };
+    })
+  );
+}
+
+/**
+ * Loads canonical question IDs and option keys for server-side scoring.
+ */
+export async function getQuestionAnswerSheetBySlugImpl(
+  ctx: QueryCtx,
+  args: {
+    locale: Locale;
+    slug: string;
+  }
+) {
+  const set = await getExerciseSet(ctx, args);
+
+  if (!set) {
+    return [];
+  }
+
+  const orderedQuestions = await getOrderedQuestions(ctx, set);
+
+  return await Promise.all(
+    orderedQuestions.map(async (question) => {
+      const choices = await getOrderedChoices(ctx, question, args.locale);
+
+      return {
+        exerciseNumber: question.number,
+        options: choices.map((choice) => ({
+          optionKey: choice.optionKey,
+          order: choice.order,
+        })),
+        questionId: question._id,
+      };
+    })
+  );
+}

--- a/packages/backend/convex/exercises/renderable/spec.ts
+++ b/packages/backend/convex/exercises/renderable/spec.ts
@@ -1,0 +1,43 @@
+import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
+import { vv } from "@repo/backend/convex/lib/validators/vv";
+import { v } from "convex/values";
+import { nullable } from "convex-helpers/validators";
+
+const renderableExerciseChoiceValidator = v.object({
+  label: v.string(),
+  value: v.boolean(),
+});
+
+const renderableExerciseChoicesValidator = v.object({
+  id: v.array(renderableExerciseChoiceValidator),
+  en: v.array(renderableExerciseChoiceValidator),
+});
+
+export const renderableRowsBySlugArgsValidator = {
+  locale: localeValidator,
+  slug: v.string(),
+};
+
+export const renderableRowsBySlugReturnValidator = nullable(
+  v.array(
+    v.object({
+      choices: renderableExerciseChoicesValidator,
+      number: v.number(),
+    })
+  )
+);
+
+export const questionAnswerSheetReturnValidator = v.array(
+  v.object({
+    exerciseNumber: v.number(),
+    options: v.array(
+      v.object({
+        optionKey: v.string(),
+        order: v.number(),
+      })
+    ),
+    questionId: vv.id("exerciseQuestions"),
+  })
+);
+
+export const exerciseSetIntegrityErrorCode = "EXERCISE_SET_INTEGRITY_ERROR";


### PR DESCRIPTION
## Summary
- Move try-out part exercise membership to the durable Convex content-sync read model instead of runtime filesystem slug discovery.
- Keep `notFound()` only for actual missing try-out route data and turn synced-content gaps into structured integrity failures.
- Preserve exact MDX question/answer rendering by loading compiled MDX modules by Convex question number.
- Split Convex renderable query implementation into `exercises/renderable/spec.ts` and `impl.ts`, with `queries.ts` focused on registered functions.

## Root Cause
Production was serving the try-out part shell, but the old route could still short-circuit to `notFound()` when runtime filesystem slug discovery returned no exercise rows. Local worked because the raw content tree was available. The `.md`/`llms.mdx` path worked because it uses a separate route trace that includes raw exercise files.

## Verification
- `pnpm format`
- `pnpm --filter @repo/backend exec vitest run convex/exercises/queries.test.ts`
- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm start`, then checked `http://localhost:3000/id/try-out/snbt/2026-set-1/part/quantitative-knowledge`
- React Doctor diff scan: `pnpm dlx react-doctor@latest --diff 65fca8d84e --blocking warning --no-score --no-telemetry --yes`

## Deployment Notes
Convex production has already been deployed with the new query. The Vercel frontend production deployment still needs this PR merged or otherwise deployed before `https://nakafa.com/id/try-out/snbt/2026-set-1/part/quantitative-knowledge` can be verified fixed in production.
