### PR TITLE
fix(design-system): keep React updates pure

### DIFF
--- a/packages/design-system/components/evilcharts/ui/reveal-animation.ts
+++ b/packages/design-system/components/evilcharts/ui/reveal-animation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 
 const BAR_REVEAL_DURATION_MS = 500;
 const BAR_REVEAL_STAGGER_MS = 50;
@@ -62,14 +62,11 @@ function useOrderedReveal(
   dataLength: number
 ) {
   const canReveal = animationType !== "none" && dataLength > 0;
-  const hasStartedReveal = useRef(false);
   const revealDuration = canReveal
     ? getOrderedRevealDurationMs(animationType, dataLength)
     : 0;
-  const revealDurationRef = useRef(revealDuration);
+  const getRevealDuration = useEffectEvent(() => revealDuration);
   const [isRevealing, setIsRevealing] = useState(() => canReveal);
-
-  revealDurationRef.current = revealDuration;
 
   useEffect(() => {
     if (!canReveal) {
@@ -77,20 +74,14 @@ function useOrderedReveal(
       return;
     }
 
-    if (hasStartedReveal.current) {
-      return;
-    }
-
-    hasStartedReveal.current = true;
     setIsRevealing(true);
     const timeout = window.setTimeout(
       () => setIsRevealing(false),
-      revealDurationRef.current
+      getRevealDuration()
     );
 
     return () => {
       window.clearTimeout(timeout);
-      hasStartedReveal.current = false;
     };
   }, [canReveal]);
 

--- a/packages/design-system/hooks/use-file-upload.ts
+++ b/packages/design-system/hooks/use-file-upload.ts
@@ -7,6 +7,7 @@ import {
   type DragEvent,
   type InputHTMLAttributes,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -64,6 +65,7 @@ export interface FileUploadActions {
   removeFile: (id: string) => void;
 }
 
+/** Manages file validation, selection state, and browser preview lifetimes. */
 export const useFileUpload = (
   options: FileUploadOptions = {}
 ): [FileUploadState, FileUploadActions] => {
@@ -91,6 +93,7 @@ export const useFileUpload = (
   });
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const objectUrlsRef = useRef(new Set<string>());
 
   const validateFile = useCallback(
     (file: File | FileMetadata): string | null => {
@@ -152,13 +155,51 @@ export const useFileUpload = (
 
   const createPreview = useCallback(
     (file: File | FileMetadata): string | undefined => {
-      if (file instanceof File) {
-        return URL.createObjectURL(file);
+      if (!(file instanceof File)) {
+        return file.url;
       }
-      return file.url;
+
+      if (!file.type.startsWith("image/")) {
+        return;
+      }
+
+      const preview = URL.createObjectURL(file);
+      objectUrlsRef.current.add(preview);
+      return preview;
     },
     []
   );
+
+  const revokePreview = useCallback((file: FileWithPreview) => {
+    if (!(file.file instanceof File && file.preview)) {
+      return;
+    }
+
+    if (!objectUrlsRef.current.delete(file.preview)) {
+      return;
+    }
+
+    URL.revokeObjectURL(file.preview);
+  }, []);
+
+  useEffect(() => {
+    const objectUrls = objectUrlsRef.current;
+
+    return () => {
+      for (const objectUrl of objectUrls) {
+        URL.revokeObjectURL(objectUrl);
+      }
+      objectUrls.clear();
+    };
+  }, []);
+
+  const resetInput = useCallback(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    inputRef.current.value = "";
+  }, []);
 
   const generateUniqueId = useCallback((file: File | FileMetadata): string => {
     if (file instanceof File) {
@@ -168,32 +209,18 @@ export const useFileUpload = (
   }, []);
 
   const clearFiles = useCallback(() => {
-    setState((prev) => {
-      // Clean up object URLs
-      for (const file of prev.files) {
-        if (
-          file.preview &&
-          file.file instanceof File &&
-          file.file.type.startsWith("image/")
-        ) {
-          URL.revokeObjectURL(file.preview);
-        }
-      }
+    for (const file of state.files) {
+      revokePreview(file);
+    }
 
-      if (inputRef.current) {
-        inputRef.current.value = "";
-      }
-
-      const newState = {
-        ...prev,
-        files: [],
-        errors: [],
-      };
-
-      onFilesChange?.(newState.files);
-      return newState;
-    });
-  }, [onFilesChange]);
+    resetInput();
+    setState((prev) => ({
+      ...prev,
+      files: [],
+      errors: [],
+    }));
+    onFilesChange?.([]);
+  }, [onFilesChange, resetInput, revokePreview, state.files]);
 
   const addFiles = useCallback(
     (newFiles: FileList | File[]) => {
@@ -207,11 +234,6 @@ export const useFileUpload = (
       // Clear existing errors when new files are uploaded
       setState((prev) => ({ ...prev, errors: [] }));
 
-      // In single file mode, clear existing files first
-      if (!multiple) {
-        clearFiles();
-      }
-
       // Check if adding these files would exceed maxFiles (only in multiple mode)
       if (
         multiple &&
@@ -221,6 +243,7 @@ export const useFileUpload = (
         errors.push(t("max-files-exceeded", { maxFiles: maxFiles.toString() }));
         setState((prev) => ({ ...prev, errors }));
         onError?.(errors);
+        resetInput();
         return;
       }
 
@@ -269,20 +292,24 @@ export const useFileUpload = (
 
       // Only update state if we have valid files to add
       if (validFiles.length > 0) {
+        if (!multiple) {
+          for (const file of state.files) {
+            revokePreview(file);
+          }
+        }
+
         // Call the onFilesAdded callback with the newly added valid files
         onFilesAdded?.(validFiles);
 
-        setState((prev) => {
-          const updatedFiles = multiple
-            ? [...prev.files, ...validFiles]
-            : validFiles;
-          onFilesChange?.(updatedFiles);
-          return {
-            ...prev,
-            files: updatedFiles,
-            errors,
-          };
-        });
+        const updatedFiles = multiple
+          ? [...state.files, ...validFiles]
+          : validFiles;
+        setState((prev) => ({
+          ...prev,
+          files: updatedFiles,
+          errors,
+        }));
+        onFilesChange?.(updatedFiles);
 
         // Call onError if there were any errors (even with some valid files)
         if (errors.length > 0) {
@@ -297,9 +324,7 @@ export const useFileUpload = (
       }
 
       // Reset input value after handling files
-      if (inputRef.current) {
-        inputRef.current.value = "";
-      }
+      resetInput();
     },
     [
       state.files,
@@ -309,37 +334,32 @@ export const useFileUpload = (
       validateFile,
       createPreview,
       generateUniqueId,
-      clearFiles,
+      revokePreview,
       onFilesChange,
       onFilesAdded,
       onError,
+      resetInput,
       t,
     ]
   );
 
   const removeFile = useCallback(
     (id: string) => {
-      setState((prev) => {
-        const fileToRemove = prev.files.find((file) => file.id === id);
-        if (
-          fileToRemove?.preview &&
-          fileToRemove.file instanceof File &&
-          fileToRemove.file.type.startsWith("image/")
-        ) {
-          URL.revokeObjectURL(fileToRemove.preview);
-        }
+      const fileToRemove = state.files.find((file) => file.id === id);
+      if (!fileToRemove) {
+        return;
+      }
 
-        const newFiles = prev.files.filter((file) => file.id !== id);
-        onFilesChange?.(newFiles);
-
-        return {
-          ...prev,
-          files: newFiles,
-          errors: [],
-        };
-      });
+      revokePreview(fileToRemove);
+      const newFiles = state.files.filter((file) => file.id !== id);
+      setState((prev) => ({
+        ...prev,
+        files: newFiles,
+        errors: [],
+      }));
+      onFilesChange?.(newFiles);
     },
-    [onFilesChange]
+    [onFilesChange, revokePreview, state.files]
   );
 
   const clearErrors = useCallback(() => {
@@ -359,7 +379,10 @@ export const useFileUpload = (
     e.preventDefault();
     e.stopPropagation();
 
-    if (e.currentTarget.contains(e.relatedTarget as Node)) {
+    if (
+      e.relatedTarget instanceof Node &&
+      e.currentTarget.contains(e.relatedTarget)
+    ) {
       return;
     }
 
@@ -440,7 +463,7 @@ export const useFileUpload = (
   ];
 };
 
-// Helper function to format bytes to human-readable format
+/** Formats a byte count for file validation messages. */
 export const formatBytes = (bytes: number, decimals = 2): string => {
   if (bytes === 0) {
     return "0 Bytes";

--- a/packages/design-system/hooks/use-file-upload.ts
+++ b/packages/design-system/hooks/use-file-upload.ts
@@ -16,6 +16,7 @@ const BASE36_RADIX = 36;
 const RANDOM_STRING_START = 2;
 const RANDOM_STRING_END = 9;
 
+/** Describes a file that is already stored outside the browser. */
 export interface FileMetadata {
   id: string;
   name: string;
@@ -24,29 +25,33 @@ export interface FileMetadata {
   url: string;
 }
 
+/** Associates a selected file with its stable ID and optional preview URL. */
 export interface FileWithPreview {
   file: File | FileMetadata;
   id: string;
   preview?: string;
 }
 
+/** Configures selection behavior; maxSize is bytes and maxFiles is for multiple mode. */
 export interface FileUploadOptions {
   accept?: string;
   initialFiles?: FileMetadata[];
-  maxFiles?: number; // Only used when multiple is true, defaults to Infinity
-  maxSize?: number; // in bytes
-  multiple?: boolean; // Defaults to false
-  onError?: (errors: string[]) => void; // Callback when errors occur
-  onFilesAdded?: (addedFiles: FileWithPreview[]) => void; // Callback when new files are added
-  onFilesChange?: (files: FileWithPreview[]) => void; // Callback when files change
+  maxFiles?: number;
+  maxSize?: number;
+  multiple?: boolean;
+  onError?: (errors: string[]) => void;
+  onFilesAdded?: (addedFiles: FileWithPreview[]) => void;
+  onFilesChange?: (files: FileWithPreview[]) => void;
 }
 
+/** Represents selected files, drag state, and validation errors. */
 export interface FileUploadState {
   errors: string[];
   files: FileWithPreview[];
   isDragging: boolean;
 }
 
+/** Exposes file selection and drag-and-drop actions for UI adapters. */
 export interface FileUploadActions {
   addFiles: (files: FileList | File[]) => void;
   clearErrors: () => void;
@@ -93,7 +98,17 @@ export const useFileUpload = (
   });
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const filesRef = useRef(state.files);
   const objectUrlsRef = useRef(new Set<string>());
+
+  /** Keeps imperative file actions aligned with the next rendered file list. */
+  const updateFiles = useCallback(
+    (files: FileWithPreview[], errors: string[]) => {
+      filesRef.current = files;
+      setState((prev) => ({ ...prev, files, errors }));
+    },
+    []
+  );
 
   const validateFile = useCallback(
     (file: File | FileMetadata): string | null => {
@@ -114,7 +129,7 @@ export const useFileUpload = (
       if (accept !== "*") {
         const acceptedTypes = accept.split(",").map((type) => type.trim());
         const fileType = file instanceof File ? file.type || "" : file.type;
-        const fileName = file instanceof File ? file.name : file.name;
+        const fileName = file.name;
         const fileNameParts = fileName.split(".");
         const lastPart = fileNameParts.at(-1);
         const fileExtension =
@@ -209,18 +224,14 @@ export const useFileUpload = (
   }, []);
 
   const clearFiles = useCallback(() => {
-    for (const file of state.files) {
+    for (const file of filesRef.current) {
       revokePreview(file);
     }
 
     resetInput();
-    setState((prev) => ({
-      ...prev,
-      files: [],
-      errors: [],
-    }));
+    updateFiles([], []);
     onFilesChange?.([]);
-  }, [onFilesChange, resetInput, revokePreview, state.files]);
+  }, [onFilesChange, resetInput, revokePreview, updateFiles]);
 
   const addFiles = useCallback(
     (newFiles: FileList | File[]) => {
@@ -229,16 +240,15 @@ export const useFileUpload = (
       }
 
       const newFilesArray = Array.from(newFiles);
+      const currentFiles = filesRef.current;
       const errors: string[] = [];
 
-      // Clear existing errors when new files are uploaded
       setState((prev) => ({ ...prev, errors: [] }));
 
-      // Check if adding these files would exceed maxFiles (only in multiple mode)
       if (
         multiple &&
         maxFiles !== Number.POSITIVE_INFINITY &&
-        state.files.length + newFilesArray.length > maxFiles
+        currentFiles.length + newFilesArray.length > maxFiles
       ) {
         errors.push(t("max-files-exceeded", { maxFiles: maxFiles.toString() }));
         setState((prev) => ({ ...prev, errors }));
@@ -250,21 +260,18 @@ export const useFileUpload = (
       const validFiles: FileWithPreview[] = [];
 
       for (const file of newFilesArray) {
-        // Only check for duplicates if multiple files are allowed
         if (multiple) {
-          const isDuplicate = state.files.some(
+          const isDuplicate = currentFiles.some(
             (existingFile) =>
               existingFile.file.name === file.name &&
               existingFile.file.size === file.size
           );
 
-          // Skip duplicate files silently
           if (isDuplicate) {
             continue;
           }
         }
 
-        // Check file size
         if (file.size > maxSize) {
           errors.push(
             multiple
@@ -290,28 +297,32 @@ export const useFileUpload = (
         }
       }
 
-      // Only update state if we have valid files to add
-      if (validFiles.length > 0) {
-        if (!multiple) {
-          for (const file of state.files) {
-            revokePreview(file);
-          }
+      if (!multiple) {
+        for (const file of currentFiles) {
+          revokePreview(file);
         }
 
-        // Call the onFilesAdded callback with the newly added valid files
-        onFilesAdded?.(validFiles);
+        updateFiles(validFiles, errors);
 
-        const updatedFiles = multiple
-          ? [...state.files, ...validFiles]
-          : validFiles;
-        setState((prev) => ({
-          ...prev,
-          files: updatedFiles,
-          errors,
-        }));
+        if (validFiles.length > 0) {
+          onFilesAdded?.(validFiles);
+        }
+        onFilesChange?.(validFiles);
+
+        if (errors.length > 0) {
+          onError?.(errors);
+        }
+
+        resetInput();
+        return;
+      }
+
+      if (validFiles.length > 0) {
+        const updatedFiles = [...currentFiles, ...validFiles];
+        updateFiles(updatedFiles, errors);
+        onFilesAdded?.(validFiles);
         onFilesChange?.(updatedFiles);
 
-        // Call onError if there were any errors (even with some valid files)
         if (errors.length > 0) {
           onError?.(errors);
         }
@@ -323,11 +334,9 @@ export const useFileUpload = (
         onError?.(errors);
       }
 
-      // Reset input value after handling files
       resetInput();
     },
     [
-      state.files,
       maxFiles,
       multiple,
       maxSize,
@@ -340,26 +349,23 @@ export const useFileUpload = (
       onError,
       resetInput,
       t,
+      updateFiles,
     ]
   );
 
   const removeFile = useCallback(
     (id: string) => {
-      const fileToRemove = state.files.find((file) => file.id === id);
+      const fileToRemove = filesRef.current.find((file) => file.id === id);
       if (!fileToRemove) {
         return;
       }
 
       revokePreview(fileToRemove);
-      const newFiles = state.files.filter((file) => file.id !== id);
-      setState((prev) => ({
-        ...prev,
-        files: newFiles,
-        errors: [],
-      }));
+      const newFiles = filesRef.current.filter((file) => file.id !== id);
+      updateFiles(newFiles, []);
       onFilesChange?.(newFiles);
     },
-    [onFilesChange, revokePreview, state.files]
+    [onFilesChange, revokePreview, updateFiles]
   );
 
   const clearErrors = useCallback(() => {
@@ -400,13 +406,11 @@ export const useFileUpload = (
       e.stopPropagation();
       setState((prev) => ({ ...prev, isDragging: false }));
 
-      // Don't process files if the input is disabled
       if (inputRef.current?.disabled) {
         return;
       }
 
       if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-        // In single file mode, only use the first file
         if (multiple) {
           addFiles(e.dataTransfer.files);
         } else {


### PR DESCRIPTION
## Summary

- preserve the existing one-shot bar reveal while removing ref mutation during render
- keep file selection state updaters pure and move callbacks, input resets, and URL cleanup to event/lifecycle boundaries
- create previews only for local images and revoke every owned object URL on remove, clear, replacement, or unmount

## Evidence

React documents that event-specific work belongs in event handlers, while Effects synchronize with external systems. This change follows that split: file callbacks and DOM input work stay in user actions; only the reveal timer and object-URL unmount cleanup remain in Effects.

React Doctor changed scope is 100/100. The full-repo score remains 49/100 because the unchanged www scope still contains repo-wide findings; this PR reduces the full result from 1,143 to 1,141 findings and from 10 to 8 errors without adding ignores or weakening configuration.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm --filter @repo/design-system typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter www exec vitest run components/school/classes/forum/conversation/input/submit.test.ts`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (100/100)
- `pnpm run doctor --verbose --scope full`
- `pnpm build` (5/5 tasks; www generated 1,304 static pages)
- production `pnpm start` browser verification for vertical and horizontal chart reveal, hover behavior, reduced motion, authenticated forum attachment surface, and all app health endpoints

No temporary tests, scripts, dependencies, suppressions, or config changes are included.
