### PR TITLE
Restore SEO-safe URL migration redirects

### DIFF
--- a/apps/www/lib/routing/public/migration.test.ts
+++ b/apps/www/lib/routing/public/migration.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { readPublicUrlMigrationRedirect } from "@/lib/routing/public/migration";
+
+describe("public url migration redirects", () => {
+  it("redirects previous Indonesian material lesson URLs to canonical material paths", async () => {
+    await expect(
+      Effect.runPromise(
+        readPublicUrlMigrationRedirect({
+          method: "GET",
+          pathname:
+            "/id/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+        })
+      )
+    ).resolves.toBe(
+      "/id/materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling"
+    );
+  });
+
+  it("redirects previous English material lesson URLs to canonical subject paths", async () => {
+    await expect(
+      Effect.runPromise(
+        readPublicUrlMigrationRedirect({
+          method: "HEAD",
+          pathname:
+            "/en/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+        })
+      )
+    ).resolves.toBe(
+      "/en/subjects/mathematics/circle/central-angle-and-inscribed-angle"
+    );
+  });
+
+  it("delegates current, non-read, and unknown previous paths", async () => {
+    const paths = [
+      {
+        expected: null,
+        method: "GET",
+        pathname:
+          "/id/materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling",
+      },
+      {
+        expected: null,
+        method: "POST",
+        pathname:
+          "/id/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+      },
+      {
+        expected: null,
+        method: "GET",
+        pathname: "/id/subject/high-school/11/mathematics",
+      },
+      {
+        expected: null,
+        method: "GET",
+        pathname: "/id/subject/high-school/11/mathematics/circle",
+      },
+      {
+        expected: null,
+        method: "GET",
+        pathname:
+          "/fr/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+      },
+      {
+        expected: null,
+        method: "GET",
+        pathname: "/id/subject/high-school/11/mathematics/not-a-real-topic",
+      },
+    ];
+
+    for (const path of paths) {
+      await expect(
+        Effect.runPromise(readPublicUrlMigrationRedirect(path))
+      ).resolves.toBe(path.expected);
+    }
+  });
+});

--- a/apps/www/lib/routing/public/migration.ts
+++ b/apps/www/lib/routing/public/migration.ts
@@ -1,0 +1,73 @@
+import {
+  findPublicContentRouteBySourcePath,
+  isMaterialLessonRoute,
+  toLocalizedContentHref,
+} from "@repo/contents/_types/route/content";
+import { routing } from "@repo/internationalization/src/routing";
+import { Effect, Option } from "effect";
+import { hasLocale } from "next-intl";
+
+const PREVIOUS_SUBJECT_NAMESPACE = "subject";
+const MATERIAL_LESSON_SOURCE_ROOT = "material/lesson";
+const REDIRECTABLE_METHODS = new Set(["GET", "HEAD"]);
+
+/**
+ * Finds the canonical target for permanent public URL migrations.
+ *
+ * Previous material lesson URLs never render old pages. They only redirect to
+ * the source-owned canonical route so Google and users land on the new surface.
+ */
+export const readPublicUrlMigrationRedirect = Effect.fn(
+  "www.routing.publicHtml.urlMigrationRedirect"
+)(function* ({ method, pathname }: { method: string; pathname: string }) {
+  if (!REDIRECTABLE_METHODS.has(method)) {
+    return null;
+  }
+
+  const sourcePath = readPreviousSubjectLessonSourcePath(pathname);
+
+  if (!sourcePath) {
+    return null;
+  }
+
+  const route = yield* findPublicContentRouteBySourcePath(
+    sourcePath.sourcePath,
+    sourcePath.locale
+  );
+
+  return Option.match(route, {
+    onNone: () => null,
+    onSome: (canonicalRoute) => {
+      if (!isMaterialLessonRoute(canonicalRoute)) {
+        return null;
+      }
+
+      return toLocalizedContentHref(canonicalRoute);
+    },
+  });
+});
+
+/** Converts one previous subject URL into its source-owned lesson path. */
+function readPreviousSubjectLessonSourcePath(pathname: string) {
+  const [locale, namespace, _category, _grade, material, ...lessonSegments] =
+    pathname.split("/").filter(Boolean);
+
+  if (!(namespace === PREVIOUS_SUBJECT_NAMESPACE && material)) {
+    return null;
+  }
+
+  if (lessonSegments.length === 0) {
+    return null;
+  }
+
+  if (!hasLocale(routing.locales, locale)) {
+    return null;
+  }
+
+  return {
+    locale,
+    sourcePath: [MATERIAL_LESSON_SOURCE_ROOT, material, ...lessonSegments].join(
+      "/"
+    ),
+  };
+}

--- a/apps/www/proxy.test.ts
+++ b/apps/www/proxy.test.ts
@@ -190,6 +190,20 @@ describe("proxy", () => {
     );
   });
 
+  it("redirects previous material lesson URLs to the canonical architecture", async () => {
+    const response = await proxy(
+      new NextRequest(
+        "http://localhost:3000/id/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle?utm=test"
+      )
+    );
+
+    expect(mockLocaleRouting.localeMiddleware).not.toHaveBeenCalled();
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/id/materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling?utm=test"
+    );
+  });
+
   it("returns real 404 responses for invalid finite source-backed HTML routes", async () => {
     const response = await proxy(
       new NextRequest("http://localhost:3000/id/quran/999")

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -12,6 +12,7 @@ import {
   type LocalizedLlmsRoute,
   resolveLlmsProxyRoute,
 } from "@/lib/llms/routes";
+import { readPublicUrlMigrationRedirect } from "@/lib/routing/public/migration";
 import { readProjectedHtmlRouteRejection } from "@/lib/routing/public/projected";
 import { readSourceBackedHtmlRouteRejection } from "@/lib/routing/public/source";
 
@@ -73,6 +74,20 @@ export async function proxy(request: NextRequest) {
 
   if (routeDecision.kind === "content-not-found") {
     return rewriteToContentNotFound(request, routeDecision.locale);
+  }
+
+  const urlMigrationRedirect = await Effect.runPromise(
+    readPublicUrlMigrationRedirect({
+      method: request.method,
+      pathname,
+    })
+  );
+
+  if (urlMigrationRedirect) {
+    const redirectUrl = new URL(request.url);
+    redirectUrl.pathname = urlMigrationRedirect;
+
+    return NextResponse.redirect(redirectUrl, 308);
   }
 
   const sourceBackedRouteRejection = await Effect.runPromise(


### PR DESCRIPTION
## Summary
- Add a public URL migration redirect seam for old material lesson URLs so crawlers/users land on the new canonical architecture.
- Wire the migration redirect into the Next proxy before stale namespace 404 handling.
- Cover the route helper and proxy branch, including query preservation.

## Indexing / Search Console
- Search Console sitemap index `https://nakafa.com/sitemap.xml` refreshed: submitted Jun 25, 2026; last read Jun 25, 2026; status Success; discovered pages 2,900.
- Live sitemap audit: 37 sitemap files, 2,900 entries, 0 old `/subject/` or `/exercises/` URLs.
- `pnpm --filter www index-now`: submitted 2,852 canonical URLs to IndexNow and Bing; 2,900 sitemap entries inspected; 48 duplicate entries skipped.
- `pnpm --filter www google-index`: inspected 2,900 sitemap entries / 2,852 canonical URLs; no Google Indexing API eligible URLs found, so general Google discovery remains Search Console + sitemap/canonical metadata.

## Verification
- `pnpm --filter www test`
- `pnpm format`
- `pnpm build`
- Local production check: old indexed lesson URL returns 308 to canonical `/id/materi/...`; canonical URL returns 200; old topic-only URL stays 404/noindex.

## Notes
- `pnpm format` still reports the existing large `packages/contents/quran/source.ts` warning.
