### PR TITLE
fix(effect): preserve typed runtime failures

### DIFF
--- a/apps/www/app/api/chat/errors.ts
+++ b/apps/www/app/api/chat/errors.ts
@@ -1,0 +1,21 @@
+import { Schema } from "effect";
+
+/** Convex mutation failure raised while preparing or persisting a chat. */
+export class ChatMutationError extends Schema.TaggedError<ChatMutationError>()(
+  "ChatMutationError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+    operation: Schema.Literal("create-chat", "save-message", "sync-user"),
+  }
+) {}
+
+/** Convex query failure raised while loading authenticated chat context. */
+export class ChatQueryError extends Schema.TaggedError<ChatQueryError>()(
+  "ChatQueryError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+    operation: Schema.Literal("load-context", "load-messages", "load-profile"),
+  }
+) {}

--- a/apps/www/app/api/chat/persistence.test.ts
+++ b/apps/www/app/api/chat/persistence.test.ts
@@ -7,6 +7,7 @@ import type {
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import {
   createChatWithMessage,
   loadMessages,
@@ -135,6 +136,26 @@ describe("app/api/chat/persistence", () => {
     );
   });
 
+  it("maps chat creation failures into the mutation error contract", async () => {
+    const cause = new Error("mutation unavailable");
+    mocks.fetchMutation.mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      createChatWithMessage({
+        message,
+        modelId,
+        ...withNinaContext(),
+        token: "session-token",
+      }).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatMutationError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "create-chat",
+    });
+  });
+
   it("passes the selected model when saving a message to an existing chat", async () => {
     const chatId = await savedChatId();
     mocks.fetchQuery.mockResolvedValue(null);
@@ -165,6 +186,28 @@ describe("app/api/chat/persistence", () => {
       },
       { token: "session-token" }
     );
+  });
+
+  it("maps message save failures into the mutation error contract", async () => {
+    const chatId = await savedChatId();
+    const cause = new Error("mutation unavailable");
+    mocks.fetchMutation.mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      saveChatMessage({
+        chatId,
+        message,
+        modelId,
+        ...withNinaContext(),
+        token: "session-token",
+      }).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatMutationError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "save-message",
+    });
   });
 
   it("loads the newest stored Nina context for pinned-chat continuation", async () => {
@@ -200,6 +243,26 @@ describe("app/api/chat/persistence", () => {
     );
 
     expect(result).toBeUndefined();
+  });
+
+  it("maps pinned-context failures into the query error contract", async () => {
+    const chatId = await savedChatId();
+    const cause = new Error("query unavailable");
+    mocks.fetchQuery.mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      loadPinnedNinaContext({
+        chatId,
+        messageIdentifier: message.id,
+        token: "session-token",
+      }).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatQueryError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "load-context",
+    });
   });
 
   it("saves an existing chat rewrite through one atomic Convex mutation", async () => {
@@ -306,6 +369,22 @@ describe("app/api/chat/persistence", () => {
       },
       { token: "session-token" }
     );
+  });
+
+  it("maps message page failures into the query error contract", async () => {
+    const chatId = await savedChatId();
+    const cause = new Error("query unavailable");
+    mocks.fetchQuery.mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      loadMessages({ chatId, token: "session-token" }).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatQueryError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "load-messages",
+    });
   });
 
   it("stops loading when compression trims the retained transcript", async () => {

--- a/apps/www/app/api/chat/persistence.ts
+++ b/apps/www/app/api/chat/persistence.ts
@@ -14,6 +14,7 @@ import { mapDBMessagesToUIMessages } from "@repo/backend/convex/chats/utils";
 import { fetchMutation, fetchQuery } from "convex/nextjs";
 import type { FunctionReturnType } from "convex/server";
 import { Effect, Option, Schema } from "effect";
+import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 
 /** Generated Convex page shape returned by the chat-message pagination query. */
 type ChatMessagesPage = FunctionReturnType<
@@ -57,22 +58,29 @@ export const createChatWithMessage = Effect.fn("chat.createChatWithMessage")(
     readonly token: string;
   }) {
     const dbParts = mapUIMessagePartsToDBParts({ messageParts: message.parts });
-    const result = yield* Effect.tryPromise(() =>
-      fetchMutation(
-        convexApi.chats.mutations.createChatWithMessage,
-        {
-          type: "study",
-          message: createPersistedMessage({
-            message,
-            modelId,
-            ninaContextSnapshot,
-            ninaContextTransition,
-          }),
-          parts: dbParts,
-        },
-        { token }
-      )
-    );
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        fetchMutation(
+          convexApi.chats.mutations.createChatWithMessage,
+          {
+            type: "study",
+            message: createPersistedMessage({
+              message,
+              modelId,
+              ninaContextSnapshot,
+              ninaContextTransition,
+            }),
+            parts: dbParts,
+          },
+          { token }
+        ),
+      catch: (cause) =>
+        new ChatMutationError({
+          cause,
+          message: "Unable to create the chat.",
+          operation: "create-chat",
+        }),
+    });
 
     return result.chatId;
   }
@@ -101,24 +109,31 @@ export const saveChatMessage = Effect.fn("chat.saveChatMessage")(function* ({
 }) {
   const dbParts = mapUIMessagePartsToDBParts({ messageParts: message.parts });
 
-  yield* Effect.tryPromise(() =>
-    fetchMutation(
-      convexApi.chats.mutations.saveMessage,
-      {
-        message: {
-          chatId,
-          ...createPersistedMessage({
-            message,
-            modelId,
-            ninaContextSnapshot,
-            ninaContextTransition,
-          }),
+  yield* Effect.tryPromise({
+    try: () =>
+      fetchMutation(
+        convexApi.chats.mutations.saveMessage,
+        {
+          message: {
+            chatId,
+            ...createPersistedMessage({
+              message,
+              modelId,
+              ninaContextSnapshot,
+              ninaContextTransition,
+            }),
+          },
+          parts: dbParts,
         },
-        parts: dbParts,
-      },
-      { token }
-    )
-  );
+        { token }
+      ),
+    catch: (cause) =>
+      new ChatMutationError({
+        cause,
+        message: "Unable to save the chat message.",
+        operation: "save-message",
+      }),
+  });
 
   return chatId;
 });
@@ -140,13 +155,20 @@ export const loadPinnedNinaContext = Effect.fn("chat.loadPinnedNinaContext")(
     readonly messageIdentifier: string;
     readonly token: string;
   }) {
-    const storedContext = yield* Effect.tryPromise(() =>
-      fetchQuery(
-        convexApi.chats.queries.getPinnedNinaContextForTurn,
-        { chatId, messageIdentifier },
-        { token }
-      )
-    );
+    const storedContext = yield* Effect.tryPromise({
+      try: () =>
+        fetchQuery(
+          convexApi.chats.queries.getPinnedNinaContextForTurn,
+          { chatId, messageIdentifier },
+          { token }
+        ),
+      catch: (cause) =>
+        new ChatQueryError({
+          cause,
+          message: "Unable to load the pinned Nina context.",
+          operation: "load-context",
+        }),
+    });
 
     const decoded = Schema.decodeUnknownOption(NinaContextSnapshotSchema)(
       storedContext
@@ -177,19 +199,26 @@ export const loadMessages = Effect.fn("chat.loadMessages")(function* ({
   let messages: MyUIMessage[] = [];
 
   while (true) {
-    const page: ChatMessagesPage = yield* Effect.tryPromise(() =>
-      fetchQuery(
-        convexApi.chats.queries.loadMessagesPage,
-        {
-          chatId,
-          paginationOpts: {
-            cursor,
-            numItems: CHAT_MESSAGES_PAGE_SIZE,
+    const page: ChatMessagesPage = yield* Effect.tryPromise({
+      try: () =>
+        fetchQuery(
+          convexApi.chats.queries.loadMessagesPage,
+          {
+            chatId,
+            paginationOpts: {
+              cursor,
+              numItems: CHAT_MESSAGES_PAGE_SIZE,
+            },
           },
-        },
-        { token }
-      )
-    );
+          { token }
+        ),
+      catch: (cause) =>
+        new ChatQueryError({
+          cause,
+          message: "Unable to load the chat messages.",
+          operation: "load-messages",
+        }),
+    });
     const nextMessages = mapDBMessagesToUIMessages([...page.page].reverse());
     messages = [...nextMessages, ...messages];
 

--- a/apps/www/app/api/chat/utils.test.ts
+++ b/apps/www/app/api/chat/utils.test.ts
@@ -3,6 +3,7 @@ import { api as convexApi } from "@repo/backend/convex/_generated/api";
 import { fetchMutation, fetchQuery } from "convex/nextjs";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import {
   getLearningProfile,
   getUserInfo,
@@ -84,6 +85,21 @@ describe("app/api/chat/utils", () => {
     );
   });
 
+  it("maps user synchronization failures into the mutation error contract", async () => {
+    const cause = new Error("mutation unavailable");
+    vi.mocked(fetchMutation).mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      getUserInfo("test-token").pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatMutationError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "sync-user",
+    });
+  });
+
   it("fetches active learning profile through the shared Convex query", async () => {
     const learningProfile = {
       interests: ["exam-prep", "assessment-prep"],
@@ -147,5 +163,20 @@ describe("app/api/chat/utils", () => {
         token: "test-token",
       }
     );
+  });
+
+  it("maps learning-profile failures into the query error contract", async () => {
+    const cause = new Error("query unavailable");
+    vi.mocked(fetchQuery).mockRejectedValueOnce(cause);
+
+    const error = await Effect.runPromise(
+      getLearningProfile("test-token", "en").pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(ChatQueryError);
+    expect(error).toMatchObject({
+      cause,
+      operation: "load-profile",
+    });
   });
 });

--- a/apps/www/app/api/chat/utils.ts
+++ b/apps/www/app/api/chat/utils.ts
@@ -3,6 +3,7 @@ import { api as convexApi } from "@repo/backend/convex/_generated/api";
 import type { Locale } from "@repo/utilities/locales";
 import { fetchMutation, fetchQuery } from "convex/nextjs";
 import { Effect, Schema } from "effect";
+import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import { nakafaContent } from "@/app/api/chat/nakafa-content";
 
 /**
@@ -24,15 +25,22 @@ export const getVerified = Effect.fn("chat.getVerified")(function* (
 export const getUserInfo = Effect.fn("chat.getUserInfo")(function* (
   token: string
 ) {
-  return yield* Effect.tryPromise(() =>
-    fetchMutation(
-      convexApi.users.mutations.syncUserInfoForChat,
-      {},
-      {
-        token,
-      }
-    )
-  );
+  return yield* Effect.tryPromise({
+    try: () =>
+      fetchMutation(
+        convexApi.users.mutations.syncUserInfoForChat,
+        {},
+        {
+          token,
+        }
+      ),
+    catch: (cause) =>
+      new ChatMutationError({
+        cause,
+        message: "Unable to synchronize the chat user.",
+        operation: "sync-user",
+      }),
+  });
 });
 
 /**
@@ -43,15 +51,22 @@ export const getUserInfo = Effect.fn("chat.getUserInfo")(function* (
  */
 export const getLearningProfile = Effect.fn("chat.getLearningProfile")(
   function* (token: string, locale: Locale) {
-    const profile = yield* Effect.tryPromise(() =>
-      fetchQuery(
-        convexApi.learningPrograms.queries.getActiveProfile,
-        { locale },
-        {
-          token,
-        }
-      )
-    );
+    const profile = yield* Effect.tryPromise({
+      try: () =>
+        fetchQuery(
+          convexApi.learningPrograms.queries.getActiveProfile,
+          { locale },
+          {
+            token,
+          }
+        ),
+      catch: (cause) =>
+        new ChatQueryError({
+          cause,
+          message: "Unable to load the active learning profile.",
+          operation: "load-profile",
+        }),
+    });
 
     return yield* Schema.decodeUnknown(
       Schema.NullOr(AgentLearningProfileSchema)

--- a/packages/ai/agents/math/agent.ts
+++ b/packages/ai/agents/math/agent.ts
@@ -10,6 +10,7 @@ import {
   mathSeries,
   mathStatistics,
 } from "@repo/ai/agents/math/descriptions";
+import { makeMathGenerationError } from "@repo/ai/agents/math/error";
 import { mathPrompt } from "@repo/ai/agents/math/prompt";
 import { repairMathToolCall } from "@repo/ai/agents/math/repair";
 import {
@@ -208,7 +209,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           }),
         },
       }),
-    catch: (error) => error,
+    catch: makeMathGenerationError,
   });
 
   return {

--- a/packages/ai/agents/math/error.test.ts
+++ b/packages/ai/agents/math/error.test.ts
@@ -1,0 +1,22 @@
+import {
+  MathGenerationError,
+  makeMathGenerationError,
+} from "@repo/ai/agents/math/error";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+describe("math generation error", () => {
+  it("maps unknown provider failures into the capability error channel", async () => {
+    const cause = new Error("provider unavailable");
+    const error = await Effect.runPromise(
+      Effect.fail(makeMathGenerationError(cause)).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(MathGenerationError);
+    expect(error).toMatchObject({
+      _tag: "MathGenerationError",
+      cause,
+      message: "Math generation failed.",
+    });
+  });
+});

--- a/packages/ai/agents/math/error.ts
+++ b/packages/ai/agents/math/error.ts
@@ -1,0 +1,18 @@
+import { Schema } from "effect";
+
+/** Language model generation failure raised by the math capability. */
+export class MathGenerationError extends Schema.TaggedError<MathGenerationError>()(
+  "MathGenerationError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
+
+/** Maps an unknown AI SDK failure into the math capability error contract. */
+export function makeMathGenerationError(cause: unknown) {
+  return new MathGenerationError({
+    cause,
+    message: "Math generation failed.",
+  });
+}

--- a/packages/ai/agents/nakafa/agent.ts
+++ b/packages/ai/agents/nakafa/agent.ts
@@ -4,6 +4,7 @@ import {
   nakafaSearch,
   nakafaTaxonomy,
 } from "@repo/ai/agents/nakafa/descriptions";
+import { makeNakafaGenerationError } from "@repo/ai/agents/nakafa/error";
 import { nakafaAgentPrompt } from "@repo/ai/agents/nakafa/prompt";
 import { NakafaSearch } from "@repo/ai/agents/nakafa/search";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
@@ -160,7 +161,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
         stopWhen: isStepCount(10),
         timeout: subAgentGenerationTimeout,
       }),
-    catch: (error) => error,
+    catch: makeNakafaGenerationError,
   });
 
   return {

--- a/packages/ai/agents/nakafa/error.test.ts
+++ b/packages/ai/agents/nakafa/error.test.ts
@@ -1,0 +1,22 @@
+import {
+  makeNakafaGenerationError,
+  NakafaGenerationError,
+} from "@repo/ai/agents/nakafa/error";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+describe("Nakafa generation error", () => {
+  it("maps unknown provider failures into the capability error channel", async () => {
+    const cause = new Error("provider unavailable");
+    const error = await Effect.runPromise(
+      Effect.fail(makeNakafaGenerationError(cause)).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(NakafaGenerationError);
+    expect(error).toMatchObject({
+      _tag: "NakafaGenerationError",
+      cause,
+      message: "Nakafa generation failed.",
+    });
+  });
+});

--- a/packages/ai/agents/nakafa/error.ts
+++ b/packages/ai/agents/nakafa/error.ts
@@ -1,0 +1,18 @@
+import { Schema } from "effect";
+
+/** Language model generation failure raised by the Nakafa capability. */
+export class NakafaGenerationError extends Schema.TaggedError<NakafaGenerationError>()(
+  "NakafaGenerationError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
+
+/** Maps an unknown AI SDK failure into the Nakafa capability error contract. */
+export function makeNakafaGenerationError(cause: unknown) {
+  return new NakafaGenerationError({
+    cause,
+    message: "Nakafa generation failed.",
+  });
+}

--- a/packages/ai/nina/capability/result.test.ts
+++ b/packages/ai/nina/capability/result.test.ts
@@ -165,6 +165,25 @@ describe("nina/capability/result", () => {
     expect(result.text).toContain("Specialist: nakafa");
     expect(result.text).toContain("Do not invent facts");
   });
+
+  it("reports the provider cause preserved by a typed capability error", async () => {
+    const reported: unknown[] = [];
+    const providerError = new Error("gateway unavailable");
+
+    const result = await Effect.runPromise(
+      recoverSpecialistFailure({
+        component: "math",
+        error: new Error("Math generation failed.", {
+          cause: providerError,
+        }),
+        errorLocation: "runMathAgent",
+        reporter: createReporter(reported),
+      })
+    );
+
+    expect(reported).toEqual([providerError]);
+    expect(result.evidence.limitations).toEqual(["Math generation failed."]);
+  });
 });
 
 /** Creates the diagnostics service used by specialist recovery tests. */

--- a/packages/ai/nina/capability/result.ts
+++ b/packages/ai/nina/capability/result.ts
@@ -125,10 +125,11 @@ export const recoverSpecialistFailure = Effect.fn("nina.specialist.recover")(
     readonly reporter: Context.Tag.Service<typeof NinaReporter>;
   }) {
     const normalizedError = normalizeError(error);
+    const diagnosticError = getDiagnosticError(normalizedError);
 
     yield* Effect.annotateCurrentSpan("component", component);
     yield* Effect.annotateCurrentSpan("errorLocation", errorLocation);
-    yield* reporter.report({ error: normalizedError, source: errorLocation });
+    yield* reporter.report({ error: diagnosticError, source: errorLocation });
 
     return {
       ...capabilityResult({
@@ -149,6 +150,11 @@ function normalizeError(error: unknown) {
   }
 
   return new SpecialistUnknownFailure({ message: String(error) });
+}
+
+/** Preserves provider diagnostics stored by a typed capability error. */
+function getDiagnosticError(error: Error) {
+  return error.cause instanceof Error ? error.cause : error;
 }
 
 /** Builds a compact model-facing status for a failed LearningCapability call. */

--- a/packages/backend/client/nakafa/verify.test.ts
+++ b/packages/backend/client/nakafa/verify.test.ts
@@ -1,0 +1,100 @@
+import { verifyNakafaContent } from "@repo/backend/client/nakafa/verify";
+import { api } from "@repo/backend/convex/_generated/api";
+import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
+import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
+import { type FunctionReference, getFunctionName } from "convex/server";
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  fetchConvexRuntimeQuery: vi.fn(),
+}));
+
+vi.mock("@repo/backend/client/runtime", () => ({
+  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+}));
+
+const convexUrl = "https://example.convex.cloud";
+const quranRef = readNakafaContentRefFixture("en", "quran/1", "quran");
+
+describe("verifyNakafaContent", () => {
+  beforeEach(() => {
+    runtimeMocks.fetchConvexRuntimeQuery.mockReset();
+  });
+
+  it("returns false without a query for unsupported references", async () => {
+    const result = await Effect.runPromise(
+      verifyNakafaContent(convexUrl, "quran/1")
+    );
+
+    expect(result).toBe(false);
+    expect(runtimeMocks.fetchConvexRuntimeQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns false when a canonical route is not present", async () => {
+    runtimeMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce(null);
+
+    const result = await Effect.runPromise(
+      verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1")
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the resolved content route is no longer active", async () => {
+    runtimeMocks.fetchConvexRuntimeQuery
+      .mockResolvedValueOnce({ ...quranRef, title: "Al-Fatihah" })
+      .mockResolvedValueOnce(null);
+
+    const result = await Effect.runPromise(
+      verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1")
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the canonical content route is active", async () => {
+    runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(
+      (_url: string, query: FunctionReference<"query">) => {
+        const name = getFunctionName(query);
+
+        if (
+          name ===
+            getFunctionName(api.contents.queries.runtime.getContentRoute) ||
+          name ===
+            getFunctionName(
+              api.contents.queries.runtime.getContentRouteByContentId
+            )
+        ) {
+          return Promise.resolve({ ...quranRef, title: "Al-Fatihah" });
+        }
+
+        return Promise.reject(new Error(`Unexpected query: ${name}`));
+      }
+    );
+
+    const result = await Effect.runPromise(
+      verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1")
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("preserves typed runtime read failures instead of returning false", async () => {
+    runtimeMocks.fetchConvexRuntimeQuery.mockRejectedValueOnce(
+      new Error("runtime unavailable")
+    );
+
+    const error = await Effect.runPromise(
+      verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1").pipe(
+        Effect.flip
+      )
+    );
+
+    expect(error).toBeInstanceOf(NakafaAgentDataReadError);
+    expect(error).toMatchObject({
+      _tag: "NakafaAgentDataReadError",
+      cause: "runtime unavailable",
+    });
+  });
+});

--- a/packages/backend/client/nakafa/verify.ts
+++ b/packages/backend/client/nakafa/verify.ts
@@ -26,5 +26,5 @@ export function verifyNakafaContent(convexUrl: string, input: string) {
     }
 
     return true;
-  }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+  });
 }


### PR DESCRIPTION
## What changed

- preserve `NakafaAgentDataReadError` when content verification cannot reach its runtime read model
- map chat Convex queries and mutations to operation-specific Effect tagged errors
- give math and Nakafa generation capability-owned typed failures
- preserve underlying provider diagnostics when specialist recovery reports a typed generation failure

## Why

Runtime outages were being collapsed into `false`, while several Promise seams leaked `UnknownException` or raw `unknown`. That made missing content indistinguishable from unavailable infrastructure and weakened typed failure handling.

## Validation

- format and lint
- boundaries
- backend: 203 files / 883 tests
- AI: 57 files / 373 tests, 100% per-file coverage
- WWW: 139 files / 843 tests, 100% per-file coverage
- backend, AI, and WWW typechecks
- React Doctor changed scope: 100/100, 0 findings
- root production build and start smoke
- local `/en/chat` browser smoke with clean console
- two independent `codex review --uncommitted` passes; the first finding was fixed and the second found no actionable defects