### PR TITLE
Stabilize EvilCharts reveal rendering

### DIFF
--- a/packages/design-system/components/evilcharts/charts/area-chart.tsx
+++ b/packages/design-system/components/evilcharts/charts/area-chart.tsx
@@ -63,8 +63,7 @@ const STACK_ID = "evil-stacked";
 const REVEAL_DURATION = 1; // intro wipe length, in seconds
 const REVEAL_EASE: [number, number, number, number] = [0, 0.7, 0.5, 1]; // intro wipe easing
 const REVEAL_PROPS = {
-  initial: { scaleX: 0 },
-  animate: { scaleX: 1 },
+  animate: { scaleX: [0, 1] },
   transition: { duration: REVEAL_DURATION, ease: REVEAL_EASE },
 };
 

--- a/packages/design-system/components/evilcharts/charts/bar-chart.tsx
+++ b/packages/design-system/components/evilcharts/charts/bar-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useReducedMotion } from "@mantine/hooks";
 import {
   type BackgroundVariant,
   ChartBackground,
@@ -24,12 +25,19 @@ import {
 } from "@repo/design-system/components/evilcharts/ui/legend";
 import { LoadingIndicator } from "@repo/design-system/components/evilcharts/ui/loading-indicator";
 import {
+  BAR_REVEAL_DURATION_MS,
+  BAR_REVEAL_STAGGER_MS,
+  getOrderedRevealStep,
+  type OrderedRevealAnimation,
+  useOrderedReveal,
+} from "@repo/design-system/components/evilcharts/ui/reveal-animation";
+import {
   ChartTooltip,
   ChartTooltipContent,
   type TooltipRoundness,
   type TooltipVariant,
 } from "@repo/design-system/components/evilcharts/ui/tooltip";
-import { m, useReducedMotion } from "motion/react";
+import { m } from "motion/react";
 import {
   type ComponentProps,
   createContext,
@@ -58,8 +66,6 @@ const DEFAULT_BAR_RADIUS = 2;
 const LOADING_BAR_DATA_KEY = "loading";
 const LOADING_ANIMATION_DURATION = 2000; // in milliseconds
 const STACK_ID = "evil-stacked";
-const BAR_GROW_DURATION = 0.5; // per-bar grow-in length, in seconds
-const BAR_STAGGER = 0.05; // delay between consecutive bars, in seconds
 const REVEAL_EASE: [number, number, number, number] = [0, 0.7, 0.5, 1]; // grow-in easing
 
 type BarVariant =
@@ -81,12 +87,7 @@ type BarLayout = "vertical" | "horizontal";
  * chart. `"none"` opts out entirely; it is also what a device with the OS
  * "reduce motion" preference falls back to automatically.
  */
-type BarAnimationType =
-  | "none"
-  | "left-to-right"
-  | "right-to-left"
-  | "center-out"
-  | "edges-in";
+type BarAnimationType = "none" | OrderedRevealAnimation;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared context
@@ -102,7 +103,6 @@ interface BarChartContextValue {
   barRadius: number; // default corner radius each <Bar /> inherits
   config: ChartConfig; // colors + labels for every series
   dataLength: number; // number of rows currently rendered
-  introStartedAt: number; // timestamp the chart mounted — anchors the one-shot grow-in
   isHorizontal: boolean; // whether bars are laid out horizontally
   isLoading: boolean; // whether the chart shows its loading skeleton
   isMouseInChart: boolean; // whether the pointer is currently over the chart
@@ -200,10 +200,6 @@ export function EvilBarChart<
   onBrushChange,
 }: EvilBarChartProps<TData, TConfig>) {
   const chartId = useId().replace(/:/g, ""); // colon-free id keeps CSS/SVG selectors valid
-  // Anchors the grow-in to a fixed moment so it plays exactly once — re-renders
-  // and Recharts' bar remounts read elapsed time from here instead of replaying.
-  // Lazy useState stamps the time once, on the initial render only.
-  const [introStartedAt] = useState(() => Date.now());
   const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
     defaultSelectedDataKey
   );
@@ -232,7 +228,6 @@ export function EvilBarChart<
       isLoading,
       barRadius,
       animationType,
-      introStartedAt,
       dataLength: displayData.length,
       selectedDataKey,
       selectDataKey,
@@ -245,7 +240,6 @@ export function EvilBarChart<
       isLoading,
       barRadius,
       animationType,
-      introStartedAt,
       displayData.length,
       selectedDataKey,
       selectDataKey,
@@ -346,7 +340,6 @@ export function Bar({
     isLoading,
     barRadius: defaultRadius,
     animationType: defaultAnimation,
-    introStartedAt,
     dataLength,
     selectedDataKey,
     selectDataKey,
@@ -355,11 +348,6 @@ export function Bar({
   const id = useId().replace(/:/g, ""); // unique id scopes this bar's style defs
   // Devices set to "reduce motion" skip the grow-in animation entirely
   const shouldReduceMotion = useReducedMotion();
-
-  // The root renders the skeleton bar while loading, so real bars step aside
-  if (isLoading) {
-    return null;
-  }
 
   const resolvedRadius = radius ?? defaultRadius;
   const isSelected = selectedDataKey === dataKey;
@@ -370,6 +358,15 @@ export function Bar({
   const revealType: BarAnimationType = shouldReduceMotion
     ? "none"
     : (animationType ?? defaultAnimation);
+  const isRevealActive = useOrderedReveal(
+    isLoading ? "none" : revealType,
+    dataLength
+  );
+
+  // The root renders the skeleton bar while loading, so real bars step aside
+  if (isLoading) {
+    return null;
+  }
 
   const customBarProps = {
     id,
@@ -382,7 +379,7 @@ export function Bar({
     enableHoverHighlight,
     isMouseInChart,
     isHorizontal,
-    introStartedAt,
+    isRevealActive,
     selectedDataKey,
     dataLength,
     colorSlots,
@@ -639,8 +636,8 @@ type CustomBarProps = {
   enableHoverHighlight?: boolean;
   isMouseInChart?: boolean;
   isHorizontal?: boolean;
+  isRevealActive?: boolean;
   animationType?: BarAnimationType;
-  introStartedAt?: number;
   selectedDataKey?: string | null;
   isActive?: boolean;
   dataLength?: number;
@@ -669,8 +666,8 @@ const CustomBar = (props: CustomBarProps) => {
     enableHoverHighlight,
     isMouseInChart,
     isHorizontal = false,
+    isRevealActive = false,
     animationType = "none",
-    introStartedAt = 0,
     selectedDataKey,
     isActive,
     dataLength = 0,
@@ -686,7 +683,7 @@ const CustomBar = (props: CustomBarProps) => {
     index,
     dataLength,
     isHorizontal,
-    introStartedAt
+    isRevealActive
   );
 
   const fill = isLastBar
@@ -767,7 +764,6 @@ const CustomBar = (props: CustomBarProps) => {
       {grow ? (
         <m.g
           animate={grow.animate}
-          initial={grow.initial}
           style={grow.style}
           transition={grow.transition}
         >
@@ -783,79 +779,48 @@ const CustomBar = (props: CustomBarProps) => {
 /**
  * Builds the motion.dev grow-in animation for a single bar, or returns `null`
  * when the bar should render statically (`"none"`, reduced motion, an unknown
- * index, or — crucially — once the bar has already finished growing).
+ * index, empty data, or once the intro window is complete).
  *
  * Every bar grows from its baseline — `scaleY` from the bottom for vertical
  * layout, `scaleX` from the left for horizontal — and `animationType` decides
  * the stagger order, so the chart fills in one bar at a time.
  *
- * The intro is anchored to `introStartedAt` (stamped once when the chart
- * mounts) rather than to component mount. Recharts remounts every bar whenever
- * the chart re-renders — e.g. on hover-highlight — so a mount-based animation
- * would replay endlessly. Reading elapsed time instead makes it a true
- * one-shot: a bar past its window renders static, and a bar caught mid-grow
- * resumes from the progress it should already be at.
+ * The owning <Bar /> series owns its reveal window. Once the window ends, every
+ * bar renders as plain SVG geometry, so long/offscreen content cannot leave
+ * bars hidden behind stale animation transforms.
  */
 const getBarGrowAnimation = (
   animationType: BarAnimationType,
   index: number,
   dataLength: number,
   isHorizontal: boolean,
-  introStartedAt: number
+  isRevealActive: boolean
 ) => {
-  if (animationType === "none" || index < 0 || dataLength <= 0) {
+  if (
+    animationType === "none" ||
+    index < 0 ||
+    dataLength <= 0 ||
+    !isRevealActive
+  ) {
     return null;
   }
 
-  const lastIndex = dataLength - 1;
-  const center = lastIndex / 2;
-
-  // How many bars this one waits behind before it starts growing
-  let step: number;
-  switch (animationType) {
-    case "right-to-left":
-      step = lastIndex - index;
-      break;
-    case "center-out":
-      step = Math.abs(index - center);
-      break;
-    case "edges-in":
-      step = center - Math.abs(index - center);
-      break;
-    default: // left-to-right
-      step = index;
-  }
-
-  const startMs = step * BAR_STAGGER * 1000;
-  const durationMs = BAR_GROW_DURATION * 1000;
-  const endMs = startMs + durationMs;
-  const elapsed = Date.now() - introStartedAt;
-
-  // Already finished — render static so re-renders/remounts can't replay it
-  if (elapsed >= endMs) {
-    return null;
-  }
-
-  // Resume from wherever this bar should already be: 0 before it starts,
-  // partway through if a remount caught it mid-grow.
-  const from = elapsed <= startMs ? 0 : (elapsed - startMs) / durationMs;
+  const step = getOrderedRevealStep(animationType, index, dataLength);
   const transition = {
-    duration: (endMs - Math.max(elapsed, startMs)) / 1000,
+    duration: BAR_REVEAL_DURATION_MS / 1000,
     ease: REVEAL_EASE,
-    delay: Math.max(0, startMs - elapsed) / 1000,
+    delay: (step * BAR_REVEAL_STAGGER_MS) / 1000,
   };
 
   // Horizontal bars grow rightward from the left edge, vertical from the bottom
   return isHorizontal
     ? {
-        initial: { scaleX: from },
-        animate: { scaleX: 1 },
+        animate: { scaleX: [0, 1] },
         transition,
         style: { originX: 0 },
       }
     : {
-        initial: { scaleY: from },
-        animate: { scaleY: 1 },
+        animate: { scaleY: [0, 1] },
         transition,
         style: { originY: 1 },
       };

--- a/packages/design-system/components/evilcharts/charts/composed-chart.tsx
+++ b/packages/design-system/components/evilcharts/charts/composed-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useReducedMotion } from "@mantine/hooks";
 import { ChartContainer } from "@repo/design-system/components/evilcharts/ui/chart";
 import {
   type ChartConfig,
@@ -25,12 +26,19 @@ import {
 } from "@repo/design-system/components/evilcharts/ui/legend";
 import { LoadingIndicator } from "@repo/design-system/components/evilcharts/ui/loading-indicator";
 import {
+  BAR_REVEAL_DURATION_MS,
+  BAR_REVEAL_STAGGER_MS,
+  getOrderedRevealStep,
+  type OrderedRevealAnimation,
+  useOrderedReveal,
+} from "@repo/design-system/components/evilcharts/ui/reveal-animation";
+import {
   ChartTooltip,
   ChartTooltipContent,
   type TooltipRoundness,
   type TooltipVariant,
 } from "@repo/design-system/components/evilcharts/ui/tooltip";
-import { m, useReducedMotion } from "motion/react";
+import { m } from "motion/react";
 import {
   Children,
   type ComponentProps,
@@ -66,12 +74,9 @@ const LOADING_ANIMATION_DURATION = 2000; // in milliseconds
 const REVEAL_DURATION = 1; // line intro wipe length, in seconds
 const REVEAL_EASE: [number, number, number, number] = [0, 0.7, 0.5, 1]; // intro easing
 const REVEAL_PROPS = {
-  initial: { scaleX: 0 },
-  animate: { scaleX: 1 },
+  animate: { scaleX: [0, 1] },
   transition: { duration: REVEAL_DURATION, ease: REVEAL_EASE },
 };
-const BAR_GROW_DURATION = 0.5; // per-bar grow-in length, in seconds
-const BAR_STAGGER = 0.05; // delay between consecutive bars, in seconds
 
 type CurveType = ComponentProps<typeof RechartsLine>["type"];
 type LineDotProp = ComponentProps<typeof RechartsLine>["dot"];
@@ -97,13 +102,8 @@ type BarVariant =
  * NOTE: the intro is a per-frame animation, heavier than a static chart.
  * `"none"` opts out — as does a device with the OS "reduce motion" preference.
  */
-type ComposedAnimationType =
-  | "none"
-  | "left-to-right"
-  | "right-to-left"
-  | "center-out"
-  | "edges-in";
-type RevealAnimationType = Exclude<ComposedAnimationType, "none">;
+type ComposedAnimationType = "none" | OrderedRevealAnimation;
+type RevealAnimationType = OrderedRevealAnimation;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared context
@@ -121,7 +121,6 @@ interface ComposedChartContextValue {
   curveType: CurveType; // default curve interpolation each <Line /> inherits
   dataLength: number; // number of rows currently rendered
   hoveredIndex: number | null; // data index currently hovered, or null when none
-  introStartedAt: number; // timestamp the chart mounted — anchors the one-shot intro
   isLoading: boolean; // whether the chart shows its loading skeleton
   selectDataKey: (dataKey: string | null) => void; // sets the selected series
   selectedDataKey: string | null; // currently selected series, or null when none
@@ -212,9 +211,6 @@ export function EvilComposedChart<
   onBrushChange,
 }: EvilComposedChartProps<TData, TConfig>) {
   const chartId = useId().replace(/:/g, ""); // colon-free id keeps CSS/SVG selectors valid
-  // Anchors the intro to a fixed moment so it plays exactly once — re-renders
-  // and Recharts remounts read elapsed time from here instead of replaying.
-  const [introStartedAt] = useState(() => Date.now());
   const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
     defaultSelectedDataKey
   );
@@ -238,7 +234,6 @@ export function EvilComposedChart<
       config,
       curveType,
       animationType,
-      introStartedAt,
       dataLength: displayData.length,
       isLoading,
       hoveredIndex,
@@ -249,7 +244,6 @@ export function EvilComposedChart<
       config,
       curveType,
       animationType,
-      introStartedAt,
       displayData.length,
       isLoading,
       hoveredIndex,
@@ -343,7 +337,6 @@ export function Bar({
   const {
     config,
     animationType: defaultAnimation,
-    introStartedAt,
     dataLength,
     isLoading,
     hoveredIndex,
@@ -354,11 +347,6 @@ export function Bar({
   // Devices set to "reduce motion" skip the grow-in animation entirely
   const shouldReduceMotion = useReducedMotion();
 
-  // The root renders the skeleton bar while loading, so real bars step aside
-  if (isLoading) {
-    return null;
-  }
-
   const isSelected = selectedDataKey === null || selectedDataKey === dataKey;
   const filter = glow ? `url(#${id}-glow)` : undefined;
   const colorSlots = getColorsCount(config[dataKey] ?? {});
@@ -368,6 +356,15 @@ export function Bar({
   const revealType: ComposedAnimationType = shouldReduceMotion
     ? "none"
     : (animationType ?? defaultAnimation);
+  const isRevealActive = useOrderedReveal(
+    isLoading ? "none" : revealType,
+    dataLength
+  );
+
+  // The root renders the skeleton bar while loading, so real bars step aside
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <>
@@ -402,8 +399,8 @@ export function Bar({
               })}
               filter={filter}
               id={id}
-              introStartedAt={introStartedAt}
               isClickable={isClickable}
+              isRevealActive={isRevealActive}
               onClick={
                 isClickable
                   ? () => {
@@ -997,7 +994,7 @@ type CustomBarProps = {
   enableHoverHighlight?: boolean; // whether hovering a column dims the others
   animationType?: ComposedAnimationType; // grow-in order for this bar
   dataLength?: number; // total bars in the series — drives the stagger
-  introStartedAt?: number; // chart-mount timestamp anchoring the one-shot grow-in
+  isRevealActive?: boolean; // whether the owning bar series is in its intro window
   onClick?: () => void; // fired when a clickable bar is clicked
 } & BarShapeProps;
 
@@ -1020,7 +1017,7 @@ const CustomBar = ({
   enableHoverHighlight,
   animationType = "none",
   dataLength = 0,
-  introStartedAt = 0,
+  isRevealActive = false,
   onClick,
 }: CustomBarProps) => {
   const cursorStyle =
@@ -1030,9 +1027,12 @@ const CustomBar = ({
   const hitAreaWidth = background?.width ?? width;
   const hitAreaHeight = background?.height ?? height;
 
-  // motion.dev grow-in props for this bar — an empty object once it has finished
-  const grow =
-    getBarGrowAnimation(animationType, index, dataLength, introStartedAt) ?? {};
+  const grow = getBarGrowAnimation(
+    animationType,
+    index,
+    dataLength,
+    isRevealActive
+  );
 
   const getFill = () => {
     switch (variant) {
@@ -1082,44 +1082,74 @@ const CustomBar = ({
     : {};
 
   if (variant === "stripped") {
+    const strippedBar = (
+      <>
+        <rect fill={getFill()} height={height} width={width} x={x} y={y} />
+        <rect
+          fill={`url(#${id}-bar-colors)`}
+          height={2}
+          width={width}
+          x={x}
+          y={y}
+        />
+      </>
+    );
+
     return (
       <g {...interactiveProps} style={cursorStyle}>
-        <m.g
-          {...grow}
-          className="transition-opacity duration-200"
-          filter={filter}
-          opacity={fillOpacity}
-        >
-          <rect fill={getFill()} height={height} width={width} x={x} y={y} />
-          <rect
-            fill={`url(#${id}-bar-colors)`}
-            height={2}
-            width={width}
-            x={x}
-            y={y}
-          />
-        </m.g>
+        {grow ? (
+          <m.g
+            animate={grow.animate}
+            className="transition-opacity duration-200"
+            filter={filter}
+            opacity={fillOpacity}
+            style={grow.style}
+            transition={grow.transition}
+          >
+            {strippedBar}
+          </m.g>
+        ) : (
+          <g
+            className="transition-opacity duration-200"
+            filter={filter}
+            opacity={fillOpacity}
+          >
+            {strippedBar}
+          </g>
+        )}
         {hitArea}
       </g>
     );
   }
 
+  const bar = (
+    <rect
+      className="transition-opacity duration-200"
+      fill={getFill()}
+      filter={filter}
+      height={height}
+      opacity={fillOpacity}
+      rx={barRadius}
+      ry={barRadius}
+      width={width}
+      x={x}
+      y={y}
+    />
+  );
+
   return (
     <g {...interactiveProps} style={cursorStyle}>
-      <m.g {...grow}>
-        <rect
-          className="transition-opacity duration-200"
-          fill={getFill()}
-          filter={filter}
-          height={height}
-          opacity={fillOpacity}
-          rx={barRadius}
-          ry={barRadius}
-          width={width}
-          x={x}
-          y={y}
-        />
-      </m.g>
+      {grow ? (
+        <m.g
+          animate={grow.animate}
+          style={grow.style}
+          transition={grow.transition}
+        >
+          {bar}
+        </m.g>
+      ) : (
+        bar
+      )}
       {hitArea}
     </g>
   );
@@ -1127,64 +1157,36 @@ const CustomBar = ({
 
 /**
  * Builds the motion.dev grow-in animation for a single bar, or returns `null`
- * when it should render statically (`"none"`, an unknown index, or — crucially —
- * once the bar has already finished growing).
+ * when it should render statically (`"none"`, an unknown index, empty data, or
+ * once the intro window is complete).
  *
- * The intro is anchored to `introStartedAt` (stamped once when the chart mounts)
- * rather than to component mount. Recharts remounts every bar whenever the chart
- * re-renders, so a mount-based animation would replay endlessly; reading elapsed
- * time instead makes it a true one-shot — a bar past its window renders static,
- * a bar caught mid-grow resumes from where it should already be.
+ * The owning <Bar /> series owns its reveal window. Once the window ends, every
+ * bar renders as plain SVG geometry, so long/offscreen content cannot leave
+ * bars hidden behind stale animation transforms.
  */
 const getBarGrowAnimation = (
   animationType: ComposedAnimationType,
   index: number,
   dataLength: number,
-  introStartedAt: number
+  isRevealActive: boolean
 ) => {
-  if (animationType === "none" || index < 0 || dataLength <= 0) {
+  if (
+    animationType === "none" ||
+    index < 0 ||
+    dataLength <= 0 ||
+    !isRevealActive
+  ) {
     return null;
   }
 
-  const lastIndex = dataLength - 1;
-  const center = lastIndex / 2;
-
-  // How many bars this one waits behind before it starts growing
-  let step: number;
-  switch (animationType) {
-    case "right-to-left":
-      step = lastIndex - index;
-      break;
-    case "center-out":
-      step = Math.abs(index - center);
-      break;
-    case "edges-in":
-      step = center - Math.abs(index - center);
-      break;
-    default: // left-to-right
-      step = index;
-  }
-
-  const startMs = step * BAR_STAGGER * 1000;
-  const durationMs = BAR_GROW_DURATION * 1000;
-  const endMs = startMs + durationMs;
-  const elapsed = Date.now() - introStartedAt;
-
-  // Already finished — render static so re-renders/remounts can't replay it
-  if (elapsed >= endMs) {
-    return null;
-  }
-
-  // Resume from wherever this bar should already be (0 before it starts)
-  const from = elapsed <= startMs ? 0 : (elapsed - startMs) / durationMs;
+  const step = getOrderedRevealStep(animationType, index, dataLength);
 
   return {
-    initial: { scaleY: from },
-    animate: { scaleY: 1 },
+    animate: { scaleY: [0, 1] },
     transition: {
-      duration: (endMs - Math.max(elapsed, startMs)) / 1000,
+      duration: BAR_REVEAL_DURATION_MS / 1000,
       ease: REVEAL_EASE,
-      delay: Math.max(0, startMs - elapsed) / 1000,
+      delay: (step * BAR_REVEAL_STAGGER_MS) / 1000,
     },
     style: { originY: 1 }, // grow upward from the baseline
   };

--- a/packages/design-system/components/evilcharts/charts/line-chart.tsx
+++ b/packages/design-system/components/evilcharts/charts/line-chart.tsx
@@ -63,8 +63,7 @@ const LOADING_ANIMATION_DURATION = 2000; // in milliseconds
 const REVEAL_DURATION = 1; // intro wipe length, in seconds
 const REVEAL_EASE: [number, number, number, number] = [0, 0.7, 0.5, 1]; // intro wipe easing
 const REVEAL_PROPS = {
-  initial: { scaleX: 0 },
-  animate: { scaleX: 1 },
+  animate: { scaleX: [0, 1] },
   transition: { duration: REVEAL_DURATION, ease: REVEAL_EASE },
 };
 

--- a/packages/design-system/components/evilcharts/ui/reveal-animation.ts
+++ b/packages/design-system/components/evilcharts/ui/reveal-animation.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const BAR_REVEAL_DURATION_MS = 500;
+const BAR_REVEAL_STAGGER_MS = 50;
+
+type OrderedRevealAnimation =
+  | "left-to-right"
+  | "right-to-left"
+  | "center-out"
+  | "edges-in";
+
+/**
+ * Returns the stagger slot for a data point in an ordered chart reveal.
+ */
+function getOrderedRevealStep(
+  animationType: OrderedRevealAnimation,
+  index: number,
+  dataLength: number
+) {
+  const lastIndex = dataLength - 1;
+  const center = lastIndex / 2;
+
+  switch (animationType) {
+    case "right-to-left":
+      return lastIndex - index;
+    case "center-out":
+      return Math.abs(index - center);
+    case "edges-in":
+      return center - Math.abs(index - center);
+    default:
+      return index;
+  }
+}
+
+/**
+ * Returns the full reveal window for a staggered bar series.
+ */
+function getOrderedRevealDurationMs(
+  animationType: OrderedRevealAnimation,
+  dataLength: number
+) {
+  if (dataLength <= 0) {
+    return 0;
+  }
+
+  const lastStep = Math.max(
+    ...Array.from({ length: dataLength }, (_, index) =>
+      getOrderedRevealStep(animationType, index, dataLength)
+    )
+  );
+
+  return BAR_REVEAL_DURATION_MS + lastStep * BAR_REVEAL_STAGGER_MS;
+}
+
+/**
+ * Enables the initial ordered bar reveal, then renders static final geometry.
+ */
+function useOrderedReveal(
+  animationType: "none" | OrderedRevealAnimation,
+  dataLength: number
+) {
+  const canReveal = animationType !== "none" && dataLength > 0;
+  const hasStartedReveal = useRef(false);
+  const revealDuration = canReveal
+    ? getOrderedRevealDurationMs(animationType, dataLength)
+    : 0;
+  const revealDurationRef = useRef(revealDuration);
+  const [isRevealing, setIsRevealing] = useState(() => canReveal);
+
+  revealDurationRef.current = revealDuration;
+
+  useEffect(() => {
+    if (!canReveal) {
+      setIsRevealing(false);
+      return;
+    }
+
+    if (hasStartedReveal.current) {
+      return;
+    }
+
+    hasStartedReveal.current = true;
+    setIsRevealing(true);
+    const timeout = window.setTimeout(
+      () => setIsRevealing(false),
+      revealDurationRef.current
+    );
+
+    return () => {
+      window.clearTimeout(timeout);
+      hasStartedReveal.current = false;
+    };
+  }, [canReveal]);
+
+  return isRevealing;
+}
+
+export {
+  BAR_REVEAL_DURATION_MS,
+  BAR_REVEAL_STAGGER_MS,
+  getOrderedRevealStep,
+  type OrderedRevealAnimation,
+  useOrderedReveal,
+};

--- a/packages/design-system/styles/globals.css
+++ b/packages/design-system/styles/globals.css
@@ -322,6 +322,11 @@
   content-visibility: auto;
 }
 
+.content-auto-card:has([data-slot="chart"]) {
+  contain-intrinsic-size: none;
+  content-visibility: visible;
+}
+
 @utility content-auto-quran-verse {
   contain-intrinsic-size: auto none auto 32rem;
   content-visibility: auto;


### PR DESCRIPTION
## Summary
- Move duplicated bar reveal timing into a shared EvilCharts helper using Mantine `useTimeout`.
- Remove hidden `initial` scale states from bar, composed, line, and area chart reveals so final SVG geometry remains visible after hydration/offscreen rendering.
- Keep chart cards out of `content-visibility: auto` so responsive charts can measure and hydrate reliably.

## Verification
- `pnpm format`
- `pnpm lint`
- `pnpm --filter @repo/design-system typecheck`
- `pnpm build`
- `pnpm run doctor --verbose --diff`
- `pnpm start` from repo root
- Checked 19 chart routes on `http://localhost:3000`: all returned `200`, no visible error shell, all included the chart runtime shell.

## Notes
- Browser plugin navigation to `localhost`, `127.0.0.1`, and the LAN URL was blocked by Browser Use URL policy before page load, so local visual screenshots could not be captured through the requested Browser tool.