### PR TITLE
Improve localized SEO metadata architecture

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
@@ -19,6 +19,7 @@ import {
   readCurriculumGroupIcon,
   readCurriculumRouteIcon,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/icons";
+import { readCurriculumSeoContext } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo";
 import { CardMaterial } from "@/components/shared/card-material";
 import { ComingSoon } from "@/components/shared/coming-soon";
 import { ContainerList } from "@/components/shared/container-list";
@@ -32,8 +33,10 @@ import { RefContent } from "@/components/shared/ref-content";
 import { SubjectItem } from "@/components/shared/subject-item";
 import { SubjectList } from "@/components/shared/subject-list";
 import { getGithubUrl } from "@/lib/utils/github";
+import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
 import { createProjectedRouteAlternates } from "@/lib/utils/seo/alternates";
 import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
+import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 
 type CurriculumPageProps =
   PageProps<"/[locale]/curricula/[curriculum]/[[...path]]">;
@@ -62,11 +65,23 @@ export function generateStaticParams({
 export async function generateMetadata({
   params,
 }: CurriculumPageProps): Promise<Metadata> {
-  const { route } = await resolveCurriculumRoute(params);
+  const { locale, route } = await resolveCurriculumRoute(params);
+  const seo = await generateSEOMetadata(
+    readCurriculumSeoContext(route),
+    locale
+  );
 
   return {
-    title: { absolute: route.title },
+    title: { absolute: seo.title },
+    description: seo.description,
     alternates: createProjectedRouteAlternates(route, readCurriculumRoutes()),
+    ...getSocialMetadata({
+      title: seo.title,
+      description: seo.description,
+      locale,
+      path: `/${locale}/${route.publicPath}`,
+      image: getOgUrl(locale, route.publicPath),
+    }),
   };
 }
 

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import { readCurriculumRoutes } from "./data";
 import { readCurriculumSeoContext } from "./seo";
 
@@ -11,7 +11,7 @@ function readRoute(publicPath: string) {
       candidate.locale === "id" && candidate.publicPath === publicPath
   );
 
-  expect(route).toBeDefined();
+  assert(route, `Missing curriculum route fixture: ${publicPath}`);
 
   return route;
 }
@@ -19,10 +19,6 @@ function readRoute(publicPath: string) {
 describe("curriculum route SEO context", () => {
   it("keeps root curriculum metadata scoped to the program title", () => {
     const route = readRoute("kurikulum/merdeka");
-
-    if (!route) {
-      return;
-    }
 
     expect(readCurriculumSeoContext(route)).toMatchObject({
       type: "curriculum-context",
@@ -38,10 +34,6 @@ describe("curriculum route SEO context", () => {
   it("includes parent and program context for nested curriculum pages", () => {
     const route = readRoute("kurikulum/merdeka/kelas-10/biologi");
 
-    if (!route) {
-      return;
-    }
-
     expect(readCurriculumSeoContext(route)).toMatchObject({
       type: "curriculum-context",
       level: "subject",
@@ -53,12 +45,21 @@ describe("curriculum route SEO context", () => {
     });
   });
 
-  it("does not duplicate the program title when the current route already uses it", () => {
+  it("does not duplicate the root program as both parent and program", () => {
     const route = readRoute("kurikulum/merdeka/kelas-10");
 
-    if (!route) {
-      return;
-    }
+    expect(readCurriculumSeoContext(route)).toMatchObject({
+      level: "class",
+      parent: "Kurikulum Merdeka",
+      program: undefined,
+      data: {
+        title: "Kelas 10",
+      },
+    });
+  });
+
+  it("does not duplicate the program title when the current route already uses it", () => {
+    const route = readRoute("kurikulum/merdeka/kelas-10");
 
     expect(
       readCurriculumSeoContext({ ...route, title: "Kurikulum Merdeka" })

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { readCurriculumRoutes } from "./data";
+import { readCurriculumSeoContext } from "./seo";
+
+/** Reads a known curriculum route fixture from projected static rows. */
+function readRoute(publicPath: string) {
+  const route = readCurriculumRoutes().find(
+    (candidate) =>
+      candidate.locale === "id" && candidate.publicPath === publicPath
+  );
+
+  expect(route).toBeDefined();
+
+  return route;
+}
+
+describe("curriculum route SEO context", () => {
+  it("keeps root curriculum metadata scoped to the program title", () => {
+    const route = readRoute("kurikulum/merdeka");
+
+    if (!route) {
+      return;
+    }
+
+    expect(readCurriculumSeoContext(route)).toMatchObject({
+      type: "curriculum-context",
+      level: "track",
+      parent: undefined,
+      program: undefined,
+      data: {
+        title: "Kurikulum Merdeka",
+      },
+    });
+  });
+
+  it("includes parent and program context for nested curriculum pages", () => {
+    const route = readRoute("kurikulum/merdeka/kelas-10/biologi");
+
+    if (!route) {
+      return;
+    }
+
+    expect(readCurriculumSeoContext(route)).toMatchObject({
+      type: "curriculum-context",
+      level: "subject",
+      parent: "Kelas 10",
+      program: "Kurikulum Merdeka",
+      data: {
+        title: "Biologi",
+      },
+    });
+  });
+
+  it("does not duplicate the program title when the current route already uses it", () => {
+    const route = readRoute("kurikulum/merdeka/kelas-10");
+
+    if (!route) {
+      return;
+    }
+
+    expect(
+      readCurriculumSeoContext({ ...route, title: "Kurikulum Merdeka" })
+    ).toMatchObject({
+      parent: "Kurikulum Merdeka",
+      program: undefined,
+    });
+  });
+});

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.ts
@@ -1,0 +1,30 @@
+import {
+  isRenderableCurriculumRoute,
+  readCurriculumAncestors,
+} from "@repo/contents/_types/route/curriculum";
+import type { PublicCurriculumRoute } from "@repo/contents/_types/route/schema";
+import { readCurriculumRoutes } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data";
+import type { SEOContext } from "@/lib/utils/seo/types";
+
+/** Builds shared SEO metadata input from one projected curriculum route. */
+export function readCurriculumSeoContext(
+  route: PublicCurriculumRoute
+): Extract<SEOContext, { type: "curriculum-context" }> {
+  const ancestors = readCurriculumAncestors(
+    route,
+    readCurriculumRoutes()
+  ).filter(isRenderableCurriculumRoute);
+  const parent = ancestors.at(-1);
+  const program = ancestors.at(0);
+
+  return {
+    type: "curriculum-context",
+    level: route.level,
+    parent: parent?.title,
+    program: program?.title === route.title ? undefined : program?.title,
+    data: {
+      title: route.title,
+      description: route.materialCardDescription,
+    },
+  };
+}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.ts
@@ -16,12 +16,18 @@ export function readCurriculumSeoContext(
   ).filter(isRenderableCurriculumRoute);
   const parent = ancestors.at(-1);
   const program = ancestors.at(0);
+  const parentTitle = parent?.title;
+  const programTitle = program?.title;
+  const programContext =
+    programTitle && programTitle !== route.title && programTitle !== parentTitle
+      ? programTitle
+      : undefined;
 
   return {
     type: "curriculum-context",
     level: route.level,
-    parent: parent?.title,
-    program: program?.title === route.title ? undefined : program?.title,
+    parent: parentTitle,
+    program: programContext,
     data: {
       title: route.title,
       description: route.materialCardDescription,

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/data.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/data.test.ts
@@ -11,12 +11,6 @@ import {
   readPracticeRoutes,
   toPracticeHref,
 } from "./routes";
-import {
-  localizeQuestionPaginationItem,
-  readExerciseSetSourceParts,
-  readGroupTitle,
-  readQuestionSourcePathParts,
-} from "./source";
 
 const runtimeMocks = vi.hoisted(() => ({
   fetchRuntimeExerciseQuestionPage: vi.fn(),
@@ -425,73 +419,6 @@ describe("practice route data", () => {
         })
       )
     ).rejects.toThrow();
-  });
-
-  it("keeps source-path parsing and pagination labels route-owned", () => {
-    expect(
-      readGroupTitle({
-        sourcePath:
-          "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1",
-      })
-    ).toBe("Try Out 2026");
-    expect(
-      readGroupTitle({
-        sourcePath:
-          "material/practice/assessment/snbt/quantitative-knowledge/drill/set-1",
-      })
-    ).toBe("drill");
-    expect(
-      readQuestionSourcePathParts(
-        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1/9"
-      )
-    ).toEqual({
-      questionNumber: 9,
-      setSourcePath:
-        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1",
-    });
-    expect(
-      readExerciseSetSourceParts(
-        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1"
-      )
-    ).toEqual({
-      category: "high-school",
-      exerciseType: "try-out",
-      material: "quantitative-knowledge",
-      type: "snbt",
-      year: "2026",
-    });
-    expect(
-      localizeQuestionPaginationItem({ href: "", title: "Previous" })
-    ).toEqual({ href: "", title: "Previous" });
-    expect(
-      localizeQuestionPaginationItem({ href: "/", title: "Next" })
-    ).toEqual({ href: "/", title: "Next" });
-    expect(
-      localizeQuestionPaginationItem({
-        href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question",
-        title: "Question",
-      })
-    ).toEqual({
-      href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question",
-      title: "Question",
-    });
-    expect(
-      localizeQuestionPaginationItem({
-        href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/2",
-        title: "Question 2",
-      })
-    ).toEqual({
-      href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question-2",
-      title: "Question 2",
-    });
-    expect(() => readQuestionSourcePathParts("question-x")).toThrow();
-    expect(() => readQuestionSourcePathParts("")).toThrow();
-    expect(() => readExerciseSetSourceParts("material/practice")).toThrow();
-    expect(() =>
-      readExerciseSetSourceParts(
-        "material/practice/assessment/unknown/quantitative-knowledge/try-out-2026/set-1"
-      )
-    ).toThrow();
   });
 });
 

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/data.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/data.ts
@@ -6,6 +6,7 @@ import {
 } from "@repo/contents/_types/route/practice/path";
 import { notFound } from "next/navigation";
 import type { Locale } from "next-intl";
+import { readPracticeSetDisplay } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display";
 import {
   findPracticeDomainRoutes,
   findPracticeRoute,
@@ -18,9 +19,12 @@ import {
   toPracticeHref,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/routes";
 import {
+  readPracticeDomainSeoContext,
+  readPracticeRouteSeoContext,
+} from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/seo";
+import {
   localizeQuestionPaginationItem,
   readExerciseSetSourceParts,
-  readGroupTitle,
   readQuestionSourcePathParts,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source";
 import {
@@ -29,6 +33,7 @@ import {
 } from "@/lib/content/runtime/pages";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { selectLearningStaticParams } from "@/lib/routing/prerender";
+import type { SEOContext } from "@/lib/utils/seo/types";
 
 type PracticeParams =
   PageProps<"/[locale]/practice/[assessment]/[domain]/[[...path]]">["params"];
@@ -84,12 +89,14 @@ export type PracticeMetadataData =
       alternatePaths: Array<{ locale: Locale; publicPath: string }>;
       locale: Locale;
       publicPath: string;
+      seoContext: Extract<SEOContext, { type: "exercise" }>;
       sourceMaterial: ExerciseSetSourceParts["material"];
     }
   | {
       kind: "route";
       locale: Locale;
       route: PracticeRoute;
+      seoContext: Extract<SEOContext, { type: "exercise" }>;
     };
 
 type PracticeGroupContext = ReturnType<typeof readPracticeGroupContext>;
@@ -182,10 +189,13 @@ export async function getPracticeMetadataData(
     return getDomainMetadataData(locale, projectedRoute.routes, routes);
   }
 
+  const seoContext = readPracticeRouteSeoContext(projectedRoute.route, routes);
+
   return {
     kind: "route",
     locale,
     route: projectedRoute.route,
+    seoContext,
   };
 }
 
@@ -258,6 +268,7 @@ function readPracticeGroupContext(
       candidate.parentPath === setRoute.parentPath
   );
   const sourceParts = readExerciseSetSourceParts(setRoute.sourcePath);
+  const display = readPracticeSetDisplay(setRoute);
 
   const description = setRoute.description;
   const assessmentPath = readPublicPracticeAssessmentPath(setRoute);
@@ -270,7 +281,7 @@ function readPracticeGroupContext(
     sourceMaterial: sourceParts.material,
     sourceType: sourceParts.type,
     material: {
-      title: readGroupTitle(setRoute),
+      title: display.groupTitle,
       description,
       href: `/${locale}/${domainPath}`,
       items: sets.map((set) => ({
@@ -406,6 +417,7 @@ function getDomainMetadataData(
     ),
     locale,
     publicPath,
+    seoContext: readPracticeDomainSeoContext(firstRoute),
     sourceMaterial: sourceParts.material,
   };
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { readPracticeSetDisplay } from "./display";
+
+describe("readPracticeSetDisplay", () => {
+  it("reads authored localized display copy for a projected set route", () => {
+    expect(
+      readPracticeSetDisplay({
+        locale: "en",
+        publicPath: "practice/snbt/quantitative-knowledge/tryout-2026/set-1",
+      })
+    ).toMatchObject({
+      groupTitle: "Try Out 2026",
+      setTitle: "Set 1",
+    });
+  });
+
+  it("fails closed when authored display metadata is missing", () => {
+    expect(() =>
+      readPracticeSetDisplay({
+        locale: "en",
+        publicPath:
+          "practice/snbt/quantitative-knowledge/tryout-2026/missing-set",
+      })
+    ).toThrow();
+  });
+});

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display.ts
@@ -1,0 +1,28 @@
+import { MATERIAL_ROUTE_DOMAINS } from "@repo/contents/_types/material/domain";
+import { MATERIAL_SOURCES } from "@repo/contents/_types/material/source";
+import { readPublicPracticeSetMatch } from "@repo/contents/_types/route/practice/set";
+import { notFound } from "next/navigation";
+import type { Locale } from "next-intl";
+
+/** Reads authored localized display copy for one projected practice set row. */
+export function readPracticeSetDisplay(route: {
+  locale: Locale;
+  publicPath: string;
+}) {
+  const match = readPublicPracticeSetMatch({
+    domains: MATERIAL_ROUTE_DOMAINS,
+    locale: route.locale,
+    materials: MATERIAL_SOURCES,
+    publicPath: route.publicPath,
+  });
+
+  if (!match) {
+    notFound();
+  }
+
+  return {
+    groupDescription: match.group.translations[route.locale].description,
+    groupTitle: match.group.translations[route.locale].title,
+    setTitle: match.set.translations[route.locale].title,
+  };
+}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/domain.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/domain.tsx
@@ -60,11 +60,7 @@ export async function PracticeDomainPage({
             link={{ href: data.assessmentPath, label: t(data.sourceType) }}
             title={title}
           />
-          <p className="sr-only">
-            {locale === "id"
-              ? "Pilih set latihan yang tersedia untuk membuka soal latihan pada domain ini."
-              : "Choose an available practice set to open the questions for this domain."}
-          </p>
+          <p className="sr-only">{t("domain-set-list-description")}</p>
           <LayoutContent>
             <ContainerList className="sm:grid-cols-1">
               {data.groups.map((group) => (

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
 import {
   getPracticeMetadataData,
   getPracticeRouteData,
@@ -18,6 +17,7 @@ import {
   createLocalizedAlternates,
   createProjectedRouteAlternates,
 } from "@/lib/utils/seo/alternates";
+import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 
 type PracticePageProps =
   PageProps<"/[locale]/practice/[assessment]/[domain]/[[...path]]">;
@@ -41,14 +41,9 @@ export async function generateMetadata({
   params,
 }: PracticePageProps): Promise<Metadata> {
   const data = await getPracticeMetadataData(params);
-  const t = await getTranslations({
-    locale: data.locale,
-    namespace: "Exercises",
-  });
-  const title =
-    data.kind === "domain" ? t(data.sourceMaterial) : data.route.title;
-  const description =
-    data.kind === "domain" ? title : (data.route.description ?? title);
+  const seo = await generateSEOMetadata(data.seoContext, data.locale);
+  const title = seo.title;
+  const description = seo.description;
   const publicPath =
     data.kind === "domain" ? data.publicPath : data.route.publicPath;
   const path = `/${data.locale}/${publicPath}`;

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/seo.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/seo.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { readPracticeRouteSeoContext } from "./seo";
+
+describe("practice route SEO support", () => {
+  it("requires question metadata to resolve through its parent set route", () => {
+    expect(() =>
+      readPracticeRouteSeoContext(
+        {
+          kind: "exercise-question",
+          locale: "en",
+          parentPath:
+            "practice/snbt/quantitative-knowledge/tryout-2026/missing-set",
+          sourcePath:
+            "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1/9",
+        },
+        []
+      )
+    ).toThrow();
+  });
+});

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/seo.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/seo.ts
@@ -1,0 +1,107 @@
+import { notFound } from "next/navigation";
+import type { Locale } from "next-intl";
+import { readPracticeSetDisplay } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/display";
+import {
+  readExerciseSetSourceParts,
+  readQuestionSourcePathParts,
+} from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source";
+import type { ContentSEOData, SEOContext } from "@/lib/utils/seo/types";
+
+type ExerciseSetSourceParts = ReturnType<typeof readExerciseSetSourceParts>;
+interface PracticeSetRouteForSeo {
+  readonly description?: string;
+  readonly kind: "exercise-set";
+  readonly locale: Locale;
+  readonly publicPath: string;
+  readonly sourcePath: string;
+}
+interface PracticeQuestionRouteForSeo {
+  readonly description?: string;
+  readonly kind: "exercise-question";
+  readonly locale: Locale;
+  readonly parentPath: string;
+  readonly sourcePath: string;
+}
+type PracticeRouteForSeo = PracticeSetRouteForSeo | PracticeQuestionRouteForSeo;
+
+/** Builds domain-level SEO context from a projected practice domain route. */
+export function readPracticeDomainSeoContext(
+  route: PracticeSetRouteForSeo
+): Extract<SEOContext, { type: "exercise" }> {
+  const sourceParts = readExerciseSetSourceParts(route.sourcePath);
+
+  return createPracticeSEOContext({
+    sourceParts,
+    data: { title: sourceParts.material },
+  });
+}
+
+/** Builds dictionary-backed SEO context from a projected practice set/question route. */
+export function readPracticeRouteSeoContext(
+  route: PracticeRouteForSeo,
+  routes: readonly PracticeSetRouteForSeo[]
+): Extract<SEOContext, { type: "exercise" }> {
+  if (route.kind === "exercise-set") {
+    const display = readPracticeSetDisplay(route);
+
+    return createPracticeSEOContext({
+      sourceParts: readExerciseSetSourceParts(route.sourcePath),
+      group: display.groupTitle,
+      set: display.setTitle,
+      data: {
+        title: display.setTitle,
+        description: route.description,
+      },
+    });
+  }
+
+  const setRoute = routes.find(
+    (candidate) =>
+      candidate.locale === route.locale &&
+      candidate.publicPath === route.parentPath
+  );
+
+  if (!setRoute) {
+    notFound();
+  }
+
+  const display = readPracticeSetDisplay(setRoute);
+  const { questionNumber } = readQuestionSourcePathParts(route.sourcePath);
+
+  return createPracticeSEOContext({
+    sourceParts: readExerciseSetSourceParts(setRoute.sourcePath),
+    group: display.groupTitle,
+    number: questionNumber,
+    set: display.setTitle,
+    data: {
+      title: display.setTitle,
+      description: route.description,
+    },
+  });
+}
+
+/** Normalizes practice source parts into the shared SEO generator context. */
+function createPracticeSEOContext({
+  data,
+  group,
+  number,
+  set,
+  sourceParts,
+}: {
+  data: ContentSEOData;
+  group?: string;
+  number?: number;
+  set?: string;
+  sourceParts: ExerciseSetSourceParts;
+}): Extract<SEOContext, { type: "exercise" }> {
+  return {
+    type: "exercise",
+    category: sourceParts.category,
+    exam: sourceParts.type,
+    material: sourceParts.material,
+    group,
+    set,
+    number,
+    data,
+  };
+}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  localizeQuestionPaginationItem,
+  readExerciseSetSourceParts,
+  readQuestionSourcePathParts,
+} from "./source";
+
+describe("practice route source parsing", () => {
+  it("parses source-owned practice set and question paths", () => {
+    expect(
+      readQuestionSourcePathParts(
+        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1/9"
+      )
+    ).toEqual({
+      questionNumber: 9,
+      setSourcePath:
+        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1",
+    });
+    expect(
+      readExerciseSetSourceParts(
+        "material/practice/assessment/snbt/quantitative-knowledge/try-out-2026/set-1"
+      )
+    ).toEqual({
+      category: "high-school",
+      exerciseType: "try-out",
+      material: "quantitative-knowledge",
+      type: "snbt",
+      year: "2026",
+    });
+  });
+
+  it("localizes numeric question pagination segments only", () => {
+    const emptyHrefItem = { href: "", title: "Question" };
+
+    expect(localizeQuestionPaginationItem(emptyHrefItem)).toBe(emptyHrefItem);
+    expect(
+      localizeQuestionPaginationItem({
+        href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question",
+        title: "Question",
+      })
+    ).toEqual({
+      href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question",
+      title: "Question",
+    });
+    expect(
+      localizeQuestionPaginationItem({
+        href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/2",
+        title: "Question 2",
+      })
+    ).toEqual({
+      href: "/en/practice/snbt/quantitative-knowledge/tryout-2026/set-1/question-2",
+      title: "Question 2",
+    });
+  });
+
+  it("fails closed for invalid source paths", () => {
+    expect(() => readQuestionSourcePathParts("question-x")).toThrow();
+    expect(() => readQuestionSourcePathParts("")).toThrow();
+    expect(() => readExerciseSetSourceParts("material/practice")).toThrow();
+    expect(() =>
+      readExerciseSetSourceParts(
+        "material/practice/assessment/unknown/quantitative-knowledge/try-out-2026/set-1"
+      )
+    ).toThrow();
+  });
+});

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source.ts
@@ -9,18 +9,6 @@ import {
 } from "@repo/contents/_types/route/practice/path";
 import { notFound } from "next/navigation";
 
-/** Uses the first set row to name the grouped practice card consistently. */
-export function readGroupTitle(route: { sourcePath: string }) {
-  const sourceParts = readExerciseSetSourceParts(route.sourcePath);
-  const suffix = sourceParts.year ? ` ${sourceParts.year}` : "";
-
-  if (sourceParts.exerciseType === "try-out") {
-    return `Try Out${suffix}`;
-  }
-
-  return `${sourceParts.exerciseType}${suffix}`;
-}
-
 /** Reads source set and question number from a projected question source path. */
 export function readQuestionSourcePathParts(sourcePath: string) {
   const parts = readPracticeQuestionSourceParts(sourcePath);

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/data.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/data.ts
@@ -13,6 +13,7 @@ import {
 import { readExerciseSetSourceParts } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/[domain]/[[...path]]/source";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { selectLearningStaticParams } from "@/lib/routing/prerender";
+import type { SEOContext } from "@/lib/utils/seo/types";
 
 type PracticeProgramParams = Promise<{ assessment: string; locale: string }>;
 
@@ -27,6 +28,7 @@ export interface PracticeProgramData {
   domains: PracticeProgramDomain[];
   locale: Locale;
   publicPath: string;
+  seoContext: Extract<SEOContext, { type: "exercise-program" }>;
   sourceCategory: ReturnType<typeof readExerciseSetSourceParts>["category"];
   sourceType: ReturnType<typeof readExerciseSetSourceParts>["type"];
 }
@@ -83,6 +85,14 @@ export async function getPracticeProgramData(
     ),
     locale,
     publicPath,
+    seoContext: {
+      type: "exercise-program",
+      category: sourceParts.category,
+      exam: sourceParts.type,
+      data: {
+        title: sourceParts.type,
+      },
+    },
     sourceCategory: sourceParts.category,
     sourceType: sourceParts.type,
   };

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/practice/[assessment]/page.tsx
@@ -20,6 +20,7 @@ import { getGithubUrl } from "@/lib/utils/github";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
 import { createLocalizedAlternates } from "@/lib/utils/seo/alternates";
 import { createBreadcrumbItems } from "@/lib/utils/seo/breadcrumbs";
+import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 
 interface PracticeProgramPageProps {
   params: Promise<{ assessment: string; locale: string }>;
@@ -39,12 +40,9 @@ export async function generateMetadata({
   params,
 }: PracticeProgramPageProps): Promise<Metadata> {
   const data = await getPracticeProgramData(params);
-  const t = await getTranslations({
-    locale: data.locale,
-    namespace: "Exercises",
-  });
-  const title = t(data.sourceType);
-  const description = t("type-description");
+  const seo = await generateSEOMetadata(data.seoContext, data.locale);
+  const title = seo.title;
+  const description = seo.description;
   const path = data.assessmentPath;
 
   return {
@@ -102,11 +100,7 @@ export default async function Page({ params }: PracticeProgramPageProps) {
             icon={getCategoryIcon(data.sourceCategory)}
             title={title}
           />
-          <p className="sr-only">
-            {data.locale === "id"
-              ? "Pilih domain latihan SNBT yang tersedia untuk membuka set soal."
-              : "Choose an available SNBT practice domain to open question sets."}
-          </p>
+          <p className="sr-only">{t("program-domain-list-description")}</p>
           <LayoutContent>
             <SubjectList>
               {data.domains.map((domain) => (

--- a/apps/www/lib/utils/seo/fallback.test.ts
+++ b/apps/www/lib/utils/seo/fallback.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { generateFallbackMetadata } from "@/lib/utils/seo/fallback";
+
+describe("generateFallbackMetadata", () => {
+  it("uses material source context for subject content fallback", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "material-lesson",
+        category: "high-school",
+        grade: "11",
+        material: "mathematics",
+        data: {
+          title: "Trigonometric Function Graph",
+          description: "Graph lesson fallback.",
+        },
+      })
+    ).toStrictEqual({
+      title: "Trigonometric Function Graph - mathematics - Nakafa",
+      description: "Graph lesson fallback. Trigonometric Function Graph",
+      keywords: [],
+    });
+  });
+
+  it("uses exercise material context for practice fallback", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        data: {
+          title: "Question 9",
+          description: "Exercise fallback.",
+        },
+      })
+    ).toStrictEqual({
+      title: "Question 9 - quantitative-knowledge - Nakafa",
+      description: "Exercise fallback. Question 9",
+      keywords: [],
+    });
+  });
+
+  it("uses the assessment key as the fallback display context", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "exercise-program",
+        category: "high-school",
+        exam: "snbt",
+        data: {
+          title: "SNBT",
+          description: "Assessment fallback.",
+        },
+      })
+    ).toStrictEqual({
+      title: "SNBT - snbt - Nakafa",
+      description: "Assessment fallback. SNBT",
+      keywords: [],
+    });
+  });
+
+  it("uses article category context for article fallback", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "article",
+        category: "politics",
+        data: {
+          title: "Regional Elections",
+          description: "Article fallback.",
+        },
+      })
+    ).toStrictEqual({
+      title: "Regional Elections - politics - Nakafa",
+      description: "Article fallback. Regional Elections",
+      keywords: [],
+    });
+  });
+
+  it("uses curriculum program context when a title is unavailable", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "curriculum-context",
+        level: "track",
+        program: "Kurikulum Merdeka",
+        data: {
+          description: "Curriculum fallback.",
+        },
+      })
+    ).toStrictEqual({
+      title: "Kurikulum Merdeka - Nakafa",
+      description: "Curriculum fallback.",
+      keywords: [],
+    });
+  });
+
+  it("prefers curriculum title context before program context", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "curriculum-context",
+        level: "subject",
+        program: "Kurikulum Merdeka",
+        data: {
+          title: "Biologi",
+        },
+      })
+    ).toStrictEqual({
+      title: "Biologi - Biologi - Nakafa",
+      description: "Biologi",
+      keywords: [],
+    });
+  });
+
+  it("falls back to the site title when curriculum context is empty", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "curriculum-context",
+        level: "track",
+        data: {},
+      })
+    ).toStrictEqual({
+      title: "Nakafa",
+      description: "",
+      keywords: [],
+    });
+  });
+
+  it("uses English Quran translation for Quran fallback", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "quran",
+        surah: {
+          name: {
+            long: "الفاتحة",
+            short: "Al-Fatihah",
+            translation: { en: "The Opening", id: "Pembukaan" },
+            transliteration: { en: "Al-Fatihah", id: "Al-Fatihah" },
+          },
+          number: 1,
+          numberOfVerses: 7,
+          preBismillah: null,
+          revelation: { arab: "مكة", en: "Meccan", id: "Makkiyah" },
+          sequence: 5,
+          verses: [],
+        },
+      })
+    ).toStrictEqual({
+      title: "The Opening - Nakafa",
+      description: "The Opening",
+      keywords: [],
+    });
+  });
+});

--- a/apps/www/lib/utils/seo/fallback.test.ts
+++ b/apps/www/lib/utils/seo/fallback.test.ts
@@ -92,7 +92,7 @@ describe("generateFallbackMetadata", () => {
     });
   });
 
-  it("prefers curriculum title context before program context", () => {
+  it("uses curriculum program context with the content title", () => {
     expect(
       generateFallbackMetadata({
         type: "curriculum-context",
@@ -103,8 +103,25 @@ describe("generateFallbackMetadata", () => {
         },
       })
     ).toStrictEqual({
-      title: "Biologi - Biologi - Nakafa",
+      title: "Biologi - Kurikulum Merdeka - Nakafa",
       description: "Biologi",
+      keywords: [],
+    });
+  });
+
+  it("uses curriculum parent context when program context is unavailable", () => {
+    expect(
+      generateFallbackMetadata({
+        type: "curriculum-context",
+        level: "class",
+        parent: "Kurikulum Merdeka",
+        data: {
+          title: "Kelas 10",
+        },
+      })
+    ).toStrictEqual({
+      title: "Kelas 10 - Kurikulum Merdeka - Nakafa",
+      description: "Kelas 10",
       keywords: [],
     });
   });

--- a/apps/www/lib/utils/seo/fallback.ts
+++ b/apps/www/lib/utils/seo/fallback.ts
@@ -1,0 +1,44 @@
+import { createSEODescription } from "@/lib/utils/seo/descriptions";
+import { createSEOTitle } from "@/lib/utils/seo/titles";
+import type { SEOContext, SEOMetadata } from "@/lib/utils/seo/types";
+
+/** Builds fallback metadata when localized SEO dictionaries are unavailable. */
+export function generateFallbackMetadata(context: SEOContext): SEOMetadata {
+  const displayName = getDisplayNameFromContext(context);
+
+  if (context.type === "quran") {
+    return {
+      title: createSEOTitle([context.surah.name.translation.en, displayName]),
+      description: createSEODescription([context.surah.name.translation.en]),
+      keywords: [],
+    };
+  }
+
+  const { data } = context;
+
+  return {
+    title: createSEOTitle([data.title, data.subject, displayName]),
+    description: createSEODescription([data.description, data.title]),
+    keywords: [],
+  };
+}
+
+/** Reads the best stable source identifier for fallback title construction. */
+function getDisplayNameFromContext(context: SEOContext): string {
+  if (context.type === "material-lesson") {
+    return context.material;
+  }
+  if (context.type === "exercise") {
+    return context.material;
+  }
+  if (context.type === "exercise-program") {
+    return context.exam;
+  }
+  if (context.type === "article") {
+    return context.category;
+  }
+  if (context.type === "curriculum-context") {
+    return context.data.title ?? context.program ?? "";
+  }
+  return "";
+}

--- a/apps/www/lib/utils/seo/fallback.ts
+++ b/apps/www/lib/utils/seo/fallback.ts
@@ -38,7 +38,7 @@ function getDisplayNameFromContext(context: SEOContext): string {
     return context.category;
   }
   if (context.type === "curriculum-context") {
-    return context.data.title ?? context.program ?? "";
+    return context.program ?? context.parent ?? "";
   }
   return "";
 }

--- a/apps/www/lib/utils/seo/generator.test.ts
+++ b/apps/www/lib/utils/seo/generator.test.ts
@@ -16,20 +16,28 @@ vi.mock("next-intl/server", () => ({
   getTranslations: mockGetTranslations,
 }));
 
-type TranslationEntry =
-  | string
-  | ((values: Record<string, number | string>) => string);
+interface TranslationValues {
+  readonly [key: string]: number | string | undefined;
+}
+type TranslationEntry = string | ((values: TranslationValues) => string);
+interface TranslationDictionary {
+  readonly [key: string]: TranslationEntry | undefined;
+}
+interface TranslationNamespaces {
+  readonly [namespace: string]: TranslationDictionary | undefined;
+}
 
 /** Reads one ICU-like mock value as display text. */
-function getValue(values: Record<string, number | string>, key: string) {
+function getValue(values: TranslationValues, key: string) {
   return String(values[key] ?? "");
 }
 
-const translations = {
+const translations: TranslationNamespaces = {
   Articles: {
     politics: "Politics",
   },
   Exercises: {
+    "high-school": "High School",
     "quantitative-knowledge": "Quantitative Knowledge",
     snbt: "SNBT",
   },
@@ -43,12 +51,59 @@ const translations = {
       `${getValue(values, "title")}, ${getValue(values, "category")}, article`,
     "article.title": (values) =>
       `${getValue(values, "title")} - ${getValue(values, "category")} | Nakafa`,
-    "exercise.description": (values) =>
-      `Take ${getValue(values, "material")} ${getValue(values, "exam")} exercise with ${getValue(values, "questionCount")} questions and explanations for checking your reasoning.`,
+    "curriculum.description": (values) => {
+      const parent = getValue(values, "parent");
+      const program = getValue(values, "program");
+      const parentText = parent === "__EMPTY__" ? "" : ` in ${parent}`;
+      const programText = program === "__EMPTY__" ? "" : ` for ${program}`;
+
+      return `Browse ${getValue(values, "title")}${parentText}${programText}.`;
+    },
+    "curriculum.keywords": (values) =>
+      [
+        getValue(values, "title"),
+        getValue(values, "parent"),
+        getValue(values, "program"),
+      ]
+        .filter((value) => value && value !== "__EMPTY__")
+        .join(", "),
+    "curriculum.title": (values) => {
+      const parent = getValue(values, "parent");
+      const program = getValue(values, "program");
+      const parentText = parent === "__EMPTY__" ? "" : ` - ${parent}`;
+      const programText = program === "__EMPTY__" ? "" : ` (${program})`;
+
+      return `${getValue(values, "title")}${parentText}${programText} | Nakafa`;
+    },
+    "exercise-program.description": (values) =>
+      `Choose ${getValue(values, "exam")} practice domains for ${getValue(values, "category")}.`,
+    "exercise-program.keywords": (values) =>
+      `${getValue(values, "exam")}, ${getValue(values, "category")}, practice questions`,
+    "exercise-program.title": (values) =>
+      `${getValue(values, "exam")} Practice Questions | Nakafa`,
+    "exercise.description": (values) => {
+      const count = getValue(values, "questionCount");
+      const countLabel =
+        count === "0" ? "practice questions" : `${count} questions`;
+
+      return `Take ${getValue(values, "material")} ${getValue(values, "exam")} exercise with ${countLabel} and explanations for checking your reasoning.`;
+    },
     "exercise.keywords": (values) =>
       `${getValue(values, "material")}, ${getValue(values, "exam")}, exercise`,
-    "exercise.title": (values) =>
-      `Question ${getValue(values, "number")}/${getValue(values, "questionCount")}: ${getValue(values, "material")} (${getValue(values, "exam")}) | Nakafa`,
+    "exercise.title": (values) => {
+      const number = getValue(values, "number");
+      const questionTotal = getValue(values, "questionTotal");
+      const total = questionTotal === "__EMPTY__" ? "" : questionTotal;
+      const questionPrefix =
+        number === "0" ? "" : `Question ${number}${total}: `;
+      const set = getValue(values, "set");
+      const setPrefix =
+        set === "__EMPTY__" ? "" : `${set}${number === "0" ? ": " : " - "}`;
+      const group = getValue(values, "group");
+      const groupPrefix = group === "__EMPTY__" ? "" : `${group} - `;
+
+      return `${questionPrefix}${setPrefix}${groupPrefix}${getValue(values, "material")} (${getValue(values, "exam")}) | Nakafa`;
+    },
     "quran.description": (values) =>
       `Read Surah ${getValue(values, "name")} with ${getValue(values, "numberOfVerses")} verses.`,
     "quran.keywords": (values) =>
@@ -73,18 +128,13 @@ const translations = {
     grade: (values) => `Grade ${getValue(values, "grade")}`,
     mathematics: "Mathematics",
   },
-} satisfies Record<string, Record<string, TranslationEntry>>;
-
-const translationMap: Record<
-  string,
-  Record<string, TranslationEntry>
-> = translations;
+};
 
 /** Returns the mocked translator for the requested namespace. */
 function getTranslator(namespace: string) {
-  const dictionary = translationMap[namespace] ?? {};
+  const dictionary = translations[namespace] ?? {};
 
-  return (key: string, values: Record<string, number | string> = {}) => {
+  return (key: string, values: TranslationValues = {}) => {
     const entry = dictionary[key];
 
     if (typeof entry === "function") {
@@ -212,26 +262,6 @@ describe("generateSEOMetadata", () => {
     expect(result.title).toBe("Nakafa: Mathematics (Grade 11) | Nakafa");
   });
 
-  it("keeps long subject titles intact in the localized title template", async () => {
-    const result = await generateSEOMetadata(
-      {
-        type: "material-lesson",
-        category: "university",
-        grade: "bachelor",
-        material: "ai-ds",
-        chapter: "Linear Methods of AI",
-        data: {
-          title: "Best Approximation in Function and Polynomial Spaces",
-        },
-      },
-      "en"
-    );
-
-    expect(result.title).toBe(
-      "Best Approximation in Function and Polynomial Spaces: Linear Methods of AI - Artificial Intelligence & Data Science (Bachelor) | Nakafa"
-    );
-  });
-
   it("uses article MDX description before generated fallback copy", async () => {
     const result = await generateSEOMetadata(
       {
@@ -247,24 +277,6 @@ describe("generateSEOMetadata", () => {
 
     expect(result.description).toBe("Hand-written article summary.");
     expect(result.title).toBe("Regional Elections - Politics | Nakafa");
-  });
-
-  it("keeps long article titles intact in the localized title template", async () => {
-    const result = await generateSEOMetadata(
-      {
-        type: "article",
-        category: "politics",
-        data: {
-          title:
-            "Nepotism: The Machinations of Power in the Political Chessboard of Governance",
-        },
-      },
-      "en"
-    );
-
-    expect(result.title).toBe(
-      "Nepotism: The Machinations of Power in the Political Chessboard of Governance - Politics | Nakafa"
-    );
   });
 
   it("uses generated article description when MDX description is missing", async () => {
@@ -325,10 +337,79 @@ describe("generateSEOMetadata", () => {
     );
 
     expect(result.title).toBe(
-      "Question 0/0: Quantitative Knowledge (SNBT) | Nakafa"
+      "Set 1: Try Out - Quantitative Knowledge (SNBT) | Nakafa"
     );
     expect(result.description).toBe(
-      "Take Quantitative Knowledge SNBT exercise with 0 questions and explanations for checking your reasoning."
+      "Take Quantitative Knowledge SNBT exercise with practice questions and explanations for checking your reasoning."
+    );
+  });
+
+  it("generates assessment-root metadata without borrowing a material title", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise-program",
+        category: "high-school",
+        exam: "snbt",
+        data: { title: "SNBT" },
+      },
+      "en"
+    );
+
+    expect(result.title).toBe("SNBT Practice Questions | Nakafa");
+    expect(result.description).toBe(
+      "Choose SNBT practice domains for High School."
+    );
+  });
+
+  it("generates curriculum metadata from source-owned route context", async () => {
+    const nested = await generateSEOMetadata(
+      {
+        type: "curriculum-context",
+        level: "subject",
+        parent: "Grade 11",
+        program: "Kurikulum Merdeka",
+        data: { title: "Mathematics" },
+      },
+      "en"
+    );
+    const root = await generateSEOMetadata(
+      {
+        type: "curriculum-context",
+        level: "track",
+        data: { title: "Mathematics" },
+      },
+      "en"
+    );
+
+    expect(nested.title).toBe(
+      "Mathematics - Grade 11 (Kurikulum Merdeka) | Nakafa"
+    );
+    expect(nested.keywords).toEqual([
+      "Mathematics",
+      "Grade 11",
+      "Kurikulum Merdeka",
+    ]);
+    expect(root.title).toBe("Mathematics | Nakafa");
+    expect(root.description).toBe("Browse Mathematics.");
+  });
+
+  it("omits the question total when metadata has no runtime count", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        group: "Try Out 2026",
+        set: "Set 1",
+        number: 9,
+        data: { title: "Set 1" },
+      },
+      "en"
+    );
+
+    expect(result.title).toBe(
+      "Question 9: Set 1 - Try Out 2026 - Quantitative Knowledge (SNBT) | Nakafa"
     );
   });
 
@@ -345,91 +426,7 @@ describe("generateSEOMetadata", () => {
     expect(result.description).toBe("Read Surah Al-Fatihah with 7 verses.");
   });
 
-  it("falls back to English Quran labels when locale labels are empty", async () => {
-    const result = await generateSEOMetadata(
-      {
-        type: "quran",
-        surah: {
-          ...surah,
-          name: {
-            ...surah.name,
-            translation: {
-              en: "The Opening",
-              id: "",
-            },
-            transliteration: {
-              en: "Al-Fatihah",
-              id: "",
-            },
-          },
-          revelation: {
-            arab: "مكة",
-            en: "Meccan",
-            id: "",
-          },
-        },
-      },
-      "id"
-    );
-
-    expect(result.title).toBe("Surah 1. Al-Fatihah - The Opening | Nakafa");
-    expect(result.keywords).toEqual(["Al-Fatihah", "The Opening", "Meccan"]);
-  });
-
-  it("falls back to the short Quran name when translated names are empty", async () => {
-    const result = await generateSEOMetadata(
-      {
-        type: "quran",
-        surah: {
-          ...surah,
-          name: {
-            ...surah.name,
-            translation: {
-              en: "",
-              id: "",
-            },
-            transliteration: {
-              en: "",
-              id: "",
-            },
-          },
-          revelation: {
-            arab: "مكة",
-            en: "",
-            id: "",
-          },
-        },
-      },
-      "id"
-    );
-
-    expect(result.title).toBe("Surah 1. Al-Fatihah - Al-Fatihah | Nakafa");
-    expect(result.keywords).toEqual(["Al-Fatihah", "Al-Fatihah", ""]);
-  });
-
-  it("keeps Quran metadata stable when all display names are empty", async () => {
-    const result = await generateSEOMetadata(
-      {
-        type: "quran",
-        surah: {
-          ...surah,
-          name: {
-            ...surah.name,
-            short: "",
-            translation: {
-              en: "",
-              id: "",
-            },
-          },
-        },
-      },
-      "id"
-    );
-
-    expect(result.title).toBe("Surah 1.  -  | Nakafa");
-  });
-
-  it("falls back to local metadata builders when translations fail", async () => {
+  it("uses fallback metadata when dictionary loading fails", async () => {
     mockGetTranslations.mockRejectedValueOnce("missing translations");
 
     const result = await generateSEOMetadata(
@@ -449,141 +446,6 @@ describe("generateSEOMetadata", () => {
     expect(result).toStrictEqual({
       title: "Trigonometric Function Graph - mathematics - Nakafa",
       description: "Graph lesson fallback. Trigonometric Function Graph",
-      keywords: [],
-    });
-  });
-
-  it("falls back when Metadata translations fail for the ultimate title fallback", async () => {
-    mockGetTranslations.mockImplementation(({ namespace }) => {
-      if (namespace === "Metadata") {
-        return Promise.reject(new Error("missing Metadata translations"));
-      }
-
-      return Promise.resolve(getTranslator(namespace));
-    });
-
-    const result = await generateSEOMetadata(
-      {
-        type: "material-lesson",
-        category: "high-school",
-        grade: "11",
-        material: "mathematics",
-        data: {},
-      },
-      "en"
-    );
-
-    expect(result).toStrictEqual({
-      title: "mathematics - Nakafa",
-      description: "",
-      keywords: [],
-    });
-  });
-
-  it("falls back when Subject translations fail", async () => {
-    mockGetTranslations.mockImplementation(({ namespace }) => {
-      if (namespace === "Subject") {
-        return Promise.reject(new Error("missing Subject translations"));
-      }
-
-      return Promise.resolve(getTranslator(namespace));
-    });
-
-    const result = await generateSEOMetadata(
-      {
-        type: "material-lesson",
-        category: "high-school",
-        grade: "11",
-        material: "mathematics",
-        data: {
-          title: "Trigonometric Function Graph",
-          description: "Graph lesson fallback.",
-        },
-      },
-      "en"
-    );
-
-    expect(result).toStrictEqual({
-      title: "Trigonometric Function Graph - mathematics - Nakafa",
-      description: "Graph lesson fallback. Trigonometric Function Graph",
-      keywords: [],
-    });
-  });
-
-  it("falls back to Quran metadata when Quran translations fail", async () => {
-    mockGetTranslations.mockRejectedValueOnce(
-      new Error("missing translations")
-    );
-
-    const result = await generateSEOMetadata(
-      {
-        type: "quran",
-        surah,
-      },
-      "en"
-    );
-
-    expect(result).toStrictEqual({
-      title: "The Opening - Nakafa",
-      description: "The Opening",
-      keywords: [],
-    });
-  });
-
-  it("falls back to exercise metadata when exercise translations fail", async () => {
-    mockGetTranslations.mockImplementation(({ namespace }) => {
-      if (namespace === "Exercises") {
-        return Promise.reject(new Error("missing Exercises translations"));
-      }
-
-      return Promise.resolve(getTranslator(namespace));
-    });
-
-    const result = await generateSEOMetadata(
-      {
-        type: "exercise",
-        category: "high-school",
-        exam: "snbt",
-        material: "quantitative-knowledge",
-        data: {
-          title: "Question 9",
-          description: "Exercise fallback.",
-        },
-      },
-      "en"
-    );
-
-    expect(result).toStrictEqual({
-      title: "Question 9 - quantitative-knowledge - Nakafa",
-      description: "Exercise fallback. Question 9",
-      keywords: [],
-    });
-  });
-
-  it("falls back to article metadata when article translations fail", async () => {
-    mockGetTranslations.mockImplementation(({ namespace }) => {
-      if (namespace === "Articles") {
-        return Promise.reject(new Error("missing Articles translations"));
-      }
-
-      return Promise.resolve(getTranslator(namespace));
-    });
-
-    const result = await generateSEOMetadata(
-      {
-        type: "article",
-        category: "politics",
-        data: {
-          title: "Regional Elections",
-          description: "Article fallback.",
-        },
-      },
-      "en"
-    );
-
-    expect(result).toStrictEqual({
-      title: "Regional Elections - politics - Nakafa",
-      description: "Article fallback. Regional Elections",
       keywords: [],
     });
   });

--- a/apps/www/lib/utils/seo/generator.test.ts
+++ b/apps/www/lib/utils/seo/generator.test.ts
@@ -320,6 +320,28 @@ describe("generateSEOMetadata", () => {
     );
   });
 
+  it("uses authored exercise descriptions before generated fallback copy", async () => {
+    const result = await generateSEOMetadata(
+      {
+        type: "exercise",
+        category: "high-school",
+        exam: "snbt",
+        material: "quantitative-knowledge",
+        group: "Try Out 2026",
+        set: "Set 1",
+        data: {
+          title: "Set 1",
+          description: "Authored route description for the practice set.",
+        },
+      },
+      "en"
+    );
+
+    expect(result.description).toBe(
+      "Authored route description for the practice set."
+    );
+  });
+
   it("uses exercise defaults when optional route data is absent", async () => {
     const result = await generateSEOMetadata(
       {

--- a/apps/www/lib/utils/seo/generator.ts
+++ b/apps/www/lib/utils/seo/generator.ts
@@ -1,111 +1,43 @@
 import { getGradeNonNumeric } from "@repo/contents/_lib/curriculum/grade";
 import type {
   ArticleCategory,
+  ExercisesCategory,
   ExercisesMaterial,
   ExercisesType,
   Grade,
   Material,
 } from "@repo/contents/_types/taxonomy";
-import { Effect, Option, Schema } from "effect";
+import { Effect, Option } from "effect";
 import { cacheLife } from "next/cache";
 import type { Locale } from "next-intl";
-import { getTranslations } from "next-intl/server";
-import { createSEODescription } from "@/lib/utils/seo/descriptions";
-import { createSEOTitle } from "@/lib/utils/seo/titles";
+import { generateFallbackMetadata } from "@/lib/utils/seo/fallback";
+import { generateQuranMetadata } from "@/lib/utils/seo/quran";
+import { fetchSEOTranslationsNamespace } from "@/lib/utils/seo/translations";
 import type {
   ContentSEOData,
   SEOContext,
   SEOMetadata,
 } from "@/lib/utils/seo/types";
 
-/** Expected failure when a localized SEO dictionary cannot be loaded. */
-class SEOTranslationLoadError extends Schema.TaggedError<SEOTranslationLoadError>()(
-  "SEOTranslationLoadError",
-  {
-    locale: Schema.String,
-    message: Schema.String,
-    namespace: Schema.String,
-  }
-) {}
-
-/** Converts unknown thrown values into readable fallback error messages. */
-function getErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return "Unknown translation loading error";
-}
-
-/**
- * Fetches translations for the Metadata namespace.
- */
+/** Fetches translations for the Metadata namespace. */
 const fetchMetadataTranslations = (locale: Locale) =>
-  Effect.tryPromise({
-    try: () => getTranslations({ locale, namespace: "Metadata" }),
-    catch: (error: unknown) =>
-      new SEOTranslationLoadError({
-        locale,
-        namespace: "Metadata",
-        message: `Failed to load Metadata translations: ${getErrorMessage(error)}`,
-      }),
-  });
+  fetchSEOTranslationsNamespace(locale, "Metadata");
 
-/**
- * Fetches translations for the Subject namespace.
- */
+/** Fetches translations for the Subject namespace. */
 const fetchSubjectTranslations = (locale: Locale) =>
-  Effect.tryPromise({
-    try: () => getTranslations({ locale, namespace: "Subject" }),
-    catch: (error: unknown) =>
-      new SEOTranslationLoadError({
-        locale,
-        namespace: "Subject",
-        message: `Failed to load Subject translations: ${getErrorMessage(error)}`,
-      }),
-  });
+  fetchSEOTranslationsNamespace(locale, "Subject");
 
-/**
- * Fetches translations for the Exercises namespace.
- */
+/** Fetches translations for the Exercises namespace. */
 const fetchExercisesTranslations = (locale: Locale) =>
-  Effect.tryPromise({
-    try: () => getTranslations({ locale, namespace: "Exercises" }),
-    catch: (error: unknown) =>
-      new SEOTranslationLoadError({
-        locale,
-        namespace: "Exercises",
-        message: `Failed to load Exercises translations: ${getErrorMessage(error)}`,
-      }),
-  });
+  fetchSEOTranslationsNamespace(locale, "Exercises");
 
-/**
- * Fetches translations for the Articles namespace.
- */
+/** Fetches translations for the Articles namespace. */
 const fetchArticlesTranslations = (locale: Locale) =>
-  Effect.tryPromise({
-    try: () => getTranslations({ locale, namespace: "Articles" }),
-    catch: (error: unknown) =>
-      new SEOTranslationLoadError({
-        locale,
-        namespace: "Articles",
-        message: `Failed to load Articles translations: ${getErrorMessage(error)}`,
-      }),
-  });
+  fetchSEOTranslationsNamespace(locale, "Articles");
 
-/**
- * Fetches translations for the SEO namespace.
- */
+/** Fetches translations for the SEO namespace. */
 const fetchSEOTranslations = (locale: Locale) =>
-  Effect.tryPromise({
-    try: () => getTranslations({ locale, namespace: "SEO" }),
-    catch: (error: unknown) =>
-      new SEOTranslationLoadError({
-        locale,
-        namespace: "SEO",
-        message: `Failed to load SEO translations: ${getErrorMessage(error)}`,
-      }),
-  });
+  fetchSEOTranslationsNamespace(locale, "SEO");
 
 /**
  * Gets effective title with fallback chain:
@@ -167,6 +99,15 @@ const translateExerciseMaterial = Effect.fn("SEO.translateExerciseMaterial")(
     Effect.gen(function* () {
       const tExercises = yield* fetchExercisesTranslations(locale);
       return tExercises(material);
+    })
+);
+
+/** Translates exercise category from Exercises namespace. */
+const translateExerciseCategory = Effect.fn("SEO.translateExerciseCategory")(
+  (category: ExercisesCategory, locale: Locale) =>
+    Effect.gen(function* () {
+      const tExercises = yield* fetchExercisesTranslations(locale);
+      return tExercises(category);
     })
 );
 
@@ -249,6 +190,48 @@ const generateSubjectMetadata = Effect.fn("SEO.generateSubjectMetadata")(
     })
 );
 
+/** Generates SEO metadata for practice assessment roots. */
+const generateExerciseProgramMetadata = Effect.fn(
+  "SEO.generateExerciseProgramMetadata"
+)(
+  (
+    context: Extract<SEOContext, { type: "exercise-program" }>,
+    locale: Locale
+  ) =>
+    Effect.gen(function* () {
+      const { category, data, exam } = context;
+      const [t, effectiveTitle, categoryDisplayName, examDisplayName] =
+        yield* Effect.all([
+          fetchSEOTranslations(locale),
+          getEffectiveTitle(data, locale),
+          translateExerciseCategory(category, locale),
+          translateExerciseType(exam, locale),
+        ]);
+
+      return {
+        title: t("exercise-program.title", {
+          category: categoryDisplayName,
+          exam: examDisplayName,
+          title: effectiveTitle,
+        }),
+        description:
+          getContentDescription(data) ??
+          t("exercise-program.description", {
+            category: categoryDisplayName,
+            exam: examDisplayName,
+            title: effectiveTitle,
+          }),
+        keywords: t("exercise-program.keywords", {
+          category: categoryDisplayName,
+          exam: examDisplayName,
+          title: effectiveTitle,
+        })
+          .split(", ")
+          .map((k: string) => k.trim()),
+      };
+    })
+);
+
 /**
  * Generates SEO metadata for exercise content.
  */
@@ -272,6 +255,8 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
 
       // Convert number to string for ICU select
       const numberValue = number && number > 0 ? String(number) : "0";
+      const questionTotalValue =
+        questionCount && questionCount > 0 ? `/${questionCount}` : "__EMPTY__";
 
       return {
         title: t("exercise.title", {
@@ -279,6 +264,7 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
           group: groupValue,
           set: setValue,
           number: numberValue,
+          questionTotal: questionTotalValue,
           questionCount: questionCount ?? 0,
           material: materialDisplayName,
           title: effectiveTitle,
@@ -297,6 +283,45 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
           set: setValue,
           material: materialDisplayName,
           title: effectiveTitle,
+        })
+          .split(", ")
+          .map((k: string) => k.trim()),
+      };
+    })
+);
+
+/** Generates SEO metadata for curriculum context pages. */
+const generateCurriculumMetadata = Effect.fn("SEO.generateCurriculumMetadata")(
+  (
+    context: Extract<SEOContext, { type: "curriculum-context" }>,
+    locale: Locale
+  ) =>
+    Effect.gen(function* () {
+      const { data, parent, program } = context;
+      const [t, effectiveTitle] = yield* Effect.all([
+        fetchSEOTranslations(locale),
+        getEffectiveTitle(data, locale),
+      ]);
+      const parentValue = parent?.trim() || "__EMPTY__";
+      const programValue = program?.trim() || "__EMPTY__";
+
+      return {
+        title: t("curriculum.title", {
+          title: effectiveTitle,
+          parent: parentValue,
+          program: programValue,
+        }),
+        description:
+          getContentDescription(data) ??
+          t("curriculum.description", {
+            title: effectiveTitle,
+            parent: parentValue,
+            program: programValue,
+          }),
+        keywords: t("curriculum.keywords", {
+          title: effectiveTitle,
+          parent: parentValue,
+          program: programValue,
         })
           .split(", ")
           .map((k: string) => k.trim()),
@@ -340,48 +365,6 @@ const generateArticleMetadata = Effect.fn("SEO.generateArticleMetadata")(
 );
 
 /**
- * Generates SEO metadata for quran content.
- */
-const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
-  (context: Extract<SEOContext, { type: "quran" }>, locale: Locale) =>
-    Effect.gen(function* () {
-      const { surah } = context;
-      const name = surah.name.short;
-      const transliteration =
-        surah.name.transliteration[locale] ||
-        surah.name.transliteration.en ||
-        name;
-      const translation =
-        surah.name.translation[locale] || surah.name.translation.en || name;
-      const revelation = surah.revelation[locale] || surah.revelation.en || "";
-      const effectiveTitle = translation || name;
-
-      const t = yield* fetchSEOTranslations(locale);
-
-      return {
-        title: t("quran.title", {
-          number: surah.number,
-          name,
-          transliteration,
-          translation: effectiveTitle,
-        }),
-        description: t("quran.description", {
-          name,
-          transliteration,
-          numberOfVerses: surah.numberOfVerses,
-        }),
-        keywords: t("quran.keywords", {
-          name,
-          translation: effectiveTitle,
-          revelation,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
-      };
-    })
-);
-
-/**
  * Main entry point for generating SEO metadata.
  */
 export async function generateSEOMetadata(
@@ -403,11 +386,19 @@ export async function generateSEOMetadata(
       return yield* generateExerciseMetadata(context, locale);
     }
 
+    if (type === "exercise-program") {
+      return yield* generateExerciseProgramMetadata(context, locale);
+    }
+
+    if (type === "curriculum-context") {
+      return yield* generateCurriculumMetadata(context, locale);
+    }
+
     if (type === "article") {
       return yield* generateArticleMetadata(context, locale);
     }
 
-    return yield* generateQuranMetadata(context, locale);
+    return yield* generateQuranMetadata(context.surah, locale);
   });
 
   return await Effect.runPromise(
@@ -417,43 +408,4 @@ export async function generateSEOMetadata(
       )
     )
   );
-}
-
-/**
- * Gets display name from context for fallback metadata.
- */
-function getDisplayNameFromContext(context: SEOContext): string {
-  if (context.type === "material-lesson") {
-    return context.material;
-  }
-  if (context.type === "exercise") {
-    return context.material;
-  }
-  if (context.type === "article") {
-    return context.category;
-  }
-  return "";
-}
-
-/** Builds fallback metadata when localized translations are unavailable. */
-function generateFallbackMetadata(context: SEOContext): SEOMetadata {
-  const displayName = getDisplayNameFromContext(context);
-
-  // Quran type doesn't have data property - handle first
-  if (context.type === "quran") {
-    return {
-      title: createSEOTitle([context.surah.name.translation.en, displayName]),
-      description: createSEODescription([context.surah.name.translation.en]),
-      keywords: [],
-    };
-  }
-
-  // Types with data: subject, exercise, article
-  const { data } = context;
-
-  return {
-    title: createSEOTitle([data.title, data.subject, displayName]),
-    description: createSEODescription([data.description, data.title]),
-    keywords: [],
-  };
 }

--- a/apps/www/lib/utils/seo/generator.ts
+++ b/apps/www/lib/utils/seo/generator.ts
@@ -279,14 +279,16 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
           material: materialDisplayName,
           title: effectiveTitle,
         }),
-        description: t("exercise.description", {
-          exam: examDisplayName,
-          group: groupValue,
-          set: setValue,
-          material: materialDisplayName,
-          questionCount: questionCount ?? 0,
-          title: effectiveTitle,
-        }),
+        description:
+          getContentDescription(data) ??
+          t("exercise.description", {
+            exam: examDisplayName,
+            group: groupValue,
+            set: setValue,
+            material: materialDisplayName,
+            questionCount: questionCount ?? 0,
+            title: effectiveTitle,
+          }),
         keywords: createSEOKeywords(
           t("exercise.keywords", {
             exam: examDisplayName,

--- a/apps/www/lib/utils/seo/generator.ts
+++ b/apps/www/lib/utils/seo/generator.ts
@@ -11,6 +11,7 @@ import { Effect, Option } from "effect";
 import { cacheLife } from "next/cache";
 import type { Locale } from "next-intl";
 import { generateFallbackMetadata } from "@/lib/utils/seo/fallback";
+import { createSEOKeywords } from "@/lib/utils/seo/keywords";
 import { generateQuranMetadata } from "@/lib/utils/seo/quran";
 import { fetchSEOTranslationsNamespace } from "@/lib/utils/seo/translations";
 import type {
@@ -18,6 +19,8 @@ import type {
   SEOContext,
   SEOMetadata,
 } from "@/lib/utils/seo/types";
+
+const EMPTY_SELECT_VALUE = "__EMPTY__";
 
 /** Fetches translations for the Metadata namespace. */
 const fetchMetadataTranslations = (locale: Locale) =>
@@ -144,6 +147,18 @@ function getContentDescription(data: ContentSEOData) {
   return description;
 }
 
+/** Converts optional metadata fields into the non-empty token ICU select expects. */
+function readOptionalSelectValue(value: string | undefined) {
+  return value?.trim() || EMPTY_SELECT_VALUE;
+}
+
+/** Formats the optional question total used only when runtime counts are available. */
+function readQuestionTotalSelectValue(questionCount: number | undefined) {
+  return questionCount && questionCount > 0
+    ? `/${questionCount}`
+    : EMPTY_SELECT_VALUE;
+}
+
 /**
  * Generates SEO metadata for material content.
  */
@@ -160,8 +175,7 @@ const generateSubjectMetadata = Effect.fn("SEO.generateSubjectMetadata")(
           translateSubjectMaterial(material, locale),
         ]);
 
-      // Use sentinel value for optional fields in ICU select
-      const chapterValue = chapter?.trim() || "__EMPTY__";
+      const chapterValue = readOptionalSelectValue(chapter);
 
       return {
         title: t("subject.title", {
@@ -178,14 +192,14 @@ const generateSubjectMetadata = Effect.fn("SEO.generateSubjectMetadata")(
             material: materialDisplayName,
             grade: gradeDisplay,
           }),
-        keywords: t("subject.keywords", {
-          title: effectiveTitle,
-          chapter: chapterValue,
-          material: materialDisplayName,
-          grade: gradeDisplay,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
+        keywords: createSEOKeywords(
+          t("subject.keywords", {
+            title: effectiveTitle,
+            chapter: chapterValue,
+            material: materialDisplayName,
+            grade: gradeDisplay,
+          })
+        ),
       };
     })
 );
@@ -221,13 +235,13 @@ const generateExerciseProgramMetadata = Effect.fn(
             exam: examDisplayName,
             title: effectiveTitle,
           }),
-        keywords: t("exercise-program.keywords", {
-          category: categoryDisplayName,
-          exam: examDisplayName,
-          title: effectiveTitle,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
+        keywords: createSEOKeywords(
+          t("exercise-program.keywords", {
+            category: categoryDisplayName,
+            exam: examDisplayName,
+            title: effectiveTitle,
+          })
+        ),
       };
     })
 );
@@ -249,14 +263,10 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
           translateExerciseType(exam, locale),
         ]);
 
-      // Use sentinel value for optional fields in ICU select
-      const groupValue = group?.trim() || "__EMPTY__";
-      const setValue = set?.trim() || "__EMPTY__";
-
-      // Convert number to string for ICU select
+      const groupValue = readOptionalSelectValue(group);
+      const setValue = readOptionalSelectValue(set);
       const numberValue = number && number > 0 ? String(number) : "0";
-      const questionTotalValue =
-        questionCount && questionCount > 0 ? `/${questionCount}` : "__EMPTY__";
+      const questionTotalValue = readQuestionTotalSelectValue(questionCount);
 
       return {
         title: t("exercise.title", {
@@ -277,15 +287,15 @@ const generateExerciseMetadata = Effect.fn("SEO.generateExerciseMetadata")(
           questionCount: questionCount ?? 0,
           title: effectiveTitle,
         }),
-        keywords: t("exercise.keywords", {
-          exam: examDisplayName,
-          group: groupValue,
-          set: setValue,
-          material: materialDisplayName,
-          title: effectiveTitle,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
+        keywords: createSEOKeywords(
+          t("exercise.keywords", {
+            exam: examDisplayName,
+            group: groupValue,
+            set: setValue,
+            material: materialDisplayName,
+            title: effectiveTitle,
+          })
+        ),
       };
     })
 );
@@ -302,8 +312,8 @@ const generateCurriculumMetadata = Effect.fn("SEO.generateCurriculumMetadata")(
         fetchSEOTranslations(locale),
         getEffectiveTitle(data, locale),
       ]);
-      const parentValue = parent?.trim() || "__EMPTY__";
-      const programValue = program?.trim() || "__EMPTY__";
+      const parentValue = readOptionalSelectValue(parent);
+      const programValue = readOptionalSelectValue(program);
 
       return {
         title: t("curriculum.title", {
@@ -318,13 +328,13 @@ const generateCurriculumMetadata = Effect.fn("SEO.generateCurriculumMetadata")(
             parent: parentValue,
             program: programValue,
           }),
-        keywords: t("curriculum.keywords", {
-          title: effectiveTitle,
-          parent: parentValue,
-          program: programValue,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
+        keywords: createSEOKeywords(
+          t("curriculum.keywords", {
+            title: effectiveTitle,
+            parent: parentValue,
+            program: programValue,
+          })
+        ),
       };
     })
 );
@@ -354,12 +364,12 @@ const generateArticleMetadata = Effect.fn("SEO.generateArticleMetadata")(
             title: effectiveTitle,
             category: categoryDisplayName,
           }),
-        keywords: t("article.keywords", {
-          title: effectiveTitle,
-          category: categoryDisplayName,
-        })
-          .split(", ")
-          .map((k: string) => k.trim()),
+        keywords: createSEOKeywords(
+          t("article.keywords", {
+            title: effectiveTitle,
+            category: categoryDisplayName,
+          })
+        ),
       };
     })
 );

--- a/apps/www/lib/utils/seo/keywords.test.ts
+++ b/apps/www/lib/utils/seo/keywords.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { createSEOKeywords } from "@/lib/utils/seo/keywords";
+
+describe("createSEOKeywords", () => {
+  it("trims comma-separated keyword tokens", () => {
+    expect(createSEOKeywords("math, algebra ,  practice ")).toEqual([
+      "math",
+      "algebra",
+      "practice",
+    ]);
+  });
+
+  it("drops empty keyword tokens", () => {
+    expect(createSEOKeywords("Al-Fatihah, The Opening, ")).toEqual([
+      "Al-Fatihah",
+      "The Opening",
+    ]);
+  });
+});

--- a/apps/www/lib/utils/seo/keywords.ts
+++ b/apps/www/lib/utils/seo/keywords.ts
@@ -1,0 +1,7 @@
+/** Normalizes comma-separated localized SEO keyword copy into keyword tokens. */
+export function createSEOKeywords(source: string): string[] {
+  return source
+    .split(",")
+    .map((keyword) => keyword.trim())
+    .filter(Boolean);
+}

--- a/apps/www/lib/utils/seo/quran.test.ts
+++ b/apps/www/lib/utils/seo/quran.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+
+import type { Surah } from "@repo/contents/_types/quran";
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateQuranMetadata } from "@/lib/utils/seo/quran";
+
+const { mockGetTranslations } = vi.hoisted(() => ({
+  mockGetTranslations: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+}));
+
+const surah = {
+  name: {
+    long: "الفاتحة",
+    short: "Al-Fatihah",
+    translation: { en: "The Opening", id: "Pembukaan" },
+    transliteration: { en: "Al-Fatihah", id: "Al-Fatihah" },
+  },
+  number: 1,
+  numberOfVerses: 7,
+  preBismillah: null,
+  revelation: { arab: "مكة", en: "Meccan", id: "Makkiyah" },
+  sequence: 5,
+  verses: [],
+} satisfies Surah;
+
+/** Reads a mocked translation value as display text. */
+function getValue(
+  values: { readonly [key: string]: number | string | undefined },
+  key: string
+) {
+  return String(values[key] ?? "");
+}
+
+describe("generateQuranMetadata", () => {
+  beforeEach(() => {
+    mockGetTranslations.mockReset();
+    mockGetTranslations.mockResolvedValue(
+      (
+        key: string,
+        values: { readonly [key: string]: number | string | undefined } = {}
+      ) => {
+        if (key === "quran.description") {
+          return `Read Surah ${getValue(values, "name")} with ${getValue(values, "numberOfVerses")} verses.`;
+        }
+        if (key === "quran.keywords") {
+          return `${getValue(values, "name")}, ${getValue(values, "translation")}, ${getValue(values, "revelation")}`;
+        }
+        return `Surah ${getValue(values, "number")}. ${getValue(values, "name")} - ${getValue(values, "translation")} | Nakafa`;
+      }
+    );
+  });
+
+  it("generates Quran metadata from the surah payload", async () => {
+    const result = await Effect.runPromise(generateQuranMetadata(surah, "en"));
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - The Opening | Nakafa");
+    expect(result.description).toBe("Read Surah Al-Fatihah with 7 verses.");
+  });
+
+  it("falls back to English Quran labels when locale labels are empty", async () => {
+    const result = await Effect.runPromise(
+      generateQuranMetadata(
+        {
+          ...surah,
+          name: {
+            ...surah.name,
+            translation: { en: "The Opening", id: "" },
+            transliteration: { en: "Al-Fatihah", id: "" },
+          },
+          revelation: { arab: "مكة", en: "Meccan", id: "" },
+        },
+        "id"
+      )
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - The Opening | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "The Opening", "Meccan"]);
+  });
+
+  it("falls back to the short Quran name when translated names are empty", async () => {
+    const result = await Effect.runPromise(
+      generateQuranMetadata(
+        {
+          ...surah,
+          name: {
+            ...surah.name,
+            translation: { en: "", id: "" },
+            transliteration: { en: "", id: "" },
+          },
+          revelation: { arab: "مكة", en: "", id: "" },
+        },
+        "id"
+      )
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah - Al-Fatihah | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "Al-Fatihah", ""]);
+  });
+
+  it("keeps Quran metadata stable when all display names are empty", async () => {
+    const result = await Effect.runPromise(
+      generateQuranMetadata(
+        {
+          ...surah,
+          name: {
+            ...surah.name,
+            short: "",
+            translation: { en: "", id: "" },
+          },
+        },
+        "id"
+      )
+    );
+
+    expect(result.title).toBe("Surah 1.  -  | Nakafa");
+  });
+});

--- a/apps/www/lib/utils/seo/quran.test.ts
+++ b/apps/www/lib/utils/seo/quran.test.ts
@@ -99,7 +99,7 @@ describe("generateQuranMetadata", () => {
     );
 
     expect(result.title).toBe("Surah 1. Al-Fatihah - Al-Fatihah | Nakafa");
-    expect(result.keywords).toEqual(["Al-Fatihah", "Al-Fatihah", ""]);
+    expect(result.keywords).toEqual(["Al-Fatihah", "Al-Fatihah"]);
   });
 
   it("keeps Quran metadata stable when all display names are empty", async () => {

--- a/apps/www/lib/utils/seo/quran.ts
+++ b/apps/www/lib/utils/seo/quran.ts
@@ -1,0 +1,43 @@
+import type { Surah } from "@repo/contents/_types/quran";
+import { Effect } from "effect";
+import type { Locale } from "next-intl";
+import { fetchSEOTranslationsNamespace } from "@/lib/utils/seo/translations";
+
+/** Generates localized SEO metadata for one Quran surah payload. */
+export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
+  (surah: Surah, locale: Locale) =>
+    Effect.gen(function* () {
+      const name = surah.name.short;
+      const transliteration =
+        surah.name.transliteration[locale] ||
+        surah.name.transliteration.en ||
+        name;
+      const translation =
+        surah.name.translation[locale] || surah.name.translation.en || name;
+      const revelation = surah.revelation[locale] || surah.revelation.en || "";
+      const effectiveTitle = translation || name;
+
+      const t = yield* fetchSEOTranslationsNamespace(locale, "SEO");
+
+      return {
+        title: t("quran.title", {
+          number: surah.number,
+          name,
+          transliteration,
+          translation: effectiveTitle,
+        }),
+        description: t("quran.description", {
+          name,
+          transliteration,
+          numberOfVerses: surah.numberOfVerses,
+        }),
+        keywords: t("quran.keywords", {
+          name,
+          translation: effectiveTitle,
+          revelation,
+        })
+          .split(", ")
+          .map((keyword: string) => keyword.trim()),
+      };
+    })
+);

--- a/apps/www/lib/utils/seo/quran.ts
+++ b/apps/www/lib/utils/seo/quran.ts
@@ -1,6 +1,7 @@
 import type { Surah } from "@repo/contents/_types/quran";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
+import { createSEOKeywords } from "@/lib/utils/seo/keywords";
 import { fetchSEOTranslationsNamespace } from "@/lib/utils/seo/translations";
 
 /** Generates localized SEO metadata for one Quran surah payload. */
@@ -31,13 +32,13 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
           transliteration,
           numberOfVerses: surah.numberOfVerses,
         }),
-        keywords: t("quran.keywords", {
-          name,
-          translation: effectiveTitle,
-          revelation,
-        })
-          .split(", ")
-          .map((keyword: string) => keyword.trim()),
+        keywords: createSEOKeywords(
+          t("quran.keywords", {
+            name,
+            translation: effectiveTitle,
+            revelation,
+          })
+        ),
       };
     })
 );

--- a/apps/www/lib/utils/seo/translations.test.ts
+++ b/apps/www/lib/utils/seo/translations.test.ts
@@ -1,0 +1,42 @@
+import { Cause, Effect, Exit, Option } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchSEOTranslationsNamespace,
+  SEOTranslationLoadError,
+} from "@/lib/utils/seo/translations";
+
+const { mockGetTranslations } = vi.hoisted(() => ({
+  mockGetTranslations: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+}));
+
+describe("fetchSEOTranslationsNamespace", () => {
+  beforeEach(() => {
+    mockGetTranslations.mockReset();
+  });
+
+  it("preserves thrown Error messages in the typed failure channel", async () => {
+    mockGetTranslations.mockRejectedValue(new Error("dictionary unavailable"));
+
+    const exit = await Effect.runPromiseExit(
+      fetchSEOTranslationsNamespace("en", "SEO")
+    );
+    const failure = Exit.isFailure(exit)
+      ? Cause.failureOption(exit.cause)
+      : Option.none();
+
+    expect(Option.isSome(failure)).toBe(true);
+    if (Option.isSome(failure)) {
+      expect(failure.value).toBeInstanceOf(SEOTranslationLoadError);
+      expect(failure.value).toMatchObject({
+        _tag: "SEOTranslationLoadError",
+        locale: "en",
+        message: "Failed to load SEO translations: dictionary unavailable",
+        namespace: "SEO",
+      });
+    }
+  });
+});

--- a/apps/www/lib/utils/seo/translations.ts
+++ b/apps/www/lib/utils/seo/translations.ts
@@ -1,0 +1,38 @@
+import { Effect, Schema } from "effect";
+import type { Locale } from "next-intl";
+import { getTranslations } from "next-intl/server";
+
+/** Expected failure when a localized SEO dictionary cannot be loaded. */
+export class SEOTranslationLoadError extends Schema.TaggedError<SEOTranslationLoadError>()(
+  "SEOTranslationLoadError",
+  {
+    locale: Schema.String,
+    message: Schema.String,
+    namespace: Schema.String,
+  }
+) {}
+
+/** Converts unknown thrown values into readable fallback error messages. */
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown translation loading error";
+}
+
+/** Fetches translations for a dictionary namespace used by SEO metadata. */
+export function fetchSEOTranslationsNamespace(
+  locale: Locale,
+  namespace: "Articles" | "Exercises" | "Metadata" | "SEO" | "Subject"
+) {
+  return Effect.tryPromise({
+    try: () => getTranslations({ locale, namespace }),
+    catch: (error: unknown) =>
+      new SEOTranslationLoadError({
+        locale,
+        namespace,
+        message: `Failed to load ${namespace} translations: ${getErrorMessage(error)}`,
+      }),
+  });
+}

--- a/apps/www/lib/utils/seo/types.ts
+++ b/apps/www/lib/utils/seo/types.ts
@@ -1,3 +1,4 @@
+import type { ProgramNavigationLevel } from "@repo/contents/_types/program/schema";
 import type { Surah } from "@repo/contents/_types/quran";
 import type {
   ArticleCategory,
@@ -46,6 +47,19 @@ export type SEOContext =
       set?: string; // Exercise set name (e.g., "Set 1")
       number?: number; // Exercise number for specific questions (e.g., 1, 2, 3)
       questionCount?: number;
+      data: ContentSEOData;
+    }
+  | {
+      type: "exercise-program";
+      category: ExercisesCategory;
+      exam: ExercisesType;
+      data: ContentSEOData;
+    }
+  | {
+      type: "curriculum-context";
+      level: ProgramNavigationLevel;
+      parent?: string;
+      program?: string;
       data: ContentSEOData;
     }
   | {

--- a/packages/contents/_lib/assessment/label.ts
+++ b/packages/contents/_lib/assessment/label.ts
@@ -51,6 +51,21 @@ export function getExerciseNumberLabel(locale: Locale, number: number) {
   );
 }
 
+/** Returns the localized public route title for one exercise question. */
+export function getExerciseQuestionRouteTitle({
+  locale,
+  number,
+  setTitle,
+}: {
+  locale: Locale;
+  number: number;
+  setTitle: string;
+}) {
+  return dictionaries[locale]["route-question-title"]
+    .replace("{set}", setTitle)
+    .replace("{number}", number.toString());
+}
+
 /** Returns the localized display label for an exercise question count. */
 export function getExerciseQuestionCountLabel(locale: Locale, count: number) {
   return `${count} ${tryoutDictionaries[locale]["question-unit"]}`;

--- a/packages/contents/_types/route/practice/identity.ts
+++ b/packages/contents/_types/route/practice/identity.ts
@@ -1,3 +1,4 @@
+import { ExercisesCategorySchema } from "@repo/contents/_types/assessment/category";
 import { ExercisesMaterialSchema } from "@repo/contents/_types/assessment/material";
 import { ExercisesTypeSchema } from "@repo/contents/_types/assessment/type";
 import type { Locale } from "@repo/contents/_types/content";
@@ -89,6 +90,9 @@ export function readPracticeSourceSetParts(sourcePath: string) {
 
   const { exercise } = projection;
   const group = exercise.groupSegments.at(0);
+  const parsedCategory = Schema.decodeUnknownOption(ExercisesCategorySchema)(
+    exercise.categorySegment
+  );
   const parsedType = Schema.decodeUnknownOption(ExercisesTypeSchema)(
     exercise.typeSegment
   );
@@ -101,6 +105,7 @@ export function readPracticeSourceSetParts(sourcePath: string) {
       group &&
       exercise.groupSegments.length === 1 &&
       exercise.setSegment &&
+      Option.isSome(parsedCategory) &&
       Option.isSome(parsedType) &&
       Option.isSome(parsedMaterial)
     )
@@ -109,7 +114,7 @@ export function readPracticeSourceSetParts(sourcePath: string) {
   }
 
   return {
-    category: exercise.categorySegment,
+    category: parsedCategory.value,
     ...readPracticeSourceGroupIdentity(group),
     material: parsedMaterial.value,
     type: parsedType.value,

--- a/packages/contents/_types/route/practice/path.ts
+++ b/packages/contents/_types/route/practice/path.ts
@@ -8,6 +8,11 @@ import type {
 } from "@repo/contents/_types/route/schema";
 import { locales } from "@repo/utilities/locales";
 
+const PUBLIC_PRACTICE_QUESTION_SEGMENTS = {
+  en: "question",
+  id: "soal",
+} satisfies { readonly [locale in Locale]: string };
+
 /** Builds the localized public practice group segment without splitting year. */
 export function toPublicPracticeGroupSegment(
   group: Pick<PracticeMaterialGroup, "routeSlugs" | "year">,
@@ -86,7 +91,7 @@ export function readPublicPracticeQuestionNumber({
     return null;
   }
 
-  const prefix = locale === "id" ? "soal-" : "question-";
+  const prefix = `${PUBLIC_PRACTICE_QUESTION_SEGMENTS[locale]}-`;
 
   if (!segment.startsWith(prefix)) {
     return null;
@@ -166,7 +171,7 @@ export function toPublicPracticeQuestionSegment({
   locale: Locale;
   number: number;
 }) {
-  return locale === "id" ? `soal-${number}` : `question-${number}`;
+  return `${PUBLIC_PRACTICE_QUESTION_SEGMENTS[locale]}-${number}`;
 }
 
 /** Parses a localized public practice set or question path into named route parts. */

--- a/packages/contents/_types/route/practice/question.ts
+++ b/packages/contents/_types/route/practice/question.ts
@@ -1,3 +1,4 @@
+import { getExerciseQuestionRouteTitle } from "@repo/contents/_lib/assessment/label";
 import { ExercisesMaterialSchema } from "@repo/contents/_types/assessment/material";
 import { ExercisesTypeSchema } from "@repo/contents/_types/assessment/type";
 import type { Locale } from "@repo/contents/_types/content";
@@ -173,10 +174,11 @@ export function readPublicPracticeQuestionRouteByPath({
     sectionKey: `question-${questionNumber}`,
     sitemap: true,
     sourcePath,
-    title:
-      locale === "id"
-        ? `${match.set.translations[locale].title} Soal ${questionNumber}`
-        : `${match.set.translations[locale].title} Question ${questionNumber}`,
+    title: getExerciseQuestionRouteTitle({
+      locale,
+      number: questionNumber,
+      setTitle: match.set.translations[locale].title,
+    }),
   });
 }
 
@@ -260,10 +262,11 @@ export function readPublicPracticeQuestionRouteBySourcePath({
           sectionKey: parts.question,
           sitemap: true,
           sourcePath: canonicalSourcePath,
-          title:
-            locale === "id"
-              ? `${set.translations[locale].title} Soal ${questionNumber}`
-              : `${set.translations[locale].title} Question ${questionNumber}`,
+          title: getExerciseQuestionRouteTitle({
+            locale,
+            number: questionNumber,
+            setTitle: set.translations[locale].title,
+          }),
         });
       }
     }

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -289,6 +289,9 @@
     "reset": "Reset",
     "explanation": "Explanation",
     "number-count": "Number {count}",
+    "route-question-title": "{set} Question {number}",
+    "program-domain-list-description": "Choose an available practice domain to open question sets.",
+    "domain-set-list-description": "Choose an available practice set to open the questions for this domain.",
     "high-school": "High School",
     "middle-school": "Middle School",
     "grade-9": "Grade 9",
@@ -1061,9 +1064,19 @@
       "keywords": "{title}, {chapter, select, __EMPTY__ {} other {{chapter}, }}{material}, {grade}, learn, material, practice problems, exercises, education"
     },
     "exercise": {
-      "title": "{number, select, 0 {} other {Question {number}/{questionCount}: }}{set, select, __EMPTY__ {} other {{set}{number, select, 0 {: } other { - }}}}{group, select, __EMPTY__ {} other {{group} - }}{material} ({exam}) | Nakafa",
+      "title": "{number, select, 0 {} other {Question {number}{questionTotal, select, __EMPTY__ {} other {{questionTotal}}}: }}{set, select, __EMPTY__ {} other {{set}{number, select, 0 {: } other { - }}}}{group, select, __EMPTY__ {} other {{group} - }}{material} ({exam}) | Nakafa",
       "description": "Take {material} {exam} exercise{group, select, __EMPTY__ {} other { {group}}}{set, select, __EMPTY__ {} other { {set}}} with {questionCount, plural, =0 {practice questions} =1 {1 question} other {{questionCount} questions}} and explanations for checking your reasoning.",
       "keywords": "{material}, {exam}, {group, select, __EMPTY__ {} other {{group}, }}{set, select, __EMPTY__ {} other {{set}, }}exercise, practice questions, solutions, exam"
+    },
+    "exercise-program": {
+      "title": "{exam} Practice Questions | Nakafa",
+      "description": "Choose {exam} practice domains for {category}. Each domain links to question sets with explanations for checking understanding.",
+      "keywords": "{exam}, {category}, practice questions, question sets, explanations, exam preparation"
+    },
+    "curriculum": {
+      "title": "{title}{parent, select, __EMPTY__ {} other { - {parent}}}{program, select, __EMPTY__ {} other { ({program})}} | Nakafa",
+      "description": "Browse {title}{parent, select, __EMPTY__ {} other { in {parent}}}{program, select, __EMPTY__ {} other { for {program}}}. This curriculum index links learners to the relevant materials and practice routes.",
+      "keywords": "{title}, {parent, select, __EMPTY__ {} other {{parent}, }}{program, select, __EMPTY__ {} other {{program}, }}curriculum, learning path, materials, practice"
     },
     "article": {
       "title": "{title} - {category} | Nakafa",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -289,6 +289,9 @@
     "reset": "Ulangi",
     "explanation": "Pembahasan",
     "number-count": "Nomor {count}",
+    "route-question-title": "{set} Soal {number}",
+    "program-domain-list-description": "Pilih domain latihan yang tersedia untuk membuka set soal.",
+    "domain-set-list-description": "Pilih set latihan yang tersedia untuk membuka soal latihan pada domain ini.",
     "high-school": "SMA",
     "middle-school": "SMP",
     "grade-9": "Kelas 9",
@@ -1061,9 +1064,19 @@
       "keywords": "{title}, {chapter, select, __EMPTY__ {} other {{chapter}, }}{material}, {grade}, belajar, materi, contoh soal, latihan, edukasi"
     },
     "exercise": {
-      "title": "{number, select, 0 {} other {Soal {number}/{questionCount}: }}{set, select, __EMPTY__ {} other {{set}{number, select, 0 {: } other { - }}}}{group, select, __EMPTY__ {} other {{group} - }}{material} ({exam}) | Nakafa",
+      "title": "{number, select, 0 {} other {Soal {number}{questionTotal, select, __EMPTY__ {} other {{questionTotal}}}: }}{set, select, __EMPTY__ {} other {{set}{number, select, 0 {: } other { - }}}}{group, select, __EMPTY__ {} other {{group} - }}{material} ({exam}) | Nakafa",
       "description": "Latihan {material} {exam}{group, select, __EMPTY__ {} other { {group}}}{set, select, __EMPTY__ {} other { {set}}} berisi {questionCount, plural, =0 {soal-soal} =1 {1 soal} other {{questionCount} soal}} dengan pembahasan untuk memeriksa cara berpikir.",
       "keywords": "{material}, {exam}, {group, select, __EMPTY__ {} other {{group}, }}{set, select, __EMPTY__ {} other {{set}, }}latihan, soal, pembahasan, ujian"
+    },
+    "exercise-program": {
+      "title": "Latihan Soal {exam} | Nakafa",
+      "description": "Pilih domain latihan {exam} untuk {category}. Setiap domain mengarah ke set soal dengan pembahasan untuk mengecek pemahaman.",
+      "keywords": "{exam}, {category}, latihan soal, set soal, pembahasan, persiapan ujian"
+    },
+    "curriculum": {
+      "title": "{title}{parent, select, __EMPTY__ {} other { - {parent}}}{program, select, __EMPTY__ {} other { ({program})}} | Nakafa",
+      "description": "Jelajahi {title}{parent, select, __EMPTY__ {} other { dalam {parent}}}{program, select, __EMPTY__ {} other { untuk {program}}}. Indeks kurikulum ini menghubungkan pelajar ke materi dan latihan yang relevan.",
+      "keywords": "{title}, {parent, select, __EMPTY__ {} other {{parent}, }}{program, select, __EMPTY__ {} other {{program}, }}kurikulum, alur belajar, materi, latihan"
     },
     "article": {
       "title": "{title} - {category} | Nakafa",


### PR DESCRIPTION
## Summary
- Add dictionary-backed SEO contexts for practice assessment roots and curriculum context routes.
- Move SEO fallback, Quran metadata, translation loading, practice display/source/SEO, and curriculum SEO into focused modules with matching tests.
- Remove hardcoded practice question labels/descriptions from route projection paths and derive localized copy from dictionaries/content source.

## Verification
- corepack pnpm format
- corepack pnpm --filter www typecheck
- corepack pnpm --filter @repo/contents typecheck
- corepack pnpm --filter www test
- corepack pnpm --filter @repo/contents test
- corepack pnpm lint
- corepack pnpm build

Note: format/lint still report the existing warning that packages/contents/quran/source.ts exceeds Ultracite's 1 MiB scan limit.