### PR TITLE
Fix Continue Learning recent identity

### DIFF
--- a/packages/backend/convex/contents/queries/recent.test.ts
+++ b/packages/backend/convex/contents/queries/recent.test.ts
@@ -9,10 +9,10 @@ import { createLearningGraphIdentityFromRoute } from "@repo/contents/_types/lear
 import { describe, expect, it } from "vitest";
 
 const NOW = Date.parse("2026-01-01T00:00:00.000Z");
-const canonicalContext = {
+const canonicalContext: CanonicalRecentContextFixture = {
   contextKey: "canonical",
   contextMode: "canonical",
-} as const;
+};
 
 describe("contents/queries/recent", () => {
   it("returns recently viewed materials through graph route projections", async () => {
@@ -143,6 +143,50 @@ describe("contents/queries/recent", () => {
         href: "/subjects/mathematics/topic-current/section-current",
         route: "subjects/mathematics/topic-current/section-current",
         title: "Material current",
+      }),
+    ]);
+  });
+
+  it("preserves the latest verified material context in the Continue Learning href", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const seeded = await t.mutation(async (ctx) => {
+      const identity = await seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "recent-context-href",
+      });
+      const ref = await insertMaterialRoute(ctx, "recent-context-href");
+
+      await insertMaterialRecent(ctx, {
+        context: {
+          contextKey: "placement:merdeka:class-10-mathematics-topic",
+          contextMode: "placement",
+          contextNodeKey: "class-10-mathematics-topic",
+          contextProgramKey: "merdeka",
+        },
+        ref,
+        lastViewedAt: NOW,
+        materialDomain: "mathematics",
+        suffix: "recent-context-href",
+        userId: identity.userId,
+      });
+
+      return identity;
+    });
+
+    const results = await t
+      .withIdentity({
+        sessionId: seeded.sessionId,
+        subject: seeded.authUserId,
+      })
+      .query(api.contents.queries.recent.getRecentlyViewed, {
+        locale: "en",
+        limit: 5,
+      });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        contextKey: "placement:merdeka:class-10-mathematics-topic",
+        href: "/subjects/mathematics/topic-recent-context-href/section-recent-context-href?ctx=merdeka~class-10-mathematics-topic",
       }),
     ]);
   });
@@ -333,12 +377,14 @@ async function insertPracticeRoute(ctx: MutationCtx, suffix: string) {
 async function insertMaterialRecent(
   ctx: MutationCtx,
   {
+    context = canonicalContext,
     ref,
     lastViewedAt,
     materialDomain,
     suffix,
     userId,
   }: {
+    context?: typeof canonicalContext | RecentContextFixture;
     ref: ReturnType<typeof getMaterialGraph>;
     lastViewedAt: number;
     materialDomain?: Doc<"userLearningRecents">["materialDomain"];
@@ -348,7 +394,7 @@ async function insertMaterialRecent(
 ) {
   await ctx.db.insert("userLearningRecents", {
     ...ref,
-    ...canonicalContext,
+    ...context,
     content_id: ref.assetId,
     description: `Description ${suffix}`,
     lastViewedAt,
@@ -360,6 +406,18 @@ async function insertMaterialRecent(
     title: `Material ${suffix}`,
     userId,
   });
+}
+
+interface CanonicalRecentContextFixture {
+  readonly contextKey: "canonical";
+  readonly contextMode: "canonical";
+}
+
+interface RecentContextFixture {
+  readonly contextKey: string;
+  readonly contextMode: "placement";
+  readonly contextNodeKey: string;
+  readonly contextProgramKey: string;
 }
 
 /** Builds the route-catalog graph identity for one material fixture. */

--- a/packages/backend/convex/contents/schema.ts
+++ b/packages/backend/convex/contents/schema.ts
@@ -134,6 +134,8 @@ const tables = {
 
   /**
    * Continue Learning read model ranked by the learner's latest verified view.
+   * One record per signed-in learner and canonical asset. Context fields store
+   * the latest validated resume path, but never define item identity.
    */
   userLearningRecents: defineTable({
     ...learningGraphIdentityValidator.fields,
@@ -149,11 +151,7 @@ const tables = {
     title: v.string(),
     userId: v.id("users"),
   })
-    .index("by_userId_and_content_id_and_contextKey", [
-      "userId",
-      "content_id",
-      "contextKey",
-    ])
+    .index("by_userId_and_content_id", ["userId", "content_id"])
     .index("by_userId_and_locale_and_section_and_lastViewedAt", [
       "userId",
       "locale",

--- a/packages/backend/convex/contents/views/recent.test.ts
+++ b/packages/backend/convex/contents/views/recent.test.ts
@@ -1,0 +1,148 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import {
+  createCanonicalLearningContext,
+  createContextKey,
+  type LearningContextStorage,
+} from "@repo/backend/convex/contents/context";
+import { upsertUserRecent } from "@repo/backend/convex/contents/views/recent";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import {
+  createConvexTestWithBetterAuth,
+  seedAuthenticatedUser,
+} from "@repo/backend/convex/test.helpers";
+import { createLearningGraphIdentityFromRoute } from "@repo/contents/_types/learning-graph";
+import { describe, expect, it } from "vitest";
+
+const NOW = Date.UTC(2026, 4, 29, 10, 0, 0);
+const MATERIAL_ROUTE = "material/lesson/mathematics/vector/addition";
+const CONTEXT_PROGRAM_KEY = "merdeka";
+const CONTEXT_NODE_KEY = "class-10-mathematics-vector";
+
+const placementContext: LearningContextStorage = {
+  contextKey: createContextKey({
+    mode: "placement",
+    nodeKey: CONTEXT_NODE_KEY,
+    programKey: CONTEXT_PROGRAM_KEY,
+  }),
+  contextMaterialKey: "lesson.mathematics.vector",
+  contextMode: "placement",
+  contextNodeKey: CONTEXT_NODE_KEY,
+  contextParentPath: "curriculum/merdeka/class-10/mathematics",
+  contextProgramKey: CONTEXT_PROGRAM_KEY,
+  contextPublicPath: "curriculum/merdeka/class-10/mathematics/vector",
+  contextSourcePath: MATERIAL_ROUTE,
+};
+
+/** Inserts one graph route projection for the recent read-model fixture. */
+async function insertMaterialRoute(ctx: MutationCtx) {
+  const identity = createLearningGraphIdentityFromRoute({
+    locale: "id",
+    route: MATERIAL_ROUTE,
+  });
+
+  if (!identity) {
+    expect.fail(`Unable to build graph fixture for ${MATERIAL_ROUTE}.`);
+  }
+
+  const routeId = await ctx.db.insert("contentRoutes", {
+    ...identity,
+    assetId: identity.assetId,
+    authors: [],
+    contentHash: "material-route-hash",
+    content_id: identity.assetId,
+    kind: "curriculum-lesson",
+    locale: "id",
+    markdown: true,
+    materialDomain: "mathematics",
+    route: MATERIAL_ROUTE,
+    section: "material",
+    sourcePath: MATERIAL_ROUTE,
+    syncedAt: NOW,
+    title: "Vector Addition",
+  });
+  const route = await ctx.db.get(routeId);
+
+  if (!route) {
+    expect.fail("Expected inserted content route fixture.");
+  }
+
+  return route;
+}
+
+/** Reads the small recent fixture table used by this test. */
+async function readRecents(ctx: MutationCtx) {
+  return await ctx.db.query("userLearningRecents").take(10);
+}
+
+/** Writes one Continue Learning recent row with an explicit view timestamp. */
+async function upsertRecent(
+  ctx: MutationCtx,
+  route: Doc<"contentRoutes">,
+  context: LearningContextStorage,
+  input: {
+    readonly lastViewedAt: number;
+    readonly userId: Doc<"users">["_id"];
+  }
+) {
+  await runConvexProgram(upsertUserRecent(ctx.db, route, context, input));
+}
+
+describe("contents/views/recent", () => {
+  it("keeps one user recent row while the latest material context changes", async () => {
+    const t = createConvexTestWithBetterAuth();
+
+    const result = await t.mutation(async (ctx) => {
+      const route = await insertMaterialRoute(ctx);
+      const user = await seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "recent-context",
+      });
+
+      await upsertRecent(ctx, route, createCanonicalLearningContext(), {
+        lastViewedAt: NOW,
+        userId: user.userId,
+      });
+      await upsertRecent(ctx, route, placementContext, {
+        lastViewedAt: NOW + 1000,
+        userId: user.userId,
+      });
+
+      const placementRecents = await readRecents(ctx);
+
+      await upsertRecent(ctx, route, createCanonicalLearningContext(), {
+        lastViewedAt: NOW + 2000,
+        userId: user.userId,
+      });
+
+      return {
+        contentId: route.content_id,
+        placementRecents,
+        recents: await readRecents(ctx),
+        userId: user.userId,
+      };
+    });
+
+    expect(result.placementRecents).toHaveLength(1);
+    expect(result.placementRecents[0]).toMatchObject({
+      content_id: result.contentId,
+      contextKey: placementContext.contextKey,
+      contextMode: "placement",
+      contextNodeKey: CONTEXT_NODE_KEY,
+      contextProgramKey: CONTEXT_PROGRAM_KEY,
+      lastViewedAt: NOW + 1000,
+      userId: result.userId,
+    });
+
+    expect(result.recents).toHaveLength(1);
+    expect(result.recents[0]).toMatchObject({
+      content_id: result.contentId,
+      contextKey: "canonical",
+      contextMode: "canonical",
+      lastViewedAt: NOW + 2000,
+      userId: result.userId,
+    });
+    expect(result.recents[0]).not.toHaveProperty("contextNodeKey");
+    expect(result.recents[0]).not.toHaveProperty("contextProgramKey");
+  });
+});

--- a/packages/backend/convex/contents/views/recent.ts
+++ b/packages/backend/convex/contents/views/recent.ts
@@ -16,7 +16,21 @@ function toRecentIoError(error: unknown) {
   });
 }
 
-/** Upserts the signed-in learner's recent content read-model row. */
+/** Builds a patch that also clears stale optional context fields. */
+function toContextPatch(context: LearningContextStorage) {
+  return {
+    contextKey: context.contextKey,
+    contextMaterialKey: context.contextMaterialKey,
+    contextMode: context.contextMode,
+    contextNodeKey: context.contextNodeKey,
+    contextParentPath: context.contextParentPath,
+    contextProgramKey: context.contextProgramKey,
+    contextPublicPath: context.contextPublicPath,
+    contextSourcePath: context.contextSourcePath,
+  };
+}
+
+/** Upserts the signed-in learner's canonical recent content read-model row. */
 export const upsertUserRecent = Effect.fn("contents.views.upsertUserRecent")(
   function* (
     db: MutationCtx["db"],
@@ -31,11 +45,8 @@ export const upsertUserRecent = Effect.fn("contents.views.upsertUserRecent")(
       try: () =>
         db
           .query("userLearningRecents")
-          .withIndex("by_userId_and_content_id_and_contextKey", (q) =>
-            q
-              .eq("userId", input.userId)
-              .eq("content_id", route.content_id)
-              .eq("contextKey", context.contextKey)
+          .withIndex("by_userId_and_content_id", (q) =>
+            q.eq("userId", input.userId).eq("content_id", route.content_id)
           )
           .unique(),
       catch: toRecentIoError,
@@ -68,7 +79,11 @@ export const upsertUserRecent = Effect.fn("contents.views.upsertUserRecent")(
     }
 
     yield* Effect.tryPromise({
-      try: () => db.patch("userLearningRecents", existing._id, row),
+      try: () =>
+        db.patch("userLearningRecents", existing._id, {
+          ...row,
+          ...toContextPatch(context),
+        }),
       catch: toRecentIoError,
     });
   }


### PR DESCRIPTION
## Summary
- key Continue Learning recents by learner + canonical content asset instead of context key
- keep latest valid learning context as navigation metadata and clear stale context fields on canonical views
- add colocated coverage for `contents/views/recent.ts` plus query coverage for contextual hrefs

## Data
- dev and prod duplicate recent rows were cleaned before the temporary cleanup function was removed
- verified both deployments have `duplicateGroups: 0` for `userLearningRecents` grouped by `userId + content_id`

## Verification
- `pnpm --filter @repo/backend typecheck`
- `pnpm lint` (passes with existing Quran source-size warning)
- `pnpm --filter @repo/backend test`