### PR TITLE
fix(content): keep material decode inside cache

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/source.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/source.tsx
@@ -68,12 +68,23 @@ async function readPublishedOwner(locale: Locale, publicPath: string) {
   applyContentRuntimeCache();
 
   const active = await getActiveContentIdentity();
-  return await Effect.runPromise(
-    readActiveContentRoute({
-      activeReleaseId: active?.releaseId ?? null,
-      family: "material",
-      locale,
-      publicPath,
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const published = yield* readActiveContentRoute({
+        activeReleaseId: active?.releaseId ?? null,
+        family: "material",
+        locale,
+        publicPath,
+      });
+      if (published.kind !== "found") {
+        return published;
+      }
+
+      const { route } = yield* decodePublishedMaterial(published.projection, {
+        locale,
+        publicPath,
+      });
+      return { ...published, route };
     })
   );
 }
@@ -128,18 +139,11 @@ async function resolveMaterialOwner(params: MaterialParams) {
     notFound();
   }
   if (published.kind === "found") {
-    const { route } = await Effect.runPromise(
-      decodePublishedMaterial(published.projection, {
-        locale: request.locale,
-        publicPath: request.publicPath,
-      })
-    );
-
     return {
       activeReleaseId: published.activeReleaseId,
       kind: "published",
       locale: request.locale,
-      route,
+      route: published.route,
     } satisfies PublishedOwner;
   }
 


### PR DESCRIPTION
## Summary
- compose published material ownership and projection decoding inside the existing Cache Component boundary
- remove the second Effect runtime start from the statically prerendered material route
- keep material pages static; no `connection()` workaround or compatibility route

## Evidence
- reproduced main failure: `next-prerender-current-time` at material `Effect.runPromise`
- `pnpm --filter www typecheck`
- focused source test: 17 passed
- `pnpm --filter www test`: 149 files, 909 tests, 100% per-file coverage
- `pnpm lint`
- root build reached 652/1306 pages without the material failure twice; both local attempts were stopped by independent Quran fetch `ETIMEDOUT` failures on different surahs
- touched file: 263 LOC

## Production context
Convex article functions are already deployed. The current www production deployment remains on the previous revision because its build exposed this SSG bug; merge and exact-SHA production deployment restore the final ownership API without adding legacy code.