### PR TITLE
fix(design-system): align mobile dialog padding

### DIFF
--- a/packages/design-system/components/ui/responsive-dialog.tsx
+++ b/packages/design-system/components/ui/responsive-dialog.tsx
@@ -67,7 +67,7 @@ export function ResponsiveDialog({
           )}
         </DrawerHeader>
         <DrawerPanel
-          className={cn("flex-1 overflow-y-auto p-4", !children && "hidden")}
+          className={cn("flex-1 overflow-y-auto", !children && "hidden")}
         >
           {children}
         </DrawerPanel>


### PR DESCRIPTION
## Summary

- remove the mobile `p-4` override from `ResponsiveDialog`
- let `DrawerPanel` apply its existing `p-6` body padding
- align the mobile header, body, and footer on the same 24px horizontal grid without changing desktop dialogs

## Verification

- `pnpm --filter @repo/design-system typecheck`
- `pnpm --filter @repo/design-system test` — 314 tests, 100% coverage
- `pnpm --filter www typecheck`
- `pnpm lint`
- React Doctor — 100/100
- `pnpm build` — 5/5 tasks, WWW generated 1,304 routes
- production-mode `pnpm start` browser check at a mobile viewport — rendered body class `p-6`, 24px padding on every side, no console errors