### PR TITLE
feat(content): add ownership migration

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -186,6 +186,9 @@ import type * as contentRelease_runtime_active from "../contentRelease/runtime/a
 import type * as contentRelease_runtime_dispatch from "../contentRelease/runtime/dispatch.js";
 import type * as contentRelease_runtime_result from "../contentRelease/runtime/result.js";
 import type * as contentRelease_runtime_snapshot from "../contentRelease/runtime/snapshot.js";
+import type * as contentRelease_scope_family from "../contentRelease/scope/family.js";
+import type * as contentRelease_scope_history from "../contentRelease/scope/history.js";
+import type * as contentRelease_scope_migrate from "../contentRelease/scope/migrate.js";
 import type * as contentRelease_search from "../contentRelease/search.js";
 import type * as contentRelease_search_sync from "../contentRelease/search/sync.js";
 import type * as contentRelease_search_write from "../contentRelease/search/write.js";
@@ -622,6 +625,9 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/runtime/dispatch": typeof contentRelease_runtime_dispatch;
   "contentRelease/runtime/result": typeof contentRelease_runtime_result;
   "contentRelease/runtime/snapshot": typeof contentRelease_runtime_snapshot;
+  "contentRelease/scope/family": typeof contentRelease_scope_family;
+  "contentRelease/scope/history": typeof contentRelease_scope_history;
+  "contentRelease/scope/migrate": typeof contentRelease_scope_migrate;
   "contentRelease/search": typeof contentRelease_search;
   "contentRelease/search/sync": typeof contentRelease_search_sync;
   "contentRelease/search/write": typeof contentRelease_search_write;

--- a/packages/backend/convex/contentRelease/abort.test.ts
+++ b/packages/backend/convex/contentRelease/abort.test.ts
@@ -37,11 +37,20 @@ describe("contentRelease/abort", () => {
     await t.mutation(async (ctx) => {
       await seedAbortRelease(ctx);
       for (let index = 0; index < ABORT_ITEM_COUNT; index += 1) {
+        const contentKey = abortContentKey(index);
         await ctx.db.insert("contentKeys", {
-          contentKey: abortContentKey(index),
+          contentKey,
           createdSequence: 1,
           family: "material",
           locale: "en",
+        });
+        await ctx.db.insert("contentOwners", {
+          contentKey,
+          family: "material",
+          locale: "en",
+          managed: true,
+          releaseId: ABORT_RELEASE_ID,
+          sequence: 1,
         });
       }
     });
@@ -52,6 +61,7 @@ describe("contentRelease/abort", () => {
     const stored = await t.run(async (ctx) => ({
       items: await ctx.db.query("contentItems").collect(),
       keys: await ctx.db.query("contentKeys").collect(),
+      owners: await ctx.db.query("contentOwners").collect(),
       release: await ctx.db.query("contentReleases").unique(),
       state: await ctx.db.query("contentState").unique(),
     }));
@@ -71,6 +81,7 @@ describe("contentRelease/abort", () => {
     expect(repeated).toEqual(completed);
     expect(stored.items).toHaveLength(0);
     expect(stored.keys).toHaveLength(0);
+    expect(stored.owners).toHaveLength(0);
     expect(stored.release?.status).toBe("aborted");
     expect(stored.state?.candidateReleaseId).toBeUndefined();
   });

--- a/packages/backend/convex/contentRelease/abort.ts
+++ b/packages/backend/convex/contentRelease/abort.ts
@@ -5,7 +5,7 @@ import type {
 import {
   abortRowCount,
   deleteAbortRows,
-  hasAbortDirectories,
+  hasAbortResidue,
 } from "@repo/backend/convex/contentRelease/abort/rows";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import {
@@ -49,7 +49,7 @@ export const validateAbortedRelease = Effect.fn(
 )(function* (ctx: MutationCtx | QueryCtx, releaseId: string) {
   const release = yield* loadRelease(ctx, releaseId);
   const state = yield* loadState(ctx);
-  const [rows, ownsDirectory] = yield* Effect.all([
+  const [rows, residue] = yield* Effect.all([
     Effect.all([
       Effect.promise(() =>
         ctx.db
@@ -84,7 +84,7 @@ export const validateAbortedRelease = Effect.fn(
           .first()
       ),
     ]),
-    hasAbortDirectories(ctx, release.sequence),
+    hasAbortResidue(ctx, releaseId, release.sequence),
   ]);
   if (
     release.status !== "aborted" ||
@@ -94,7 +94,7 @@ export const validateAbortedRelease = Effect.fn(
     state?.activeReleaseId === releaseId ||
     state?.candidateReleaseId === releaseId ||
     state?.recoveryReleaseId === releaseId ||
-    ownsDirectory ||
+    residue ||
     rows.some((row) => row !== null)
   ) {
     return yield* releaseFail(
@@ -160,10 +160,10 @@ export const abortProgram = Effect.fn("contentRelease.abort")(function* (
     );
   }
   const complete = processed === total;
-  if (complete && (yield* hasAbortDirectories(ctx, release.sequence))) {
+  if (complete && (yield* hasAbortResidue(ctx, releaseId, release.sequence))) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
-      `Release ${releaseId} retained staged directory ownership.`
+      `Release ${releaseId} retained staged publication ownership.`
     );
   }
   const now = Date.now();

--- a/packages/backend/convex/contentRelease/abort/rows.ts
+++ b/packages/backend/convex/contentRelease/abort/rows.ts
@@ -3,8 +3,12 @@ import type {
   MutationCtx,
   QueryCtx,
 } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { retainOrphanedArtifacts } from "@repo/backend/convex/contentRelease/retention";
-import { RELEASE_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/spec";
+import {
+  EXACT_SCOPE_LIMIT,
+  RELEASE_PAGE_LIMIT,
+} from "@repo/backend/convex/contentRelease/spec";
 import { Effect } from "effect";
 
 interface AbortCounts {
@@ -64,34 +68,66 @@ const deleteOwnedPath = Effect.fn("contentRelease.deleteAbortPath")(function* (
   }
 });
 
-/** Checks whether an aborted sequence still owns a directory identity. */
-export const hasAbortDirectories = Effect.fn(
-  "contentRelease.hasAbortDirectories"
-)(function* (ctx: MutationCtx | QueryCtx, sequence: number) {
-  const [key, path] = yield* Effect.all([
-    Effect.promise(() =>
+/** Removes every bounded exact ownership transition for one invisible release. */
+const deleteOwnedOwners = Effect.fn("contentRelease.deleteAbortOwners")(
+  function* (ctx: MutationCtx, releaseId: string) {
+    const owners = yield* Effect.promise(() =>
       ctx.db
-        .query("contentKeys")
-        .withIndex("by_createdSequence_and_contentKey_and_locale", (query) =>
-          query.eq("createdSequence", sequence)
+        .query("contentOwners")
+        .withIndex("by_releaseId_and_contentKey_and_locale", (query) =>
+          query.eq("releaseId", releaseId)
         )
-        .first()
-    ),
-    Effect.promise(() =>
-      ctx.db
-        .query("contentPaths")
-        .withIndex("by_createdSequence_and_locale_and_publicPath", (query) =>
-          query.eq("createdSequence", sequence)
-        )
-        .first()
-    ),
-  ]);
-  return key !== null || path !== null;
-});
+        .take(EXACT_SCOPE_LIMIT + 1)
+    );
+    if (owners.length > EXACT_SCOPE_LIMIT) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_LIMIT",
+        `Release ${releaseId} exceeds the exact ownership abort limit.`
+      );
+    }
+    for (const owner of owners) {
+      yield* Effect.promise(() => ctx.db.delete("contentOwners", owner._id));
+    }
+  }
+);
+
+/** Checks whether an aborted release still owns auxiliary publication state. */
+export const hasAbortResidue = Effect.fn("contentRelease.hasAbortResidue")(
+  function* (ctx: MutationCtx | QueryCtx, releaseId: string, sequence: number) {
+    const [key, owner, path] = yield* Effect.all([
+      Effect.promise(() =>
+        ctx.db
+          .query("contentKeys")
+          .withIndex("by_createdSequence_and_contentKey_and_locale", (query) =>
+            query.eq("createdSequence", sequence)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("contentOwners")
+          .withIndex("by_releaseId_and_contentKey_and_locale", (query) =>
+            query.eq("releaseId", releaseId)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("contentPaths")
+          .withIndex("by_createdSequence_and_locale_and_publicPath", (query) =>
+            query.eq("createdSequence", sequence)
+          )
+          .first()
+      ),
+    ]);
+    return key !== null || owner !== null || path !== null;
+  }
+);
 
 /** Deletes one bounded release-owned page and its staged directory identities. */
 export const deleteAbortRows = Effect.fn("contentRelease.deleteAbortRows")(
   function* (ctx: MutationCtx, releaseId: string, sequence: number) {
+    yield* deleteOwnedOwners(ctx, releaseId);
     const heads = yield* Effect.promise(() =>
       ctx.db
         .query("contentHeads")

--- a/packages/backend/convex/contentRelease/compact.test.ts
+++ b/packages/backend/convex/contentRelease/compact.test.ts
@@ -1,3 +1,4 @@
+import { internal } from "@repo/backend/convex/_generated/api";
 import {
   compactProgram,
   runProgram,
@@ -53,6 +54,7 @@ describe("contentRelease/compact", () => {
       bindings: await ctx.db.query("contentBindings").collect(),
       heads: await ctx.db.query("contentHeads").collect(),
       items: await ctx.db.query("contentItems").collect(),
+      owners: await ctx.db.query("contentOwners").collect(),
       search: await ctx.db.query("contentIndex").collect(),
       releases: await ctx.db.query("contentReleases").collect(),
       state: await ctx.db.query("contentState").unique(),
@@ -64,6 +66,7 @@ describe("contentRelease/compact", () => {
     ).toMatchObject({ sequence: 3 });
     expect(stored.bindings.map((row) => row.sequence).sort()).toEqual([3, 4]);
     expect(stored.items).toHaveLength(0);
+    expect(stored.owners).toMatchObject([{ managed: true, sequence: 3 }]);
     expect(stored.search).toMatchObject([
       { contentKey: "test:compact-0", sequence: 4 },
     ]);
@@ -120,6 +123,74 @@ describe("contentRelease/compact", () => {
     );
     expect(receipt).toMatchObject({ complete: true, floor: 2 });
     expect(sequences.sort()).toEqual([2, 3, 4, 5]);
+  });
+
+  it("does not persist a compaction cycle before ownership migration", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      const first = compactionIdentity(1);
+      const base = compactionIdentity(2);
+      const active = compactionIdentity(3);
+      await insertZeroRelease(ctx, {
+        ...first,
+        role: "candidate",
+        status: "completed",
+      });
+      await insertZeroRelease(ctx, {
+        ...base,
+        base: first,
+        role: "candidate",
+        status: "completed",
+      });
+      await insertZeroRelease(ctx, {
+        ...active,
+        base,
+        role: "candidate",
+        status: "completed",
+      });
+      await insertTestState(ctx, { active, nextSequence: 4 });
+      const firstRelease = await ctx.db
+        .query("contentReleases")
+        .withIndex("by_releaseId", (query) =>
+          query.eq("releaseId", first.releaseId)
+        )
+        .unique();
+      expect(firstRelease).toBeDefined();
+      if (!firstRelease) {
+        return;
+      }
+      await ctx.db.patch("contentReleases", firstRelease._id, {
+        createdAt: COMPACTION_OLD_TIME,
+      });
+    });
+
+    await expect(
+      t.mutation((ctx) => runConvexProgram(compactProgram(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
+    const blocked = await t.run((ctx) => ctx.db.query("contentState").unique());
+    expect(blocked).toMatchObject({ nextSequence: 4 });
+    expect(blocked?.compactCursor).toBeUndefined();
+    expect(blocked?.compactFloor).toBeUndefined();
+    expect(blocked?.compactFrom).toBeUndefined();
+    expect(blocked?.compactPhase).toBeUndefined();
+    expect(blocked?.compactStartedAt).toBeUndefined();
+
+    await expect(
+      t.mutation(internal.contentRelease.scope.migrate.migrateOwnership, {
+        apply: true,
+        expectedOwners: 0,
+        expectedReleases: 3,
+      })
+    ).resolves.toMatchObject({
+      pendingOwners: 0,
+      pendingReleases: 3,
+      updatedReleases: 3,
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(compactProgram(ctx)))
+    ).resolves.toMatchObject({ complete: false, floor: 2, phase: "heads" });
   });
 
   it("freezes artifact expiry at the durable cycle start", async () => {

--- a/packages/backend/convex/contentRelease/compact.ts
+++ b/packages/backend/convex/contentRelease/compact.ts
@@ -33,6 +33,9 @@ function nextPhase(
   phase: CompactionCycle["phase"]
 ): CompactionCycle["phase"] | null {
   if (phase === "heads") {
+    return "owners";
+  }
+  if (phase === "owners") {
     return "bindings";
   }
   if (phase === "bindings") {

--- a/packages/backend/convex/contentRelease/compact/owners.ts
+++ b/packages/backend/convex/contentRelease/compact/owners.ts
@@ -1,0 +1,79 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadContentOwner } from "@repo/backend/convex/contentRelease/scope/owner";
+import {
+  COMPACTION_PAGE_BYTES,
+  COMPACTION_PAGE_COUNT,
+} from "@repo/backend/convex/contentRelease/spec";
+import { Effect } from "effect";
+
+/** Deletes one ownership version while retaining the effective floor state. */
+const compactOwner = Effect.fn("contentRelease.compactOwner")(function* (
+  ctx: MutationCtx,
+  row: Doc<"contentOwners">,
+  from: number,
+  floor: number
+) {
+  const anchor = yield* loadContentOwner(
+    ctx,
+    row.contentKey,
+    row.locale,
+    floor
+  );
+  if (!anchor) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Content ${row.contentKey}/${row.locale} lost its ownership anchor.`
+    );
+  }
+  let deleted = 0;
+  if (anchor._id !== row._id) {
+    yield* Effect.promise(() => ctx.db.delete("contentOwners", row._id));
+    deleted += 1;
+  }
+  const prior = yield* loadContentOwner(
+    ctx,
+    row.contentKey,
+    row.locale,
+    row.sequence - 1
+  );
+  if (prior && prior.sequence < from && prior._id !== anchor._id) {
+    yield* Effect.promise(() => ctx.db.delete("contentOwners", prior._id));
+    deleted += 1;
+  }
+  return deleted;
+});
+
+/** Compacts one bounded immutable exact-ownership page. */
+export const compactOwners = Effect.fn("contentRelease.compactOwners")(
+  function* (
+    ctx: MutationCtx,
+    from: number,
+    floor: number,
+    cursor: null | string
+  ) {
+    const page = yield* Effect.promise(() =>
+      ctx.db
+        .query("contentOwners")
+        .withIndex("by_sequence", (query) =>
+          query.gte("sequence", from).lte("sequence", floor)
+        )
+        .paginate({
+          cursor,
+          maximumBytesRead: COMPACTION_PAGE_BYTES,
+          maximumRowsRead: COMPACTION_PAGE_COUNT,
+          numItems: COMPACTION_PAGE_COUNT,
+        })
+    );
+    let deleted = 0;
+    for (const row of page.page) {
+      deleted += yield* compactOwner(ctx, row, from, floor);
+    }
+    return {
+      cursor: page.isDone ? null : page.continueCursor,
+      deleted,
+      done: page.isDone,
+    };
+  }
+);

--- a/packages/backend/convex/contentRelease/compact/rows.ts
+++ b/packages/backend/convex/contentRelease/compact/rows.ts
@@ -1,6 +1,7 @@
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { compactArtifacts } from "@repo/backend/convex/contentRelease/compact/artifacts";
+import { compactOwners } from "@repo/backend/convex/contentRelease/compact/owners";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import {
   loadRouteBinding,
@@ -263,6 +264,9 @@ export const compactRows = Effect.fn("contentRelease.compactRows")(function* (
 ) {
   if (phase === "heads") {
     return yield* compactHeads(ctx, from, floor, cursor);
+  }
+  if (phase === "owners") {
+    return yield* compactOwners(ctx, from, floor, cursor);
   }
   if (phase === "bindings") {
     return yield* compactBindings(ctx, from, floor, cursor);

--- a/packages/backend/convex/contentRelease/compact/state.ts
+++ b/packages/backend/convex/contentRelease/compact/state.ts
@@ -196,6 +196,37 @@ const retainedFloor = Effect.fn("contentRelease.retainedFloor")(function* (
   return boundary ? Math.min(boundary.sequence, ceiling) : from;
 });
 
+/** Blocks every cycle transaction until its removable releases own their scope. */
+const requireOwnedReleases = Effect.fn("contentRelease.requireOwnedReleases")(
+  function* (ctx: MutationCtx, from: number, floor: number) {
+    const releases = yield* Effect.promise(() =>
+      ctx.db
+        .query("contentReleases")
+        .withIndex("by_sequence", (query) =>
+          query.gte("sequence", from).lt("sequence", floor)
+        )
+        .take(RELEASE_SCAN_COUNT + 2)
+    );
+    if (releases.length > RELEASE_SCAN_COUNT + 1) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Content compaction exceeded its bounded ownership range."
+      );
+    }
+    const incomplete = releases.find(
+      (release) =>
+        release.baseFamilies === undefined ||
+        release.resultFamilies === undefined
+    );
+    if (incomplete) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_STATE",
+        `Release ${incomplete.releaseId} requires ownership migration before compaction.`
+      );
+    }
+  }
+);
+
 /** Validates and returns a previously persisted compaction cycle. */
 const activeCycle = Effect.fn("contentRelease.activeCompaction")(function* (
   state: Doc<"contentState">,
@@ -261,6 +292,7 @@ export const ensureCompaction = Effect.fn("contentRelease.ensureCompaction")(
     }
     const existing = yield* activeCycle(state, compactedFloor);
     if (existing) {
+      yield* requireOwnedReleases(ctx, existing.from, existing.floor);
       return existing;
     }
     const ceiling = yield* protectedFloor(ctx, state);
@@ -268,6 +300,7 @@ export const ensureCompaction = Effect.fn("contentRelease.ensureCompaction")(
     if (floor <= compactedFloor) {
       return null;
     }
+    yield* requireOwnedReleases(ctx, compactedFloor, floor);
     const now = Date.now();
     yield* Effect.promise(() =>
       ctx.db.patch("contentState", state._id, {

--- a/packages/backend/convex/contentRelease/manifest.test.ts
+++ b/packages/backend/convex/contentRelease/manifest.test.ts
@@ -99,6 +99,17 @@ describe("contentRelease/manifest", () => {
       releaseId: CANDIDATE.releaseId,
     });
     expect(unchanged).toEqual(created);
+    const stored = await t.run(async (ctx) => ({
+      release: await ctx.db.query("contentReleases").unique(),
+      state: await ctx.db.query("contentState").unique(),
+    }));
+    expect(stored.state).toMatchObject({
+      candidateReleaseId: CANDIDATE.releaseId,
+    });
+    expect(stored.release).toMatchObject({
+      baseFamilies: [],
+      resultFamilies: ["article", "material", "question"],
+    });
     await expect(
       t.mutation(stageRelease, {
         releaseJson: candidateJson({
@@ -125,6 +136,32 @@ describe("contentRelease/manifest", () => {
       phase: "staging",
       releaseId: RECOVERY.releaseId,
     });
+    const stored = await t.run(async (ctx) => ({
+      releases: await ctx.db
+        .query("contentReleases")
+        .withIndex("by_sequence")
+        .collect(),
+      state: await ctx.db.query("contentState").unique(),
+    }));
+    expect(stored.state).toMatchObject({
+      candidateReleaseId: CANDIDATE.releaseId,
+      recoveryReleaseId: RECOVERY.releaseId,
+    });
+    expect(
+      stored.releases.map(({ baseFamilies, resultFamilies }) => ({
+        baseFamilies,
+        resultFamilies,
+      }))
+    ).toEqual([
+      {
+        baseFamilies: [],
+        resultFamilies: ["article", "material", "question"],
+      },
+      {
+        baseFamilies: ["article", "material", "question"],
+        resultFamilies: [],
+      },
+    ]);
     await expect(
       t.mutation(stageRecovery, {
         releaseJson: recoveryJson(),
@@ -236,6 +273,10 @@ describe("contentRelease/manifest", () => {
     await t.mutation(async (ctx) => {
       await insertZeroRelease(ctx, {
         ...CANDIDATE,
+        ownership: {
+          base: [],
+          result: ["article", "material", "question"],
+        },
         role: "candidate",
         status: "completed",
       });

--- a/packages/backend/convex/contentRelease/manifest.ts
+++ b/packages/backend/convex/contentRelease/manifest.ts
@@ -1,3 +1,4 @@
+import type { SignedContentRelease } from "@nakafa/aksara-contracts/release";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/_generated/server";
@@ -16,6 +17,15 @@ import {
 } from "@repo/backend/convex/contentRelease/parse";
 import { completedReceipt } from "@repo/backend/convex/contentRelease/receipt";
 import { hasRendererIdentity } from "@repo/backend/convex/contentRelease/renderer";
+import {
+  deriveReleaseFamilies,
+  hasExactFamilies,
+  loadReleaseFamilies,
+} from "@repo/backend/convex/contentRelease/scope/family";
+import {
+  stageContentOwners,
+  validateContentOwners,
+} from "@repo/backend/convex/contentRelease/scope/owner";
 import {
   abortReceiptValidator,
   statusValidator,
@@ -55,10 +65,12 @@ const releaseStatus = Effect.fn("contentRelease.releaseStatus")(function* (
 /** Confirms an idempotent release still owns the same immutable role slot. */
 const validateExisting = Effect.fn("contentRelease.validateExisting")(
   function* (
+    ctx: MutationCtx,
     release: Doc<"contentReleases">,
     role: ReleaseRole,
     releaseJson: string,
     rendererJson: string,
+    signed: SignedContentRelease,
     state: Doc<"contentState">
   ) {
     if (
@@ -69,6 +81,21 @@ const validateExisting = Effect.fn("contentRelease.validateExisting")(
       return yield* releaseFail(
         "CONTENT_RELEASE_CONFLICT",
         `Content release ${release.releaseId} already has different authenticated bytes.`
+      );
+    }
+    const [derivedFamilies, storedFamilies] = yield* Effect.all([
+      deriveReleaseFamilies(ctx, signed.manifest),
+      loadReleaseFamilies(release),
+    ]);
+    if (
+      !(
+        hasExactFamilies(derivedFamilies.base, storedFamilies.base) &&
+        hasExactFamilies(derivedFamilies.result, storedFamilies.result)
+      )
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Content release ${release.releaseId} changed ownership.`
       );
     }
     if (release.status === "completed") {
@@ -87,6 +114,7 @@ const validateExisting = Effect.fn("contentRelease.validateExisting")(
       role === "candidate" ? state.candidateReleaseId : state.recoveryReleaseId;
     const slotSequence =
       role === "candidate" ? state.candidateSequence : state.recoverySequence;
+    yield* validateContentOwners(ctx, release, signed.manifest);
     if (slotId !== release.releaseId || slotSequence !== release.sequence) {
       return yield* releaseFail(
         "CONTENT_RELEASE_STATE",
@@ -124,10 +152,12 @@ const stageProgram = Effect.fn("contentRelease.stageRelease")(function* (
   );
   if (existing) {
     yield* validateExisting(
+      ctx,
       existing,
       role,
       canonicalRelease,
       canonicalRenderer,
+      signed,
       state
     );
     return yield* releaseStatus(existing);
@@ -150,15 +180,18 @@ const stageProgram = Effect.fn("contentRelease.stageRelease")(function* (
     yield* validateRecoveryBase(ctx, signed.manifest, canonicalRenderer, state);
   }
   yield* validateExistingSnapshots(ctx, signed.manifest);
+  const families = yield* deriveReleaseFamilies(ctx, signed.manifest);
   const now = Date.now();
   const sequence = state.nextSequence;
   const row = {
+    baseFamilies: families.base,
     checkedIndex: -1,
     checkedItems: 0,
     createdAt: now,
     releaseId: signed.manifest.releaseId,
     releaseJson: canonicalRelease,
     rendererJson: canonicalRenderer,
+    resultFamilies: families.result,
     role,
     sequence,
     stagedArtifacts: 0,
@@ -174,6 +207,7 @@ const stageProgram = Effect.fn("contentRelease.stageRelease")(function* (
   } satisfies WithoutSystemFields<Doc<"contentReleases">>;
   yield* ensureDocumentSize(`Content release ${row.releaseId}`, row);
   yield* Effect.promise(() => ctx.db.insert("contentReleases", row));
+  yield* stageContentOwners(ctx, row, signed.manifest);
   const slot =
     role === "candidate"
       ? {

--- a/packages/backend/convex/contentRelease/proof/verify.test.ts
+++ b/packages/backend/convex/contentRelease/proof/verify.test.ts
@@ -55,12 +55,14 @@ function runProof(
 async function insertRelease(ctx: MutationCtx) {
   const now = Date.UTC(2026, 6, 22, 12, 0, 0);
   await ctx.db.insert("contentReleases", {
+    baseFamilies: [],
     checkedIndex: -1,
     checkedItems: 0,
     createdAt: now,
     releaseId,
     releaseJson: JSON.stringify(signedRelease),
     rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
+    resultFamilies: [...signedRelease.manifest.scope.families],
     role: "candidate",
     sequence: 1,
     stagedArtifacts: 0,
@@ -128,12 +130,14 @@ async function insertDeleteRelease(ctx: MutationCtx, count: number) {
   const signed = testSignedRelease(nextManifest);
   const now = Date.UTC(2026, 6, 22, 12, 0, 0);
   await ctx.db.insert("contentReleases", {
+    baseFamilies: [],
     checkedIndex: -1,
     checkedItems: 0,
     createdAt: now,
     releaseId,
     releaseJson: JSON.stringify(signed),
     rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
+    resultFamilies: [...signed.manifest.scope.families],
     role: "candidate",
     sequence: 1,
     stagedArtifacts: 0,

--- a/packages/backend/convex/contentRelease/schema.ts
+++ b/packages/backend/convex/contentRelease/schema.ts
@@ -1,3 +1,4 @@
+import scopeSchema from "@repo/backend/convex/contentRelease/scope/schema";
 import snapshotSchema from "@repo/backend/convex/contentRelease/snapshot/schema";
 import {
   bindingOperationValidator,
@@ -218,6 +219,7 @@ const tables = {
     abortingAt: v.optional(v.number()),
     articleIndex: v.optional(v.number()),
     articleSyncedAt: v.optional(v.number()),
+    baseFamilies: v.optional(v.array(contentFamilyValidator)),
     cleanupAt: v.optional(v.number()),
     cleanupDeletedArtifacts: v.optional(v.number()),
     cleanupFutureAt: v.optional(v.number()),
@@ -231,6 +233,7 @@ const tables = {
     releaseId: v.string(),
     releaseJson: v.string(),
     rendererJson: v.string(),
+    resultFamilies: v.optional(v.array(contentFamilyValidator)),
     role: releaseRoleValidator,
     searchIndex: v.optional(v.number()),
     searchSyncedAt: v.optional(v.number()),
@@ -284,6 +287,7 @@ const tables = {
     .index("by_artifactHash", ["artifactHash"])
     .index("by_sequence", ["sequence"]),
 
+  ...scopeSchema,
   ...snapshotSchema,
 
   /** Singleton identities selecting active, candidate, and recovery sequences. */

--- a/packages/backend/convex/contentRelease/scope/family.ts
+++ b/packages/backend/convex/contentRelease/scope/family.ts
@@ -1,0 +1,126 @@
+import {
+  type ContentFamily,
+  ContentFamilySchema,
+} from "@nakafa/aksara-contracts/content";
+import type { ContentReleaseManifest } from "@nakafa/aksara-contracts/release";
+import type { PublicationScope } from "@nakafa/aksara-contracts/release/snapshot";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadRelease } from "@repo/backend/convex/contentRelease/model";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import { Effect } from "effect";
+
+type ReadCtx = MutationCtx | QueryCtx;
+
+/** Returns every family once in the canonical shared-contract order. */
+export function mergeManagedFamilies(
+  current: readonly ContentFamily[],
+  selected: readonly ContentFamily[]
+) {
+  return ContentFamilySchema.literals.filter(
+    (family) => current.includes(family) || selected.includes(family)
+  );
+}
+
+/** Compares two canonical family lists without coercion. */
+export function hasExactFamilies(
+  stored: readonly ContentFamily[],
+  derived: readonly ContentFamily[]
+) {
+  return (
+    stored.length === derived.length &&
+    stored.every((family, index) => family === derived[index])
+  );
+}
+
+/** Compares two canonical signed publication scopes field by field. */
+export function hasSamePublicationScope(
+  left: PublicationScope,
+  right: PublicationScope
+) {
+  return (
+    hasExactFamilies(left.families, right.families) &&
+    left.snapshots.length === right.snapshots.length &&
+    left.snapshots.every(
+      (snapshot, index) => snapshot === right.snapshots[index]
+    ) &&
+    left.content.length === right.content.length &&
+    left.content.every((identity, index) => {
+      const compared = right.content[index];
+      return (
+        compared?.contentKey === identity.contentKey &&
+        compared.family === identity.family &&
+        compared.locale === identity.locale
+      );
+    })
+  );
+}
+
+/** Requires one immutable release to retain canonical family ownership. */
+export const loadReleaseFamilies = Effect.fn(
+  "contentRelease.loadReleaseFamilies"
+)(function* (
+  release: Pick<
+    Doc<"contentReleases">,
+    "baseFamilies" | "releaseId" | "resultFamilies"
+  >
+) {
+  if (!(release.baseFamilies && release.resultFamilies)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      `Release ${release.releaseId} has not completed its ownership migration.`
+    );
+  }
+  const base = mergeManagedFamilies([], release.baseFamilies);
+  const result = mergeManagedFamilies([], release.resultFamilies);
+  if (
+    !(
+      hasExactFamilies(release.baseFamilies, base) &&
+      hasExactFamilies(release.resultFamilies, result)
+    )
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Release ${release.releaseId} has non-canonical family ownership.`
+    );
+  }
+  return { base, result };
+});
+
+/** Derives immutable base and result families from the signed release graph. */
+export const deriveReleaseFamilies = Effect.fn(
+  "contentRelease.deriveReleaseFamilies"
+)(function* (ctx: ReadCtx, manifest: ContentReleaseManifest) {
+  const base =
+    manifest.baseReleaseId === null
+      ? []
+      : (yield* loadReleaseFamilies(
+          yield* loadRelease(ctx, manifest.baseReleaseId)
+        )).result;
+  if (manifest.origin.kind === "git") {
+    return {
+      base,
+      result: mergeManagedFamilies(base, manifest.scope.families),
+    };
+  }
+  if (manifest.baseReleaseId !== manifest.origin.releaseId) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_CONFLICT",
+      `Rollback ${manifest.releaseId} does not target its signed origin.`
+    );
+  }
+  const origin = yield* loadRelease(ctx, manifest.origin.releaseId);
+  const signedOrigin = yield* decodeReleaseJson(origin.releaseJson);
+  if (!hasSamePublicationScope(manifest.scope, signedOrigin.manifest.scope)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_CONFLICT",
+      `Rollback ${manifest.releaseId} changed its origin publication scope.`
+    );
+  }
+  const originFamilies = yield* loadReleaseFamilies(origin);
+  return { base, result: originFamilies.base };
+});

--- a/packages/backend/convex/contentRelease/scope/history.test.ts
+++ b/packages/backend/convex/contentRelease/scope/history.test.ts
@@ -1,0 +1,61 @@
+import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
+import { deriveOwnership } from "@repo/backend/convex/contentRelease/scope/history";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { testPublicationScope } from "@repo/backend/test/content-release";
+import {
+  insertZeroRelease,
+  type TestIdentity,
+} from "@repo/backend/test/content-state";
+import { convexTest } from "convex-test";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+const FORWARD = {
+  manifestHash: `sha256:${"1".repeat(64)}`,
+  releaseId: "release-history-forward",
+  sequence: 1,
+} satisfies TestIdentity;
+const RECOVERY = {
+  manifestHash: `sha256:${"2".repeat(64)}`,
+  releaseId: "release-history-recovery",
+  sequence: 2,
+} satisfies TestIdentity;
+
+describe("contentRelease/scope/history", () => {
+  it("rejects a recovery that changes its immutable origin scope", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertZeroRelease(ctx, {
+        ...FORWARD,
+        role: "candidate",
+        scope: testPublicationScope({ families: ["article"] }),
+        status: "completed",
+      });
+      await insertZeroRelease(ctx, {
+        ...RECOVERY,
+        base: FORWARD,
+        originReleaseId: FORWARD.releaseId,
+        role: "recovery",
+        scope: testPublicationScope({
+          content: [
+            {
+              contentKey: ContentKeySchema.make("test:scope-drift"),
+              family: "material",
+              locale: "en",
+            },
+          ],
+          families: [],
+        }),
+        status: "verified",
+      });
+    });
+    const releases = await t.run((ctx) =>
+      ctx.db.query("contentReleases").withIndex("by_sequence").take(101)
+    );
+
+    await expect(
+      Effect.runPromise(deriveOwnership(releases).pipe(Effect.flip))
+    ).resolves.toMatchObject({ code: "CONTENT_RELEASE_CONFLICT" });
+  });
+});

--- a/packages/backend/convex/contentRelease/scope/history.ts
+++ b/packages/backend/convex/contentRelease/scope/history.ts
@@ -1,0 +1,135 @@
+import {
+  type ContentFamily,
+  type ContentPublicationIdentity,
+  headIdentity,
+} from "@nakafa/aksara-contracts/content";
+import type { ContentReleaseManifest } from "@nakafa/aksara-contracts/release";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import {
+  hasSamePublicationScope,
+  mergeManagedFamilies,
+} from "@repo/backend/convex/contentRelease/scope/family";
+import { Effect } from "effect";
+
+interface OwnershipSnapshot {
+  readonly content: Map<string, ContentPublicationIdentity>;
+  readonly families: ContentFamily[];
+}
+
+export interface ReleaseOwnership {
+  readonly base: OwnershipSnapshot;
+  readonly result: OwnershipSnapshot;
+}
+
+export interface OwnerVersion {
+  readonly contentKey: string;
+  readonly family: ContentFamily;
+  readonly locale: ContentPublicationIdentity["locale"];
+  readonly managed: boolean;
+  readonly releaseId: string;
+  readonly sequence: number;
+}
+
+/** Copies one ownership snapshot before applying a release transition. */
+function copySnapshot(snapshot: OwnershipSnapshot): OwnershipSnapshot {
+  return {
+    content: new Map(snapshot.content),
+    families: [...snapshot.families],
+  };
+}
+
+/** Applies one reviewed Git scope to its immutable base ownership. */
+function applyGitScope(
+  base: OwnershipSnapshot,
+  content: readonly ContentPublicationIdentity[],
+  families: readonly ContentFamily[]
+) {
+  const result = {
+    content: new Map(base.content),
+    families: mergeManagedFamilies(base.families, families),
+  };
+  for (const identity of content) {
+    result.content.set(headIdentity(identity), identity);
+  }
+  return result;
+}
+
+/** Reconstructs family state and exact owner versions from release history. */
+export const deriveOwnership = Effect.fn("contentRelease.deriveOwnership")(
+  function* (releases: readonly Doc<"contentReleases">[]) {
+    const history = new Map<string, ReleaseOwnership>();
+    const manifests = new Map<string, ContentReleaseManifest>();
+    const owners: OwnerVersion[] = [];
+    let previousSequence = 0;
+    for (const release of releases) {
+      if (
+        release.sequence <= previousSequence ||
+        history.has(release.releaseId)
+      ) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_INTEGRITY",
+          "Ownership migration found unordered release identities."
+        );
+      }
+      const signed = yield* decodeReleaseJson(release.releaseJson);
+      let base: OwnershipSnapshot = { content: new Map(), families: [] };
+      if (signed.manifest.baseReleaseId !== null) {
+        const baseOwnership = history.get(signed.manifest.baseReleaseId);
+        if (!baseOwnership) {
+          return yield* releaseFail(
+            "CONTENT_RELEASE_INTEGRITY",
+            `Release ${release.releaseId} lost its ownership base.`
+          );
+        }
+        base = baseOwnership.result;
+      }
+      let result: OwnershipSnapshot;
+      if (signed.manifest.origin.kind === "git") {
+        result = applyGitScope(
+          base,
+          signed.manifest.scope.content,
+          signed.manifest.scope.families
+        );
+      } else {
+        const forward = history.get(signed.manifest.origin.releaseId);
+        const forwardManifest = manifests.get(signed.manifest.origin.releaseId);
+        if (
+          !(forward && forwardManifest) ||
+          signed.manifest.baseReleaseId !== signed.manifest.origin.releaseId
+        ) {
+          return yield* releaseFail(
+            "CONTENT_RELEASE_INTEGRITY",
+            `Recovery ${release.releaseId} lost its forward ownership state.`
+          );
+        }
+        if (
+          !hasSamePublicationScope(signed.manifest.scope, forwardManifest.scope)
+        ) {
+          return yield* releaseFail(
+            "CONTENT_RELEASE_CONFLICT",
+            `Recovery ${release.releaseId} changed its origin publication scope.`
+          );
+        }
+        result = copySnapshot(forward.base);
+      }
+      history.set(release.releaseId, { base, result });
+      manifests.set(release.releaseId, signed.manifest);
+      if (release.status !== "aborted") {
+        for (const identity of signed.manifest.scope.content) {
+          if (!result.families.includes(identity.family)) {
+            owners.push({
+              ...identity,
+              managed: result.content.has(headIdentity(identity)),
+              releaseId: release.releaseId,
+              sequence: release.sequence,
+            });
+          }
+        }
+      }
+      previousSequence = release.sequence;
+    }
+    return { history, owners };
+  }
+);

--- a/packages/backend/convex/contentRelease/scope/migrate.test.ts
+++ b/packages/backend/convex/contentRelease/scope/migrate.test.ts
@@ -1,0 +1,227 @@
+import { internal } from "@repo/backend/convex/_generated/api";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  ACTIVE,
+  MATERIAL_KEY,
+  RECOVERY,
+  seedOwnershipHistory,
+} from "@repo/backend/test/owner-migration";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+const migrate = internal.contentRelease.scope.migrate.migrateOwnership;
+const stageRecovery = internal.contentRelease.manifest.stageRecovery;
+const stageRelease = internal.contentRelease.manifest.stageRelease;
+
+describe("contentRelease/scope/migrate", () => {
+  it("previews, applies, and idempotently proves production ownership", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(seedOwnershipHistory);
+
+    const expected = {
+      activeFamilies: ["article"],
+      insertedOwners: 0,
+      ownerCount: 6,
+      pendingOwners: 6,
+      pendingReleases: 8,
+      recoveryFamilies: [],
+      releaseCount: 8,
+      updatedReleases: 0,
+    };
+    await expect(
+      t.mutation(migrate, {
+        apply: false,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).resolves.toEqual(expected);
+    await expect(
+      t.mutation(migrate, {
+        apply: true,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).resolves.toEqual({
+      ...expected,
+      insertedOwners: 6,
+      updatedReleases: 8,
+    });
+    await expect(
+      t.mutation(migrate, {
+        apply: true,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).resolves.toEqual({
+      ...expected,
+      pendingOwners: 0,
+      pendingReleases: 0,
+    });
+
+    const owners = await t.run((ctx) =>
+      ctx.db.query("contentOwners").withIndex("by_sequence").take(1001)
+    );
+    expect(
+      owners.map(({ locale, managed, sequence }) => ({
+        locale,
+        managed,
+        sequence,
+      }))
+    ).toEqual([
+      { locale: "en", managed: true, sequence: 1 },
+      { locale: "id", managed: true, sequence: 1 },
+      { locale: "en", managed: false, sequence: 2 },
+      { locale: "id", managed: false, sequence: 2 },
+      { locale: "en", managed: true, sequence: 3 },
+      { locale: "id", managed: true, sequence: 3 },
+    ]);
+    const [active, recovery] = await t.run((ctx) =>
+      Promise.all([
+        ctx.db
+          .query("contentReleases")
+          .withIndex("by_releaseId", (query) =>
+            query.eq("releaseId", ACTIVE.releaseId)
+          )
+          .unique(),
+        ctx.db
+          .query("contentReleases")
+          .withIndex("by_releaseId", (query) =>
+            query.eq("releaseId", RECOVERY.releaseId)
+          )
+          .unique(),
+      ])
+    );
+    expect(active).toBeDefined();
+    expect(recovery).toBeDefined();
+    if (!(active && recovery)) {
+      return;
+    }
+    await expect(
+      t.mutation(stageRelease, {
+        releaseJson: active.releaseJson,
+        rendererJson: active.rendererJson,
+      })
+    ).resolves.toMatchObject({ phase: "completed" });
+    await expect(
+      t.mutation(stageRecovery, {
+        releaseJson: recovery.releaseJson,
+        rendererJson: recovery.rendererJson,
+      })
+    ).resolves.toMatchObject({ phase: "verified" });
+  });
+
+  it("initializes an empty deployment and rejects unsafe assumptions", async () => {
+    const empty = convexTest(schema, convexModules);
+    await expect(
+      empty.mutation(migrate, {
+        apply: true,
+        expectedOwners: 0,
+        expectedReleases: 0,
+      })
+    ).resolves.toEqual({
+      activeFamilies: [],
+      insertedOwners: 0,
+      ownerCount: 0,
+      pendingOwners: 0,
+      pendingReleases: 0,
+      releaseCount: 0,
+      updatedReleases: 0,
+    });
+
+    const bounded = convexTest(schema, convexModules);
+    await bounded.mutation(seedOwnershipHistory);
+    await expect(
+      bounded.mutation(migrate, {
+        apply: false,
+        expectedOwners: 6,
+        expectedReleases: 7,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_LIMIT" },
+    });
+    await expect(
+      bounded.mutation(migrate, {
+        apply: false,
+        expectedOwners: 5,
+        expectedReleases: 8,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_LIMIT" },
+    });
+    await bounded.mutation(async (ctx) => {
+      const state = await ctx.db.query("contentState").unique();
+      expect(state).toBeDefined();
+      if (!state) {
+        return;
+      }
+      await ctx.db.patch("contentState", state._id, {
+        compactFloor: 2,
+        compactFrom: 1,
+        compactPhase: "heads",
+        compactStartedAt: 0,
+      });
+    });
+    await expect(
+      bounded.mutation(migrate, {
+        apply: false,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
+  });
+
+  it("rejects conflicting exact and family ownership state", async () => {
+    const ownerConflict = convexTest(schema, convexModules);
+    await ownerConflict.mutation(seedOwnershipHistory);
+    await ownerConflict.mutation((ctx) =>
+      ctx.db.insert("contentOwners", {
+        contentKey: MATERIAL_KEY,
+        family: "material",
+        locale: "en",
+        managed: false,
+        releaseId: "release-material",
+        sequence: 1,
+      })
+    );
+    await expect(
+      ownerConflict.mutation(migrate, {
+        apply: false,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+
+    const familyConflict = convexTest(schema, convexModules);
+    await familyConflict.mutation(seedOwnershipHistory);
+    await familyConflict.mutation(async (ctx) => {
+      const release = await ctx.db
+        .query("contentReleases")
+        .withIndex("by_releaseId", (query) =>
+          query.eq("releaseId", "release-article")
+        )
+        .unique();
+      expect(release).toBeDefined();
+      if (!release) {
+        return;
+      }
+      await ctx.db.patch("contentReleases", release._id, {
+        baseFamilies: [],
+        resultFamilies: [],
+      });
+    });
+    await expect(
+      familyConflict.mutation(migrate, {
+        apply: false,
+        expectedOwners: 6,
+        expectedReleases: 8,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/scope/migrate.ts
+++ b/packages/backend/convex/contentRelease/scope/migrate.ts
@@ -1,0 +1,259 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { internalMutation } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadState } from "@repo/backend/convex/contentRelease/model";
+import { hasExactFamilies } from "@repo/backend/convex/contentRelease/scope/family";
+import {
+  deriveOwnership,
+  type OwnerVersion,
+  type ReleaseOwnership,
+} from "@repo/backend/convex/contentRelease/scope/history";
+import { contentFamilyValidator } from "@repo/backend/convex/contentRelease/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { v } from "convex/values";
+import { Effect } from "effect";
+
+const MIGRATION_RELEASE_LIMIT = 100;
+const MIGRATION_OWNER_LIMIT = 1000;
+
+const migrationResultValidator = v.object({
+  activeFamilies: v.array(contentFamilyValidator),
+  insertedOwners: v.number(),
+  ownerCount: v.number(),
+  pendingOwners: v.number(),
+  pendingReleases: v.number(),
+  recoveryFamilies: v.optional(v.array(contentFamilyValidator)),
+  releaseCount: v.number(),
+  updatedReleases: v.number(),
+});
+
+/** Returns one stable key for comparing exact migration owner versions. */
+function ownerIdentity(owner: OwnerVersion | Doc<"contentOwners">) {
+  return `${owner.releaseId}\0${owner.contentKey}\0${owner.locale}`;
+}
+
+/** Checks stored owner rows and inserts only missing exact versions. */
+const reconcileOwners = Effect.fn("contentRelease.reconcileOwners")(function* (
+  ctx: MutationCtx,
+  expected: readonly OwnerVersion[],
+  apply: boolean,
+  expectedOwners: number
+) {
+  if (
+    !Number.isSafeInteger(expectedOwners) ||
+    expectedOwners < 0 ||
+    expectedOwners > MIGRATION_OWNER_LIMIT ||
+    expected.length !== expectedOwners
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_LIMIT",
+      `Ownership migration expected ${expectedOwners} owner rows and derived ${expected.length}.`
+    );
+  }
+  const stored = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentOwners")
+      .withIndex("by_sequence")
+      .take(MIGRATION_OWNER_LIMIT + 1)
+  );
+  const expectedByIdentity = new Map(
+    expected.map((owner) => [ownerIdentity(owner), owner])
+  );
+  const storedIdentities = new Set<string>();
+  for (const owner of stored) {
+    const identity = ownerIdentity(owner);
+    const derived = expectedByIdentity.get(identity);
+    if (
+      storedIdentities.has(identity) ||
+      !derived ||
+      owner.family !== derived.family ||
+      owner.managed !== derived.managed ||
+      owner.sequence !== derived.sequence
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_CONFLICT",
+        "Ownership migration found conflicting exact-content state."
+      );
+    }
+    storedIdentities.add(identity);
+  }
+  const missing = expected.filter(
+    (owner) => !storedIdentities.has(ownerIdentity(owner))
+  );
+  if (apply) {
+    for (const owner of missing) {
+      yield* Effect.promise(() => ctx.db.insert("contentOwners", owner));
+    }
+  }
+  return {
+    inserted: apply ? missing.length : 0,
+    pending: missing.length,
+  };
+});
+
+/** Checks and optionally writes immutable family ownership on every release. */
+const reconcileReleaseFamilies = Effect.fn(
+  "contentRelease.reconcileReleaseFamilies"
+)(function* (
+  ctx: MutationCtx,
+  releases: readonly Doc<"contentReleases">[],
+  history: ReadonlyMap<string, ReleaseOwnership>,
+  apply: boolean
+) {
+  let updated = 0;
+  for (const release of releases) {
+    const ownership = history.get(release.releaseId);
+    if (!ownership) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Release ${release.releaseId} lost its derived ownership.`
+      );
+    }
+    const hasBase = release.baseFamilies !== undefined;
+    const hasResult = release.resultFamilies !== undefined;
+    if (hasBase !== hasResult) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_CONFLICT",
+        `Release ${release.releaseId} has partial family ownership.`
+      );
+    }
+    if (hasBase && hasResult) {
+      if (
+        !(
+          hasExactFamilies(
+            release.baseFamilies ?? [],
+            ownership.base.families
+          ) &&
+          hasExactFamilies(
+            release.resultFamilies ?? [],
+            ownership.result.families
+          )
+        )
+      ) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_CONFLICT",
+          `Release ${release.releaseId} has conflicting family ownership.`
+        );
+      }
+      continue;
+    }
+    updated += 1;
+    if (apply) {
+      yield* Effect.promise(() =>
+        ctx.db.patch("contentReleases", release._id, {
+          baseFamilies: ownership.base.families,
+          resultFamilies: ownership.result.families,
+          updatedAt: Date.now(),
+        })
+      );
+    }
+  }
+  return {
+    pending: updated,
+    updated: apply ? updated : 0,
+  };
+});
+
+/** Derives and optionally applies explicit immutable publication ownership. */
+const migrateProgram = Effect.fn("contentRelease.migrateOwnership")(function* (
+  ctx: MutationCtx,
+  apply: boolean,
+  expectedReleases: number,
+  expectedOwners: number
+) {
+  const state = yield* loadState(ctx);
+  const releases = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentReleases")
+      .withIndex("by_sequence")
+      .order("asc")
+      .take(MIGRATION_RELEASE_LIMIT + 1)
+  );
+  if (
+    releases.length > MIGRATION_RELEASE_LIMIT ||
+    releases.length !== expectedReleases
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_LIMIT",
+      `Ownership migration expected ${expectedReleases} releases and found ${releases.length}.`
+    );
+  }
+  if (!state && releases.length > 0) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Ownership migration found releases without publication state."
+    );
+  }
+  if (state?.compactPhase !== undefined) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Ownership migration cannot run during release compaction."
+    );
+  }
+  const derived = yield* deriveOwnership(releases);
+  const empty: ReleaseOwnership = {
+    base: { content: new Map(), families: [] },
+    result: { content: new Map(), families: [] },
+  };
+  const active = state?.activeReleaseId
+    ? derived.history.get(state.activeReleaseId)
+    : empty;
+  const candidate = state?.candidateReleaseId
+    ? derived.history.get(state.candidateReleaseId)
+    : undefined;
+  const recovery = state?.recoveryReleaseId
+    ? derived.history.get(state.recoveryReleaseId)
+    : undefined;
+  if (
+    !active ||
+    (state?.candidateReleaseId && !candidate) ||
+    (state?.recoveryReleaseId && !recovery)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Ownership migration found a slot outside release history."
+    );
+  }
+  const owners = yield* reconcileOwners(
+    ctx,
+    derived.owners,
+    apply,
+    expectedOwners
+  );
+  const familyReleases = yield* reconcileReleaseFamilies(
+    ctx,
+    releases,
+    derived.history,
+    apply
+  );
+  return {
+    activeFamilies: active.result.families,
+    insertedOwners: owners.inserted,
+    ownerCount: derived.owners.length,
+    pendingOwners: owners.pending,
+    pendingReleases: familyReleases.pending,
+    recoveryFamilies: recovery?.result.families,
+    releaseCount: releases.length,
+    updatedReleases: familyReleases.updated,
+  };
+});
+
+/** Temporarily migrates explicit ownership before schema narrowing. */
+export const migrateOwnership = internalMutation({
+  args: {
+    apply: v.boolean(),
+    expectedOwners: v.number(),
+    expectedReleases: v.number(),
+  },
+  returns: migrationResultValidator,
+  handler: (ctx, args) =>
+    runConvexProgram(
+      migrateProgram(
+        ctx,
+        args.apply,
+        args.expectedReleases,
+        args.expectedOwners
+      )
+    ),
+});

--- a/packages/backend/convex/contentRelease/scope/owner.test.ts
+++ b/packages/backend/convex/contentRelease/scope/owner.test.ts
@@ -1,0 +1,314 @@
+import { ContentPublicationIdentitySchema } from "@nakafa/aksara-contracts/content";
+import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
+import { internal } from "@repo/backend/convex/_generated/api";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  testPublicationScope,
+  testRendererJson,
+} from "@repo/backend/test/content-release";
+import {
+  insertTestState,
+  insertZeroRelease,
+  type TestIdentity,
+} from "@repo/backend/test/content-state";
+import {
+  TEST_OWNER_CANDIDATE as CANDIDATE,
+  TEST_OWNER_KEY as CONTENT_KEY,
+  TEST_OWNER_SCOPE as EXACT_SCOPE,
+  markOwnerVerified,
+  ownerReleaseJson,
+  TEST_OWNER_RECOVERY as RECOVERY,
+  stageVerifiedOwner,
+} from "@repo/backend/test/release-owner";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+const begin = internal.contentRelease.verify.begin;
+const activate = internal.contentRelease.activate.activate;
+const abortRelease = internal.contentRelease.manifest.abort;
+const stageRecovery = internal.contentRelease.manifest.stageRecovery;
+const stageRelease = internal.contentRelease.manifest.stageRelease;
+
+describe("contentRelease/scope/owner", () => {
+  it("owns and verifies exact unchanged content without a release item", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(stageRelease, {
+      releaseJson: ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE }),
+      rendererJson: testRendererJson(),
+    });
+
+    const stored = await t.run(async (ctx) => ({
+      items: await ctx.db.query("contentItems").collect(),
+      owners: await ctx.db.query("contentOwners").collect(),
+    }));
+    expect(stored.items).toHaveLength(0);
+    expect(stored.owners).toMatchObject([
+      {
+        contentKey: CONTENT_KEY,
+        managed: true,
+        releaseId: CANDIDATE.releaseId,
+        sequence: CANDIDATE.sequence,
+      },
+    ]);
+    await expect(
+      t.mutation(begin, { releaseId: CANDIDATE.releaseId })
+    ).resolves.toBe(-1);
+
+    const missing = convexTest(schema, convexModules);
+    await missing.mutation(stageRelease, {
+      releaseJson: ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE }),
+      rendererJson: testRendererJson(),
+    });
+    await missing.mutation(async (ctx) => {
+      const owner = await ctx.db.query("contentOwners").unique();
+      if (!owner) {
+        throw new Error("Expected staged owner.");
+      }
+      await ctx.db.delete("contentOwners", owner._id);
+    });
+    await expect(
+      missing.mutation(begin, { releaseId: CANDIDATE.releaseId })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const abandoned = convexTest(schema, convexModules);
+    await abandoned.mutation(stageRelease, {
+      releaseJson: ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE }),
+      rendererJson: testRendererJson(),
+    });
+    await expect(
+      abandoned.mutation(abortRelease, { releaseId: CANDIDATE.releaseId })
+    ).resolves.toMatchObject({ complete: true, totalItems: 0 });
+    await expect(
+      abandoned.run((ctx) => ctx.db.query("contentOwners").collect())
+    ).resolves.toEqual([]);
+  });
+
+  it("restores absent and previously managed exact ownership", async () => {
+    const absent = convexTest(schema, convexModules);
+    await stageVerifiedOwner(
+      absent,
+      CANDIDATE,
+      ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE })
+    );
+    await absent.mutation(stageRecovery, {
+      releaseJson: ownerReleaseJson(RECOVERY, {
+        base: CANDIDATE,
+        originReleaseId: CANDIDATE.releaseId,
+        scope: EXACT_SCOPE,
+      }),
+      rendererJson: testRendererJson(),
+    });
+    const absentOwners = await absent.run((ctx) =>
+      ctx.db.query("contentOwners").withIndex("by_sequence").collect()
+    );
+    expect(absentOwners.map(({ managed }) => managed)).toEqual([true, false]);
+
+    const managed = convexTest(schema, convexModules);
+    const base = {
+      manifestHash: `sha256:${"3".repeat(64)}`,
+      releaseId: "release-owner-base",
+      sequence: 1,
+    } satisfies TestIdentity;
+    const forward = { ...CANDIDATE, sequence: 2 };
+    const inverse = { ...RECOVERY, sequence: 3 };
+    await managed.mutation(async (ctx) => {
+      await insertZeroRelease(ctx, {
+        ...base,
+        ownership: { base: [], result: [] },
+        role: "candidate",
+        scope: EXACT_SCOPE,
+        status: "completed",
+      });
+      await insertTestState(ctx, {
+        active: base,
+        nextSequence: 2,
+      });
+      await ctx.db.insert("contentOwners", {
+        contentKey: CONTENT_KEY,
+        family: "material",
+        locale: "en",
+        managed: true,
+        releaseId: base.releaseId,
+        sequence: base.sequence,
+      });
+    });
+    await stageVerifiedOwner(
+      managed,
+      forward,
+      ownerReleaseJson(forward, { base, scope: EXACT_SCOPE })
+    );
+    await managed.mutation(stageRecovery, {
+      releaseJson: ownerReleaseJson(inverse, {
+        base: forward,
+        originReleaseId: forward.releaseId,
+        scope: EXACT_SCOPE,
+      }),
+      rendererJson: testRendererJson(),
+    });
+    const managedOwners = await managed.run((ctx) =>
+      ctx.db.query("contentOwners").withIndex("by_sequence").collect()
+    );
+    expect(managedOwners.map(({ managed: value }) => value)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it("keeps recovery validation immutable after candidate activation", async () => {
+    const t = convexTest(schema, convexModules);
+    await stageVerifiedOwner(
+      t,
+      CANDIDATE,
+      ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE })
+    );
+    const input = {
+      releaseJson: ownerReleaseJson(RECOVERY, {
+        base: CANDIDATE,
+        originReleaseId: CANDIDATE.releaseId,
+        scope: EXACT_SCOPE,
+      }),
+      rendererJson: testRendererJson(),
+    };
+    await t.mutation(stageRecovery, input);
+    await markOwnerVerified(t, RECOVERY.releaseId);
+    await t.mutation(activate, {
+      manifestHash: CANDIDATE.manifestHash,
+      releaseId: CANDIDATE.releaseId,
+      rendererJson: testRendererJson(),
+    });
+
+    await expect(t.mutation(stageRecovery, input)).resolves.toMatchObject({
+      phase: "verified",
+      releaseId: RECOVERY.releaseId,
+    });
+  });
+
+  it("derives a forward rollback from its immutable origin base", async () => {
+    const t = convexTest(schema, convexModules);
+    const base = {
+      manifestHash: `sha256:${"3".repeat(64)}`,
+      releaseId: "release-family-origin",
+      sequence: 1,
+    } satisfies TestIdentity;
+    const rollback = {
+      manifestHash: `sha256:${"4".repeat(64)}`,
+      releaseId: "release-family-rollback",
+      sequence: 2,
+    } satisfies TestIdentity;
+    const scope = testPublicationScope({ families: ["material"] });
+    await t.mutation(async (ctx) => {
+      await insertZeroRelease(ctx, {
+        ...base,
+        ownership: { base: [], result: ["material"] },
+        role: "candidate",
+        scope,
+        status: "completed",
+      });
+      await insertTestState(ctx, {
+        active: base,
+        nextSequence: rollback.sequence,
+      });
+    });
+    await t.mutation(stageRelease, {
+      releaseJson: ownerReleaseJson(rollback, {
+        base,
+        originReleaseId: base.releaseId,
+        scope,
+      }),
+      rendererJson: testRendererJson(),
+    });
+
+    const release = await t.run((ctx) =>
+      ctx.db
+        .query("contentReleases")
+        .withIndex("by_releaseId", (query) =>
+          query.eq("releaseId", rollback.releaseId)
+        )
+        .unique()
+    );
+    expect(release).toMatchObject({
+      baseFamilies: ["material"],
+      resultFamilies: [],
+      role: "candidate",
+    });
+  });
+
+  it("rejects a rollback that changes its immutable origin scope", async () => {
+    const t = convexTest(schema, convexModules);
+    await stageVerifiedOwner(
+      t,
+      CANDIDATE,
+      ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE })
+    );
+    const changedKey = ContentKeySchema.make("test:owner-changed");
+
+    await expect(
+      t.mutation(stageRecovery, {
+        releaseJson: ownerReleaseJson(RECOVERY, {
+          base: CANDIDATE,
+          originReleaseId: CANDIDATE.releaseId,
+          scope: testPublicationScope({
+            content: [
+              {
+                contentKey: changedKey,
+                family: "material",
+                locale: "en",
+              },
+            ],
+            families: [],
+          }),
+        }),
+        rendererJson: testRendererJson(),
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+  });
+
+  it("rejects conflicting rows and oversized exact scopes", async () => {
+    const conflict = convexTest(schema, convexModules);
+    await conflict.mutation((ctx) =>
+      ctx.db.insert("contentOwners", {
+        contentKey: CONTENT_KEY,
+        family: "material",
+        locale: "en",
+        managed: true,
+        releaseId: CANDIDATE.releaseId,
+        sequence: CANDIDATE.sequence,
+      })
+    );
+    await expect(
+      conflict.mutation(stageRelease, {
+        releaseJson: ownerReleaseJson(CANDIDATE, { scope: EXACT_SCOPE }),
+        rendererJson: testRendererJson(),
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+
+    const content = Array.from({ length: 65 }, (_, index) =>
+      ContentPublicationIdentitySchema.make({
+        contentKey: ContentKeySchema.make(
+          `test:owner-${index.toString().padStart(2, "0")}`
+        ),
+        family: "material",
+        locale: "en",
+      })
+    );
+    const limited = convexTest(schema, convexModules);
+    await expect(
+      limited.mutation(stageRelease, {
+        releaseJson: ownerReleaseJson(CANDIDATE, {
+          scope: testPublicationScope({ content, families: [] }),
+        }),
+        rendererJson: testRendererJson(),
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_LIMIT" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/scope/owner.ts
+++ b/packages/backend/convex/contentRelease/scope/owner.ts
@@ -1,0 +1,204 @@
+import type { ContentLocale } from "@nakafa/aksara-contracts/content";
+import type { ContentReleaseManifest } from "@nakafa/aksara-contracts/release";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadRelease } from "@repo/backend/convex/contentRelease/model";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import {
+  deriveReleaseFamilies,
+  hasExactFamilies,
+  loadReleaseFamilies,
+} from "@repo/backend/convex/contentRelease/scope/family";
+import { EXACT_SCOPE_LIMIT } from "@repo/backend/convex/contentRelease/spec";
+import { Effect } from "effect";
+
+type ReadCtx = MutationCtx | QueryCtx;
+type OwnerRelease = Pick<
+  Doc<"contentReleases">,
+  "baseFamilies" | "releaseId" | "resultFamilies" | "sequence"
+>;
+
+/** Returns one stable key for exact ownership comparison. */
+function ownerIdentity(
+  owner: Pick<Doc<"contentOwners">, "contentKey" | "family" | "locale">
+) {
+  return `${owner.family}\0${owner.contentKey}\0${owner.locale}`;
+}
+
+/** Resolves explicit exact-content ownership at one publication sequence. */
+export const loadContentOwner = Effect.fn("contentRelease.loadContentOwner")(
+  function* (
+    ctx: ReadCtx,
+    contentKey: string,
+    locale: ContentLocale,
+    sequence: number
+  ) {
+    const rows = yield* Effect.promise(() =>
+      ctx.db
+        .query("contentOwners")
+        .withIndex("by_contentKey_and_locale_and_sequence", (query) =>
+          query
+            .eq("contentKey", contentKey)
+            .eq("locale", locale)
+            .lte("sequence", sequence)
+        )
+        .order("desc")
+        .take(2)
+    );
+    if (rows[0] && rows[1]?.sequence === rows[0].sequence) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Content ${contentKey}/${locale} has duplicate ownership at sequence ${rows[0].sequence}.`
+      );
+    }
+    return rows[0] ?? null;
+  }
+);
+
+/** Loads the immutable sequence restored by one rollback-origin release. */
+const loadRollbackSequence = Effect.fn(
+  "contentRelease.loadRollbackOwnershipSequence"
+)(function* (ctx: ReadCtx, manifest: ContentReleaseManifest) {
+  if (manifest.origin.kind === "git") {
+    return null;
+  }
+  const origin = yield* loadRelease(ctx, manifest.origin.releaseId);
+  const signed = yield* decodeReleaseJson(origin.releaseJson);
+  if (signed.manifest.baseReleaseId === null) {
+    return null;
+  }
+  return (yield* loadRelease(ctx, signed.manifest.baseReleaseId)).sequence;
+});
+
+/** Derives bounded exact ownership rows from the immutable release graph. */
+const expectedContentOwners = Effect.fn("contentRelease.expectedContentOwners")(
+  function* (
+    ctx: ReadCtx,
+    release: OwnerRelease,
+    manifest: ContentReleaseManifest
+  ) {
+    if (manifest.scope.content.length > EXACT_SCOPE_LIMIT) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_LIMIT",
+        `Release ${release.releaseId} exceeds ${EXACT_SCOPE_LIMIT} exact ownership identities.`
+      );
+    }
+    const [derivedFamilies, storedFamilies] = yield* Effect.all([
+      deriveReleaseFamilies(ctx, manifest),
+      loadReleaseFamilies(release),
+    ]);
+    if (
+      !(
+        hasExactFamilies(derivedFamilies.base, storedFamilies.base) &&
+        hasExactFamilies(derivedFamilies.result, storedFamilies.result)
+      )
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Release ${release.releaseId} changed its family ownership.`
+      );
+    }
+    const selected = manifest.scope.content.filter(
+      ({ family }) => !storedFamilies.result.includes(family)
+    );
+    const rollbackSequence = yield* loadRollbackSequence(ctx, manifest);
+    return yield* Effect.forEach(selected, (identity) =>
+      Effect.gen(function* () {
+        const prior =
+          rollbackSequence === null
+            ? null
+            : yield* loadContentOwner(
+                ctx,
+                identity.contentKey,
+                identity.locale,
+                rollbackSequence
+              );
+        return {
+          ...identity,
+          managed:
+            manifest.origin.kind === "git" ? true : (prior?.managed ?? false),
+          releaseId: release.releaseId,
+          sequence: release.sequence,
+        };
+      })
+    );
+  }
+);
+
+/** Stages every exact ownership transition without requiring a body change. */
+export const stageContentOwners = Effect.fn(
+  "contentRelease.stageContentOwners"
+)(function* (
+  ctx: MutationCtx,
+  release: OwnerRelease,
+  manifest: ContentReleaseManifest
+) {
+  const owners = yield* expectedContentOwners(ctx, release, manifest);
+  for (const owner of owners) {
+    const existing = yield* Effect.promise(() =>
+      ctx.db
+        .query("contentOwners")
+        .withIndex("by_releaseId_and_contentKey_and_locale", (query) =>
+          query
+            .eq("releaseId", owner.releaseId)
+            .eq("contentKey", owner.contentKey)
+            .eq("locale", owner.locale)
+        )
+        .unique()
+    );
+    if (existing) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_CONFLICT",
+        `Content ${owner.contentKey}/${owner.locale} repeats ownership in ${owner.releaseId}.`
+      );
+    }
+    yield* Effect.promise(() => ctx.db.insert("contentOwners", owner));
+  }
+});
+
+/** Proves an invisible release retained its complete signed ownership scope. */
+export const validateContentOwners = Effect.fn(
+  "contentRelease.validateContentOwners"
+)(function* (
+  ctx: ReadCtx,
+  release: OwnerRelease,
+  manifest: ContentReleaseManifest
+) {
+  const expected = yield* expectedContentOwners(ctx, release, manifest);
+  const stored = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentOwners")
+      .withIndex("by_releaseId_and_contentKey_and_locale", (query) =>
+        query.eq("releaseId", release.releaseId)
+      )
+      .take(EXACT_SCOPE_LIMIT + 1)
+  );
+  const expectedByIdentity = new Map(
+    expected.map((owner) => [ownerIdentity(owner), owner])
+  );
+  if (stored.length !== expected.length) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Release ${release.releaseId} lost exact ownership rows.`
+    );
+  }
+  for (const owner of stored) {
+    const expectedOwner = expectedByIdentity.get(ownerIdentity(owner));
+    if (
+      !expectedOwner ||
+      owner.family !== expectedOwner.family ||
+      owner.managed !== expectedOwner.managed ||
+      owner.releaseId !== expectedOwner.releaseId ||
+      owner.sequence !== expectedOwner.sequence
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Release ${release.releaseId} has conflicting exact ownership.`
+      );
+    }
+  }
+});

--- a/packages/backend/convex/contentRelease/scope/schema.ts
+++ b/packages/backend/convex/contentRelease/scope/schema.ts
@@ -1,0 +1,31 @@
+import {
+  contentFamilyValidator,
+  localeValidator,
+} from "@repo/backend/convex/contentRelease/spec";
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+const scopeSchema = {
+  /** Immutable exact-content ownership selected by publication sequence. */
+  contentOwners: defineTable({
+    contentKey: v.string(),
+    family: contentFamilyValidator,
+    locale: localeValidator,
+    managed: v.boolean(),
+    releaseId: v.string(),
+    sequence: v.number(),
+  })
+    .index("by_contentKey_and_locale_and_sequence", [
+      "contentKey",
+      "locale",
+      "sequence",
+    ])
+    .index("by_releaseId_and_contentKey_and_locale", [
+      "releaseId",
+      "contentKey",
+      "locale",
+    ])
+    .index("by_sequence", ["sequence"]),
+};
+
+export default scopeSchema;

--- a/packages/backend/convex/contentRelease/spec.ts
+++ b/packages/backend/convex/contentRelease/spec.ts
@@ -25,6 +25,9 @@ export const TRANSACTION_READ_HEADROOM = 4 * 1024 * 1024;
 /** Eight body-bearing transitions preserve headroom under transaction limits. */
 export const RELEASE_PAGE_LIMIT = 8;
 
+/** Maximum exact identities owned atomically by one narrow release scope. */
+export const EXACT_SCOPE_LIMIT = 64;
+
 /** Maximum history rows considered by one compaction transaction. */
 export const COMPACTION_PAGE_COUNT = 32;
 
@@ -68,6 +71,7 @@ export const releaseRoleValidator = literals("candidate", "recovery");
 /** Ordered durable phases for one crash-safe history compaction cycle. */
 export const compactionPhaseValidator = literals(
   "heads",
+  "owners",
   "bindings",
   "items",
   "batches",

--- a/packages/backend/convex/contentRelease/verify.ts
+++ b/packages/backend/convex/contentRelease/verify.ts
@@ -4,6 +4,7 @@ import { internalMutation } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { loadStaged } from "@repo/backend/convex/contentRelease/model";
 import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import { validateContentOwners } from "@repo/backend/convex/contentRelease/scope/owner";
 import {
   progressValidator,
   RELEASE_PAGE_LIMIT,
@@ -23,6 +24,7 @@ const beginProgram = Effect.fn("contentRelease.beginVerify")(function* (
     return release.checkedIndex;
   }
   const signed = yield* decodeReleaseJson(release.releaseJson);
+  yield* validateContentOwners(ctx, release, signed.manifest);
   const complete =
     release.status === "staging" &&
     release.abortingAt === undefined &&

--- a/packages/backend/test/content-compact.ts
+++ b/packages/backend/test/content-compact.ts
@@ -4,6 +4,7 @@ import { testArtifactJson } from "@repo/backend/test/content-artifact";
 import {
   TEST_DIGEST,
   testProjectionJson,
+  testPublicationScope,
   testRollbackJson,
   testRouteJson,
   testUpsertJson,
@@ -35,7 +36,9 @@ export async function insertCompletedRelease(
   await insertZeroRelease(ctx, {
     ...identity,
     base,
+    ownership: { base: base ? ["material"] : [], result: ["material"] },
     role: "candidate",
+    scope: testPublicationScope({ families: ["material"] }),
     status: "completed",
   });
   const release = await ctx.db
@@ -104,6 +107,22 @@ async function insertBinding(
   });
 }
 
+/** Inserts one immutable exact-content ownership version. */
+async function insertOwner(
+  ctx: MutationCtx,
+  identity: TestIdentity,
+  managed: boolean
+) {
+  await ctx.db.insert("contentOwners", {
+    contentKey: "test:owner",
+    family: "material",
+    locale: "en",
+    managed,
+    releaseId: identity.releaseId,
+    sequence: identity.sequence,
+  });
+}
+
 /** Seeds old versions, release rows, and artifacts around a protected floor. */
 export async function seedCompactionHistory(ctx: MutationCtx) {
   const releases = Array.from({ length: 5 }, (_, index) =>
@@ -148,6 +167,8 @@ export async function seedCompactionHistory(ctx: MutationCtx) {
   await insertBinding(ctx, fourth, "test:route", 0, "test/route");
   await insertBinding(ctx, first, "test:path-anchor", 1, "test/path-anchor");
   await insertBinding(ctx, third, "test:path-anchor", 0, "test/path-anchor");
+  await insertOwner(ctx, first, false);
+  await insertOwner(ctx, third, true);
   const staleHash = `sha256:${"c".repeat(64)}`;
   const retainedHash = `sha256:${"d".repeat(64)}`;
   await insertHead(ctx, fourth, "test:retained", 41, retainedHash);

--- a/packages/backend/test/content-release.ts
+++ b/packages/backend/test/content-release.ts
@@ -105,18 +105,20 @@ interface ReleaseOptions {
   readonly rollbackDigest?: string;
   readonly routeCount?: number;
   readonly routeDigest?: string;
+  readonly scope?: PublicationScope;
   readonly snapshots?: ContentSnapshotSet;
   readonly upsertCount?: number;
 }
 
 /** Creates canonical broad test scope plus every replaced snapshot family. */
 export function testPublicationScope(options?: {
+  readonly content?: PublicationScope["content"];
   readonly families?: PublicationScope["families"];
   readonly snapshots?: ContentSnapshotSet;
 }) {
   const snapshots = options?.snapshots ?? inheritContentSnapshots(null);
   return PublicationScopeSchema.make({
-    content: [],
+    content: options?.content ?? [],
     families: options?.families ?? ContentFamilySchema.literals,
     snapshots: ContentSnapshotKindSchema.literals.filter(
       (family) => snapshots[family].mode !== "inherit"
@@ -162,7 +164,7 @@ export function testReleaseJson(options?: ReleaseOptions) {
       rollbackDigest: options?.rollbackDigest ?? TEST_DIGEST,
       routeCount: options?.routeCount ?? upsertCount,
       routeDigest: options?.routeDigest ?? TEST_DIGEST,
-      scope: testPublicationScope({ snapshots }),
+      scope: options?.scope ?? testPublicationScope({ snapshots }),
       snapshots,
       upsertCount,
     },

--- a/packages/backend/test/content-stage.ts
+++ b/packages/backend/test/content-stage.ts
@@ -1,23 +1,31 @@
+import type { ContentFamily } from "@nakafa/aksara-contracts/content";
 import type { ReleaseId } from "@nakafa/aksara-contracts/ids";
 import type { SignedContentRelease } from "@nakafa/aksara-contracts/release";
-import type { ContentSnapshotSet } from "@nakafa/aksara-contracts/release/snapshot";
+import type {
+  ContentSnapshotSet,
+  PublicationScope,
+} from "@nakafa/aksara-contracts/release/snapshot";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
   TEST_MANIFEST_HASH,
   TEST_RELEASE_ID,
+  testPublicationScope,
   testReleaseJson,
   testRendererJson,
 } from "@repo/backend/test/content-release";
 
 interface StagedReleaseOptions {
+  readonly baseFamilies?: readonly ContentFamily[];
   readonly checkedIndex?: number;
   readonly checkedItems?: number;
   readonly deleteCount?: number;
   readonly itemCount?: number;
   readonly projectionCount?: number;
   readonly releaseId?: string;
+  readonly resultFamilies?: readonly ContentFamily[];
   readonly role?: "candidate" | "recovery";
   readonly routeCount?: number;
+  readonly scope?: PublicationScope;
   readonly sequence?: number;
   readonly snapshots?: ContentSnapshotSet;
   readonly stagedArtifacts?: number;
@@ -41,12 +49,14 @@ export async function insertSignedCandidate(
 ) {
   const now = Date.UTC(2026, 6, 22, 12);
   await ctx.db.insert("contentReleases", {
+    baseFamilies: [],
     checkedIndex: -1,
     checkedItems: 0,
     createdAt: now,
     releaseId,
     releaseJson: JSON.stringify(release),
     rendererJson,
+    resultFamilies: [...release.manifest.scope.families],
     role: "candidate",
     sequence: 1,
     stagedArtifacts: 0,
@@ -81,7 +91,13 @@ export async function insertTestRelease(
   const sequence = options?.sequence ?? 1;
   const itemCount = options?.itemCount ?? 1;
   const upsertCount = options?.upsertCount ?? itemCount;
+  const scope =
+    options?.scope ??
+    testPublicationScope({
+      snapshots: options?.snapshots,
+    });
   await ctx.db.insert("contentReleases", {
+    baseFamilies: [...(options?.baseFamilies ?? [])],
     checkedIndex: options?.checkedIndex ?? -1,
     checkedItems: options?.checkedItems ?? 0,
     createdAt: now,
@@ -92,10 +108,15 @@ export async function insertTestRelease(
       projectionCount: options?.projectionCount ?? upsertCount,
       releaseId,
       routeCount: options?.routeCount ?? upsertCount,
+      scope,
       snapshots: options?.snapshots,
       upsertCount,
     }),
     rendererJson: testRendererJson(),
+    resultFamilies: [
+      ...(options?.resultFamilies ??
+        (role === "candidate" ? scope.families : [])),
+    ],
     role,
     sequence,
     stagedArtifacts: options?.stagedArtifacts ?? 0,

--- a/packages/backend/test/content-state.ts
+++ b/packages/backend/test/content-state.ts
@@ -1,5 +1,7 @@
+import type { ContentFamily } from "@nakafa/aksara-contracts/content";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { EMPTY_RESULT_CATALOG_DIGEST } from "@nakafa/aksara-contracts/release/result";
+import type { PublicationScope } from "@nakafa/aksara-contracts/release/snapshot";
 import { inheritContentSnapshots } from "@nakafa/aksara-contracts/release/snapshot";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
@@ -22,7 +24,12 @@ export interface TestIdentity {
 interface TestReleaseOptions extends TestIdentity {
   readonly base?: TestIdentity;
   readonly originReleaseId?: string;
+  readonly ownership?: {
+    readonly base: readonly ContentFamily[];
+    readonly result: readonly ContentFamily[];
+  };
   readonly role: "candidate" | "recovery";
+  readonly scope?: PublicationScope;
   readonly status: "aborted" | "completed" | "verified";
 }
 
@@ -50,6 +57,7 @@ export function zeroReleaseJson(options: TestReleaseOptions) {
     resultCount: 0,
     resultDigest: EMPTY_RESULT_CATALOG_DIGEST,
     routeCount: 0,
+    scope: options.scope,
     upsertCount: 0,
   });
 }
@@ -91,6 +99,12 @@ export async function insertZeroRelease(
       ? {
           completedAt: now,
           receiptJson: JSON.stringify(receipt),
+        }
+      : {}),
+    ...(options.ownership
+      ? {
+          baseFamilies: [...options.ownership.base],
+          resultFamilies: [...options.ownership.result],
         }
       : {}),
     checkedIndex: -1,
@@ -169,12 +183,14 @@ export async function insertAbortedRelease(ctx: MutationCtx) {
     abortedAt: now,
     abortedRows: 0,
     abortingAt: now,
+    baseFamilies: [],
     checkedIndex: -1,
     checkedItems: 0,
     createdAt: now,
     releaseId: "release-cleanup-dispatch",
     releaseJson: "{}",
     rendererJson: "{}",
+    resultFamilies: [],
     role: "candidate",
     sequence: 1,
     stagedArtifacts: 0,
@@ -217,6 +233,7 @@ export async function insertActiveRelease(
     stagedSnapshotRows: 0,
   };
   await ctx.db.insert("contentReleases", {
+    baseFamilies: [],
     checkedIndex: -1,
     checkedItems: 0,
     completedAt: now,
@@ -227,6 +244,7 @@ export async function insertActiveRelease(
     releaseId: activeReleaseId,
     releaseJson: JSON.stringify(active),
     rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
+    resultFamilies: [],
     role: "candidate",
     sequence: 1,
     stagedArtifacts: 0,

--- a/packages/backend/test/owner-migration.ts
+++ b/packages/backend/test/owner-migration.ts
@@ -1,0 +1,133 @@
+import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
+import { testPublicationScope } from "@repo/backend/test/content-release";
+import {
+  insertZeroRelease,
+  type TestIdentity,
+} from "@repo/backend/test/content-state";
+
+export const MATERIAL_KEY = ContentKeySchema.make(
+  "material/lesson/mathematics/function-composition-inverse-function/function-concept"
+);
+const MATERIAL_SCOPE = testPublicationScope({
+  content: [
+    { contentKey: MATERIAL_KEY, family: "material", locale: "en" },
+    { contentKey: MATERIAL_KEY, family: "material", locale: "id" },
+  ],
+  families: [],
+});
+const MATERIAL = {
+  manifestHash: `sha256:${"1".repeat(64)}`,
+  releaseId: "release-material",
+  sequence: 1,
+} satisfies TestIdentity;
+const MATERIAL_RECOVERY = {
+  manifestHash: `sha256:${"2".repeat(64)}`,
+  releaseId: "recovery-material",
+  sequence: 2,
+} satisfies TestIdentity;
+const MATERIAL_RESTORE = {
+  manifestHash: `sha256:${"3".repeat(64)}`,
+  releaseId: "restore-material",
+  sequence: 3,
+} satisfies TestIdentity;
+const MATERIAL_RESTORE_RECOVERY = {
+  manifestHash: `sha256:${"4".repeat(64)}`,
+  releaseId: "restore-material-recovery",
+  sequence: 4,
+} satisfies TestIdentity;
+const ARTICLE = {
+  manifestHash: `sha256:${"5".repeat(64)}`,
+  releaseId: "release-article",
+  sequence: 5,
+} satisfies TestIdentity;
+const ARTICLE_RECOVERY = {
+  manifestHash: `sha256:${"6".repeat(64)}`,
+  releaseId: "recovery-article",
+  sequence: 6,
+} satisfies TestIdentity;
+export const ACTIVE = {
+  manifestHash: `sha256:${"7".repeat(64)}`,
+  releaseId: "restore-article",
+  sequence: 7,
+} satisfies TestIdentity;
+export const RECOVERY = {
+  manifestHash: `sha256:${"8".repeat(64)}`,
+  releaseId: "restore-article-recovery",
+  sequence: 8,
+} satisfies TestIdentity;
+
+/** Seeds the exact completed, aborted, and retained production topology. */
+export async function seedOwnershipHistory(
+  ctx: Parameters<typeof insertZeroRelease>[0]
+) {
+  await insertZeroRelease(ctx, {
+    ...MATERIAL,
+    role: "candidate",
+    scope: MATERIAL_SCOPE,
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...MATERIAL_RECOVERY,
+    base: MATERIAL,
+    originReleaseId: MATERIAL.releaseId,
+    role: "recovery",
+    scope: MATERIAL_SCOPE,
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...MATERIAL_RESTORE,
+    base: MATERIAL_RECOVERY,
+    role: "candidate",
+    scope: MATERIAL_SCOPE,
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...MATERIAL_RESTORE_RECOVERY,
+    base: MATERIAL_RESTORE,
+    originReleaseId: MATERIAL_RESTORE.releaseId,
+    role: "recovery",
+    scope: MATERIAL_SCOPE,
+    status: "aborted",
+  });
+  await insertZeroRelease(ctx, {
+    ...ARTICLE,
+    base: MATERIAL_RESTORE,
+    role: "candidate",
+    scope: testPublicationScope({ families: ["article"] }),
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...ARTICLE_RECOVERY,
+    base: ARTICLE,
+    originReleaseId: ARTICLE.releaseId,
+    role: "recovery",
+    scope: testPublicationScope({ families: ["article"] }),
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...ACTIVE,
+    base: ARTICLE_RECOVERY,
+    role: "candidate",
+    scope: testPublicationScope({ families: ["article"] }),
+    status: "completed",
+  });
+  await insertZeroRelease(ctx, {
+    ...RECOVERY,
+    base: ACTIVE,
+    originReleaseId: ACTIVE.releaseId,
+    role: "recovery",
+    scope: testPublicationScope({ families: ["article"] }),
+    status: "verified",
+  });
+  await ctx.db.insert("contentState", {
+    activeManifestHash: ACTIVE.manifestHash,
+    activeReleaseId: ACTIVE.releaseId,
+    activeSequence: ACTIVE.sequence,
+    key: "primary",
+    nextSequence: 9,
+    recoveryManifestHash: RECOVERY.manifestHash,
+    recoveryReleaseId: RECOVERY.releaseId,
+    recoverySequence: RECOVERY.sequence,
+    updatedAt: 0,
+  });
+}

--- a/packages/backend/test/release-owner.ts
+++ b/packages/backend/test/release-owner.ts
@@ -1,0 +1,98 @@
+import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
+import { EMPTY_RESULT_CATALOG_DIGEST } from "@nakafa/aksara-contracts/release/result";
+import type { PublicationScope } from "@nakafa/aksara-contracts/release/snapshot";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type schema from "@repo/backend/convex/schema";
+import {
+  testPublicationScope,
+  testReleaseJson,
+  testRendererJson,
+} from "@repo/backend/test/content-release";
+import type { TestIdentity } from "@repo/backend/test/content-state";
+import type { TestConvex } from "convex-test";
+
+export const TEST_OWNER_KEY = ContentKeySchema.make("test:owner");
+export const TEST_OWNER_SCOPE = testPublicationScope({
+  content: [
+    {
+      contentKey: TEST_OWNER_KEY,
+      family: "material",
+      locale: "en",
+    },
+  ],
+  families: [],
+});
+export const TEST_OWNER_CANDIDATE = {
+  manifestHash: `sha256:${"1".repeat(64)}`,
+  releaseId: "release-owner-candidate",
+  sequence: 1,
+} satisfies TestIdentity;
+export const TEST_OWNER_RECOVERY = {
+  manifestHash: `sha256:${"2".repeat(64)}`,
+  releaseId: "release-owner-recovery",
+  sequence: 2,
+} satisfies TestIdentity;
+
+interface OwnerReleaseOptions {
+  readonly base?: TestIdentity;
+  readonly originReleaseId?: string;
+  readonly scope: PublicationScope;
+}
+
+/** Creates one zero-body envelope whose signed scope owns exact identities. */
+export function ownerReleaseJson(
+  identity: TestIdentity,
+  options: OwnerReleaseOptions
+) {
+  return testReleaseJson({
+    baseManifestHash: options.base?.manifestHash ?? null,
+    baseReleaseId: options.base?.releaseId ?? null,
+    baseResultCount: 0,
+    baseResultDigest: EMPTY_RESULT_CATALOG_DIGEST,
+    itemCount: 0,
+    manifestHash: identity.manifestHash,
+    originReleaseId: options.originReleaseId,
+    projectionCount: 0,
+    releaseId: identity.releaseId,
+    resultCount: 0,
+    resultDigest: EMPTY_RESULT_CATALOG_DIGEST,
+    routeCount: 0,
+    scope: options.scope,
+    upsertCount: 0,
+  });
+}
+
+/** Marks one staged technical owner release verified for lifecycle tests. */
+export async function markOwnerVerified(
+  t: TestConvex<typeof schema>,
+  releaseId: string
+) {
+  await t.mutation(async (ctx) => {
+    const release = await ctx.db
+      .query("contentReleases")
+      .withIndex("by_releaseId", (query) => query.eq("releaseId", releaseId))
+      .unique();
+    if (!release) {
+      throw new Error("Expected staged exact release.");
+    }
+    await ctx.db.patch("contentReleases", release._id, {
+      proofAt: 1,
+      proofJson: "{}",
+      status: "verified",
+      verifiedAt: 1,
+    });
+  });
+}
+
+/** Stages one candidate and gives it the evidence required by recovery. */
+export async function stageVerifiedOwner(
+  t: TestConvex<typeof schema>,
+  identity: TestIdentity,
+  releaseJson: string
+) {
+  await t.mutation(internal.contentRelease.manifest.stageRelease, {
+    releaseJson,
+    rendererJson: testRendererJson(),
+  });
+  await markOwnerVerified(t, identity.releaseId);
+}


### PR DESCRIPTION
## Summary

- add optional immutable family ownership to existing release rows
- add indexed exact-content owner versions selected by publication sequence
- make every newly staged release derive and persist ownership transactionally
- reconstruct existing ownership from signed release history through one bounded, fail-closed internal migration
- make abort and compaction clean up owner rows without deleting the effective-floor anchor
- validate rollback origin/scope, exact expected counts, idempotency, conflicts, and active/recovery slot reachability
- keep publication reads unchanged until the strict follow-up rollout

## Rollout

1. Merge and deploy this additive schema to dev.
2. Preview, apply, and re-preview exact dev counts.
3. Deploy the same merged tree to production and migrate the verified 8 releases / 6 owner versions.
4. Do **not** activate retained recovery sequence 8.
5. Follow immediately with the strict runtime PR: consume immutable owners, remove the temporary migration and its tests/routes, and make ownership fields required.

## Verification

Exact reviewed head: `5b73ac11fac609e17e41e19b67fab0e6e6e098ff`

- `pnpm test`: 12/12 root tasks passed
- backend: 211 files / 916 tests passed
- focused ownership, migration, and compaction coverage: 5 files / 28 tests passed
- `pnpm build`: 5/5 tasks passed; www generated 1,306 static pages
- backend TypeScript typecheck passed
- `pnpm format` passed
- `pnpm lint` passed
- `pnpm boundaries` passed
- `pnpm effect:source:check` passed for Effect 3.22.0
- changed-scope React Doctor found no applicable React source changes
- Convex production dry-run passed ordinary typechecking, added exactly three owner indexes, and removed zero indexes
- read-only audit: dev has zero releases; production retains ordered releases 1–8 and both deployment floors remain at genesis (`compactedFloor=1`)
- local root `pnpm start` was intentionally not run because port 3000 belongs to another active Nakafa worktree; the isolated GitHub build/start/AFDocs job is the authoritative start gate

No release activation, schema deploy, data write, or production mutation is part of this PR itself.