### PR TITLE
fix: improve AFDocs markdown availability

### DIFF
--- a/apps/www/__tests__/proxy.test.ts
+++ b/apps/www/__tests__/proxy.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config, proxy } from "@/proxy";
@@ -12,9 +13,9 @@ const mockLocaleRouting = vi.hoisted(() => ({
       })
   ),
 }));
-const mockFetchRuntimeContentRoute = vi.hoisted(() => vi.fn());
-const mockFetchRuntimeContentRoutesByKindPage = vi.hoisted(() => vi.fn());
-const mockFetchRuntimeContentRoutesByParentPage = vi.hoisted(() => vi.fn());
+const mockGetRuntimeContentRoute = vi.hoisted(() => vi.fn());
+const mockGetRuntimeContentRouteKindPage = vi.hoisted(() => vi.fn());
+const mockGetRuntimeContentRouteParentPage = vi.hoisted(() => vi.fn());
 
 vi.mock("@repo/internationalization/src/routing", () => ({
   routing: {
@@ -28,28 +29,33 @@ vi.mock("next-intl/middleware", () => ({
 }));
 
 vi.mock("@/lib/content/runtime", () => ({
-  fetchRuntimeContentRoute: mockFetchRuntimeContentRoute,
-  fetchRuntimeContentRoutesByKindPage: mockFetchRuntimeContentRoutesByKindPage,
-  fetchRuntimeContentRoutesByParentPage:
-    mockFetchRuntimeContentRoutesByParentPage,
+  getRuntimeContentRoute: mockGetRuntimeContentRoute,
+  getRuntimeContentRouteKindPage: mockGetRuntimeContentRouteKindPage,
+  getRuntimeContentRouteParentPage: mockGetRuntimeContentRouteParentPage,
 }));
 
 describe("proxy", () => {
   beforeEach(() => {
-    mockFetchRuntimeContentRoute.mockReset();
-    mockFetchRuntimeContentRoutesByKindPage.mockReset();
-    mockFetchRuntimeContentRoutesByParentPage.mockReset();
-    mockFetchRuntimeContentRoute.mockResolvedValue({ route: "fixture" });
-    mockFetchRuntimeContentRoutesByKindPage.mockResolvedValue({
-      continueCursor: null,
-      isDone: true,
-      page: [{ route: "fixture" }],
-    });
-    mockFetchRuntimeContentRoutesByParentPage.mockResolvedValue({
-      continueCursor: null,
-      isDone: true,
-      page: [{ route: "fixture" }],
-    });
+    mockGetRuntimeContentRoute.mockReset();
+    mockGetRuntimeContentRouteKindPage.mockReset();
+    mockGetRuntimeContentRouteParentPage.mockReset();
+    mockGetRuntimeContentRoute.mockReturnValue(
+      Effect.succeed({ route: "fixture" })
+    );
+    mockGetRuntimeContentRouteKindPage.mockReturnValue(
+      Effect.succeed({
+        continueCursor: null,
+        isDone: true,
+        page: [{ route: "fixture" }],
+      })
+    );
+    mockGetRuntimeContentRouteParentPage.mockReturnValue(
+      Effect.succeed({
+        continueCursor: null,
+        isDone: true,
+        page: [{ route: "fixture" }],
+      })
+    );
     mockLocaleRouting.localeMiddleware.mockClear();
   });
 
@@ -147,7 +153,7 @@ describe("proxy", () => {
 
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(1);
     expect(response.headers.get("x-locale-proxy")).toBe("1");
-    expect(mockFetchRuntimeContentRoute).toHaveBeenCalledWith({
+    expect(mockGetRuntimeContentRoute).toHaveBeenCalledWith({
       locale: "en",
       route: "subject/high-school/10/chemistry/green-chemistry/definition",
     });
@@ -160,8 +166,8 @@ describe("proxy", () => {
 
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(1);
     expect(response.headers.get("x-locale-proxy")).toBe("1");
-    expect(mockFetchRuntimeContentRoute).not.toHaveBeenCalled();
-    expect(mockFetchRuntimeContentRoutesByParentPage).toHaveBeenCalledWith({
+    expect(mockGetRuntimeContentRoute).not.toHaveBeenCalled();
+    expect(mockGetRuntimeContentRouteParentPage).toHaveBeenCalledWith({
       cursor: null,
       kind: "subject-topic",
       limit: 1,
@@ -179,7 +185,7 @@ describe("proxy", () => {
 
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(1);
     expect(response.headers.get("x-locale-proxy")).toBe("1");
-    expect(mockFetchRuntimeContentRoutesByKindPage).toHaveBeenCalledWith({
+    expect(mockGetRuntimeContentRouteKindPage).toHaveBeenCalledWith({
       cursor: null,
       kind: "subject-topic",
       limit: 1,
@@ -206,7 +212,7 @@ describe("proxy", () => {
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(
       routes.length
     );
-    expect(mockFetchRuntimeContentRoutesByKindPage).toHaveBeenCalledWith({
+    expect(mockGetRuntimeContentRouteKindPage).toHaveBeenCalledWith({
       cursor: null,
       kind: "exercise-group",
       limit: 1,
@@ -214,7 +220,7 @@ describe("proxy", () => {
       prefix: "exercises/middle-school/grade-9/",
       section: "exercises",
     });
-    expect(mockFetchRuntimeContentRoutesByParentPage).toHaveBeenCalledWith({
+    expect(mockGetRuntimeContentRouteParentPage).toHaveBeenCalledWith({
       cursor: null,
       kind: "exercise-group",
       limit: 1,
@@ -235,7 +241,7 @@ describe("proxy", () => {
       )
     );
 
-    expect(mockFetchRuntimeContentRoute).not.toHaveBeenCalled();
+    expect(mockGetRuntimeContentRoute).not.toHaveBeenCalled();
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(1);
     expect(response.headers.get("x-locale-proxy")).toBe("1");
   });
@@ -245,7 +251,7 @@ describe("proxy", () => {
       new NextRequest("http://localhost:3000/en/unknown-content-root/example")
     );
 
-    expect(mockFetchRuntimeContentRoute).not.toHaveBeenCalled();
+    expect(mockGetRuntimeContentRoute).not.toHaveBeenCalled();
     expect(mockLocaleRouting.localeMiddleware).toHaveBeenCalledTimes(1);
     expect(response.headers.get("x-locale-proxy")).toBe("1");
   });
@@ -268,6 +274,47 @@ describe("proxy", () => {
     );
   });
 
+  it("rewrites source-backed legal routes when markdown is requested", async () => {
+    const response = await proxy(
+      new NextRequest("http://localhost:3000/en/terms-of-service", {
+        headers: {
+          accept: "text/markdown",
+        },
+      })
+    );
+
+    expect(mockLocaleRouting.localeMiddleware).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3000/llms.mdx/en/terms-of-service"
+    );
+  });
+
+  it("routes static markdown negotiation to the llms source resolver", async () => {
+    const response = await proxy(
+      new NextRequest("http://localhost:3000/en/search", {
+        headers: {
+          accept: "text/markdown",
+        },
+      })
+    );
+
+    expect(mockLocaleRouting.localeMiddleware).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3000/llms.mdx/en/search"
+    );
+  });
+
+  it("routes static .md URLs to the llms source resolver", async () => {
+    const response = await proxy(
+      new NextRequest("http://localhost:3000/en/contributor.md")
+    );
+
+    expect(mockLocaleRouting.localeMiddleware).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3000/llms.mdx/en/contributor"
+    );
+  });
+
   it("delegates subject chapter routes so app routes can redirect", async () => {
     const response = await proxy(
       new NextRequest(
@@ -280,7 +327,7 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing markdown public content routes", async () => {
-    mockFetchRuntimeContentRoute.mockResolvedValueOnce(null);
+    mockGetRuntimeContentRoute.mockReturnValueOnce(Effect.succeed(null));
 
     const response = await proxy(
       new NextRequest(
@@ -301,7 +348,7 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing html public content routes", async () => {
-    mockFetchRuntimeContentRoute.mockResolvedValueOnce(null);
+    mockGetRuntimeContentRoute.mockReturnValueOnce(Effect.succeed(null));
 
     const response = await proxy(
       new NextRequest(
@@ -318,7 +365,7 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing Quran content routes", async () => {
-    mockFetchRuntimeContentRoute.mockResolvedValueOnce(null);
+    mockGetRuntimeContentRoute.mockReturnValueOnce(Effect.succeed(null));
 
     const response = await proxy(
       new NextRequest("http://localhost:3000/id/quran/999")
@@ -332,7 +379,7 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing html content HEAD requests", async () => {
-    mockFetchRuntimeContentRoute.mockResolvedValueOnce(null);
+    mockGetRuntimeContentRoute.mockReturnValueOnce(Effect.succeed(null));
 
     const response = await proxy(
       new NextRequest(
@@ -351,11 +398,13 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing article listing routes", async () => {
-    mockFetchRuntimeContentRoutesByParentPage.mockResolvedValueOnce({
-      continueCursor: null,
-      isDone: true,
-      page: [],
-    });
+    mockGetRuntimeContentRouteParentPage.mockReturnValueOnce(
+      Effect.succeed({
+        continueCursor: null,
+        isDone: true,
+        page: [],
+      })
+    );
 
     const response = await proxy(
       new NextRequest(
@@ -371,11 +420,13 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing subject grade listing routes", async () => {
-    mockFetchRuntimeContentRoutesByKindPage.mockResolvedValueOnce({
-      continueCursor: null,
-      isDone: true,
-      page: [],
-    });
+    mockGetRuntimeContentRouteKindPage.mockReturnValueOnce(
+      Effect.succeed({
+        continueCursor: null,
+        isDone: true,
+        page: [],
+      })
+    );
 
     const response = await proxy(
       new NextRequest(
@@ -391,11 +442,13 @@ describe("proxy", () => {
   });
 
   it("returns a real 404 for missing subject material listing routes", async () => {
-    mockFetchRuntimeContentRoutesByParentPage.mockResolvedValueOnce({
-      continueCursor: null,
-      isDone: true,
-      page: [],
-    });
+    mockGetRuntimeContentRouteParentPage.mockReturnValueOnce(
+      Effect.succeed({
+        continueCursor: null,
+        isDone: true,
+        page: [],
+      })
+    );
 
     const response = await proxy(
       new NextRequest(
@@ -425,8 +478,8 @@ describe("proxy", () => {
   });
 
   it("fails open when the exact route lookup is temporarily unavailable", async () => {
-    mockFetchRuntimeContentRoute.mockRejectedValueOnce(
-      new Error("Convex unavailable")
+    mockGetRuntimeContentRoute.mockReturnValueOnce(
+      Effect.fail(new Error("Convex unavailable"))
     );
 
     const response = await proxy(
@@ -440,8 +493,8 @@ describe("proxy", () => {
   });
 
   it("fails open when a listing route probe is temporarily unavailable", async () => {
-    mockFetchRuntimeContentRoutesByParentPage.mockRejectedValueOnce(
-      new Error("Convex unavailable")
+    mockGetRuntimeContentRouteParentPage.mockReturnValueOnce(
+      Effect.fail(new Error("Convex unavailable"))
     );
 
     const response = await proxy(

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -152,7 +152,9 @@ export default async function Layout({ children }: LayoutProps<"/[locale]">) {
       <body className="relative">
         <p className="sr-only">
           AI agents can use <Link href="/llms.txt">/llms.txt</Link> as a
-          documentation index with markdown links for supported content pages.
+          documentation index. Follow listed markdown links; <code>.md</code>{" "}
+          URLs and <code>Accept: text/markdown</code> work only for supported
+          source-backed pages.
         </p>
         <EducationalOrgJsonLd />
         <WebsiteJsonLd locale={locale} />

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -152,9 +152,7 @@ export default async function Layout({ children }: LayoutProps<"/[locale]">) {
       <body className="relative">
         <p className="sr-only">
           AI agents can use <Link href="/llms.txt">/llms.txt</Link> as a
-          documentation index. Markdown versions are available by appending{" "}
-          <code>.md</code> to content URLs or sending{" "}
-          <code>Accept: text/markdown</code>.
+          documentation index with markdown links for supported content pages.
         </p>
         <EducationalOrgJsonLd />
         <WebsiteJsonLd locale={locale} />

--- a/apps/www/app/llms.mdx/[...slug]/route.test.ts
+++ b/apps/www/app/llms.mdx/[...slug]/route.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/llms.mdx/[...slug]/route";
+
+const mockGetLlmsMarkdownText = vi.hoisted(() => vi.fn());
+const mockGetCachedLlmsSectionIndexText = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/llms/content", () => ({
+  getLlmsMarkdownText: mockGetLlmsMarkdownText,
+}));
+
+vi.mock("@/lib/llms/indexes", () => ({
+  buildRootLlmsIndexText: () => "# Nakafa llms index\n",
+  getCachedLlmsSectionIndexText: mockGetCachedLlmsSectionIndexText,
+}));
+
+describe("llms.mdx route", () => {
+  beforeEach(() => {
+    mockGetCachedLlmsSectionIndexText.mockReset();
+    mockGetLlmsMarkdownText.mockReset();
+    mockGetCachedLlmsSectionIndexText.mockResolvedValue(null);
+    mockGetLlmsMarkdownText.mockReturnValue(Effect.succeed(null));
+  });
+
+  it("serves cached section index markdown before page markdown", async () => {
+    mockGetCachedLlmsSectionIndexText.mockResolvedValueOnce(
+      "# Subject index\n"
+    );
+
+    const response = await GET(
+      new NextRequest("https://nakafa.com/llms.mdx/en/subject/high-school/12"),
+      {
+        params: Promise.resolve({
+          slug: ["en", "subject", "high-school", "12"],
+        }),
+      }
+    );
+
+    await expect(response.text()).resolves.toBe("# Subject index\n");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8"
+    );
+    expect(mockGetLlmsMarkdownText).not.toHaveBeenCalled();
+  });
+
+  it("serves page markdown for source-backed localized routes", async () => {
+    mockGetLlmsMarkdownText.mockReturnValueOnce(
+      Effect.succeed("# Terms of Service\n")
+    );
+
+    const response = await GET(
+      new NextRequest("https://nakafa.com/llms.mdx/en/terms-of-service"),
+      {
+        params: Promise.resolve({
+          slug: ["en", "terms-of-service"],
+        }),
+      }
+    );
+
+    await expect(response.text()).resolves.toBe("# Terms of Service\n");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8"
+    );
+    expect(mockGetLlmsMarkdownText).toHaveBeenCalledWith({
+      cleanSlug: "terms-of-service",
+      locale: "en",
+    });
+  });
+
+  it("serves the root llms index without requiring a locale prefix", async () => {
+    const response = await GET(
+      new NextRequest("https://nakafa.com/llms.mdx/llms"),
+      {
+        params: Promise.resolve({
+          slug: ["llms"],
+        }),
+      }
+    );
+
+    await expect(response.text()).resolves.toBe("# Nakafa llms index\n");
+    expect(response.status).toBe(200);
+    expect(mockGetLlmsMarkdownText).toHaveBeenCalledWith({
+      cleanSlug: "llms",
+      locale: "en",
+    });
+  });
+
+  it("keeps missing llms index routes as plain 404s", async () => {
+    const response = await GET(
+      new NextRequest("https://nakafa.com/llms.mdx/en/llms/missing"),
+      {
+        params: Promise.resolve({
+          slug: ["en", "llms", "missing"],
+        }),
+      }
+    );
+
+    await expect(response.text()).resolves.toBe("Not found");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8"
+    );
+    expect(mockGetLlmsMarkdownText).not.toHaveBeenCalled();
+  });
+
+  it("returns a hard 404 markdown body when no page markdown source exists", async () => {
+    const response = await GET(
+      new NextRequest("https://nakafa.com/llms.mdx/en/search"),
+      {
+        params: Promise.resolve({
+          slug: ["en", "search"],
+        }),
+      }
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8"
+    );
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(body).toContain("# Markdown page not found");
+    expect(body).toContain("https://nakafa.com/en/search");
+    expect(body).toContain("https://nakafa.com/llms/en/site/llms.txt");
+  });
+});

--- a/apps/www/app/llms.mdx/[...slug]/route.ts
+++ b/apps/www/app/llms.mdx/[...slug]/route.ts
@@ -2,6 +2,10 @@ import { routing } from "@repo/internationalization/src/routing";
 import { Effect } from "effect";
 import type { NextRequest } from "next/server";
 import { hasLocale } from "next-intl";
+import {
+  AGENT_DISCOVERY_LINK_HEADER,
+  LLMS_TEXT_PATH,
+} from "@/lib/agent-discovery";
 import { LLMS_CACHE_CONTROL } from "@/lib/llms/constants";
 import { getLlmsMarkdownText } from "@/lib/llms/content";
 import { stripLlmsRouteExtension } from "@/lib/llms/format";
@@ -9,6 +13,7 @@ import {
   buildRootLlmsIndexText,
   getCachedLlmsSectionIndexText,
 } from "@/lib/llms/indexes";
+import { buildUnsupportedMarkdownRouteText } from "@/lib/llms/unsupported";
 
 const MARKDOWN_HEADERS = {
   "Cache-Control": LLMS_CACHE_CONTROL,
@@ -22,7 +27,20 @@ const TEXT_HEADERS = {
   Vary: "Accept",
 };
 
-/** Serves section indexes or page-level markdown for agent retrieval. */
+const MARKDOWN_NOT_FOUND_HEADERS = {
+  ...MARKDOWN_HEADERS,
+  Link: AGENT_DISCOVERY_LINK_HEADER,
+  "X-Llms-Txt": LLMS_TEXT_PATH,
+  "X-Robots-Tag": "noindex",
+};
+
+/**
+ * Serves source-backed markdown for agent retrieval.
+ *
+ * Section indexes are resolved first, page markdown sources second, and the
+ * root llms index last. Known localized routes without source return 404 with
+ * a markdown body so agents get navigation help without a soft 404.
+ */
 export async function GET(
   _req: NextRequest,
   ctx: RouteContext<"/llms.mdx/[...slug]">
@@ -63,8 +81,14 @@ export async function GET(
     });
   }
 
-  return new Response("Not found", {
-    headers: TEXT_HEADERS,
-    status: 404,
-  });
+  return new Response(
+    buildUnsupportedMarkdownRouteText({
+      locale,
+      route: `/${cleanSlug}`,
+    }),
+    {
+      headers: MARKDOWN_NOT_FOUND_HEADERS,
+      status: 404,
+    }
+  );
 }

--- a/apps/www/lib/llms/content.test.ts
+++ b/apps/www/lib/llms/content.test.ts
@@ -9,6 +9,7 @@ import {
 const mockGetCachedLlmsExerciseText = vi.hoisted(() => vi.fn());
 const mockGetCachedLlmsSectionIndexText = vi.hoisted(() => vi.fn());
 const mockGetCachedLlmsMdxText = vi.hoisted(() => vi.fn());
+const mockGetLlmsLegalPageText = vi.hoisted(() => vi.fn());
 const mockGetLlmsExerciseText = vi.hoisted(() => vi.fn());
 const mockGetLlmsSectionIndexText = vi.hoisted(() => vi.fn());
 const mockGetLlmsMdxText = vi.hoisted(() => vi.fn());
@@ -22,6 +23,10 @@ vi.mock("@/lib/llms/exercises", () => ({
 vi.mock("@/lib/llms/indexes", () => ({
   getCachedLlmsSectionIndexText: mockGetCachedLlmsSectionIndexText,
   getLlmsSectionIndexText: mockGetLlmsSectionIndexText,
+}));
+
+vi.mock("@/lib/llms/legal", () => ({
+  getLlmsLegalPageText: mockGetLlmsLegalPageText,
 }));
 
 vi.mock("@/lib/llms/mdx", () => ({
@@ -38,6 +43,7 @@ describe("llms markdown content resolver", () => {
     mockGetCachedLlmsExerciseText.mockReset();
     mockGetCachedLlmsSectionIndexText.mockReset();
     mockGetCachedLlmsMdxText.mockReset();
+    mockGetLlmsLegalPageText.mockReset();
     mockGetLlmsExerciseText.mockReset();
     mockGetLlmsSectionIndexText.mockReset();
     mockGetLlmsMdxText.mockReset();
@@ -46,6 +52,7 @@ describe("llms markdown content resolver", () => {
     mockGetCachedLlmsExerciseText.mockResolvedValue(null);
     mockGetCachedLlmsSectionIndexText.mockResolvedValue(null);
     mockGetCachedLlmsMdxText.mockResolvedValue(null);
+    mockGetLlmsLegalPageText.mockReturnValue(Effect.succeed(null));
     mockGetLlmsExerciseText.mockReturnValue(Effect.succeed(null));
     mockGetLlmsSectionIndexText.mockReturnValue(Effect.succeed(null));
     mockGetLlmsMdxText.mockReturnValue(Effect.succeed(null));
@@ -95,6 +102,21 @@ describe("llms markdown content resolver", () => {
         })
       )
     ).resolves.toBe("MDX markdown");
+
+    expect(mockGetCachedLlmsSectionIndexText).not.toHaveBeenCalled();
+  });
+
+  it("returns legal source markdown before route index fallbacks", async () => {
+    mockGetLlmsLegalPageText.mockReturnValue(Effect.succeed("Legal markdown"));
+
+    await expect(
+      Effect.runPromise(
+        getLlmsMarkdownText({
+          cleanSlug: "terms-of-service",
+          locale: "en",
+        })
+      )
+    ).resolves.toBe("Legal markdown");
 
     expect(mockGetCachedLlmsSectionIndexText).not.toHaveBeenCalled();
   });
@@ -224,6 +246,23 @@ describe("llms markdown content resolver", () => {
         })
       )
     ).resolves.toBe("Source MDX markdown");
+
+    expect(mockGetLlmsSectionIndexText).not.toHaveBeenCalled();
+  });
+
+  it("returns source legal markdown before source index fallbacks", async () => {
+    mockGetLlmsLegalPageText.mockReturnValue(
+      Effect.succeed("Source legal markdown")
+    );
+
+    await expect(
+      Effect.runPromise(
+        getLlmsSourceMarkdownText({
+          cleanSlug: "terms-of-service",
+          locale: "en",
+        })
+      )
+    ).resolves.toBe("Source legal markdown");
 
     expect(mockGetLlmsSectionIndexText).not.toHaveBeenCalled();
   });

--- a/apps/www/lib/llms/content.ts
+++ b/apps/www/lib/llms/content.ts
@@ -8,10 +8,17 @@ import {
   getCachedLlmsSectionIndexText,
   getLlmsSectionIndexText,
 } from "@/lib/llms/indexes";
+import { getLlmsLegalPageText } from "@/lib/llms/legal";
 import { getCachedLlmsMdxText, getLlmsMdxText } from "@/lib/llms/mdx";
 import { getQuranLlmsText } from "@/lib/llms/quran";
 
-/** Resolves markdown for one public content route or its sitemap-derived index. */
+/**
+ * Resolves cached markdown for one agent-facing route.
+ *
+ * The source chain is ordered from concrete page sources to derived indexes:
+ * Quran, exercises, MDX content, legal MDX, then sitemap-derived section or
+ * listing indexes. A null result means the route has no markdown source.
+ */
 export const getLlmsMarkdownText = Effect.fn("www.llms.markdown.cached")(
   function* ({ cleanSlug, locale }: { cleanSlug: string; locale: Locale }) {
     const quranText = yield* getQuranLlmsText({ cleanSlug, locale });
@@ -35,6 +42,11 @@ export const getLlmsMarkdownText = Effect.fn("www.llms.markdown.cached")(
       return mdxText;
     }
 
+    const legalText = yield* getLlmsLegalPageText({ cleanSlug, locale });
+    if (legalText) {
+      return legalText;
+    }
+
     return yield* Effect.tryPromise({
       try: () =>
         getCachedLlmsSectionIndexText({
@@ -45,7 +57,13 @@ export const getLlmsMarkdownText = Effect.fn("www.llms.markdown.cached")(
   }
 );
 
-/** Resolves uncached markdown for build-time public artifacts. */
+/**
+ * Resolves uncached markdown for build-time public artifacts.
+ *
+ * This mirrors the request-time source chain without using Next cache helpers,
+ * so generated llms artifacts and route handlers agree on which routes have
+ * source-backed markdown and which routes should remain unsupported.
+ */
 export const getLlmsSourceMarkdownText = Effect.fn("www.llms.markdown.source")(
   function* ({ cleanSlug, locale }: { cleanSlug: string; locale: Locale }) {
     const quranText = yield* getQuranLlmsText({ cleanSlug, locale });
@@ -61,6 +79,11 @@ export const getLlmsSourceMarkdownText = Effect.fn("www.llms.markdown.source")(
     const mdxText = yield* getLlmsMdxText({ cleanSlug, locale });
     if (mdxText) {
       return mdxText;
+    }
+
+    const legalText = yield* getLlmsLegalPageText({ cleanSlug, locale });
+    if (legalText) {
+      return legalText;
     }
 
     return yield* getLlmsSectionIndexText(`llms/${locale}/${cleanSlug}`);

--- a/apps/www/lib/llms/entries.test.ts
+++ b/apps/www/lib/llms/entries.test.ts
@@ -4,6 +4,7 @@ import type { FunctionReturnType } from "convex/server";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getContentListingLlmsEntries,
   getContentPageLlmsEntries,
   getLlmsSections,
   getRouteSection,
@@ -19,6 +20,8 @@ type RuntimeContentRouteItem =
 
 const mockGetRuntimeContentRoute = vi.hoisted(() => vi.fn());
 const mockGetRuntimeContentRouteArtifactPage = vi.hoisted(() => vi.fn());
+const mockGetRuntimeContentRouteKindPage = vi.hoisted(() => vi.fn());
+const mockGetRuntimeContentRouteParentPage = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/llms/quran", () => ({
   getQuranRouteMetadata: () =>
@@ -32,11 +35,15 @@ vi.mock("@/lib/llms/quran", () => ({
 vi.mock("@/lib/content/runtime", () => ({
   getRuntimeContentRoute: mockGetRuntimeContentRoute,
   getRuntimeContentRouteArtifactPage: mockGetRuntimeContentRouteArtifactPage,
+  getRuntimeContentRouteKindPage: mockGetRuntimeContentRouteKindPage,
+  getRuntimeContentRouteParentPage: mockGetRuntimeContentRouteParentPage,
 }));
 
 beforeEach(() => {
   mockGetRuntimeContentRoute.mockReset();
   mockGetRuntimeContentRouteArtifactPage.mockReset();
+  mockGetRuntimeContentRouteKindPage.mockReset();
+  mockGetRuntimeContentRouteParentPage.mockReset();
   mockGetRuntimeContentRouteArtifactPage.mockImplementation(
     ({ locale, page, section }) =>
       Effect.succeed({
@@ -47,6 +54,20 @@ beforeEach(() => {
         section,
         syncedAt: 1,
       })
+  );
+  mockGetRuntimeContentRouteKindPage.mockImplementation(({ prefix }) =>
+    Effect.succeed({
+      continueCursor: null,
+      isDone: true,
+      page: routeRows.filter((row) => row.route.startsWith(prefix)),
+    })
+  );
+  mockGetRuntimeContentRouteParentPage.mockImplementation(({ parentRoute }) =>
+    Effect.succeed({
+      continueCursor: null,
+      isDone: true,
+      page: routeRows.filter((row) => row.route.startsWith(`${parentRoute}/`)),
+    })
   );
   mockGetRuntimeContentRoute.mockImplementation(({ route }) => {
     if (route === "articles/politics/dynastic-politics-asian-values") {
@@ -273,6 +294,137 @@ describe("llms entries", () => {
       page: 0,
       section: "articles",
     });
+  });
+
+  it("builds listing entries from parent-scoped route rows", async () => {
+    const entries = await Effect.runPromise(
+      getContentListingLlmsEntries({
+        locale: "en",
+        route: "articles/politics",
+      })
+    );
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values.md",
+          route: "/articles/politics/dynastic-politics-asian-values",
+        }),
+      ])
+    );
+    expect(mockGetRuntimeContentRouteParentPage).toHaveBeenCalledWith({
+      cursor: null,
+      kind: "article",
+      limit: 100,
+      locale: "en",
+      order: "date-desc",
+      parentRoute: "articles/politics",
+      section: "articles",
+    });
+  });
+
+  it("builds listing entries from kind-scoped route rows", async () => {
+    const entries = await Effect.runPromise(
+      getContentListingLlmsEntries({
+        locale: "en",
+        route: "subject/high-school/10",
+      })
+    );
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "https://nakafa.com/en/subject/high-school/10/chemistry/green-chemistry/definition.md",
+          route: "/subject/high-school/10/chemistry/green-chemistry/definition",
+        }),
+      ])
+    );
+    expect(mockGetRuntimeContentRouteKindPage).toHaveBeenCalledWith({
+      cursor: null,
+      kind: "subject-topic",
+      limit: 100,
+      locale: "en",
+      prefix: "subject/high-school/10",
+      section: "subject",
+    });
+  });
+
+  it("uses bounded catalog rows for exercise and material listings", async () => {
+    const cases = [
+      {
+        expectedHref:
+          "https://nakafa.com/en/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-1.md",
+        route: "exercises/high-school/snbt",
+      },
+      {
+        expectedHref:
+          "https://nakafa.com/en/exercises/high-school/snbt/quantitative-knowledge/try-out/2026/set-1.md",
+        route: "exercises/high-school/snbt/quantitative-knowledge",
+      },
+      {
+        expectedHref:
+          "https://nakafa.com/en/subject/high-school/10/chemistry/green-chemistry/definition.md",
+        route: "subject/high-school/10/chemistry",
+      },
+    ];
+
+    for (const { expectedHref, route } of cases) {
+      const entries = await Effect.runPromise(
+        getContentListingLlmsEntries({
+          locale: "en",
+          route,
+        })
+      );
+
+      expect(entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            href: expectedHref,
+          }),
+        ])
+      );
+    }
+
+    expect(mockGetRuntimeContentRouteKindPage).toHaveBeenCalledWith({
+      cursor: null,
+      kind: "exercise-group",
+      limit: 100,
+      locale: "en",
+      prefix: "exercises/high-school/snbt/",
+      section: "exercises",
+    });
+    expect(mockGetRuntimeContentRouteParentPage).toHaveBeenCalledWith({
+      cursor: null,
+      kind: "exercise-group",
+      limit: 100,
+      locale: "en",
+      order: "route",
+      parentRoute: "exercises/high-school/snbt/quantitative-knowledge",
+      section: "exercises",
+    });
+    expect(mockGetRuntimeContentRouteParentPage).toHaveBeenCalledWith({
+      cursor: null,
+      kind: "subject-topic",
+      limit: 100,
+      locale: "en",
+      order: "route",
+      parentRoute: "subject/high-school/10/chemistry",
+      section: "subject",
+    });
+  });
+
+  it("returns null for routes without listing markdown support", async () => {
+    await expect(
+      Effect.runPromise(
+        getContentListingLlmsEntries({
+          locale: "en",
+          route: "articles",
+        })
+      )
+    ).resolves.toBeNull();
+
+    expect(mockGetRuntimeContentRouteKindPage).not.toHaveBeenCalled();
+    expect(mockGetRuntimeContentRouteParentPage).not.toHaveBeenCalled();
   });
 
   it("returns no entries when a materialized route page is missing", async () => {

--- a/apps/www/lib/llms/entries.ts
+++ b/apps/www/lib/llms/entries.ts
@@ -1,8 +1,14 @@
+import {
+  getPublicContentRouteCheck,
+  type PublicContentRouteCheck,
+} from "@repo/contents/_lib/manifest/public-route";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import {
   getRuntimeContentRoute,
   getRuntimeContentRouteArtifactPage,
+  getRuntimeContentRouteKindPage,
+  getRuntimeContentRouteParentPage,
 } from "@/lib/content/runtime";
 import {
   BASE_URL,
@@ -17,6 +23,23 @@ import {
 } from "@/lib/sitemap/routes";
 
 const LLMS_ENTRY_BUILD_CONCURRENCY = 16;
+const LLMS_LISTING_ENTRY_LIMIT = 100;
+
+interface ParentListingRowsArgs {
+  kind: "article" | "exercise-group" | "subject-topic";
+  locale: Locale;
+  order: "date-desc" | "route";
+  parentRoute: string;
+  section: "articles" | "exercises" | "subject";
+}
+
+interface KindListingRowsArgs {
+  kind: "exercise-group" | "subject-topic";
+  locale: Locale;
+  prefix: string;
+  section: "exercises" | "subject";
+}
+
 /** Classifies a sitemap route into the llms section that owns it. */
 export function getRouteSection(route: string): LlmsSection {
   const firstSegment = route.split("/").filter(Boolean)[0];
@@ -79,6 +102,28 @@ export const getContentPageLlmsEntries = Effect.fn(
   return yield* buildLocalizedLlmsEntriesFromRoutes({ locale, routes });
 });
 
+/**
+ * Builds entries for one public content listing route from route-catalog rows.
+ *
+ * Unsupported route shapes return null instead of fabricated entries. Supported
+ * shapes read one bounded catalog page and reuse the same entry formatter as
+ * normal llms indexes, so listing pages advertise only source-backed routes.
+ */
+export const getContentListingLlmsEntries = Effect.fn(
+  "www.llms.contentListingEntries"
+)(function* ({ locale, route }: { locale: Locale; route: string }) {
+  const cleanRoute = route.replace(/^\/+|\/+$/g, "");
+  const routeCheck = getPublicContentRouteCheck(cleanRoute);
+  const rows = yield* readContentListingRows({ locale, routeCheck });
+
+  if (rows === null) {
+    return null;
+  }
+
+  const routes = rows.map((row) => `/${row.route}`);
+  return yield* buildLocalizedLlmsEntriesFromRoutes({ locale, routes });
+});
+
 /** Builds locale-specific llms entries from already scoped route strings. */
 function buildLocalizedLlmsEntriesFromRoutes({
   locale,
@@ -94,6 +139,99 @@ function buildLocalizedLlmsEntriesFromRoutes({
       concurrency: LLMS_ENTRY_BUILD_CONCURRENCY,
     }
   );
+}
+
+/**
+ * Reads one bounded route-catalog page for supported listing route shapes.
+ *
+ * The interface returns null when the route is not a listing. Every supported
+ * branch delegates to an indexed kind or parent page read with a fixed limit.
+ */
+function readContentListingRows({
+  locale,
+  routeCheck,
+}: {
+  locale: Locale;
+  routeCheck: PublicContentRouteCheck;
+}) {
+  if (routeCheck.mode === "article-category") {
+    return readParentListingRows({
+      kind: "article",
+      locale,
+      order: "date-desc",
+      parentRoute: routeCheck.parentRoute,
+      section: "articles",
+    });
+  }
+
+  if (routeCheck.mode === "exercise-type") {
+    return readKindListingRows({
+      kind: "exercise-group",
+      locale,
+      prefix: routeCheck.prefix,
+      section: "exercises",
+    });
+  }
+
+  if (routeCheck.mode === "exercise-material") {
+    return readParentListingRows({
+      kind: "exercise-group",
+      locale,
+      order: "route",
+      parentRoute: routeCheck.parentRoute,
+      section: "exercises",
+    });
+  }
+
+  if (routeCheck.mode === "subject-grade") {
+    return readKindListingRows({
+      kind: "subject-topic",
+      locale,
+      prefix: routeCheck.prefix,
+      section: "subject",
+    });
+  }
+
+  if (routeCheck.mode === "subject-material") {
+    return readParentListingRows({
+      kind: "subject-topic",
+      locale,
+      order: "route",
+      parentRoute: routeCheck.parentRoute,
+      section: "subject",
+    });
+  }
+
+  return Effect.succeed(null);
+}
+
+/**
+ * Reads one parent-scoped route page for a listing markdown document.
+ *
+ * Callers provide the already-classified parent route, and the helper enforces
+ * the shared listing limit so listing indexes do not drift into full-table
+ * collection.
+ */
+function readParentListingRows(args: ParentListingRowsArgs) {
+  return getRuntimeContentRouteParentPage({
+    ...args,
+    cursor: null,
+    limit: LLMS_LISTING_ENTRY_LIMIT,
+  }).pipe(Effect.map((page) => page.page));
+}
+
+/**
+ * Reads one kind-scoped route page for a listing markdown document.
+ *
+ * Prefix and kind come from the content route classifier; this helper keeps the
+ * query bounded and returns only the rows the llms entry builder needs.
+ */
+function readKindListingRows(args: KindListingRowsArgs) {
+  return getRuntimeContentRouteKindPage({
+    ...args,
+    cursor: null,
+    limit: LLMS_LISTING_ENTRY_LIMIT,
+  }).pipe(Effect.map((page) => page.page));
 }
 
 /** Builds one locale-specific llms entry from a sitemap route. */

--- a/apps/www/lib/llms/indexes.test.ts
+++ b/apps/www/lib/llms/indexes.test.ts
@@ -10,6 +10,7 @@ import {
 
 const mockCacheLife = vi.hoisted(() => vi.fn());
 const mockCacheTag = vi.hoisted(() => vi.fn());
+const mockGetContentListingLlmsEntries = vi.hoisted(() => vi.fn());
 const mockGetContentPageLlmsEntries = vi.hoisted(() => vi.fn());
 const mockGetSiteLlmsEntries = vi.hoisted(() => vi.fn());
 
@@ -26,6 +27,7 @@ vi.mock("@/lib/llms/entries", async () => {
     Object.hasOwn(constants.SECTION_LABELS, section);
 
   return {
+    getContentListingLlmsEntries: mockGetContentListingLlmsEntries,
     getContentPageLlmsEntries: mockGetContentPageLlmsEntries,
     getLlmsSections: () => Object.keys(constants.SECTION_LABELS),
     getSiteLlmsEntries: mockGetSiteLlmsEntries,
@@ -61,8 +63,10 @@ vi.mock("@/lib/sitemap/routes", () => ({
 beforeEach(() => {
   mockCacheLife.mockClear();
   mockCacheTag.mockClear();
+  mockGetContentListingLlmsEntries.mockReset();
   mockGetContentPageLlmsEntries.mockReset();
   mockGetSiteLlmsEntries.mockReset();
+  mockGetContentListingLlmsEntries.mockReturnValue(Effect.succeed(null));
   mockGetContentPageLlmsEntries.mockReturnValue(
     Effect.succeed([
       createFixtureEntry({
@@ -138,6 +142,43 @@ describe("llms indexes", () => {
     });
   });
 
+  it("builds one content listing index from route-catalog entries", async () => {
+    mockGetContentListingLlmsEntries.mockReturnValueOnce(
+      Effect.succeed([
+        createFixtureEntry({
+          route: "/articles/politics/dynastic-politics",
+          title: "Dynastic Politics",
+        }),
+      ])
+    );
+
+    const text = await Effect.runPromise(
+      getLlmsSectionIndexText("llms/en/articles/politics")
+    );
+
+    expect(text).toContain("# Politics Articles");
+    expect(text).toContain(
+      "- [Dynastic Politics](https://nakafa.com/en/articles/politics/dynastic-politics.md)"
+    );
+    expect(mockGetContentListingLlmsEntries).toHaveBeenCalledWith({
+      locale: "en",
+      route: "articles/politics",
+    });
+  });
+
+  it("renders an explicit empty content listing index", async () => {
+    mockGetContentListingLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
+
+    const text = await Effect.runPromise(
+      getLlmsSectionIndexText("llms/en/articles/politics")
+    );
+
+    expect(text).toContain("# Politics Articles");
+    expect(text).toContain(
+      "This English articles listing currently has no markdown entries."
+    );
+  });
+
   it("renders an explicit empty bounded content page index", async () => {
     mockGetContentPageLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
 
@@ -157,7 +198,7 @@ describe("llms indexes", () => {
     );
 
     expect(text).toContain("# Nakafa English Site Pages");
-    expect(text).toContain("https://nakafa.com/en/search.md");
+    expect(text).toContain("https://nakafa.com/en/search");
     expect(mockGetSiteLlmsEntries).toHaveBeenCalledWith("en");
     expect(mockGetContentPageLlmsEntries).not.toHaveBeenCalled();
   });
@@ -171,9 +212,6 @@ describe("llms indexes", () => {
     ).resolves.toBeNull();
     await expect(
       Effect.runPromise(getLlmsSectionIndexText("llms/en/unknown"))
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(getLlmsSectionIndexText("llms/en/articles/politics"))
     ).resolves.toBeNull();
     await expect(
       Effect.runPromise(getLlmsSectionIndexText("llms/en/articles/shard/999"))
@@ -210,10 +248,14 @@ function createFixtureEntry({
   const entrySection = section === "articles" ? "articles" : "site";
   const segments =
     entrySection === "site" ? ["site", ...routeSegments] : routeSegments;
+  const href =
+    entrySection === "site"
+      ? `https://nakafa.com/en${route === "/" ? "" : route}`
+      : `https://nakafa.com/en${route}.md`;
 
   return {
     description,
-    href: `https://nakafa.com/en${route}.md`,
+    href,
     route,
     section: entrySection,
     segments,

--- a/apps/www/lib/llms/indexes.ts
+++ b/apps/www/lib/llms/indexes.ts
@@ -9,13 +9,18 @@ import {
   SECTION_LABELS,
 } from "@/lib/llms/constants";
 import {
+  getContentListingLlmsEntries,
   getContentPageLlmsEntries,
   getLlmsSections,
   getSiteLlmsEntries,
   isLlmsSection,
   type LlmsEntry,
 } from "@/lib/llms/entries";
-import { getLocaleLabel, stripLlmsRouteExtension } from "@/lib/llms/format";
+import {
+  formatRouteTitle,
+  getLocaleLabel,
+  stripLlmsRouteExtension,
+} from "@/lib/llms/format";
 import {
   type ContentSitemapPage,
   getSitemapPageDescriptorsEffect,
@@ -93,6 +98,20 @@ export const getLlmsSectionIndexText = Effect.fn("www.llms.index.text")(
         page,
         section,
       });
+    }
+
+    if (prefixParts.length > 1) {
+      const route = prefixParts.join("/");
+      const entries = yield* getContentListingLlmsEntries({ locale, route });
+
+      if (entries !== null) {
+        return buildLlmsListingIndexText({
+          entries,
+          locale,
+          route: `/${route}`,
+          section,
+        });
+      }
     }
 
     if (prefixParts.length === 1) {
@@ -184,6 +203,42 @@ function buildLlmsSectionPageMapText({
     lines,
     summary: `For AI agents: choose a bounded ${sectionLabel.toLowerCase()} route artifact page, then follow page-level \`.md\` links. This index reads materialized page descriptors, not section routes.`,
     title: `Nakafa ${localeLabel} ${sectionLabel} Pages`,
+  });
+}
+
+/**
+ * Builds a markdown index for one content listing page.
+ *
+ * Empty listings render an explicit empty index, while null listing lookups are
+ * handled before this function and mean the route is unsupported.
+ */
+function buildLlmsListingIndexText({
+  entries,
+  locale,
+  route,
+  section,
+}: {
+  entries: LlmsEntry[];
+  locale: Locale;
+  route: string;
+  section: Exclude<LlmsSection, "site">;
+}) {
+  const localeLabel = getLocaleLabel(locale);
+  const sectionLabel = SECTION_LABELS[section];
+  const title = `${formatRouteTitle(route)} ${sectionLabel}`;
+
+  if (entries.length === 0) {
+    return renderIndexText({
+      lines: [],
+      summary: `This ${localeLabel} ${sectionLabel.toLowerCase()} listing currently has no markdown entries.`,
+      title,
+    });
+  }
+
+  return renderIndexText({
+    lines: entries.map(formatLlmsEntryLine),
+    summary: `For AI agents: source-backed ${localeLabel} ${sectionLabel.toLowerCase()} links for ${route}. Follow page-level \`.md\` links for clean markdown content.`,
+    title,
   });
 }
 

--- a/apps/www/lib/llms/legal.test.ts
+++ b/apps/www/lib/llms/legal.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getLlmsLegalPageText } from "@/lib/llms/legal";
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  mockReadFile.mockImplementation(actual.readFile);
+
+  return {
+    ...actual,
+    readFile: mockReadFile,
+  };
+});
+
+describe("legal llms markdown", () => {
+  beforeEach(() => {
+    mockReadFile.mockClear();
+  });
+
+  it("reads legal markdown from the MDX source file", async () => {
+    const text = await Effect.runPromise(
+      getLlmsLegalPageText({
+        cleanSlug: "terms-of-service",
+        locale: "en",
+      })
+    );
+
+    expect(text).toContain("# Terms of Service");
+    expect(text).toContain("Last updated:");
+  });
+
+  it("returns null when the route has no legal MDX source", async () => {
+    await expect(
+      Effect.runPromise(
+        getLlmsLegalPageText({
+          cleanSlug: "search",
+          locale: "en",
+        })
+      )
+    ).resolves.toBeNull();
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "app/[locale]/(app)/(shared)/(site)/(legal)/search/en.mdx"
+      ),
+      "utf8"
+    );
+  });
+
+  it("rejects nested or hidden source paths before reading", async () => {
+    const slugs = ["privacy-policy/extra", "../privacy-policy", ".env"];
+
+    for (const cleanSlug of slugs) {
+      await expect(
+        Effect.runPromise(
+          getLlmsLegalPageText({
+            cleanSlug,
+            locale: "en",
+          })
+        )
+      ).resolves.toBeNull();
+    }
+
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it("returns null when a declared legal source file is missing", async () => {
+    const error = Object.assign(new Error("missing"), { code: "ENOENT" });
+    mockReadFile.mockRejectedValueOnce(error);
+
+    await expect(
+      Effect.runPromise(
+        getLlmsLegalPageText({
+          cleanSlug: "terms-of-service",
+          locale: "en",
+        })
+      )
+    ).resolves.toBeNull();
+  });
+
+  it("surfaces unexpected legal source read failures", async () => {
+    const failures = [
+      Object.assign(new Error("denied"), { code: "EACCES" }),
+      new Error("unknown"),
+      Object.assign(new Error("unknown code"), { code: 1 }),
+      "read failed",
+    ];
+
+    for (const failure of failures) {
+      mockReadFile.mockRejectedValueOnce(failure);
+
+      await expect(
+        Effect.runPromise(
+          getLlmsLegalPageText({
+            cleanSlug: "terms-of-service",
+            locale: "en",
+          })
+        )
+      ).rejects.toHaveProperty(
+        "name",
+        "(FiberFailure) LegalMarkdownReadFailed"
+      );
+    }
+  });
+});

--- a/apps/www/lib/llms/legal.ts
+++ b/apps/www/lib/llms/legal.ts
@@ -1,0 +1,119 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { Effect, Schema } from "effect";
+import type { Locale } from "next-intl";
+
+/** Expected miss when a declared legal MDX source file is absent. */
+class LegalMarkdownSourceMissing extends Schema.TaggedError<LegalMarkdownSourceMissing>()(
+  "LegalMarkdownSourceMissing",
+  {
+    cause: Schema.Unknown,
+    path: Schema.String,
+  }
+) {}
+
+/** Unexpected failure while reading a declared legal MDX source file. */
+class LegalMarkdownReadFailed extends Schema.TaggedError<LegalMarkdownReadFailed>()(
+  "LegalMarkdownReadFailed",
+  {
+    cause: Schema.Unknown,
+    path: Schema.String,
+  }
+) {}
+
+/**
+ * Reads source MDX for one public legal page.
+ *
+ * Only one-segment slugs can resolve to legal MDX source files. Unsupported
+ * slugs and absent source files return null so callers can continue through
+ * the markdown source chain; unexpected filesystem failures remain typed
+ * Effect failures for diagnosability.
+ */
+export const getLlmsLegalPageText = Effect.fn("www.llms.legal.text")(
+  function* ({ cleanSlug, locale }: { cleanSlug: string; locale: Locale }) {
+    const slug = getLegalSourceSlug(cleanSlug);
+
+    if (!slug) {
+      return null;
+    }
+
+    const sourcePath = getLegalSourcePath({ locale, slug });
+
+    return yield* Effect.tryPromise({
+      try: () => readFile(sourcePath, "utf8"),
+      catch: (cause) => toLegalMarkdownReadError(sourcePath, cause),
+    }).pipe(
+      Effect.catchTag("LegalMarkdownSourceMissing", () => Effect.succeed(null))
+    );
+  }
+);
+
+/**
+ * Converts an llms clean slug into a safe legal source directory name.
+ *
+ * Legal source lookup is intentionally source-backed: any one-segment slug is
+ * allowed to prove itself by file existence, while nested or hidden paths are
+ * rejected before filesystem IO.
+ */
+function getLegalSourceSlug(cleanSlug: string) {
+  const slug = cleanSlug.replace(/^\/+|\/+$/g, "");
+
+  if (!slug || slug.includes("/") || slug.includes("\\")) {
+    return null;
+  }
+
+  if (slug === "." || slug === ".." || slug.startsWith(".")) {
+    return null;
+  }
+
+  return slug;
+}
+
+/**
+ * Resolves one traced legal MDX source path from the app project root.
+ *
+ * The path stays inside the legal route group so Next output tracing can
+ * include the exact MDX source files needed by the markdown route handler.
+ */
+function getLegalSourcePath({
+  locale,
+  slug,
+}: {
+  locale: Locale;
+  slug: string;
+}) {
+  return path.join(
+    process.cwd(),
+    "app/[locale]/(app)/(shared)/(site)/(legal)",
+    slug,
+    `${locale}.mdx`
+  );
+}
+
+/**
+ * Converts filesystem failures into the legal markdown error model.
+ *
+ * Missing source is an expected unsupported route mode. All other read
+ * failures keep their original cause attached to a typed Effect error.
+ */
+function toLegalMarkdownReadError(sourcePath: string, cause: unknown) {
+  if (getErrorCode(cause) === "ENOENT") {
+    return new LegalMarkdownSourceMissing({ cause, path: sourcePath });
+  }
+
+  return new LegalMarkdownReadFailed({ cause, path: sourcePath });
+}
+
+/** Reads a Node-style error code without widening the error type. */
+function getErrorCode(cause: unknown) {
+  if (!(cause instanceof Error)) {
+    return null;
+  }
+
+  if (!("code" in cause)) {
+    return null;
+  }
+
+  const code = cause.code;
+  return typeof code === "string" ? code : null;
+}

--- a/apps/www/lib/llms/routes.ts
+++ b/apps/www/lib/llms/routes.ts
@@ -1,0 +1,297 @@
+import {
+  getPublicContentRouteCheck,
+  type PublicContentRouteCheck,
+} from "@repo/contents/_lib/manifest/public-route";
+import { routing } from "@repo/internationalization/src/routing";
+import { Effect } from "effect";
+import {
+  getRuntimeContentRoute,
+  getRuntimeContentRouteKindPage,
+  getRuntimeContentRouteParentPage,
+} from "@/lib/content/runtime";
+import { baseRoutes } from "@/lib/sitemap/routes";
+
+type SupportedLocale = (typeof routing.locales)[number];
+type VerifiedContentRouteCheck = Exclude<
+  PublicContentRouteCheck,
+  { mode: "outside" }
+>;
+
+export interface LocalizedLlmsRoute {
+  locale: SupportedLocale;
+  markdownExtension: string;
+  route: string;
+}
+
+export interface LlmsProxyRouteRequest {
+  acceptHeader: string | null;
+  method: string;
+  pathname: string;
+}
+
+export type LlmsProxyRouteDecision =
+  | { kind: "content-not-found"; locale: SupportedLocale }
+  | { kind: "delegate" }
+  | { kind: "rewrite-markdown"; localizedRoute: LocalizedLlmsRoute };
+
+const MARKDOWN_EXTENSION_PATTERN = /\.mdx?$/;
+const SITEMAP_BASE_ROUTES = new Set(baseRoutes);
+
+/**
+ * Classifies one localized HTTP request for the proxy adapter.
+ *
+ * The interface hides locale parsing, `.md` suffix handling, sitemap-backed
+ * static route discovery, and bounded content route probes. Catalog read
+ * failures fail open so transient Convex/runtime issues do not create false
+ * 404s, while confirmed missing content returns an explicit 404 decision.
+ */
+export const resolveLlmsProxyRoute = Effect.fn("www.llms.routes.resolveProxy")(
+  function* (request: LlmsProxyRouteRequest) {
+    const localizedRoute = getLocalizedLlmsRoute(request.pathname);
+
+    if (!localizedRoute) {
+      const decision: LlmsProxyRouteDecision = { kind: "delegate" };
+      return decision;
+    }
+
+    const wantsMarkdown = isLlmsMarkdownRequest({
+      acceptHeader: request.acceptHeader,
+      markdownExtension: localizedRoute.markdownExtension,
+    });
+    const routeCheck = getPublicContentRouteCheck(localizedRoute.route);
+
+    if (routeCheck.mode === "outside") {
+      if (wantsMarkdown && SITEMAP_BASE_ROUTES.has(localizedRoute.route)) {
+        const decision: LlmsProxyRouteDecision = {
+          kind: "rewrite-markdown",
+          localizedRoute,
+        };
+        return decision;
+      }
+
+      const decision: LlmsProxyRouteDecision = { kind: "delegate" };
+      return decision;
+    }
+
+    if (shouldVerifyContentRoute(request.method)) {
+      const exists = yield* contentRouteExists({
+        locale: localizedRoute.locale,
+        routeCheck,
+      });
+
+      if (!exists) {
+        const decision: LlmsProxyRouteDecision = {
+          kind: "content-not-found",
+          locale: localizedRoute.locale,
+        };
+        return decision;
+      }
+    }
+
+    if (wantsMarkdown) {
+      const decision: LlmsProxyRouteDecision = {
+        kind: "rewrite-markdown",
+        localizedRoute,
+      };
+      return decision;
+    }
+
+    const decision: LlmsProxyRouteDecision = { kind: "delegate" };
+    return decision;
+  }
+);
+
+/**
+ * Parses the locale-prefixed URL path into the route model used by llms.
+ *
+ * The returned route always starts with `/`, has any markdown extension
+ * removed, and carries the stripped extension separately so content negotiation
+ * and suffix requests share the same downstream source lookup.
+ */
+function getLocalizedLlmsRoute(pathname: string): LocalizedLlmsRoute | null {
+  const [rawLocale, ...routeSegments] = pathname.split("/").filter(Boolean);
+  const locale = getSupportedLocale(rawLocale);
+
+  if (!locale) {
+    return null;
+  }
+
+  const rawRoute = `/${routeSegments.join("/")}`;
+  const markdownExtension =
+    rawRoute.match(MARKDOWN_EXTENSION_PATTERN)?.[0] ?? "";
+  const route = rawRoute.replace(MARKDOWN_EXTENSION_PATTERN, "");
+
+  return {
+    locale,
+    markdownExtension,
+    route,
+  };
+}
+
+/**
+ * Narrows a raw URL segment to the configured locales without widening the type.
+ *
+ * Returning null keeps unknown locale prefixes in the normal Next/next-intl
+ * route flow instead of treating them as llms-capable pages.
+ */
+function getSupportedLocale(locale: string | undefined) {
+  for (const supportedLocale of routing.locales) {
+    if (supportedLocale === locale) {
+      return supportedLocale;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Detects the two markdown request forms AFDocs checks.
+ *
+ * `.md` and `.mdx` suffixes are explicit route variants; `Accept:
+ * text/markdown` is content negotiation for the HTML URL. Both forms map to
+ * the same source-backed markdown resolver.
+ */
+function isLlmsMarkdownRequest({
+  acceptHeader,
+  markdownExtension,
+}: {
+  acceptHeader: string | null;
+  markdownExtension: string;
+}) {
+  return (
+    Boolean(markdownExtension) ||
+    acceptHeader?.includes("text/markdown") === true
+  );
+}
+
+/**
+ * Limits content existence probes to safe read methods.
+ *
+ * Non-read methods keep normal application routing so proxy checks do not add
+ * side effects or method-specific behavior to content pages.
+ */
+function shouldVerifyContentRoute(method: string) {
+  return method === "GET" || method === "HEAD";
+}
+
+/**
+ * Verifies that a content route classified by the manifest has backing rows.
+ *
+ * Exact routes use one indexed route lookup. Listing routes use a single
+ * bounded page read scoped by kind, parent, or prefix. App shell routes are
+ * treated as present, known invalid taxonomy routes are treated as missing,
+ * and transient catalog failures fail open to preserve URL stability.
+ */
+const contentRouteExists = Effect.fn("www.llms.routes.contentExists")(
+  function* ({
+    locale,
+    routeCheck,
+  }: {
+    locale: SupportedLocale;
+    routeCheck: VerifiedContentRouteCheck;
+  }) {
+    if (routeCheck.mode === "app") {
+      return true;
+    }
+
+    if (routeCheck.mode === "missing") {
+      return false;
+    }
+
+    if (routeCheck.mode === "exact") {
+      return yield* getRuntimeContentRoute({
+        locale,
+        route: routeCheck.route,
+      }).pipe(
+        Effect.match({
+          onFailure: () => true,
+          onSuccess: (contentRoute) => contentRoute !== null,
+        })
+      );
+    }
+
+    if (routeCheck.mode === "article-category") {
+      return yield* contentRoutePageHasRows(
+        getRuntimeContentRouteParentPage({
+          cursor: null,
+          kind: "article",
+          limit: 1,
+          locale,
+          order: "date-desc",
+          parentRoute: routeCheck.parentRoute,
+          section: "articles",
+        })
+      );
+    }
+
+    if (routeCheck.mode === "exercise-type") {
+      return yield* contentRoutePageHasRows(
+        getRuntimeContentRouteKindPage({
+          cursor: null,
+          kind: "exercise-group",
+          limit: 1,
+          locale,
+          prefix: routeCheck.prefix,
+          section: "exercises",
+        })
+      );
+    }
+
+    if (routeCheck.mode === "exercise-material") {
+      return yield* contentRoutePageHasRows(
+        getRuntimeContentRouteParentPage({
+          cursor: null,
+          kind: "exercise-group",
+          limit: 1,
+          locale,
+          order: "route",
+          parentRoute: routeCheck.parentRoute,
+          section: "exercises",
+        })
+      );
+    }
+
+    if (routeCheck.mode === "subject-grade") {
+      return yield* contentRoutePageHasRows(
+        getRuntimeContentRouteKindPage({
+          cursor: null,
+          kind: "subject-topic",
+          limit: 1,
+          locale,
+          prefix: routeCheck.prefix,
+          section: "subject",
+        })
+      );
+    }
+
+    return yield* contentRoutePageHasRows(
+      getRuntimeContentRouteParentPage({
+        cursor: null,
+        kind: "subject-topic",
+        limit: 1,
+        locale,
+        order: "route",
+        parentRoute: routeCheck.parentRoute,
+        section: "subject",
+      })
+    );
+  }
+);
+
+/**
+ * Reads one already-scoped route catalog page and converts it to existence.
+ *
+ * The supplied Effect must already be bounded and indexed by the caller.
+ * Failures return true so transient catalog outages fail open instead of
+ * producing crawler-visible false 404s.
+ */
+function contentRoutePageHasRows(
+  pageEffect: Effect.Effect<{ page: readonly unknown[] }, unknown>
+) {
+  return pageEffect.pipe(
+    Effect.match({
+      onFailure: () => true,
+      onSuccess: (page) => page.page.length > 0,
+    })
+  );
+}

--- a/apps/www/lib/llms/unsupported.ts
+++ b/apps/www/lib/llms/unsupported.ts
@@ -1,0 +1,38 @@
+import { LLMS_TEXT_PATH } from "@/lib/agent-discovery";
+import { BASE_URL } from "@/lib/llms/constants";
+
+const ROOT_ROUTE_PATTERN = /^\/$/;
+
+/**
+ * Builds the agent-readable body for unsupported markdown routes.
+ *
+ * Callers must still return HTTP 404. The body points agents to source-backed
+ * indexes and the HTML URL without pretending the requested markdown page
+ * exists.
+ */
+export function buildUnsupportedMarkdownRouteText({
+  locale,
+  route,
+}: {
+  locale: string;
+  route: string;
+}) {
+  const htmlPath = `/${locale}${route.replace(ROOT_ROUTE_PATTERN, "")}`;
+  const markdownPath = `${htmlPath}.md`;
+
+  return [
+    "# Markdown page not found",
+    "",
+    `The markdown page \`${markdownPath}\` does not exist for Nakafa.`,
+    "",
+    "Use these source-backed routes instead:",
+    "",
+    `- HTML page: ${BASE_URL}${htmlPath}`,
+    `- Agent index: ${BASE_URL}${LLMS_TEXT_PATH}`,
+    `- Localized content index: ${BASE_URL}/llms/${locale}/llms.txt`,
+    `- Static site index: ${BASE_URL}/llms/${locale}/site/llms.txt`,
+    "",
+    "Markdown is available only for supported content and legal pages advertised from the llms indexes. Those pages use `.md` URLs or `Accept: text/markdown`.",
+    "",
+  ].join("\n");
+}

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -198,6 +198,11 @@ const nextConfig = {
   // `process.cwd()` resolves to the app directory (`apps/www`) during Next.js
   // config loading, so walking up two levels targets the monorepo root.
   outputFileTracingRoot: path.join(process.cwd(), "../.."),
+  outputFileTracingIncludes: {
+    "/llms.mdx/[...slug]": [
+      "./app/[locale]/(app)/(shared)/(site)/(legal)/**/*.mdx",
+    ],
+  },
   serverExternalPackages: [
     ...(config.serverExternalPackages ?? []),
     "@takumi-rs/core",

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -1,8 +1,4 @@
 import { isPostHogProxyPathname } from "@repo/analytics/posthog/config";
-import {
-  getPublicContentRouteCheck,
-  type PublicContentRouteCheck,
-} from "@repo/contents/_lib/manifest/public-route";
 import { routing } from "@repo/internationalization/src/routing";
 import { Effect } from "effect";
 import type { ProxyConfig } from "next/server";
@@ -13,22 +9,12 @@ import {
   LLMS_TEXT_PATH,
 } from "@/lib/agent-discovery";
 import {
-  fetchRuntimeContentRoute,
-  fetchRuntimeContentRoutesByKindPage,
-  fetchRuntimeContentRoutesByParentPage,
-} from "@/lib/content/runtime";
-
-type RuntimeRoutePage =
-  | Awaited<ReturnType<typeof fetchRuntimeContentRoutesByKindPage>>
-  | Awaited<ReturnType<typeof fetchRuntimeContentRoutesByParentPage>>;
-type VerifiedContentRouteCheck = Exclude<
-  PublicContentRouteCheck,
-  { mode: "outside" }
->;
+  type LocalizedLlmsRoute,
+  resolveLlmsProxyRoute,
+} from "@/lib/llms/routes";
 
 const handleLocalizedRequest = createMiddleware(routing);
 const TRAILING_SLASH_PATTERN = /\/+$/;
-const MARKDOWN_EXTENSION_PATTERN = /\.mdx?$/;
 const AUTH_REDIRECT_PATH_COOKIE = "auth-redirect-path";
 const LOCALE_BYPASS_PATHS = new Set([
   "/mcp",
@@ -42,9 +28,12 @@ const LOCALE_BYPASS_PATHS = new Set([
 ]);
 
 /**
- * Run locale routing while leaving the same-origin PostHog proxy untouched.
- * Public content route existence is checked before rendering so missing
- * matched content URLs return a real 404 instead of a streamed soft 404.
+ * Adapts Next/Vercel proxy requests to Nakafa route decisions.
+ *
+ * The proxy keeps platform concerns here: PostHog bypasses, canonical slash
+ * redirects, public discovery bypasses, locale middleware, and response
+ * rewrites. Markdown support and content existence live behind the llms routes
+ * seam so route capability knowledge does not accumulate in this adapter.
  *
  * References:
  * https://nextjs.org/docs/app/api-reference/file-conventions/proxy
@@ -68,41 +57,20 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const localizedContentRoute = getLocalizedContentRoute(pathname);
+  const routeDecision = await Effect.runPromise(
+    resolveLlmsProxyRoute({
+      acceptHeader: request.headers.get("accept"),
+      method: request.method,
+      pathname,
+    })
+  );
 
-  if (localizedContentRoute) {
-    const routeCheck = getPublicContentRouteCheck(localizedContentRoute.route);
+  if (routeDecision.kind === "rewrite-markdown") {
+    return rewriteToLlmsMdx(request, routeDecision.localizedRoute);
+  }
 
-    if (routeCheck.mode === "outside") {
-      request.cookies.set(AUTH_REDIRECT_PATH_COOKIE, pathname);
-
-      const response = handleLocalizedRequest(request);
-      response.headers.append("Link", AGENT_DISCOVERY_LINK_HEADER);
-      response.headers.set("X-Llms-Txt", LLMS_TEXT_PATH);
-
-      return response;
-    }
-
-    if (shouldVerifyContentRoute(request)) {
-      const exists = await contentRouteExists(
-        localizedContentRoute.locale,
-        routeCheck
-      );
-
-      if (!exists) {
-        return rewriteToContentNotFound(request, localizedContentRoute.locale);
-      }
-    }
-
-    if (
-      localizedContentRoute.markdownExtension ||
-      request.headers.get("accept")?.includes("text/markdown")
-    ) {
-      const rewriteUrl = new URL(request.url);
-      rewriteUrl.pathname = `/llms.mdx/${localizedContentRoute.locale}${localizedContentRoute.route}`;
-
-      return NextResponse.rewrite(rewriteUrl);
-    }
+  if (routeDecision.kind === "content-not-found") {
+    return rewriteToContentNotFound(request, routeDecision.locale);
   }
 
   request.cookies.set(AUTH_REDIRECT_PATH_COOKIE, pathname);
@@ -121,155 +89,15 @@ function isLocaleBypassPath(pathname: string) {
   );
 }
 
-/** Returns one localized route, stripped of markdown suffixes. */
-function getLocalizedContentRoute(pathname: string) {
-  const [rawLocale, ...routeSegments] = pathname.split("/").filter(Boolean);
-  const locale = getSupportedLocale(rawLocale);
-
-  if (!locale) {
-    return null;
-  }
-
-  const rawRoute = `/${routeSegments.join("/")}`;
-  const markdownExtension =
-    rawRoute.match(MARKDOWN_EXTENSION_PATTERN)?.[0] ?? "";
-  const route = rawRoute.replace(MARKDOWN_EXTENSION_PATTERN, "");
-
-  return {
-    locale,
-    markdownExtension,
-    route,
-  };
-}
-
-/** Returns one supported locale segment without widening it to any string. */
-function getSupportedLocale(locale: string | undefined) {
-  for (const supportedLocale of routing.locales) {
-    if (supportedLocale === locale) {
-      return supportedLocale;
-    }
-  }
-
-  return null;
-}
-
-/** Returns whether one request should reject missing public content routes. */
-function shouldVerifyContentRoute(request: NextRequest) {
-  return request.method === "GET" || request.method === "HEAD";
-}
-
-/** Checks one public content route with the narrowest bounded catalog read. */
-function contentRouteExists(
-  locale: (typeof routing.locales)[number],
-  routeCheck: VerifiedContentRouteCheck
+/** Rewrites a localized route to the source-backed markdown handler. */
+function rewriteToLlmsMdx(
+  request: NextRequest,
+  localizedRoute: LocalizedLlmsRoute
 ) {
-  if (routeCheck.mode === "app") {
-    return Promise.resolve(true);
-  }
+  const rewriteUrl = new URL(request.url);
+  rewriteUrl.pathname = `/llms.mdx/${localizedRoute.locale}${localizedRoute.route}`;
 
-  if (routeCheck.mode === "missing") {
-    return Promise.resolve(false);
-  }
-
-  if (routeCheck.mode === "exact") {
-    return exactContentRouteExists({ locale, route: routeCheck.route });
-  }
-
-  if (routeCheck.mode === "article-category") {
-    return contentRoutePageHasRows(() =>
-      fetchRuntimeContentRoutesByParentPage({
-        cursor: null,
-        kind: "article",
-        limit: 1,
-        locale,
-        order: "date-desc",
-        parentRoute: routeCheck.parentRoute,
-        section: "articles",
-      })
-    );
-  }
-
-  if (routeCheck.mode === "exercise-type") {
-    return contentRoutePageHasRows(() =>
-      fetchRuntimeContentRoutesByKindPage({
-        cursor: null,
-        kind: "exercise-group",
-        limit: 1,
-        locale,
-        prefix: routeCheck.prefix,
-        section: "exercises",
-      })
-    );
-  }
-
-  if (routeCheck.mode === "exercise-material") {
-    return contentRoutePageHasRows(() =>
-      fetchRuntimeContentRoutesByParentPage({
-        cursor: null,
-        kind: "exercise-group",
-        limit: 1,
-        locale,
-        order: "route",
-        parentRoute: routeCheck.parentRoute,
-        section: "exercises",
-      })
-    );
-  }
-
-  if (routeCheck.mode === "subject-grade") {
-    return contentRoutePageHasRows(() =>
-      fetchRuntimeContentRoutesByKindPage({
-        cursor: null,
-        kind: "subject-topic",
-        limit: 1,
-        locale,
-        prefix: routeCheck.prefix,
-        section: "subject",
-      })
-    );
-  }
-
-  return contentRoutePageHasRows(() =>
-    fetchRuntimeContentRoutesByParentPage({
-      cursor: null,
-      kind: "subject-topic",
-      limit: 1,
-      locale,
-      order: "route",
-      parentRoute: routeCheck.parentRoute,
-      section: "subject",
-    })
-  );
-}
-
-/** Reads one catalog probe and fails open on transient read errors. */
-function contentRoutePageHasRows(readPage: () => Promise<RuntimeRoutePage>) {
-  return Effect.runPromise(
-    Effect.tryPromise(readPage).pipe(
-      Effect.match({
-        onFailure: () => true,
-        onSuccess: (page) => page.page.length > 0,
-      })
-    )
-  );
-}
-
-/** Reads the exact Convex route row and fails open on transient read errors. */
-function exactContentRouteExists({
-  locale,
-  route,
-}: {
-  locale: (typeof routing.locales)[number];
-  route: string;
-}) {
-  return Effect.runPromise(
-    Effect.tryPromise(() => fetchRuntimeContentRoute({ locale, route })).pipe(
-      Effect.match({
-        onFailure: () => true,
-        onSuccess: (contentRoute) => contentRoute !== null,
-      })
-    )
-  );
+  return NextResponse.rewrite(rewriteUrl);
 }
 
 /** Rewrites missing content to the styled app not-found route with 404 status. */


### PR DESCRIPTION
## Rationale

AFDocs Markdown Availability expects real documentation pages to return `200 text/markdown` for both `.md` URLs and `Accept: text/markdown`. AFDocs URL Stability warns against soft 404s, but explicitly allows a helpful 404 body. This patch keeps unsupported static markdown routes as real 404s and derives markdown support from existing Nakafa sources instead of inventing page markdown.

Source checks used:
- AFDocs Markdown Availability: `.md` and `Accept: text/markdown` must return markdown for real docs pages.
- AFDocs URL Stability: missing pages must keep 4xx status; helpful body is fine as long as status stays 404.
- AFDocs Improve Your Score: target specific checks and improve discoverability through llms indexes rather than fake fallback pages; HTML directives should mention markdown support when it exists.
- Agent-Friendly Documentation Spec and Vercel content-negotiation guidance: pair a top-of-page `llms.txt` pointer with markdown variants/content negotiation so agents can discover and retrieve clean markdown.
- Installed Next 16.2.9 docs/source: one proxy file may import route-specific modules; `NextResponse.rewrite()` is the correct internal rewrite mechanism; output tracing includes must be narrow route globs.
- Convex guidance/runtime source: listing pages use indexed, bounded route-catalog reads.
- pnpm `devEngines.runtime`: lockfile runtime is Node 24.16.0 and scripts use the local runtime.

## Changed files grouped by AFDocs check

### Markdown URL Support and Content Negotiation
- `apps/www/lib/llms/routes.ts`: new llms route capability Module. Its Interface returns proxy decisions and hides locale parsing, `.md` stripping, `Accept: text/markdown`, sitemap-backed static route discovery, and bounded route-catalog existence probes.
- `apps/www/proxy.ts`: reduced to the Next/Vercel request Adapter. It delegates route capability to `resolveLlmsProxyRoute` and maps decisions to rewrite/404/locale middleware.
- `apps/www/lib/llms/content.ts`, `apps/www/lib/llms/legal.ts`, `apps/www/app/llms.mdx/[...slug]/route.ts`: legal MDX is now source-backed markdown, and missing source returns unsupported behavior rather than fake content.
- `apps/www/lib/llms/entries.ts`, `apps/www/lib/llms/indexes.ts`: content listing/index markdown uses route-catalog rows and existing entry formatting with bounded reads.
- `apps/www/next.config.ts`: narrowly traces legal MDX files into the `/llms.mdx/[...slug]` production route.

### Discovery and Unsupported Static Markdown
- `apps/www/app/[locale]/layout.tsx`: visually hidden directive no longer claims every static page has `.md`; it points agents to `/llms.txt`, tells them to follow listed markdown links, and advertises `.md`/`Accept: text/markdown` only for supported source-backed pages.
- `apps/www/lib/llms/unsupported.ts`: unsupported markdown routes return a small source-backed navigation body, but callers keep HTTP 404.

### Tests
- `apps/www/__tests__/proxy.test.ts`
- `apps/www/app/llms.mdx/[...slug]/route.test.ts`
- `apps/www/lib/llms/content.test.ts`
- `apps/www/lib/llms/entries.test.ts`
- `apps/www/lib/llms/indexes.test.ts`
- `apps/www/lib/llms/legal.test.ts`

## 404 behavior decision

Unsupported markdown URLs such as `/en/search.md` and `/en/contributor.md` remain real `404` responses. They use `Content-Type: text/markdown; charset=utf-8` with a helpful body pointing agents to the HTML URL, `/llms.txt`, localized content indexes, and the static site index. This avoids soft 404s while keeping agent navigation useful.

Hard-coded route exceptions were removed. There is no `/search` or `/contributor` denylist/allowlist in `proxy.ts`; static markdown requests are routed to the source-backed llms resolver only when the route is already present in the sitemap base routes. If the source chain cannot resolve markdown, the llms route returns the 404 body.

## Architecture note

The route capability Seam lives in `apps/www/lib/llms/routes.ts`. Deleting that Module would move locale parsing, markdown negotiation, sitemap route discovery, route-catalog existence probes, and fail-open/fail-closed rules back into `apps/www/proxy.ts`; the Module has real Depth rather than being a pass-through. This improves Locality because markdown route support rules live in one llms Module, and it improves Leverage because proxy tests and route handler behavior cross the same small Interface.

The directive copy in `apps/www/app/[locale]/layout.tsx` is intentionally not a route classifier. It advertises the route capability Interface exposed by the llms Module while keeping the route support rules localized in that deeper seam.

## Node 24 handling

No repo code change was needed. The shell default was Node v22.14.0, but `pnpm node -v` and `pnpm exec node -v` resolve to Node v24.16.0 from `pnpm-lock.yaml` (`node@runtime:24.16.0`). Verification commands were run with:

```bash
PATH="$PWD/node_modules/.pnpm/node@runtime+24.16.0/node_modules/node/bin:$PATH"
```

That made `node -v`, `pnpm node -v`, and `pnpm exec node -v` all report `v24.16.0` and avoided engine warnings without changing `package.json`.

## Verification

All commands were run from repo root with the Node 24 PATH override unless noted.

- `pnpm format`: passed, no fixes applied.
- Focused tests: `pnpm --filter www exec vitest run lib/llms/content.test.ts lib/llms/entries.test.ts lib/llms/indexes.test.ts lib/llms/legal.test.ts 'app/llms.mdx/[...slug]/route.test.ts' __tests__/proxy.test.ts --coverage.enabled=false` passed, 6 files / 71 tests.
- `pnpm --filter www typecheck`: passed.
- `pnpm lint`: passed.
- `pnpm build`: passed, 17 successful tasks; `www:test` passed with 644 tests and 100% statements/branches/functions/lines; production `www` Next build passed.
- Follow-up directive review after commit `c435b8d2d`: `pnpm format`, `pnpm --filter www typecheck`, `pnpm lint`, and `pnpm build` all passed under Node 24.
- Output trace check: `apps/www/.next/server/app/llms.mdx/[...slug]/route.js.nft.json` includes `privacy-policy`, `security-policy`, and `terms-of-service` legal MDX source files for `en` and `id`.
- `pnpm start`: built app served at `http://localhost:3000`; ports were cleaned up after verification.
- `git diff --check`: passed.
- Hard-code/effect hygiene scans: no `HTML_ONLY_SITE_ROUTES`, no `/search`/`/contributor` route exception lists, no raw `try`/`.catch()` in touched app seams, no `any`/TypeScript suppression comments.

### Curl evidence from production `pnpm start`

- `GET /en/subject/high-school/10/chemistry/green-chemistry/definition.md` -> `200 text/markdown; charset=utf-8`
- `GET /en/subject/high-school/10/chemistry/green-chemistry/definition` with `Accept: text/markdown` -> `200 text/markdown; charset=utf-8`
- `GET /en/subject/high-school/12.md` -> `200 text/markdown; charset=utf-8`
- `GET /en/subject/high-school/12` with `Accept: text/markdown` -> `200 text/markdown; charset=utf-8`
- `GET /en/articles/politics.md` -> `200 text/markdown; charset=utf-8`
- `GET /en/articles/politics` with `Accept: text/markdown` -> `200 text/markdown; charset=utf-8`
- `GET /en/terms-of-service.md` -> `200 text/markdown; charset=utf-8`
- `GET /en/terms-of-service` with `Accept: text/markdown` -> `200 text/markdown; charset=utf-8`
- `GET /en/search.md` -> `404 text/markdown; charset=utf-8`
- `GET /en/search` with `Accept: text/markdown` -> `404 text/markdown; charset=utf-8`
- `GET /en/contributor.md` -> `404 text/markdown; charset=utf-8`
- `GET /en/contributor` with `Accept: text/markdown` -> `404 text/markdown; charset=utf-8`
- `GET /en/search` normally -> `200 text/html; charset=utf-8`
- `GET /llms/en/site/llms.txt` contains HTML links for Search and Contributor, with no `/en/search.md` or `/en/contributor.md` leaks.

### AFDocs targeted checks

- `pnpm dlx afdocs check http://localhost:3000 --sampling curated --urls 'http://localhost:3000/en/subject/high-school/10/chemistry/green-chemistry/definition,http://localhost:3000/en/subject/high-school/12,http://localhost:3000/en/articles/politics,http://localhost:3000/en/terms-of-service' --checks markdown-url-support,content-negotiation --verbose` -> passed; `markdown-url-support: 4/4`, `content-negotiation: 4/4`.
- `pnpm dlx afdocs check http://localhost:3000 --sampling curated --urls 'http://localhost:3000/en/search.md,http://localhost:3000/en/contributor.md' --checks http-status-codes --verbose` -> passed; all 2 pages return proper error codes.

### Browser smoke

- In-app Browser was attempted, but its webview attach timed out.
- Playwright fallback using `@playwright/test` passed: `/en/search` loaded with title `Search Learning Materials - Nakafa: Free Lessons from K-12 to University` and a `main` landmark; `/en/terms-of-service.md` returned `200 text/markdown; charset=utf-8` and rendered markdown text.

## Out of scope

Page Size, Content Parity, Authentication, and other AFDocs score sections were not changed. They are separate checks unless future tracing proves they share this same markdown delivery root cause.