### PR TITLE
Classify React Doctor baseline diagnostics

### DIFF
--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+  "ignore": {
+    "overrides": [
+      {
+        "files": [
+          "components/ai/context/use-current-chat.tsx",
+          "components/school/classes/forum/panel.tsx",
+          "components/school/classes/people/invite.tsx",
+          "apps/www/components/ai/context/use-current-chat.tsx",
+          "apps/www/components/school/classes/forum/panel.tsx",
+          "apps/www/components/school/classes/people/invite.tsx"
+        ],
+        "rules": ["react-doctor/query-destructure-result"]
+      },
+      {
+        "files": [
+          "components/contents/**/*.tsx",
+          "components/three/**/*.tsx",
+          "components/ui/orb.tsx",
+          "packages/design-system/components/contents/**/*.tsx",
+          "packages/design-system/components/three/**/*.tsx",
+          "packages/design-system/components/ui/orb.tsx"
+        ],
+        "rules": ["react-doctor/no-unknown-property"]
+      },
+      {
+        "files": [
+          "components/ai/mermaid.tsx",
+          "packages/design-system/components/ai/mermaid.tsx"
+        ],
+        "rules": ["react-doctor/no-danger", "react-doctor/prefer-tag-over-role"]
+      },
+      {
+        "files": [
+          "components/ai/code-block.tsx",
+          "components/code-block/index.tsx",
+          "components/code-block/server.tsx",
+          "components/markdown/code.tsx",
+          "json-ld/index.tsx",
+          "packages/design-system/components/ai/code-block.tsx",
+          "packages/design-system/components/code-block/index.tsx",
+          "packages/design-system/components/code-block/server.tsx",
+          "packages/design-system/components/markdown/code.tsx",
+          "packages/seo/json-ld/index.tsx"
+        ],
+        "rules": ["react-doctor/no-danger"]
+      }
+    ]
+  },
+  "surfaces": {
+    "ciFailure": {
+      "excludeRules": ["deslop/unused-file", "socket/low-supply-chain-score"]
+    },
+    "prComment": {
+      "excludeRules": ["deslop/unused-file", "socket/low-supply-chain-score"]
+    },
+    "score": {
+      "excludeRules": ["deslop/unused-file", "socket/low-supply-chain-score"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a root `doctor.config.json` for the existing React Doctor baseline.
- Classify confirmed analyzer mismatches narrowly: Convex `useQuery` is not TanStack Query, and React Three Fiber JSX props are valid through `@react-three/fiber` JSX augmentation.
- Keep Mermaid source unchanged. The image data URL idea was rejected because it changes Mermaid SVG font/CSS inheritance semantics; inline SVG remains the intentional trusted rendering seam.
- Keep full CLI diagnostics visible while excluding noisy/accepted-risk surfaces from score/PR/CI where React Doctor cannot target more narrowly.

## Classification details
- `react-doctor/query-destructure-result`: exact Convex `useQuery` files only.
- `react-doctor/no-unknown-property`: R3F/Three content and `components/three` paths only.
- `react-doctor/no-danger`: exact trusted rendering seams for Shiki/code HTML, Mermaid strict-security SVG, and escaped JSON-LD.
- `deslop/unused-file`: excluded from PR/CI/score surfaces because this repo has many framework/package/content entrypoints that the dead-code graph cannot prove. It remains visible in full CLI diagnostics.
- `socket/low-supply-chain-score`: excluded from PR/CI/score surfaces at rule level because React Doctor surface controls support tags/categories/rules, not package-name selectors. Current findings were reviewed as accepted-risk dependencies: Next's `server-only` marker package and actively used `@icons-pack/react-simple-icons`. This remains visible in full CLI diagnostics, and future dependency review still needs to check the full CLI report.

## Verification
- `pnpm format`
- `pnpm lint`
- `git diff --check`
- `pnpm --filter email typecheck`
- `pnpm --filter email build`
- `pnpm dlx react-doctor@latest . --yes --json --json-compact --diff origin/preview --blocking none` -> 0 diagnostics
- Full scan before: 49/100 Critical, 2,750 diagnostics
- Full scan after: 87/100 Great, 1,391 diagnostics still visible locally
- No-dead-code scan after: 87/100 Great, 75 diagnostics still visible locally

## Scope
This PR intentionally does not modify app behavior or PR #173. Remaining full CLI diagnostics are baseline follow-up work, not claimed as fixed here.