### PR TITLE
Default material header back link to home

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/page.tsx
@@ -1,10 +1,7 @@
 import type { LearningContextInput } from "@repo/backend/convex/contents/context";
 import { getHeadings } from "@repo/contents/_lib/toc";
 import { formatContentDateISO } from "@repo/contents/_shared/date";
-import {
-  isMaterialLessonRoute,
-  toLocalizedContentHref,
-} from "@repo/contents/_types/route/content";
+import { toLocalizedContentHref } from "@repo/contents/_types/route/content";
 import type { MaterialContextIdentity } from "@repo/contents/_types/route/material/reference";
 import type { PublicContentRoute } from "@repo/contents/_types/route/schema";
 import { ArticleJsonLd } from "@repo/seo/json-ld/article";
@@ -116,10 +113,6 @@ export default async function Page({
     resolveMaterialRoute(params),
     searchParams,
   ]);
-
-  if (!isMaterialLessonRoute(route)) {
-    notFound();
-  }
 
   const [runtimeLesson, content] = await Promise.all([
     fetchRuntimeCurriculumPage({
@@ -263,7 +256,7 @@ async function MaterialLessonPage({
           <HeaderContent
             content={raw}
             icon={icon}
-            link={headerLink}
+            link={headerLink ?? { href: "/home", label: tCommon("home") }}
             slug={toLocalizedContentHref(route)}
             title={metadata.title}
           />


### PR DESCRIPTION
## Summary

- Adds a localized Home fallback link for normal material lesson headers when no contextual parent link is available.
- Keeps contextual material visits unchanged: valid curriculum context still links back to the curriculum card parent.
- Removes a redundant material-lesson guard already guaranteed by `resolveMaterialRoute`.

## Why

Direct material page visits could render the shared header with no back link because the content index intentionally returns no contextual parent for canonical visits. Falling back to `/home` gives every material page a cohesive escape path while preserving contextual navigation when it exists.

## Validation

- `pnpm format`
- `pnpm --filter www exec vitest run lib/routing/material/query.test.ts lib/routing/locale/resolve.test.ts`
- `pnpm --filter @repo/contents exec vitest run _types/route/learning/public.test.ts _types/route/material/context.test.ts --coverage.enabled=false`
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm build`
