### PR TITLE
fix(ci): authenticate production content build

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Load main content runtime token
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          CONTENT_RUNTIME_TOKEN: ${{ secrets.CONTENT_RUNTIME_TOKEN }}
+        run: |
+          test -n "$CONTENT_RUNTIME_TOKEN"
+          echo "CONTENT_RUNTIME_TOKEN=$CONTENT_RUNTIME_TOKEN" >> "$GITHUB_ENV"
+
       - name: Build production app
         run: pnpm build
         env:


### PR DESCRIPTION
## Summary

- expose the existing read-only content runtime token to the Agent-Friendly Docs workflow through a GitHub Actions secret
- keep the token out of source and logs
- allow main-branch production-catalog prerendering to authenticate successfully

## Root cause

The post-merge Agent-Friendly Docs run for `76167badf3d4f6b6f639285fd7290e3780b01c00` selected the production Convex deployment, but its build environment omitted `CONTENT_RUNTIME_TOKEN`. The two active Aksara material routes therefore failed closed during prerender, as designed.

## Verification

- repository secret `CONTENT_RUNTIME_TOKEN` populated from the existing Convex production environment without printing the value
- `pnpm lint`
- exact `www` production-path build with production Convex URLs and the same production runtime token
- prior exact SHA Vercel deployments for www/api/mcp/cas are READY
- production `/en/chat` hard-reload smoke renders the correct chat UI with no console warnings/errors