### PR TITLE
refactor(effect): align runtime diagnostics

### DIFF
--- a/.agents/skills/effect-best-practices/SKILL.md
+++ b/.agents/skills/effect-best-practices/SKILL.md
@@ -32,6 +32,20 @@ npm install @effect/language-service --save-dev
 3. Configure your editor to use workspace TypeScript:
    - **VSCode**: F1 → "TypeScript: Select TypeScript Version" → "Use Workspace Version"
    - **JetBrains**: Settings → Languages & Frameworks → TypeScript → Use workspace version
+   - **Zed**: Use the repository-pinned `vtsls` configuration in `.zed/settings.json`.
+     Nakafa intentionally resolves the JavaScript TypeScript 6 API for the Effect language
+     plugin while its `tsc` command uses native TypeScript 7. The Zed `tsgo` extension uses
+     Microsoft's upstream native server; it does not automatically substitute the
+     Effect-enhanced `@effect/tsgo` fork.
+
+### TypeScript 7 and `@effect/tsgo`
+
+The installed `@effect/language-service` README directs TypeScript 7 projects to
+`@effect/tsgo`. That fork supports Effect 3 and Effect 4, but its official project still
+labels it alpha and says it targets Effect 4 primarily. Do not replace this repository's
+stable editor path or CI compiler with it automatically. Re-evaluate it as an explicit
+toolchain migration after its release status, executable packaging, editor integration,
+and full repository gates are verified.
 
 ### Features
 

--- a/.agents/skills/effect-best-practices/references/language-server.md
+++ b/.agents/skills/effect-best-practices/references/language-server.md
@@ -2,6 +2,11 @@
 
 The Effect Language Service is a TypeScript language plugin that provides Effect-specific diagnostics, completions, refactors, and hover information. It catches errors that TypeScript alone cannot detect.
 
+The current `@effect/language-service` package is the JavaScript TypeScript language-plugin
+path. Its README directs TypeScript 7 users to `@effect/tsgo`, which remains an alpha,
+Effect-4-primary tool that also supports Effect 3. Treat that switch as a toolchain migration,
+not as an automatic dependency bump.
+
 ## Installation
 
 ```bash
@@ -28,6 +33,27 @@ Add to `tsconfig.json`:
 ### JetBrains (WebStorm, IntelliJ)
 
 Settings → Languages & Frameworks → TypeScript → Select workspace `node_modules/typescript`
+
+### Zed
+
+Zed defaults to `vtsls` for TypeScript. Nakafa pins that server in `.zed/settings.json` so it
+loads the workspace JavaScript TypeScript API and the configured Effect plugin:
+
+```json
+{
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["vtsls", "!typescript-language-server", "..."]
+    },
+    "TSX": {
+      "language_servers": ["vtsls", "!typescript-language-server", "..."]
+    }
+  }
+}
+```
+
+Zed's `tsgo` extension installs Microsoft's upstream native TypeScript server. It does not
+automatically install or select the Effect-enhanced `@effect/tsgo` fork.
 
 ### Neovim (nvim-lspconfig)
 

--- a/.agents/skills/effect-ts/SKILL.md
+++ b/.agents/skills/effect-ts/SKILL.md
@@ -10,13 +10,31 @@ resource safety.
 
 ## When to Apply
 
-- Writing or reviewing TypeScript code that imports from `effect`, `@effect/schema`, or `@effect/platform`
+- Writing or reviewing TypeScript code that imports from `effect`, `effect/*`, or `@effect/*`
 - Implementing typed error handling with `Effect<Success, Error, Requirements>`
 - Building services and layers for dependency injection
 - Working with Schema for data validation, decoding, and transformation
 - Using fiber-based concurrency (queues, semaphores, PubSub, deferred)
 - Processing data with Stream and Sink
 - Migrating from Promises, fp-ts, neverthrow, or ZIO to Effect
+
+## Source and Version Discipline
+
+- Verify the installed Effect version before prescribing APIs. Prefer the installed declarations,
+  official docs at <https://effect.website/docs>, and a repository-pinned Effect source checkout.
+- Treat `@effect/schema` as a legacy migration signal. Current Effect 3 code imports `Schema` from
+  `"effect"` unless the installed version says otherwise.
+- Do not import from, build, lint, or test a vendored Effect source checkout as application code.
+  It is a read-only reference, and its exact commit must be mechanically verifiable.
+- `Context.Tag` plus `Layer` is the documented service pattern. `Effect.Service` combines a tag
+  and default layer for projects that adopt it, but Effect 3.22.0 marks that API experimental;
+  follow the repository's architecture and verify the installed declaration before using it.
+- Treat a major prerelease as a separate migration, not an automatic update. Check npm dist-tags,
+  every installed `@effect/*` peer range, official migration guidance, and the repository's full
+  verification surface before proposing it. A stable submodule does not make a beta runtime
+  production-stable.
+- This entrypoint was last reconciled on 2026-07-25 against Effect 3.22.0. Re-check current
+  installed docs and declarations because Effect evolves quickly.
 
 ## How to Use
 
@@ -93,29 +111,44 @@ Effect<Success, Error, Requirements>
 
 ### Creating Effects
 ```ts
-import { Effect } from "effect"
+import { Data, Effect } from "effect"
 
 // From sync values
 const succeed = Effect.succeed(42)
-const fail = Effect.fail(new Error("oops"))
 
-// From sync code that may throw
-const sync = Effect.try(() => JSON.parse(data))
+class JsonParseError extends Data.TaggedError("JsonParseError")<{
+  readonly cause: unknown
+}> {}
 
-// From promises
-const async = Effect.tryPromise(() => fetch(url))
+class RequestError extends Data.TaggedError("RequestError")<{
+  readonly cause: unknown
+}> {}
+
+// Map thrown exceptions into the typed error channel
+const sync = Effect.try({
+  try: () => JSON.parse(data),
+  catch: (cause) => new JsonParseError({ cause })
+})
+
+// Map Promise rejection into the typed error channel
+const request = Effect.tryPromise({
+  try: () => fetch(url),
+  catch: (cause) => new RequestError({ cause })
+})
 
 // From generators (recommended for complex flows)
-const program = Effect.gen(function* () {
+const loadTodos = Effect.fn("Todos.load")(function* (id: string) {
   const user = yield* getUser(id)
   const todos = yield* getTodos(user.id)
   return { user, todos }
 })
+
+const program = loadTodos("1")
 ```
 
 ### Running Effects
 ```ts
-// Async (returns Promise)
+// Run only at framework, CLI, test, or event boundaries.
 Effect.runPromise(program)
 
 // With full Exit information
@@ -127,12 +160,14 @@ Effect.runSync(program)
 
 ### Typed Errors
 ```ts
-import { Data, Effect } from "effect"
+import { Data, Effect, Schema } from "effect"
 
-class NotFound extends Data.TaggedError("NotFound")<{
-  readonly id: string
-}> {}
+// Prefer Schema.TaggedError for serializable/schema-derived domain contracts.
+class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+  id: Schema.String
+}) {}
 
+// Data.TaggedError remains appropriate for in-memory-only failures.
 class Unauthorized extends Data.TaggedError("Unauthorized")<{}> {}
 
 // Error type is tracked: Effect<User, NotFound | Unauthorized>
@@ -146,25 +181,25 @@ const getUser = (id: string) =>
 ```ts
 import { Context, Effect, Layer } from "effect"
 
-// Define a service
+// Define a service contract.
 class UserRepo extends Context.Tag("UserRepo")<
   UserRepo,
   { readonly findById: (id: string) => Effect.Effect<User, NotFound> }
 >() {}
 
-// Use in effects — adds to Requirements channel
+// Use in effects — adds UserRepo to the Requirements channel.
 const program = Effect.gen(function* () {
   const repo = yield* UserRepo
   return yield* repo.findById("1")
 })
 
-// Implement with a Layer
+// Provide an implementation with a Layer.
 const UserRepoLive = Layer.succeed(UserRepo, {
   findById: (id) => Effect.succeed({ id, name: "Alice" })
 })
 
-// Provide and run
-program.pipe(Effect.provide(UserRepoLive), Effect.runPromise)
+// Effect.Service may combine the contract and default Layer when the repository
+// explicitly adopts its experimental API and the installed version supports it.
 ```
 
 ### Schema Validation

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -35,11 +35,14 @@
         }
       }
     },
-    "typescript-language-server": {
+    "vtsls": {
       "settings": {
         "typescript": {
           "preferences": {
             "includePackageJsonAutoImports": "on"
+          },
+          "tsserver": {
+            "maxTsServerMemory": 8192
           }
         }
       }
@@ -47,6 +50,7 @@
   },
   "languages": {
     "JavaScript": {
+      "language_servers": ["vtsls", "!typescript-language-server", "..."],
       "formatter": {
         "language_server": {
           "name": "biome"
@@ -58,6 +62,7 @@
       }
     },
     "TypeScript": {
+      "language_servers": ["vtsls", "!typescript-language-server", "..."],
       "formatter": {
         "language_server": {
           "name": "biome"
@@ -69,6 +74,7 @@
       }
     },
     "TSX": {
+      "language_servers": ["vtsls", "!typescript-language-server", "..."],
       "formatter": {
         "language_server": {
           "name": "biome"

--- a/apps/mcp/lib/mcp/effect.ts
+++ b/apps/mcp/lib/mcp/effect.ts
@@ -61,14 +61,18 @@ export function toMcpToolOutputJsonSchema(schema: Schema.Schema.AnyNoContext) {
 export function decodeNakafaMcpToolInput<
   TSchema extends Schema.Schema.AnyNoContext,
 >(schema: TSchema, input: unknown, message: string) {
-  return Effect.try({
-    try: () => Schema.decodeUnknownSync(schema, MCP_PARSE_OPTIONS)(input),
-    catch: (error) =>
-      new NakafaAgentInputError({
-        cause: getUnknownErrorMessage(error),
-        message,
-      }),
-  });
+  return Schema.decodeUnknown(
+    schema,
+    MCP_PARSE_OPTIONS
+  )(input).pipe(
+    Effect.mapError(
+      (error) =>
+        new NakafaAgentInputError({
+          cause: getUnknownErrorMessage(error),
+          message,
+        })
+    )
+  );
 }
 
 /** Validates successful structured tool output against its Effect schema. */

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/chat/[id]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/chat/[id]/page.tsx
@@ -28,20 +28,15 @@ export async function generateMetadata({
   const { id } = await params;
   const defaultMetadata = {};
   const title = await Effect.runPromise(
-    Effect.tryPromise({
-      try: () => getChatTitle(id as Id<"chats">),
-      catch: (error) => error,
-    }).pipe(
-      Effect.catchAll((error) =>
+    Effect.tryPromise(() => getChatTitle(id as Id<"chats">)).pipe(
+      Effect.catchTag("UnknownException", ({ error }) =>
         Effect.gen(function* () {
-          yield* Effect.tryPromise({
-            try: () =>
-              captureServerException(error, undefined, {
-                chat_id: id,
-                source: "chat-page-metadata",
-              }),
-            catch: (cause) => cause,
-          }).pipe(Effect.ignore);
+          yield* Effect.tryPromise(() =>
+            captureServerException(error, undefined, {
+              chat_id: id,
+              source: "chat-page-metadata",
+            })
+          ).pipe(Effect.ignore);
 
           return null;
         })

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/source.test.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/source.test.tsx
@@ -112,10 +112,9 @@ function params() {
 /** Extracts the typed Effect failure preserved by a framework promise boundary. */
 async function readRejectedFailure(read: () => Promise<unknown>) {
   const rejected = await Effect.runPromise(
-    Effect.tryPromise({
-      try: read,
-      catch: (cause) => cause,
-    }).pipe(Effect.flip)
+    Effect.tryPromise(read).pipe(
+      Effect.catchTag("UnknownException", ({ error }) => Effect.succeed(error))
+    )
   );
   if (!Runtime.isFiberFailure(rejected)) {
     throw new Error("Expected an Effect FiberFailure.");

--- a/apps/www/app/[locale]/(app)/school/(authenticated)/onboarding/create/form.tsx
+++ b/apps/www/app/[locale]/(app)/school/(authenticated)/onboarding/create/form.tsx
@@ -51,14 +51,11 @@ export function SchoolOnboardingCreateForm() {
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            const { slug } = await createSchool(value);
-            router.push(`/school/${slug}`);
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          const { slug } = await createSchool(value);
+          router.push(`/school/${slug}`);
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-onboarding-create",
             }).pipe(

--- a/apps/www/app/[locale]/(app)/school/(authenticated)/onboarding/join/form.tsx
+++ b/apps/www/app/[locale]/(app)/school/(authenticated)/onboarding/join/form.tsx
@@ -36,14 +36,11 @@ export function SchoolOnboardingJoinForm() {
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            const { slug } = await joinSchool(value);
-            router.push(`/school/${slug}`);
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          const { slug } = await joinSchool(value);
+          router.push(`/school/${slug}`);
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-onboarding-join",
             }).pipe(

--- a/apps/www/app/api/chat/failure.ts
+++ b/apps/www/app/api/chat/failure.ts
@@ -3,7 +3,16 @@ import type { ModelId } from "@repo/ai/config/model";
 import { api as convexApi } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { fetchAction } from "convex/nextjs";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
+
+/** Expected Convex boundary failure while persisting an assistant marker. */
+export class PersistAssistantFailureError extends Schema.TaggedError<PersistAssistantFailureError>()(
+  "PersistAssistantFailureError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
 
 /**
  * Schedules a durable failed assistant marker through Convex.
@@ -38,6 +47,9 @@ export const persistAssistantFailure = Effect.fn(
         { token }
       ),
     catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
+      new PersistAssistantFailureError({
+        cause: error,
+        message: "Unable to persist the failed assistant marker.",
+      }),
   });
 });

--- a/apps/www/app/api/chat/observability.ts
+++ b/apps/www/app/api/chat/observability.ts
@@ -5,9 +5,18 @@ import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { logError } from "@repo/utilities/logging/effect";
 import type { LogContext } from "@repo/utilities/logging/types";
 import { waitUntil } from "@vercel/functions";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 
 const source = "chat-api";
+
+/** PostHog capture failure at the chat streaming observability boundary. */
+class ChatErrorCaptureFailure extends Schema.TaggedError<ChatErrorCaptureFailure>()(
+  "ChatErrorCaptureFailure",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
 
 /** Preserves real Error details while giving non-Error failures a stable shape. */
 function toError(error: unknown) {
@@ -66,10 +75,14 @@ export function createChatErrorReporter({
             Effect.tryPromise({
               try: () =>
                 captureServerException(normalizedError, userId, errorContext),
-              catch: toError,
+              catch: (cause) =>
+                new ChatErrorCaptureFailure({
+                  cause,
+                  message: "Unable to capture the chat stream failure.",
+                }),
             }).pipe(
               Effect.catchAll((captureError) =>
-                logError(captureError, {
+                logError(toError(captureError.cause), {
                   ...errorContext,
                   errorLocation: "posthog-capture",
                 })

--- a/apps/www/app/api/internal/routing/locale/route.ts
+++ b/apps/www/app/api/internal/routing/locale/route.ts
@@ -37,22 +37,22 @@ const readLocaleRouteResponse = Effect.fn("www.routing.locale.route")(
       locale,
     }).pipe(
       Effect.map((localizedHref) => NextResponse.json({ href: localizedHref })),
-      Effect.catchTag("InvalidLocalizedHrefError", () =>
-        Effect.succeed(
-          NextResponse.json({ error: "Invalid href" }, { status: 400 })
-        )
-      ),
-      Effect.catchTag("MissingLocalizedRouteProjectionError", (error) =>
-        Effect.succeed(
-          NextResponse.json(
-            {
-              error: "Missing localized route projection",
-              path: error.publicPath,
-            },
-            { status: 404 }
-          )
-        )
-      )
+      Effect.catchTags({
+        InvalidLocalizedHrefError: () =>
+          Effect.succeed(
+            NextResponse.json({ error: "Invalid href" }, { status: 400 })
+          ),
+        MissingLocalizedRouteProjectionError: (error) =>
+          Effect.succeed(
+            NextResponse.json(
+              {
+                error: "Missing localized route projection",
+                path: error.publicPath,
+              },
+              { status: 404 }
+            )
+          ),
+      })
     );
   }
 );

--- a/apps/www/app/sitemap.xml/route.test.ts
+++ b/apps/www/app/sitemap.xml/route.test.ts
@@ -1,10 +1,15 @@
 // @vitest-environment node
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/sitemap.xml/route";
 
 const mockReadSitemapPageDescriptors = vi.hoisted(() => vi.fn());
 const mockCaptureServerException = vi.hoisted(() => vi.fn());
+
+/** Test-only typed sitemap failure. */
+class TestSitemapIndexError extends Data.TaggedError("TestSitemapIndexError")<{
+  readonly message: string;
+}> {}
 
 vi.mock("@/lib/sitemap/catalog", () => ({
   readSitemapPageDescriptors: mockReadSitemapPageDescriptors,
@@ -36,16 +41,17 @@ describe("sitemap index route", () => {
   });
 
   it("reports descriptor failures and returns a plain error response", async () => {
-    mockReadSitemapPageDescriptors.mockReturnValueOnce(
-      Effect.fail(new Error("descriptor read failed"))
-    );
+    const failure = new TestSitemapIndexError({
+      message: "descriptor read failed",
+    });
+    mockReadSitemapPageDescriptors.mockReturnValueOnce(Effect.fail(failure));
 
     const response = await GET();
 
     expect(response.status).toBe(500);
     expect(await response.text()).toBe("Internal Server Error");
     expect(mockCaptureServerException).toHaveBeenCalledWith(
-      expect.any(Error),
+      failure,
       undefined,
       { source: "sitemap-index" }
     );

--- a/apps/www/app/sitemap.xml/route.ts
+++ b/apps/www/app/sitemap.xml/route.ts
@@ -41,8 +41,7 @@ const buildSitemapIndexResponse = Effect.fn("www.sitemap.index.response")(
 
 /** Reports sitemap route failures without exposing implementation details. */
 function reportSitemapRouteError(error: unknown, source: string) {
-  return Effect.tryPromise({
-    try: () => captureServerException(error, undefined, { source }),
-    catch: (cause) => cause,
-  }).pipe(Effect.ignore);
+  return Effect.tryPromise(() =>
+    captureServerException(error, undefined, { source })
+  ).pipe(Effect.ignore);
 }

--- a/apps/www/app/sitemap/[id]/route.test.ts
+++ b/apps/www/app/sitemap/[id]/route.test.ts
@@ -1,11 +1,16 @@
 // @vitest-environment node
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/sitemap/[id]/route";
 
 const mockGetSitemapEntries = vi.hoisted(() => vi.fn());
 const mockGetSitemapPageDescriptor = vi.hoisted(() => vi.fn());
 const mockCaptureServerException = vi.hoisted(() => vi.fn());
+
+/** Test-only typed sitemap page failure. */
+class TestSitemapPageError extends Data.TaggedError("TestSitemapPageError")<{
+  readonly message: string;
+}> {}
 
 vi.mock("@/lib/sitemap/entries", () => ({
   getSitemapEntries: mockGetSitemapEntries,
@@ -118,9 +123,8 @@ describe("sitemap page route", () => {
   });
 
   it("reports page failures and returns a plain error response", async () => {
-    mockGetSitemapEntries.mockReturnValueOnce(
-      Effect.fail(new Error("page read failed"))
-    );
+    const failure = new TestSitemapPageError({ message: "page read failed" });
+    mockGetSitemapEntries.mockReturnValueOnce(Effect.fail(failure));
 
     const response = await GET(
       new Request("https://nakafa.com/sitemap/base.xml"),
@@ -130,7 +134,7 @@ describe("sitemap page route", () => {
     expect(response.status).toBe(500);
     expect(await response.text()).toBe("Internal Server Error");
     expect(mockCaptureServerException).toHaveBeenCalledWith(
-      expect.any(Error),
+      failure,
       undefined,
       { source: "sitemap-page" }
     );

--- a/apps/www/app/sitemap/[id]/route.ts
+++ b/apps/www/app/sitemap/[id]/route.ts
@@ -73,8 +73,7 @@ const buildSitemapPageResponse = Effect.fn("www.sitemap.page.response")(
 
 /** Reports sitemap route failures without exposing implementation details. */
 function reportSitemapRouteError(error: unknown, source: string) {
-  return Effect.tryPromise({
-    try: () => captureServerException(error, undefined, { source }),
-    catch: (cause) => cause,
-  }).pipe(Effect.ignore);
+  return Effect.tryPromise(() =>
+    captureServerException(error, undefined, { source })
+  ).pipe(Effect.ignore);
 }

--- a/apps/www/components/school/classes/add/dialog.tsx
+++ b/apps/www/components/school/classes/add/dialog.tsx
@@ -48,20 +48,17 @@ export function CreateSchoolClassDialog({
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            const classId = await createClass({
-              ...value,
-              schoolId,
-            });
+        Effect.tryPromise(async () => {
+          const classId = await createClass({
+            ...value,
+            schoolId,
+          });
 
-            router.push(`${pathname}/${classId}`);
-            setOpenAction(false);
-            form.reset();
-          },
-          catch: (error) => error,
+          router.push(`${pathname}/${classId}`);
+          setOpenAction(false);
+          form.reset();
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-class-create",
             }).pipe(

--- a/apps/www/components/school/classes/assessments/dialog/create.tsx
+++ b/apps/www/components/school/classes/assessments/dialog/create.tsx
@@ -167,15 +167,12 @@ function AssessmentDialogShell({
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await onSubmit(value);
-            form.reset();
-            setOpenAction(false);
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await onSubmit(value);
+          form.reset();
+          setOpenAction(false);
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-assessment-create",
             }).pipe(

--- a/apps/www/components/school/classes/assessments/item.tsx
+++ b/apps/www/components/school/classes/assessments/item.tsx
@@ -170,15 +170,12 @@ function AssessmentActions({
   function handleDelete() {
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await deleteAssessment({
-              schoolId: assessment.schoolId,
-              assessmentId: assessment._id,
-            });
-            toast.success(schoolT("assessment-deleted"));
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await deleteAssessment({
+            schoolId: assessment.schoolId,
+            assessmentId: assessment._id,
+          });
+          toast.success(schoolT("assessment-deleted"));
         }).pipe(
           Effect.catchAll(() =>
             Effect.sync(() => {

--- a/apps/www/components/school/classes/forum/conversation/header.tsx
+++ b/apps/www/components/school/classes/forum/conversation/header.tsx
@@ -106,14 +106,13 @@ function ForumReactions() {
   const handleToggleReaction = (emoji: string) => {
     startTransition(() =>
       Effect.runPromise(
-        Effect.tryPromise({
-          try: () => toggleReaction({ forumId: forum._id, emoji }),
-          catch: (cause) => cause,
-        }).pipe(
+        Effect.tryPromise(() =>
+          toggleReaction({ forumId: forum._id, emoji })
+        ).pipe(
           Effect.asVoid,
-          Effect.catchAll((cause) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             Effect.sync(() => {
-              captureException(cause, {
+              captureException(error, {
                 source: "forum-reaction-toggle",
               });
             })
@@ -187,14 +186,13 @@ function ForumActions() {
   const handleToggleReaction = (emoji: string) => {
     startTransition(() =>
       Effect.runPromise(
-        Effect.tryPromise({
-          try: () => toggleReaction({ forumId: forum._id, emoji }),
-          catch: (cause) => cause,
-        }).pipe(
+        Effect.tryPromise(() =>
+          toggleReaction({ forumId: forum._id, emoji })
+        ).pipe(
           Effect.asVoid,
-          Effect.catchAll((cause) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             Effect.sync(() => {
-              captureException(cause, {
+              captureException(error, {
                 source: "forum-reaction-picker",
               });
             })

--- a/apps/www/components/school/classes/forum/conversation/input/submit.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/submit.ts
@@ -242,7 +242,7 @@ export const submitForumPost = Effect.fn("www.forum.submitPost")(function* ({
       uploadIds: attachmentUploadIds,
     });
 
-    return yield* Effect.fail(failedUpload.left);
+    return yield* failedUpload.left;
   }
 
   yield* Effect.tryPromise({

--- a/apps/www/components/school/classes/forum/conversation/item/actions.tsx
+++ b/apps/www/components/school/classes/forum/conversation/item/actions.tsx
@@ -88,14 +88,13 @@ export function PostItemActions({ post }: { post: ForumPost }) {
             onEmojiSelect={({ emoji }) => {
               startTransition(() =>
                 Effect.runPromise(
-                  Effect.tryPromise({
-                    try: () => toggleReaction({ postId: post._id, emoji }),
-                    catch: (cause) => cause,
-                  }).pipe(
+                  Effect.tryPromise(() =>
+                    toggleReaction({ postId: post._id, emoji })
+                  ).pipe(
                     Effect.asVoid,
-                    Effect.catchAll((cause) =>
+                    Effect.catchTag("UnknownException", ({ error }) =>
                       Effect.sync(() => {
-                        captureException(cause, {
+                        captureException(error, {
                           source: "post-reaction-picker",
                         });
                       })

--- a/apps/www/components/school/classes/forum/conversation/item/reactions.tsx
+++ b/apps/www/components/school/classes/forum/conversation/item/reactions.tsx
@@ -41,15 +41,13 @@ export function PostReactions({ post }: { post: ForumPost }) {
                   onClick={() => {
                     startTransition(() =>
                       Effect.runPromise(
-                        Effect.tryPromise({
-                          try: () =>
-                            toggleReaction({ postId: post._id, emoji }),
-                          catch: (cause) => cause,
-                        }).pipe(
+                        Effect.tryPromise(() =>
+                          toggleReaction({ postId: post._id, emoji })
+                        ).pipe(
                           Effect.asVoid,
-                          Effect.catchAll((cause) =>
+                          Effect.catchTag("UnknownException", ({ error }) =>
                             Effect.sync(() => {
-                              captureException(cause, {
+                              captureException(error, {
                                 source: "post-reaction-toggle",
                               });
                             })

--- a/apps/www/components/school/classes/forum/conversation/viewport/read.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/read.test.ts
@@ -78,12 +78,10 @@ describe("conversation/viewport/read", () => {
             readAttempts.push(postId);
 
             if (readAttempts.length === 1) {
-              return yield* Effect.fail(
-                new ViewportReadError({
-                  cause: "test",
-                  message: "First read sync failed in test.",
-                })
-              );
+              return yield* new ViewportReadError({
+                cause: "test",
+                message: "First read sync failed in test.",
+              });
             }
 
             rig.readPostIds.push(postId);

--- a/apps/www/components/school/classes/forum/new.tsx
+++ b/apps/www/components/school/classes/forum/new.tsx
@@ -104,23 +104,20 @@ function SchoolClassesForumNewContent() {
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            const forumId = await createForum({ ...value, classId });
-            const href = getSchoolClassesForumHref({
-              classRouteId: routeParams.id,
-              forumId,
-              queryString: searchParams.toString(),
-              slug: routeParams.slug,
-            });
+        Effect.tryPromise(async () => {
+          const forumId = await createForum({ ...value, classId });
+          const href = getSchoolClassesForumHref({
+            classRouteId: routeParams.id,
+            forumId,
+            queryString: searchParams.toString(),
+            slug: routeParams.slug,
+          });
 
-            dialog.close();
-            form.reset();
-            router.push(href);
-          },
-          catch: (error) => error,
+          dialog.close();
+          form.reset();
+          router.push(href);
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-forum-create",
             }).pipe(

--- a/apps/www/components/school/classes/header-join.tsx
+++ b/apps/www/components/school/classes/header-join.tsx
@@ -51,16 +51,13 @@ export function SchoolClassesHeaderJoin() {
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            const { classId } = await joinClass(value);
-            router.push(`${pathname}/${classId}`);
-            openHandlers.close();
-            form.reset();
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          const { classId } = await joinClass(value);
+          router.push(`${pathname}/${classId}`);
+          openHandlers.close();
+          form.reset();
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-class-join-header",
             }).pipe(

--- a/apps/www/components/school/classes/info.tsx
+++ b/apps/www/components/school/classes/info.tsx
@@ -77,15 +77,13 @@ function InfoCustomizeButton() {
   const handleImageClick = (image: SchoolClassImage) => {
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: () =>
-            updateClassImage({
-              classId,
-              image,
-            }),
-          catch: (error) => error,
-        }).pipe(
-          Effect.catchAll((error) =>
+        Effect.tryPromise(() =>
+          updateClassImage({
+            classId,
+            image,
+          })
+        ).pipe(
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               image,
               source: "school-class-image-update",

--- a/apps/www/components/school/classes/join-form.tsx
+++ b/apps/www/components/school/classes/join-form.tsx
@@ -59,15 +59,12 @@ export function SchoolClassesJoinForm({ classId, visibility }: Props) {
   function handlePublicJoin() {
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await joinPublicClass({ classId });
-            router.replace(pathname);
-            router.refresh();
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await joinPublicClass({ classId });
+          router.replace(pathname);
+          router.refresh();
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-class-join-public",
             }).pipe(
@@ -90,15 +87,12 @@ export function SchoolClassesJoinForm({ classId, visibility }: Props) {
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await joinClass(value);
-            router.replace(pathname);
-            router.refresh();
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await joinClass(value);
+          router.replace(pathname);
+          router.refresh();
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, {
               source: "school-class-join-private",
             }).pipe(

--- a/apps/www/components/school/classes/materials/editor-dialog.tsx
+++ b/apps/www/components/school/classes/materials/editor-dialog.tsx
@@ -190,15 +190,12 @@ function MaterialGroupDialogShell({
     },
     onSubmit: async ({ value }) => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await onSubmit(value);
-            form.reset();
-            setOpenAction(false);
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await onSubmit(value);
+          form.reset();
+          setOpenAction(false);
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             reportClientException(error, errorContext).pipe(
               Effect.zipRight(
                 Effect.sync(() => {

--- a/apps/www/components/school/classes/materials/item.tsx
+++ b/apps/www/components/school/classes/materials/item.tsx
@@ -190,12 +190,9 @@ function MaterialGroupActions({
   function handleDelete() {
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: async () => {
-            await deleteGroup({ groupId: group._id });
-            toast.success(schoolT("material-deleted"));
-          },
-          catch: (error) => error,
+        Effect.tryPromise(async () => {
+          await deleteGroup({ groupId: group._id });
+          toast.success(schoolT("material-deleted"));
         }).pipe(
           Effect.catchAll(() =>
             Effect.sync(() => {

--- a/apps/www/components/shared/quran-audio-controls.ts
+++ b/apps/www/components/shared/quran-audio-controls.ts
@@ -213,10 +213,9 @@ export function useQuranAudioControls({
       audio.onended = stopThisAudio;
 
       Effect.runFork(
-        Effect.tryPromise({
-          try: () => audio.play(),
-          catch: (error) => error,
-        }).pipe(Effect.catchAll(() => Effect.sync(handlePlaybackFailure)))
+        Effect.tryPromise(() => audio.play()).pipe(
+          Effect.catchAll(() => Effect.sync(handlePlaybackFailure))
+        )
       );
     }
 

--- a/apps/www/components/tryout/runtime/choice.tsx
+++ b/apps/www/components/tryout/runtime/choice.tsx
@@ -72,10 +72,11 @@ export function TryoutChoices({ value }: { value: TryoutChoicesValue }) {
     });
 
     Effect.runPromise(
-      Effect.tryPromise({
-        try: () => saveRequest,
-        catch: (cause) => cause,
-      }).pipe(Effect.catchAll((error) => handleSubmitError(error, tExercises)))
+      Effect.tryPromise(() => saveRequest).pipe(
+        Effect.catchTag("UnknownException", ({ error }) =>
+          handleSubmitError(error, tExercises)
+        )
+      )
     );
   }
 

--- a/apps/www/components/tryout/runtime/controls.client.tsx
+++ b/apps/www/components/tryout/runtime/controls.client.tsx
@@ -77,14 +77,12 @@ export function TryoutRuntimeControls({
 
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: () =>
-            completeSection({
-              attemptId: runtime.attemptId,
-              sectionKey: runtime.section.sectionKey,
-            }),
-          catch: (cause) => cause,
-        }).pipe(
+        Effect.tryPromise(() =>
+          completeSection({
+            attemptId: runtime.attemptId,
+            sectionKey: runtime.section.sectionKey,
+          })
+        ).pipe(
           Effect.tap(() =>
             Effect.sync(() => {
               closeDialog();

--- a/apps/www/components/tryout/section/start.tsx
+++ b/apps/www/components/tryout/section/start.tsx
@@ -33,14 +33,12 @@ export function StartSectionButton({
 
     startTransition(async () => {
       await Effect.runPromise(
-        Effect.tryPromise({
-          try: () =>
-            startSection({
-              attemptId,
-              sectionKey,
-            }),
-          catch: (cause) => cause,
-        }).pipe(
+        Effect.tryPromise(() =>
+          startSection({
+            attemptId,
+            sectionKey,
+          })
+        ).pipe(
           Effect.tap(() =>
             Effect.sync(() => {
               toast.success(tTryouts("start-part-success"), {

--- a/apps/www/components/user/settings/curriculum.tsx
+++ b/apps/www/components/user/settings/curriculum.tsx
@@ -113,6 +113,11 @@ function UserSettingsCurriculumForm({
       onChange: formSchema,
     },
     onSubmit: async ({ value }) => {
+      const handleMutationError = (error: CurriculumPreferenceMutationError) =>
+        reportClientException(error, {
+          source: "user-settings-curriculum",
+        }).pipe(Effect.as(false));
+      const handleValidationError = () => Effect.succeed(false);
       const didSave = await Effect.runPromise(
         submitCurriculumPreference({
           locale,
@@ -121,14 +126,10 @@ function UserSettingsCurriculumForm({
           value,
         }).pipe(
           Effect.as(true),
-          Effect.catchTag("CurriculumPreferenceMutationError", (error) =>
-            reportClientException(error, {
-              source: "user-settings-curriculum",
-            }).pipe(Effect.as(false))
-          ),
-          Effect.catchTag("CurriculumPreferenceValidationError", () =>
-            Effect.succeed(false)
-          )
+          Effect.catchTags({
+            CurriculumPreferenceMutationError: handleMutationError,
+            CurriculumPreferenceValidationError: handleValidationError,
+          })
         )
       );
 
@@ -243,11 +244,9 @@ function submitCurriculumPreference({
     );
 
     if (!program) {
-      return yield* Effect.fail(
-        new CurriculumPreferenceValidationError({
-          cause: formValue.preferredCurriculumProgramKey,
-        })
-      );
+      return yield* new CurriculumPreferenceValidationError({
+        cause: formValue.preferredCurriculumProgramKey,
+      });
     }
 
     yield* Effect.tryPromise({

--- a/apps/www/lib/content/article/catalog.test.ts
+++ b/apps/www/lib/content/article/catalog.test.ts
@@ -107,14 +107,13 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/lib/content/cache", () => ({
   applyPublishedCatalogCache: cacheMock,
 }));
-vi.mock("@/lib/content/runtime/query", () => ({
-  fetchRuntimeQuery: fetchMock,
-  readRuntimeQuery: (_name: string, read: () => Promise<unknown>) =>
-    Effect.tryPromise({
-      catch: (cause) => cause,
-      try: read,
-    }),
-}));
+vi.mock("@/lib/content/runtime/query", async () => {
+  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  return {
+    fetchRuntimeQuery: fetchMock,
+    readRuntimeQuery: readTestRuntimeQuery,
+  };
+});
 
 describe("published article catalog", () => {
   beforeEach(() => {

--- a/apps/www/lib/content/article/ownership.test.ts
+++ b/apps/www/lib/content/article/ownership.test.ts
@@ -7,14 +7,13 @@ import { readPublishedArticleCategory } from "@/lib/content/article/ownership";
 const fetchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/content/runtime/query", () => ({
-  fetchRuntimeQuery: fetchMock,
-  readRuntimeQuery: (_name: string, read: () => Promise<unknown>) =>
-    Effect.tryPromise({
-      catch: (cause) => cause,
-      try: read,
-    }),
-}));
+vi.mock("@/lib/content/runtime/query", async () => {
+  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  return {
+    fetchRuntimeQuery: fetchMock,
+    readRuntimeQuery: readTestRuntimeQuery,
+  };
+});
 
 describe("published article category ownership", () => {
   beforeEach(() => {

--- a/apps/www/lib/content/article/sitemap.test.ts
+++ b/apps/www/lib/content/article/sitemap.test.ts
@@ -10,14 +10,13 @@ import {
 const fetchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/content/runtime/query", () => ({
-  fetchRuntimeQuery: fetchMock,
-  readRuntimeQuery: (_name: string, read: () => Promise<unknown>) =>
-    Effect.tryPromise({
-      catch: (cause) => cause,
-      try: read,
-    }),
-}));
+vi.mock("@/lib/content/runtime/query", async () => {
+  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  return {
+    fetchRuntimeQuery: fetchMock,
+    readRuntimeQuery: readTestRuntimeQuery,
+  };
+});
 
 describe("published article sitemap", () => {
   beforeEach(() => {

--- a/apps/www/lib/content/preview/material.ts
+++ b/apps/www/lib/content/preview/material.ts
@@ -41,9 +41,9 @@ const readReadyContent = Effect.fn("NakafaContent.readReadyPreview")(function* (
   config: PreviewConfig
 ) {
   const previewArtifact = manifest.artifacts[0];
-  const projection = Schema.decodeUnknownSync(MaterialLessonProjectionSchema)(
-    previewArtifact.projection
-  );
+  const projection = yield* Schema.decodeUnknown(
+    MaterialLessonProjectionSchema
+  )(previewArtifact.projection);
 
   const route = yield* decodeMaterialPreviewRoute(projection);
   const rendered = yield* executePreviewArtifact({

--- a/apps/www/lib/content/published/active.test.ts
+++ b/apps/www/lib/content/published/active.test.ts
@@ -10,6 +10,7 @@ import {
   getActiveContentIdentity,
   readActiveContentIdentity,
 } from "@/lib/content/published/active";
+import { readTestRuntimeQuery } from "@/test/runtime-query";
 
 const applyContentRuntimeCacheMock = vi.hoisted(() => vi.fn());
 const fetchQueryMock = vi.hoisted(() => vi.fn());
@@ -28,10 +29,7 @@ beforeEach(() => {
   applyContentRuntimeCacheMock.mockReset();
   fetchQueryMock.mockReset();
   readQueryMock.mockReset();
-  readQueryMock.mockImplementation(
-    (_name: string, read: () => Promise<unknown>) =>
-      Effect.tryPromise({ catch: () => new Error("read"), try: read })
-  );
+  readQueryMock.mockImplementation(readTestRuntimeQuery);
 });
 
 describe("published active identity", () => {

--- a/apps/www/lib/content/published/route.test.ts
+++ b/apps/www/lib/content/published/route.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readActiveContentRoute } from "@/lib/content/published/route";
 import { testArticleProjection } from "@/test/content-article";
 import { previewProjection } from "@/test/content-preview";
+import { readTestRuntimeQuery } from "@/test/runtime-query";
 
 const fetchQueryMock = vi.hoisted(() => vi.fn());
 const readQueryMock = vi.hoisted(() => vi.fn());
@@ -26,10 +27,7 @@ vi.mock("@/lib/content/runtime/query", () => ({
 beforeEach(() => {
   fetchQueryMock.mockReset();
   readQueryMock.mockReset();
-  readQueryMock.mockImplementation(
-    (_name: string, read: () => Promise<unknown>) =>
-      Effect.tryPromise({ catch: () => new Error("read"), try: read })
-  );
+  readQueryMock.mockImplementation(readTestRuntimeQuery);
 });
 
 describe("published content route", () => {

--- a/apps/www/lib/content/renderer/manifest.test.ts
+++ b/apps/www/lib/content/renderer/manifest.test.ts
@@ -96,5 +96,5 @@ describe("renderer manifest", () => {
         expect(capability.supportedComponents).toEqual([]);
       }
     }
-  }, 10_000);
+  }, 20_000);
 });

--- a/apps/www/lib/hooks/use-record-content-view.ts
+++ b/apps/www/lib/hooks/use-record-content-view.ts
@@ -86,18 +86,16 @@ export function useRecordContentView({
 
     const timeoutId = window.setTimeout(() => {
       Effect.runFork(
-        Effect.tryPromise({
-          try: () =>
-            recordView({
-              contentId,
-              ...(context ? { context } : {}),
-              locale,
-              deviceId,
-            }),
-          catch: (error) => error,
-        }).pipe(
+        Effect.tryPromise(() =>
+          recordView({
+            contentId,
+            ...(context ? { context } : {}),
+            locale,
+            deviceId,
+          })
+        ).pipe(
           Effect.tap(() => Effect.sync(() => markAsViewed(viewKey))),
-          Effect.catchAll((error) =>
+          Effect.catchTag("UnknownException", ({ error }) =>
             Effect.sync(() =>
               captureException(error, {
                 contentId,

--- a/apps/www/lib/og.tsx
+++ b/apps/www/lib/og.tsx
@@ -27,10 +27,9 @@ async function getLogoDataUrl() {
   cacheLife("max");
 
   return await Effect.runPromise(
-    Effect.tryPromise({
-      try: () => readFile(join(process.cwd(), "public", "logo.svg"), "utf8"),
-      catch: (error) => error,
-    }).pipe(
+    Effect.tryPromise(() =>
+      readFile(join(process.cwd(), "public", "logo.svg"), "utf8")
+    ).pipe(
       Effect.map(
         (logo) => `data:image/svg+xml;charset=utf-8,${encodeURIComponent(logo)}`
       )
@@ -43,10 +42,7 @@ export function generateOGImage(options: GenerateOGImageOptions) {
   return Effect.runPromise(
     Effect.gen(function* () {
       const { height = 630, icon, width = 1200, ...imageProps } = options;
-      const logoDataUrl = yield* Effect.tryPromise({
-        try: getLogoDataUrl,
-        catch: (error) => error,
-      });
+      const logoDataUrl = yield* Effect.tryPromise(getLogoDataUrl);
 
       return new ImageResponse(
         <OgImage

--- a/apps/www/lib/react-query/use-weather.tsx
+++ b/apps/www/lib/react-query/use-weather.tsx
@@ -7,10 +7,9 @@ type Weather = Effect.Effect.Success<ReturnType<typeof getWeather>>;
 
 /** Load the current weather summary through the app API route. */
 const fetchWeather = Effect.fn("www.weather.fetch")(function* () {
-  return yield* Effect.tryPromise({
-    try: () => ky.post<Weather>("/api/weather").json(),
-    catch: (error) => error,
-  });
+  return yield* Effect.tryPromise(() =>
+    ky.post<Weather>("/api/weather").json()
+  );
 });
 
 /** Return a cached React Query handle for the current weather summary. */

--- a/apps/www/lib/routing/public/source.test.ts
+++ b/apps/www/lib/routing/public/source.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readSourceBackedHtmlRouteRejection } from "@/lib/routing/public/source";
 
@@ -14,6 +14,11 @@ const publishedMocks = vi.hoisted(() => ({
 const previewMocks = vi.hoisted(() => ({
   matchesPreviewRoute: vi.fn(),
 }));
+
+/** Test-only typed runtime lookup failure. */
+class TestRuntimeRouteError extends Data.TaggedError("TestRuntimeRouteError")<{
+  readonly message: string;
+}> {}
 
 vi.mock("@/lib/content/runtime/routes", () => ({
   getRuntimeContentRoute: runtimeMocks.getRuntimeContentRoute,
@@ -229,7 +234,7 @@ describe("source-backed public html route rejection", () => {
 
   it("propagates exact article lookup failures", async () => {
     runtimeMocks.getRuntimeContentRoute.mockReturnValueOnce(
-      Effect.fail(new Error("runtime unavailable"))
+      Effect.fail(new TestRuntimeRouteError({ message: "runtime unavailable" }))
     );
 
     await expect(

--- a/apps/www/lib/school/server.ts
+++ b/apps/www/lib/school/server.ts
@@ -2,7 +2,7 @@ import { captureServerException } from "@repo/analytics/posthog/server";
 import { api } from "@repo/backend/convex/_generated/api";
 import { preloadedQueryResult } from "convex/nextjs";
 import { ConvexError } from "convex/values";
-import { Effect } from "effect";
+import { type Cause, Effect } from "effect";
 import { cache } from "react";
 import { fetchAuthQuery, getToken, preloadAuthQuery } from "@/lib/auth/server";
 
@@ -31,16 +31,15 @@ function hasConvexErrorCode(error: unknown, allowedCodes: readonly string[]) {
 
 /** Captures an unexpected school route error and preserves the original failure. */
 function captureSchoolRouteError(
-  error: unknown,
+  failure: Cause.UnknownException,
   context: Record<string | number, unknown>
 ) {
   return Effect.gen(function* () {
-    yield* Effect.tryPromise({
-      try: () => captureServerException(error, undefined, context),
-      catch: (cause) => cause,
-    }).pipe(Effect.ignore);
+    yield* Effect.tryPromise(() =>
+      captureServerException(failure.error, undefined, context)
+    ).pipe(Effect.ignore);
 
-    return yield* Effect.fail(error);
+    return yield* failure;
   });
 }
 
@@ -59,16 +58,14 @@ export const getSchoolRouteSnapshot = cache(
     }
 
     return Effect.runPromise(
-      Effect.tryPromise({
-        try: () =>
-          fetchAuthQuery(api.schools.queries.getSchoolBySlug, {
-            slug,
-          }),
-        catch: (error) => error,
-      }).pipe(
+      Effect.tryPromise(() =>
+        fetchAuthQuery(api.schools.queries.getSchoolBySlug, {
+          slug,
+        })
+      ).pipe(
         Effect.catchIf(
-          (error) =>
-            hasConvexErrorCode(error, [
+          (failure) =>
+            hasConvexErrorCode(failure.error, [
               "SCHOOL_NOT_FOUND",
               "MEMBERSHIP_NOT_FOUND",
             ]),
@@ -99,18 +96,16 @@ export async function preloadClassRoute({ classId }: { classId: string }) {
   }
 
   return Effect.runPromise(
-    Effect.tryPromise({
-      try: () =>
-        preloadAuthQuery(api.classes.queries.getClassRoute, { classId }),
-      catch: (error) => error,
-    }).pipe(
+    Effect.tryPromise(() =>
+      preloadAuthQuery(api.classes.queries.getClassRoute, { classId })
+    ).pipe(
       Effect.map((preloaded) => ({
         preloaded,
         value: preloadedQueryResult(preloaded),
       })),
       Effect.catchIf(
-        (error) =>
-          hasConvexErrorCode(error, [
+        (failure) =>
+          hasConvexErrorCode(failure.error, [
             "ACCESS_DENIED",
             "CLASS_ARCHIVED",
             "CLASS_NOT_FOUND",
@@ -136,16 +131,14 @@ export async function getSchoolSwitcherPage() {
   }
 
   return Effect.runPromise(
-    Effect.tryPromise({
-      try: () =>
-        fetchAuthQuery(api.schools.queries.getMySchoolsPage, {
-          paginationOpts: {
-            cursor: null,
-            numItems: SCHOOL_SWITCHER_PAGE_SIZE,
-          },
-        }),
-      catch: (error) => error,
-    }).pipe(
+    Effect.tryPromise(() =>
+      fetchAuthQuery(api.schools.queries.getMySchoolsPage, {
+        paginationOpts: {
+          cursor: null,
+          numItems: SCHOOL_SWITCHER_PAGE_SIZE,
+        },
+      })
+    ).pipe(
       Effect.catchAll((error) =>
         captureSchoolRouteError(error, {
           source: "school-switcher-page",

--- a/apps/www/lib/sitemap/content.ts
+++ b/apps/www/lib/sitemap/content.ts
@@ -29,9 +29,7 @@ export const buildSitemapContentPageRoutes = Effect.fn(
     }
 
     if (paths.has(route.path)) {
-      return yield* Effect.fail(
-        new DuplicateSitemapContentRouteError({ path: route.path })
-      );
+      return yield* new DuplicateSitemapContentRouteError({ path: route.path });
     }
 
     paths.add(route.path);

--- a/apps/www/lib/sitemap/routes.ts
+++ b/apps/www/lib/sitemap/routes.ts
@@ -39,7 +39,7 @@ export const readSitemapRoutePage = Effect.fn("www.sitemap.routePage")(
   function* (pageId: string) {
     const page = getSitemapPageDescriptor(pageId);
     if (!page) {
-      return yield* Effect.fail(new SitemapPageNotFoundError({ pageId }));
+      return yield* new SitemapPageNotFoundError({ pageId });
     }
 
     if (isPublicSitemapPage(page)) {
@@ -48,7 +48,7 @@ export const readSitemapRoutePage = Effect.fn("www.sitemap.routePage")(
         page: page.page,
       });
       if (!artifact) {
-        return yield* Effect.fail(new SitemapPageNotFoundError({ pageId }));
+        return yield* new SitemapPageNotFoundError({ pageId });
       }
       return {
         routes: artifact.paths.map((path) => ({
@@ -64,7 +64,7 @@ export const readSitemapRoutePage = Effect.fn("www.sitemap.routePage")(
         page.bucket
       );
       if (!artifact) {
-        return yield* Effect.fail(new SitemapPageNotFoundError({ pageId }));
+        return yield* new SitemapPageNotFoundError({ pageId });
       }
       return {
         routes: artifact.routes
@@ -89,7 +89,7 @@ export const readSitemapRoutePage = Effect.fn("www.sitemap.routePage")(
       section: page.section,
     });
     if (!artifact) {
-      return yield* Effect.fail(new SitemapPageNotFoundError({ pageId }));
+      return yield* new SitemapPageNotFoundError({ pageId });
     }
     return { routes: yield* buildSitemapContentPageRoutes(artifact.routes) };
   }

--- a/apps/www/lib/utils/system.ts
+++ b/apps/www/lib/utils/system.ts
@@ -52,24 +52,24 @@ export function getStaticParams(config: ParamConfig): Promise<StaticParam[]> {
 }
 
 /** Builds static params from route catalog paths as a native Effect program. */
-function buildStaticParams(config: ParamConfig) {
-  return Effect.gen(function* () {
-    const routes = yield* getStaticParamRoutes(config);
-    const params = new Map<string, StaticParam>();
+const buildStaticParams = Effect.fn("www.system.getStaticParams")(function* (
+  config: ParamConfig
+) {
+  const routes = yield* getStaticParamRoutes(config);
+  const params = new Map<string, StaticParam>();
 
-    for (const route of routes) {
-      const param = routeToStaticParam(route, config);
+  for (const route of routes) {
+    const param = routeToStaticParam(route, config);
 
-      if (!param) {
-        continue;
-      }
-
-      params.set(JSON.stringify(param), param);
+    if (!param) {
+      continue;
     }
 
-    return Array.from(params.values());
-  }).pipe(Effect.withSpan("www.system.getStaticParams"));
-}
+    params.set(JSON.stringify(param), param);
+  }
+
+  return Array.from(params.values());
+});
 
 /** Reads deliberate latest-content candidates for one static params generator. */
 function getStaticParamRoutes(config: ParamConfig) {

--- a/apps/www/scripts/google-index.ts
+++ b/apps/www/scripts/google-index.ts
@@ -22,7 +22,7 @@ Effect.runPromise(
     Effect.catchAll((error) =>
       Effect.sync(() => {
         logger.error(`Error running Google indexing script: ${error}`);
-        process.exit(1);
+        process.exitCode = 1;
       })
     )
   )

--- a/apps/www/scripts/index-now.ts
+++ b/apps/www/scripts/index-now.ts
@@ -16,7 +16,7 @@ Effect.runPromise(
     Effect.catchAll((error) =>
       Effect.sync(() => {
         logger.error(`Error running indexing script: ${error}`);
-        process.exit(1);
+        process.exitCode = 1;
       })
     )
   )

--- a/apps/www/scripts/indexing/google/auth.ts
+++ b/apps/www/scripts/indexing/google/auth.ts
@@ -143,12 +143,10 @@ export const getGoogleAccessToken = Effect.fn("scripts.google.auth.getToken")(
     });
 
     if (!tokenResponse.ok) {
-      return yield* Effect.fail(
-        new GoogleTokenRequestError({
-          message: "Google token request failed.",
-          responseText: tokenResponse.responseText,
-        })
-      );
+      return yield* new GoogleTokenRequestError({
+        message: "Google token request failed.",
+        responseText: tokenResponse.responseText,
+      });
     }
 
     return (yield* decodeGoogleTokenResponse(tokenResponse.responseText))

--- a/apps/www/scripts/indexing/google/eligibility.ts
+++ b/apps/www/scripts/indexing/google/eligibility.ts
@@ -66,12 +66,10 @@ const readEligibleGoogleIndexingUrl = Effect.fn(
   });
 
   if (!ok) {
-    return yield* Effect.fail(
-      new GoogleIndexPageFetchError({
-        message: `Google Indexing API eligibility fetch returned HTTP ${status}.`,
-        url,
-      })
-    );
+    return yield* new GoogleIndexPageFetchError({
+      message: `Google Indexing API eligibility fetch returned HTTP ${status}.`,
+      url,
+    });
   }
 
   const blocks = readJsonLdScriptBodies(html);

--- a/apps/www/scripts/indexing/google/run.ts
+++ b/apps/www/scripts/indexing/google/run.ts
@@ -140,12 +140,10 @@ export const runGoogleIndexing = Effect.fn("scripts.indexing.google.run")(
     }
 
     if (successfullySubmittedCount === 0) {
-      return yield* Effect.fail(
-        new GoogleIndexSubmitError({
-          cause: "No eligible URLs were successfully submitted.",
-          message: "Google Indexing API submission submitted zero queued URLs.",
-        })
-      );
+      return yield* new GoogleIndexSubmitError({
+        cause: "No eligible URLs were successfully submitted.",
+        message: "Google Indexing API submission submitted zero queued URLs.",
+      });
     }
 
     logger.header("Google Indexing API Submission Process Completed");

--- a/apps/www/scripts/indexing/indexnow/submit.ts
+++ b/apps/www/scripts/indexing/indexnow/submit.ts
@@ -104,12 +104,10 @@ const submitBatchToIndexNow = Effect.fn(
   });
 
   if (status !== HTTP_STATUS_CODE_OK) {
-    return yield* Effect.fail(
-      new IndexNowSubmitError({
-        cause: status,
-        message: `IndexNow batch ${batchCount} failed with HTTP ${status}.`,
-      })
-    );
+    return yield* new IndexNowSubmitError({
+      cause: status,
+      message: `IndexNow batch ${batchCount} failed with HTTP ${status}.`,
+    });
   }
 
   logger.success(`Batch ${batchCount} completed (${batch.length} URLs)`);

--- a/apps/www/test/runtime-query.ts
+++ b/apps/www/test/runtime-query.ts
@@ -1,0 +1,20 @@
+import { Data, Effect } from "effect";
+
+/** Test-only typed failure for mocked runtime query Promise rejections. */
+class TestRuntimeQueryError extends Data.TaggedError("TestRuntimeQueryError")<{
+  readonly message: string;
+}> {}
+
+/** Preserves a mocked runtime query rejection message in the Effect error channel. */
+export function readTestRuntimeQuery(
+  _name: string,
+  read: () => Promise<unknown>
+) {
+  return Effect.tryPromise({
+    try: read,
+    catch: (cause) =>
+      new TestRuntimeQueryError({
+        message: String(cause),
+      }),
+  });
+}

--- a/packages/ai/agents/math/agent.ts
+++ b/packages/ai/agents/math/agent.ts
@@ -36,7 +36,7 @@ import type { MathAgentParams } from "@repo/ai/types/agents";
 import { mathOperations } from "@repo/math/schema/operations";
 import { MathService } from "@repo/math/service";
 import { generateText, isStepCount, tool } from "ai";
-import { Effect } from "effect";
+import { Effect, Runtime } from "effect";
 
 const MAX_MATH_STEPS = mathOperations.length;
 
@@ -54,6 +54,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
   context,
   writer,
 }: MathAgentParams) {
+  const runPromise = Runtime.runPromise(yield* Effect.runtime());
   const result = yield* Effect.tryPromise({
     try: () =>
       generateText({
@@ -64,7 +65,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           google: getFastModelProviderOptions(modelId),
         },
         repairToolCall: (options) =>
-          Effect.runPromise(
+          runPromise(
             repairMathToolCall({
               ...options,
               modelId,
@@ -80,7 +81,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           algebra: tool({
             description: mathAlgebra,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -93,7 +94,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           arithmetic: tool({
             description: mathArithmetic,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -106,7 +107,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           calculus: tool({
             description: mathCalculus,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -119,7 +120,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           discrete: tool({
             description: mathDiscrete,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -132,7 +133,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           equation: tool({
             description: mathEquation,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -145,7 +146,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           geometry: tool({
             description: mathGeometry,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -158,7 +159,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           matrix: tool({
             description: mathMatrix,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -171,7 +172,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           probability: tool({
             description: mathProbability,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -184,7 +185,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           series: tool({
             description: mathSeries,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,
@@ -197,7 +198,7 @@ export const runMathAgent = Effect.fn("math.runMathAgent")(function* ({
           statistics: tool({
             description: mathStatistics,
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 compute({
                   input,
                   toolCallId,

--- a/packages/ai/agents/math/repair.ts
+++ b/packages/ai/agents/math/repair.ts
@@ -80,19 +80,18 @@ export const repairMathToolCall = Effect.fn("math.repairToolCall")(function* ({
     onSome: (input) => JSON.stringify(input, null, 2),
   });
 
-  const repaired = yield* Effect.tryPromise({
-    try: () =>
-      generateText({
-        model: provider.languageModel(modelId),
-        output: Output.object({ schema: tool.inputSchema }),
-        prompt: createPrompt({
-          taskContext: `
+  const repaired = yield* Effect.tryPromise(() =>
+    generateText({
+      model: provider.languageModel(modelId),
+      output: Output.object({ schema: tool.inputSchema }),
+      prompt: createPrompt({
+        taskContext: `
         # Repair Task
 
         Repair the math tool arguments without changing the selected tool.
       `,
 
-          toolUsageGuidelines: `
+        toolUsageGuidelines: `
         # Repair Rules
 
         - Keep the operation field exactly the same as the failed arguments.
@@ -111,7 +110,7 @@ export const repairMathToolCall = Effect.fn("math.repairToolCall")(function* ({
         - Include the requested probability point or event bounds.
       `,
 
-          backgroundData: `
+        backgroundData: `
         # Selected Tool
 
         ${toolCall.toolName}
@@ -132,16 +131,15 @@ export const repairMathToolCall = Effect.fn("math.repairToolCall")(function* ({
 
         ${error.message}
       `,
-        }),
-        providerOptions: {
-          gateway: gatewayProviderOptions,
-          google: getFastModelProviderOptions(modelId),
-        },
-        instructions,
-        timeout: backgroundGenerationTimeout,
       }),
-    catch: (error) => error,
-  }).pipe(Effect.option);
+      providerOptions: {
+        gateway: gatewayProviderOptions,
+        google: getFastModelProviderOptions(modelId),
+      },
+      instructions,
+      timeout: backgroundGenerationTimeout,
+    })
+  ).pipe(Effect.option);
 
   if (Option.isNone(repaired)) {
     return null;

--- a/packages/ai/agents/nakafa/agent.ts
+++ b/packages/ai/agents/nakafa/agent.ts
@@ -30,7 +30,7 @@ import { NakafaAgentReadOptionsSchema } from "@repo/contents/_lib/agent/schema/r
 import { NakafaAgentSearchOptionsSchema } from "@repo/contents/_lib/agent/schema/search";
 import { NakafaAgentTaxonomyOptionsSchema } from "@repo/contents/_lib/agent/schema/taxonomy";
 import { generateText, isStepCount, tool } from "ai";
-import { Effect } from "effect";
+import { Effect, Runtime } from "effect";
 
 const nakafaSearchInputSchema = createEffectSchema(
   NakafaAgentSearchOptionsSchema
@@ -53,6 +53,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
   nakafa,
 }: NakafaAgentParams) {
   const searchService = yield* NakafaSearch;
+  const runPromise = Runtime.runPromise(yield* Effect.runtime());
   let hasPendingContentRead = false;
   const result = yield* Effect.tryPromise({
     /** Runs the AI SDK Nakafa specialist loop with MCP-equivalent tools. */
@@ -73,7 +74,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
             outputSchema: textOutputSchema,
             /** Runs content search and records whether the next step should read. */
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 search({ input, locale, toolCallId, writer }).pipe(
                   Effect.provideService(NakafaSearch, searchService),
                   Effect.tap((output) =>
@@ -96,7 +97,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
             execute: (input, { toolCallId }) => {
               hasPendingContentRead = false;
 
-              return Effect.runPromise(
+              return runPromise(
                 read({ input, toolCallId, writer }).pipe(provideNakafa(nakafa))
               );
             },
@@ -107,7 +108,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
             outputSchema: textOutputSchema,
             /** Reads Quran references through the injected Nakafa service. */
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 quran({ input, locale, toolCallId, writer }).pipe(
                   provideNakafa(nakafa)
                 )
@@ -119,7 +120,7 @@ export const runNakafaAgent = Effect.fn("nakafa.runNakafaAgent")(function* ({
             outputSchema: textOutputSchema,
             /** Lists content taxonomy through the injected Nakafa service. */
             execute: (input, { toolCallId }) =>
-              Effect.runPromise(
+              runPromise(
                 taxonomy({ input, locale, toolCallId, writer }).pipe(
                   provideNakafa(nakafa)
                 )

--- a/packages/ai/agents/research/agent.ts
+++ b/packages/ai/agents/research/agent.ts
@@ -55,7 +55,7 @@ import {
   tool,
   wrapLanguageModel,
 } from "ai";
-import { Effect } from "effect";
+import { Effect, Runtime } from "effect";
 
 // Keep exact user source scraping parallel without allowing unlimited fan-out.
 const exactSourceScrapeConcurrency = 3;
@@ -75,6 +75,7 @@ export const runResearchAgent = Effect.fn("research.runResearchAgent")(
     toolCallId,
     writer,
   }: ResearchAgentParams) {
+    const runPromise = Runtime.runPromise(yield* Effect.runtime());
     let triedGoogleGrounding = false;
     const sourceReferences = getUniqueSourceReferences([
       ...messageSourceReferences,
@@ -108,7 +109,7 @@ export const runResearchAgent = Effect.fn("research.runResearchAgent")(
               inputSchema: webSearchInputSchema,
               outputSchema: textOutputSchema,
               execute: ({ queries, sourcePreference }, { toolCallId }) =>
-                Effect.runPromise(
+                runPromise(
                   searchWeb({
                     queries,
                     sourcePreference,
@@ -134,7 +135,7 @@ export const runResearchAgent = Effect.fn("research.runResearchAgent")(
               inputSchema: scrapeInputSchema,
               outputSchema: textOutputSchema,
               execute: ({ urlToCrawl }, { toolCallId }) =>
-                Effect.runPromise(
+                runPromise(
                   scrapeUrl({
                     toolCallId,
                     url: urlToCrawl,

--- a/packages/ai/agents/research/tools/scrape.ts
+++ b/packages/ai/agents/research/tools/scrape.ts
@@ -63,7 +63,7 @@ export const scrapeUrl = Effect.fn("research.scrapeUrl")(function* ({
     {
       nativeMarkdown: safeUrl.right.nativeFetchUrl
         ? fetchSourceMarkdown(safeUrl.right.nativeFetchUrl)
-        : Effect.succeed(undefined),
+        : Effect.as(Effect.void, undefined),
       scrapeResult: Effect.tryPromise({
         try: () =>
           readFirecrawlApp().scrape(publicUrl, {

--- a/packages/ai/clients/weather/client.ts
+++ b/packages/ai/clients/weather/client.ts
@@ -113,18 +113,18 @@ const fetchGeoData = Effect.fn("weather.fetchGeoData")(function* (
     url: `${GEO_BASE_URL}/reverse`,
   }).pipe(
     Effect.flatMap(Schema.decodeUnknown(ReverseGeocodeSchema)),
-    Effect.catchTag("WeatherClientRequestError", (error) =>
-      logError(new Error(error.message), {
-        ...context,
-        operation: "fetchGeoData",
-      }).pipe(Effect.as([]))
-    ),
-    Effect.catchTag("ParseError", (error) =>
-      Effect.logWarning("Geocoding validation failed").pipe(
-        Effect.annotateLogs({ ...context, cause: error.message }),
-        Effect.as([])
-      )
-    )
+    Effect.catchTags({
+      WeatherClientRequestError: (error) =>
+        logError(new Error(error.message), {
+          ...context,
+          operation: "fetchGeoData",
+        }).pipe(Effect.as([])),
+      ParseError: (error) =>
+        Effect.logWarning("Geocoding validation failed").pipe(
+          Effect.annotateLogs({ ...context, cause: error.message }),
+          Effect.as([])
+        ),
+    })
   );
 
   const location = locations.at(0);
@@ -164,18 +164,18 @@ const fetchWeatherForecast = Effect.fn("weather.fetchWeatherForecast")(
       url: `${WEATHER_BASE_URL}/forecast`,
     }).pipe(
       Effect.flatMap(Schema.decodeUnknown(WeatherResponseSchema)),
-      Effect.catchTag("WeatherClientRequestError", (error) =>
-        logError(new Error(error.message), {
-          ...context,
-          operation: "fetchWeatherForecast",
-        }).pipe(Effect.as(null))
-      ),
-      Effect.catchTag("ParseError", (error) =>
-        Effect.logWarning("Weather forecast validation failed").pipe(
-          Effect.annotateLogs({ ...context, cause: error.message }),
-          Effect.as(null)
-        )
-      )
+      Effect.catchTags({
+        WeatherClientRequestError: (error) =>
+          logError(new Error(error.message), {
+            ...context,
+            operation: "fetchWeatherForecast",
+          }).pipe(Effect.as(null)),
+        ParseError: (error) =>
+          Effect.logWarning("Weather forecast validation failed").pipe(
+            Effect.annotateLogs({ ...context, cause: error.message }),
+            Effect.as(null)
+          ),
+      })
     );
   }
 );
@@ -202,18 +202,18 @@ const fetchAirPollution = Effect.fn("weather.fetchAirPollution")(function* (
     url: `${WEATHER_BASE_URL}/air_pollution`,
   }).pipe(
     Effect.flatMap(Schema.decodeUnknown(AirPollutionResponseSchema)),
-    Effect.catchTag("WeatherClientRequestError", (error) =>
-      logError(new Error(error.message), {
-        ...context,
-        operation: "fetchAirPollution",
-      }).pipe(Effect.as(emptyAirPollution(latitude, longitude)))
-    ),
-    Effect.catchTag("ParseError", (error) =>
-      Effect.logWarning("Air pollution validation failed").pipe(
-        Effect.annotateLogs({ ...context, cause: error.message }),
-        Effect.as(emptyAirPollution(latitude, longitude))
-      )
-    )
+    Effect.catchTags({
+      WeatherClientRequestError: (error) =>
+        logError(new Error(error.message), {
+          ...context,
+          operation: "fetchAirPollution",
+        }).pipe(Effect.as(emptyAirPollution(latitude, longitude))),
+      ParseError: (error) =>
+        Effect.logWarning("Air pollution validation failed").pipe(
+          Effect.annotateLogs({ ...context, cause: error.message }),
+          Effect.as(emptyAirPollution(latitude, longitude))
+        ),
+    })
   );
 });
 
@@ -237,18 +237,18 @@ const fetchAirPollutionForecast = Effect.fn(
     url: `${WEATHER_BASE_URL}/air_pollution/forecast`,
   }).pipe(
     Effect.flatMap(Schema.decodeUnknown(AirPollutionResponseSchema)),
-    Effect.catchTag("WeatherClientRequestError", (error) =>
-      logError(new Error(error.message), {
-        ...context,
-        operation: "fetchAirPollutionForecast",
-      }).pipe(Effect.as(emptyAirPollution(latitude, longitude)))
-    ),
-    Effect.catchTag("ParseError", (error) =>
-      Effect.logWarning("Air pollution forecast validation failed").pipe(
-        Effect.annotateLogs({ ...context, cause: error.message }),
-        Effect.as(emptyAirPollution(latitude, longitude))
-      )
-    )
+    Effect.catchTags({
+      WeatherClientRequestError: (error) =>
+        logError(new Error(error.message), {
+          ...context,
+          operation: "fetchAirPollutionForecast",
+        }).pipe(Effect.as(emptyAirPollution(latitude, longitude))),
+      ParseError: (error) =>
+        Effect.logWarning("Air pollution forecast validation failed").pipe(
+          Effect.annotateLogs({ ...context, cause: error.message }),
+          Effect.as(emptyAirPollution(latitude, longitude))
+        ),
+    })
   );
 });
 

--- a/packages/ai/nina/capability/catalog.ts
+++ b/packages/ai/nina/capability/catalog.ts
@@ -39,7 +39,7 @@ import { NakafaAgentContentRefInputSchema } from "@repo/contents/_lib/agent/sche
 import type { Locale } from "@repo/contents/_types/content";
 import type { LogContext } from "@repo/utilities/logging/types";
 import { tool, type UIMessageStreamWriter } from "ai";
-import { Effect } from "effect";
+import { Effect, Runtime } from "effect";
 
 type NinaUsage = Effect.Effect.Success<ReturnType<typeof trackUsage>>;
 
@@ -73,6 +73,7 @@ export const createNinaCapabilityCatalog = Effect.fn("nina.capability.catalog")(
     const search = yield* NakafaSearch;
     const reporter = yield* NinaReporter;
     const store = yield* NinaStore;
+    const runPromise = Runtime.runPromise(yield* Effect.runtime());
 
     return {
       [NAKAFA_CAPABILITY]: tool({
@@ -81,7 +82,7 @@ export const createNinaCapabilityCatalog = Effect.fn("nina.capability.catalog")(
         inputSchema: nakafaToolInputSchema,
         /** Runs the Nakafa specialist with one-time current-page fetch support. */
         execute: (input, { toolCallId }) =>
-          Effect.runPromise(
+          runPromise(
             traceLearningCapability({
               capability: NAKAFA_CAPABILITY,
               responseMessageIdentifier,
@@ -109,17 +110,7 @@ export const createNinaCapabilityCatalog = Effect.fn("nina.capability.catalog")(
                     },
                     toolCallId,
                     writer,
-                  }).pipe(
-                    Effect.provideService(Nakafa, nakafa),
-                    Effect.catchAll((error) =>
-                      recoverSpecialistFailure({
-                        component: NAKAFA_CAPABILITY,
-                        error,
-                        errorLocation: "readNakafaCurrentPage",
-                        reporter,
-                      })
-                    )
-                  );
+                  }).pipe(Effect.provideService(Nakafa, nakafa));
 
                   if (typeof text !== "string") {
                     return text;
@@ -180,7 +171,7 @@ export const createNinaCapabilityCatalog = Effect.fn("nina.capability.catalog")(
         inputSchema: researchToolInputSchema,
         /** Runs the external research specialist and records its token usage. */
         execute: (input, { messages, toolCallId }) =>
-          Effect.runPromise(
+          runPromise(
             traceLearningCapability({
               capability: RESEARCH_CAPABILITY,
               responseMessageIdentifier,
@@ -245,7 +236,7 @@ export const createNinaCapabilityCatalog = Effect.fn("nina.capability.catalog")(
         inputSchema: mathToolInputSchema,
         /** Runs the deterministic math specialist and records its token usage. */
         execute: (input, { toolCallId }) =>
-          Effect.runPromise(
+          runPromise(
             traceLearningCapability({
               capability: MATH_CAPABILITY,
               responseMessageIdentifier,

--- a/packages/ai/nina/runtime/repair.ts
+++ b/packages/ai/nina/runtime/repair.ts
@@ -88,35 +88,30 @@ export const repairNinaToolCall = Effect.fn("nina.repair.toolCall")(function* ({
     return null;
   }
 
-  const schema = yield* Effect.tryPromise({
-    try: () => inputSchema(toolCall),
-    catch: (cause) => cause,
-  }).pipe(
-    Effect.tapError((cause) =>
-      reporter.report({ error: cause, source: "repair.inputSchema" })
+  const schema = yield* Effect.tryPromise(() => inputSchema(toolCall)).pipe(
+    Effect.tapError(({ error }) =>
+      reporter.report({ error, source: "repair.inputSchema" })
     )
   );
-  const { output: recoveredArgs } = yield* Effect.tryPromise({
-    try: () =>
-      generateText({
-        model: provider.languageModel(defaultModel),
-        output: Output.object({ schema: tool.inputSchema }),
-        prompt: [
-          `The model tried to call the tool "${toolCall.toolName}"` +
-            " with the following arguments:",
-          JSON.stringify(toolCall.input, null, 2),
-          "The tool accepts the following schema:",
-          JSON.stringify(schema, null, 2),
-          "Please fix the arguments.",
-        ].join("\n"),
-        providerOptions: {
-          gateway: gatewayProviderOptions,
-          google: getFastModelProviderOptions(defaultModel),
-        },
-        timeout: backgroundGenerationTimeout,
-      }),
-    catch: (cause) => cause,
-  });
+  const { output: recoveredArgs } = yield* Effect.tryPromise(() =>
+    generateText({
+      model: provider.languageModel(defaultModel),
+      output: Output.object({ schema: tool.inputSchema }),
+      prompt: [
+        `The model tried to call the tool "${toolCall.toolName}"` +
+          " with the following arguments:",
+        JSON.stringify(toolCall.input, null, 2),
+        "The tool accepts the following schema:",
+        JSON.stringify(schema, null, 2),
+        "Please fix the arguments.",
+      ].join("\n"),
+      providerOptions: {
+        gateway: gatewayProviderOptions,
+        google: getFastModelProviderOptions(defaultModel),
+      },
+      timeout: backgroundGenerationTimeout,
+    })
+  );
 
   yield* Effect.logInfo("Tool call successfully recovered").pipe(
     Effect.annotateLogs(sessionLogger)

--- a/packages/ai/nina/runtime/stream.ts
+++ b/packages/ai/nina/runtime/stream.ts
@@ -33,7 +33,7 @@ import {
   pruneMessages,
   type UIMessageStreamWriter,
 } from "ai";
-import { Effect, Schema } from "effect";
+import { Effect, Runtime, Schema } from "effect";
 
 /** Raised when NinaHarness cannot prepare or stream one turn. */
 export class NinaStreamError extends Schema.TaggedError<NinaStreamError>()(
@@ -51,6 +51,9 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
     const reporter = yield* NinaReporter;
     const nakafa = yield* Nakafa;
     const search = yield* NakafaSearch;
+    const effectRuntime = yield* Effect.runtime();
+    const runFork = Runtime.runFork(effectRuntime);
+    const runPromise = Runtime.runPromise(effectRuntime);
     const messages = yield* store.loadMessages();
     const logContext = createNinaLogContext(turn);
     const originalMessageCount = messages.length;
@@ -102,7 +105,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
       }
 
       failureScheduled = true;
-      Effect.runFork(
+      runFork(
         Effect.all(
           [
             reporter.report({ error, source }),
@@ -123,7 +126,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
     const stream = createUIMessageStream<MyUIMessage>({
       /** Runs Nina's Effect program at the AI SDK stream callback boundary. */
       execute: ({ writer }) =>
-        Effect.runPromise(
+        runPromise(
           runNinaWriterTurn({
             finalMessages,
             logContext,
@@ -168,7 +171,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
         }
 
         if (isFirstMessage) {
-          Effect.runFork(
+          runFork(
             store
               .saveTitle({ messages: updatedMessages })
               .pipe(
@@ -179,7 +182,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
           );
         }
 
-        Effect.runFork(
+        runFork(
           store
             .saveAssistant({
               context: page.nina,
@@ -221,6 +224,9 @@ const runNinaWriterTurn = Effect.fn("nina.stream.writer")(function* ({
   readonly user: NinaTurn["user"];
   readonly writer: UIMessageStreamWriter<MyUIMessage>;
 }) {
+  const effectRuntime = yield* Effect.runtime();
+  const runPromise = Runtime.runPromise(effectRuntime);
+  const runSync = Runtime.runSync(effectRuntime);
   const usage = yield* trackUsage();
   const context = createNinaAgentContext({ page, runtime, user });
   const pageFetch = createPageFetchState(context.needsPageFetch);
@@ -242,7 +248,7 @@ const runNinaWriterTurn = Effect.fn("nina.stream.writer")(function* ({
     runtime,
     settings: {
       repairToolCall: (options) =>
-        Effect.runPromise(
+        runPromise(
           repairNinaToolCall({
             ...options,
             reporter,
@@ -262,7 +268,7 @@ const runNinaWriterTurn = Effect.fn("nina.stream.writer")(function* ({
         }),
       onError: onStreamError,
       readFinishMetadata: (mainUsage) =>
-        Effect.runSync(
+        runSync(
           usage.metadata({
             mainUsage,
             modelId: runtime.modelId,

--- a/packages/backend/convex/audioStudies/contentAudios/impl.ts
+++ b/packages/backend/convex/audioStudies/contentAudios/impl.ts
@@ -84,12 +84,10 @@ const requireContentAudio = Effect.fn(
     return audio;
   }
 
-  return yield* Effect.fail(
-    new ContentAudioNotFoundError({
-      code: contentAudioNotFoundCode,
-      message: "Content audio record not found.",
-    })
-  );
+  return yield* new ContentAudioNotFoundError({
+    code: contentAudioNotFoundCode,
+    message: "Content audio record not found.",
+  });
 });
 
 /** Loads canonical rows for one content reference and locale. */
@@ -111,12 +109,10 @@ const loadContentAudioRecords = Effect.fn(
     return records;
   }
 
-  return yield* Effect.fail(
-    new ContentAudioDuplicateLimitExceededError({
-      code: contentAudioDuplicateLimitExceededCode,
-      message: "Content audio duplicate limit exceeded.",
-    })
-  );
+  return yield* new ContentAudioDuplicateLimitExceededError({
+    code: contentAudioDuplicateLimitExceededCode,
+    message: "Content audio duplicate limit exceeded.",
+  });
 });
 
 /** Keeps the earliest content-audio row and deletes duplicate rows. */
@@ -126,12 +122,10 @@ const collapseDuplicateContentAudioRecords = Effect.fn(
   const [keeper, ...duplicates] = records;
 
   if (!keeper) {
-    return yield* Effect.fail(
-      new ContentAudioNotFoundError({
-        code: contentAudioNotFoundCode,
-        message: "Content audio record not found.",
-      })
-    );
+    return yield* new ContentAudioNotFoundError({
+      code: contentAudioNotFoundCode,
+      message: "Content audio record not found.",
+    });
   }
 
   for (const duplicate of duplicates) {

--- a/packages/backend/convex/audioStudies/generation/impl.ts
+++ b/packages/backend/convex/audioStudies/generation/impl.ts
@@ -104,12 +104,10 @@ const verifyContentHash = Effect.fn(
     })
   );
 
-  return yield* Effect.fail(
-    new AudioContentChangedError({
-      code: audioContentChangedCode,
-      message: input.errorMessage,
-    })
-  );
+  return yield* new AudioContentChangedError({
+    code: audioContentChangedCode,
+    message: input.errorMessage,
+  });
 });
 
 /** Runs the provider and persistence steps after script generation is claimed. */
@@ -126,12 +124,10 @@ const runClaimedScriptGeneration = Effect.fn(
   });
 
   if (!data) {
-    return yield* Effect.fail(
-      new AudioSourceNotFoundError({
-        code: audioSourceNotFoundCode,
-        message: "Audio or content not found",
-      })
-    );
+    return yield* new AudioSourceNotFoundError({
+      code: audioSourceNotFoundCode,
+      message: "Audio or content not found",
+    });
   }
 
   yield* verifyContentHash(store, {
@@ -233,12 +229,10 @@ const runClaimedSpeechGeneration = Effect.fn(
   });
 
   if (!audio) {
-    return yield* Effect.fail(
-      new AudioSourceNotFoundError({
-        code: audioSourceNotFoundCode,
-        message: "No script found for audio generation",
-      })
-    );
+    return yield* new AudioSourceNotFoundError({
+      code: audioSourceNotFoundCode,
+      message: "No script found for audio generation",
+    });
   }
 
   yield* verifyContentHash(store, {
@@ -252,12 +246,10 @@ const runClaimedSpeechGeneration = Effect.fn(
   const chunks = chunkScript(audio.script, DEFAULT_CHUNK_CONFIG);
 
   if (chunks.length === 0) {
-    return yield* Effect.fail(
-      new AudioScriptEmptyError({
-        code: audioScriptEmptyCode,
-        message: "Script chunking returned no content for speech generation.",
-      })
-    );
+    return yield* new AudioScriptEmptyError({
+      code: audioScriptEmptyCode,
+      message: "Script chunking returned no content for speech generation.",
+    });
   }
 
   yield* Effect.sync(() =>

--- a/packages/backend/convex/auth/username/availability.ts
+++ b/packages/backend/convex/auth/username/availability.ts
@@ -53,12 +53,10 @@ export const resolveUniqueGeneratedUsername = Effect.fn(
     }
   }
 
-  return yield* Effect.fail(
-    new GeneratedUsernameExhaustedError({
-      message: "Unable to create a unique generated username",
-      username: input.username,
-    })
-  );
+  return yield* new GeneratedUsernameExhaustedError({
+    message: "Unable to create a unique generated username",
+    username: input.username,
+  });
 });
 
 /**

--- a/packages/backend/convex/contentRelease/ingress/call.ts
+++ b/packages/backend/convex/contentRelease/ingress/call.ts
@@ -23,10 +23,10 @@ function decodeExpectedFailure(cause: unknown) {
 
 /** Invokes one internal Convex capability without sanitizing unknown defects. */
 export function callInternal<A>(invoke: () => Promise<A>) {
-  return Effect.tryPromise({ catch: (cause) => cause, try: invoke }).pipe(
-    Effect.catchAll((cause) => {
-      const expected = decodeExpectedFailure(cause);
-      return expected ? Effect.fail(expected) : Effect.die(cause);
+  return Effect.tryPromise(invoke).pipe(
+    Effect.catchTag("UnknownException", ({ error }) => {
+      const expected = decodeExpectedFailure(error);
+      return expected ? Effect.fail(expected) : Effect.die(error);
     })
   );
 }

--- a/packages/backend/convex/contents/analytics/impl.ts
+++ b/packages/backend/convex/contents/analytics/impl.ts
@@ -88,12 +88,10 @@ export const claimContentAnalyticsPartition = Effect.fn(
   processPartition: ProcessContentAnalyticsPartitionReference
 ) {
   if (!isContentAnalyticsPartition(args.partition)) {
-    return yield* Effect.fail(
-      new InvalidContentAnalyticsPartitionError({
-        code: invalidContentAnalyticsPartitionCode,
-        message: "Content analytics partition is out of range.",
-      })
-    );
+    return yield* new InvalidContentAnalyticsPartitionError({
+      code: invalidContentAnalyticsPartitionCode,
+      message: "Content analytics partition is out of range.",
+    });
   }
 
   const queuedItem = yield* Effect.tryPromise({
@@ -184,12 +182,10 @@ export const processClaimedContentAnalyticsPartition = Effect.fn(
   processPartition: ProcessContentAnalyticsPartitionReference
 ) {
   if (!isContentAnalyticsPartition(args.partition)) {
-    return yield* Effect.fail(
-      new InvalidContentAnalyticsPartitionError({
-        code: invalidContentAnalyticsPartitionCode,
-        message: "Content analytics partition is out of range.",
-      })
-    );
+    return yield* new InvalidContentAnalyticsPartitionError({
+      code: invalidContentAnalyticsPartitionCode,
+      message: "Content analytics partition is out of range.",
+    });
   }
 
   const now = yield* Clock.currentTimeMillis;

--- a/packages/backend/convex/contents/sitemap/impl.ts
+++ b/packages/backend/convex/contents/sitemap/impl.ts
@@ -181,12 +181,10 @@ export const getPublicSitemapPageImpl = Effect.fn(
   "contents.publicSitemap.getPage"
 )(function* (ctx: QueryCtx, args: GetPublicSitemapPageArgs) {
   if (!Number.isSafeInteger(args.page) || args.page < 0) {
-    return yield* Effect.fail(
-      new SitemapRuntimeError({
-        code: "PUBLIC_SITEMAP_PAGE_INVALID",
-        message: "Public sitemap page must be a non-negative integer.",
-      })
-    );
+    return yield* new SitemapRuntimeError({
+      code: "PUBLIC_SITEMAP_PAGE_INVALID",
+      message: "Public sitemap page must be a non-negative integer.",
+    });
   }
 
   const count = yield* Effect.promise(() =>
@@ -239,12 +237,10 @@ export const getPublicSitemapPageImpl = Effect.fn(
   );
 
   if (page.paths.length !== expectedPathCount) {
-    return yield* Effect.fail(
-      new SitemapRuntimeError({
-        code: "PUBLIC_SITEMAP_PAGE_OVERFLOW",
-        message: `Public sitemap page ${args.locale}/${args.page} has an invalid path count.`,
-      })
-    );
+    return yield* new SitemapRuntimeError({
+      code: "PUBLIC_SITEMAP_PAGE_OVERFLOW",
+      message: `Public sitemap page ${args.locale}/${args.page} has an invalid path count.`,
+    });
   }
 
   const pathsAreSorted = page.paths.every((path, index) => {

--- a/packages/backend/convex/customers/checkout/impl.ts
+++ b/packages/backend/convex/customers/checkout/impl.ts
@@ -30,10 +30,8 @@ export const validateCheckoutRequest = Effect.fn(
   });
 
   if (successUrl.origin !== siteOrigin) {
-    return yield* Effect.fail(
-      invalidSuccessUrl(
-        "Checkout success URL must stay on the primary site origin."
-      )
+    return yield* invalidSuccessUrl(
+      "Checkout success URL must stay on the primary site origin."
     );
   }
 

--- a/packages/backend/convex/customers/polar/impl.ts
+++ b/packages/backend/convex/customers/polar/impl.ts
@@ -38,12 +38,10 @@ export const normalizeStoredCustomer: (
   "customers.polar.normalizeStoredCustomer"
 )(function* (customer: PolarCustomerSource) {
   if (typeof customer.email !== "string") {
-    return yield* Effect.fail(
-      new PolarCustomerError({
-        code: polarCustomerErrorCode,
-        message: `Polar customer ${customer.id} is missing a valid email address.`,
-      })
-    );
+    return yield* new PolarCustomerError({
+      code: polarCustomerErrorCode,
+      message: `Polar customer ${customer.id} is missing a valid email address.`,
+    });
   }
 
   return {
@@ -74,15 +72,13 @@ export const syncExistingCustomer: (
     storedCustomer.externalId !== null &&
     storedCustomer.externalId !== input.externalId
   ) {
-    return yield* Effect.fail(
-      new PolarCustomerEmailConflict({
-        code: polarCustomerEmailConflictCode,
-        existingExternalId: storedCustomer.externalId,
-        message:
-          "This email is already linked to a different Polar customer identity.",
-        polarCustomerId: storedCustomer.id,
-      })
-    );
+    return yield* new PolarCustomerEmailConflict({
+      code: polarCustomerEmailConflictCode,
+      existingExternalId: storedCustomer.externalId,
+      message:
+        "This email is already linked to a different Polar customer identity.",
+      polarCustomerId: storedCustomer.id,
+    });
   }
 
   const currentMetadata = JSON.stringify(storedCustomer.metadata);
@@ -173,10 +169,8 @@ export const ensureCustomer: (
     return yield* syncExistingCustomer(gateway, racedCustomer, input);
   }
 
-  return yield* Effect.fail(
-    new PolarCustomerError({
-      code: polarCustomerErrorCode,
-      message: createAttempt.left.message,
-    })
-  );
+  return yield* new PolarCustomerError({
+    code: polarCustomerErrorCode,
+    message: createAttempt.left.message,
+  });
 });

--- a/packages/backend/convex/customers/polar/live.ts
+++ b/packages/backend/convex/customers/polar/live.ts
@@ -153,15 +153,13 @@ export const polarGateway: PolarCustomerGateway = {
     ),
 
   deleteCustomer: (polarCustomerId) =>
-    Effect.tryPromise({
-      try: () =>
-        customersDelete(polarClient, {
-          anonymize: true,
-          id: polarCustomerId,
-        }),
-      catch: (error) => error,
-    }).pipe(
-      Effect.catchAll((error) => {
+    Effect.tryPromise(() =>
+      customersDelete(polarClient, {
+        anonymize: true,
+        id: polarCustomerId,
+      })
+    ).pipe(
+      Effect.catchTag("UnknownException", ({ error }) => {
         if (isMissingPolarCustomer(error)) {
           return Effect.succeed(null);
         }
@@ -219,14 +217,12 @@ export const polarGateway: PolarCustomerGateway = {
     ),
 
   getCustomerByExternalId: (externalId) =>
-    Effect.tryPromise({
-      try: () =>
-        customersGetExternal(polarClient, {
-          externalId,
-        }),
-      catch: (error) => error,
-    }).pipe(
-      Effect.catchAll((error) => {
+    Effect.tryPromise(() =>
+      customersGetExternal(polarClient, {
+        externalId,
+      })
+    ).pipe(
+      Effect.catchTag("UnknownException", ({ error }) => {
         if (isMissingPolarCustomer(error)) {
           return Effect.succeed(null);
         }
@@ -261,14 +257,12 @@ export const polarGateway: PolarCustomerGateway = {
     ),
 
   getCustomerById: (polarCustomerId) =>
-    Effect.tryPromise({
-      try: () =>
-        customersGet(polarClient, {
-          id: polarCustomerId,
-        }),
-      catch: (error) => error,
-    }).pipe(
-      Effect.catchAll((error) => {
+    Effect.tryPromise(() =>
+      customersGet(polarClient, {
+        id: polarCustomerId,
+      })
+    ).pipe(
+      Effect.catchTag("UnknownException", ({ error }) => {
         if (isMissingPolarCustomer(error)) {
           return Effect.succeed(null);
         }

--- a/packages/backend/convex/customers/sync/impl.ts
+++ b/packages/backend/convex/customers/sync/impl.ts
@@ -186,12 +186,10 @@ export const requireCustomer: (
   const [user, localCustomer] = yield* loadCustomerSyncState(ctx, userId);
 
   if (!user) {
-    return yield* Effect.fail(
-      new UserNotFound({
-        code: userNotFoundCode,
-        message: `User not found for userId: ${userId}`,
-      })
-    );
+    return yield* new UserNotFound({
+      code: userNotFoundCode,
+      message: `User not found for userId: ${userId}`,
+    });
   }
 
   return yield* syncCustomerForUser(ctx, {

--- a/packages/backend/scripts/lib/mdx-parser/content.ts
+++ b/packages/backend/scripts/lib/mdx-parser/content.ts
@@ -36,11 +36,9 @@ export const parseDateToEpoch = Effect.fn("mdx.parseDateToEpoch")(function* (
   const date = parseContentDate(dateStr);
 
   if (Option.isNone(date)) {
-    return yield* Effect.fail(
-      new MdxReadError({
-        message: `Invalid date format: ${dateStr}. Expected YYYY-MM-DD`,
-      })
-    );
+    return yield* new MdxReadError({
+      message: `Invalid date format: ${dateStr}. Expected YYYY-MM-DD`,
+    });
   }
 
   return date.value.getTime();
@@ -53,9 +51,9 @@ export const parseMdxContent = Effect.fn("mdx.parseMdxContent")(function* (
   const match = content.match(METADATA_REGEX);
 
   if (!match) {
-    return yield* Effect.fail(
-      new MdxReadError({ message: "No metadata export found in MDX file" })
-    );
+    return yield* new MdxReadError({
+      message: "No metadata export found in MDX file",
+    });
   }
 
   const metadataObject = yield* Effect.try({

--- a/packages/backend/scripts/lib/mdx-parser/paths.ts
+++ b/packages/backend/scripts/lib/mdx-parser/paths.ts
@@ -20,11 +20,9 @@ export const parseArticlePath = Effect.fn("mdx.parseArticlePath")(function* (
   const match = normalized.match(ARTICLE_PATH_REGEX);
 
   if (!match) {
-    return yield* Effect.fail(
-      new MdxPathValidationError({
-        message: `Invalid article path: ${filePath}`,
-      })
-    );
+    return yield* new MdxPathValidationError({
+      message: `Invalid article path: ${filePath}`,
+    });
   }
 
   const [, rawCategory, articleSlug, rawLocale] = match;
@@ -50,11 +48,9 @@ export const parseMaterialLessonPath = Effect.fn("mdx.parseMaterialLessonPath")(
     const match = normalized.match(MATERIAL_LESSON_PATH_REGEX);
 
     if (!match) {
-      return yield* Effect.fail(
-        new MdxPathValidationError({
-          message: `Invalid material lesson path: ${filePath}`,
-        })
-      );
+      return yield* new MdxPathValidationError({
+        message: `Invalid material lesson path: ${filePath}`,
+      });
     }
 
     const [, rawMaterial, topic, section, rawLocale] = match;

--- a/packages/backend/scripts/sync-content/cli/command.test.ts
+++ b/packages/backend/scripts/sync-content/cli/command.test.ts
@@ -1,5 +1,6 @@
 import { NAKAFA_CONTENT_SECTIONS } from "@repo/backend/convex/contents/constants";
 import type { NakafaSection } from "@repo/backend/convex/lib/validators/contents";
+import { ScriptFailureError } from "@repo/backend/scripts/lib/errors";
 import type {
   ConvexConfig,
   SyncOptions,
@@ -74,7 +75,9 @@ const loadCli = async (options: CliTestOptions = {}) => {
       events.push("syncLearningPrograms");
 
       if (options.learningProgramFails) {
-        return Effect.fail(new Error("learning program sync failed"));
+        return Effect.fail(
+          new ScriptFailureError({ message: "learning program sync failed" })
+        );
       }
 
       return Effect.succeed(syncResult);
@@ -150,9 +153,10 @@ const loadCli = async (options: CliTestOptions = {}) => {
       }
 
       return Effect.fail(
-        new Error(
-          "Incremental sync does not support --locale because sync state is shared across locales"
-        )
+        new ScriptFailureError({
+          message:
+            "Incremental sync does not support --locale because sync state is shared across locales",
+        })
       );
     },
   }));

--- a/packages/backend/scripts/sync-content/cli/command.ts
+++ b/packages/backend/scripts/sync-content/cli/command.ts
@@ -48,11 +48,9 @@ export const parseSyncArgs = Effect.fn("sync.parseArgs")(function* (
       const locale = locales.find((candidate) => candidate === localeArgument);
 
       if (!locale) {
-        return yield* Effect.fail(
-          new ScriptFailureError({
-            message: `Invalid locale: ${localeArgument ?? "missing"}`,
-          })
-        );
+        return yield* new ScriptFailureError({
+          message: `Invalid locale: ${localeArgument ?? "missing"}`,
+        });
       }
 
       options.locale = locale;
@@ -280,9 +278,9 @@ export const runCommand = Effect.fn("sync.runCommand")(function* (
     default:
       logError(`Unknown command: ${type}`);
       printUsage();
-      return yield* Effect.fail(
-        new ScriptFailureError({ message: `Unknown command: ${type}` })
-      );
+      return yield* new ScriptFailureError({
+        message: `Unknown command: ${type}`,
+      });
   }
 });
 

--- a/packages/backend/scripts/sync-content/content/curriculum.ts
+++ b/packages/backend/scripts/sync-content/content/curriculum.ts
@@ -225,20 +225,16 @@ export const syncCurriculumLessons = Effect.fn("sync.curriculumLessons")(
               return null;
             }
 
-            return yield* Effect.fail(
-              new ScriptFailureError({
-                message: `Missing curriculum lesson order for ${pathInfo.locale}:${pathInfo.slug}. Add this section to the typed Material source before syncing the mapped curriculum topic.`,
-              })
-            );
+            return yield* new ScriptFailureError({
+              message: `Missing curriculum lesson order for ${pathInfo.locale}:${pathInfo.slug}. Add this section to the typed Material source before syncing the mapped curriculum topic.`,
+            });
           }
 
           const { metadata, body } = yield* readMdxFile(file);
           if (sectionOrder.topic !== pathInfo.topic) {
-            return yield* Effect.fail(
-              new ScriptFailureError({
-                message: `Material lesson order for ${pathInfo.locale}:${pathInfo.slug} points at ${sectionOrder.topic}, expected ${pathInfo.topic}.`,
-              })
-            );
+            return yield* new ScriptFailureError({
+              message: `Material lesson order for ${pathInfo.locale}:${pathInfo.slug} points at ${sectionOrder.topic}, expected ${pathInfo.topic}.`,
+            });
           }
 
           const date = yield* parseDateToEpoch(metadata.date);
@@ -398,11 +394,9 @@ const readCurriculumLessonPlacementIndex = Effect.fn(
       const key = `${topic.locale}:${section.slug}`;
 
       if (orderBySlug.has(key)) {
-        return yield* Effect.fail(
-          new ScriptFailureError({
-            message: `Duplicate curriculum lesson material order for ${key}.`,
-          })
-        );
+        return yield* new ScriptFailureError({
+          message: `Duplicate curriculum lesson material order for ${key}.`,
+        });
       }
 
       orderBySlug.set(key, {

--- a/packages/backend/scripts/sync-content/content/programs.ts
+++ b/packages/backend/scripts/sync-content/content/programs.ts
@@ -207,11 +207,9 @@ function assertCoverageAlignments() {
       return;
     }
 
-    return yield* Effect.fail(
-      new LearningProgramCoverageAlignmentError({
-        message: `Invalid learning program coverage alignment: ${issues[0]}`,
-      })
-    );
+    return yield* new LearningProgramCoverageAlignmentError({
+      message: `Invalid learning program coverage alignment: ${issues[0]}`,
+    });
   });
 }
 

--- a/packages/backend/scripts/sync-content/content/tryout/route.ts
+++ b/packages/backend/scripts/sync-content/content/tryout/route.ts
@@ -32,11 +32,9 @@ export const addTryoutCountry = Effect.fn("sync.addTryoutCountry")(function* (
       return;
     }
 
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Conflicting shared try-out country: ${row.locale}:${row.countryKey}.`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Conflicting shared try-out country: ${row.locale}:${row.countryKey}.`,
+    });
   }
 
   countries.set(identity, row);
@@ -51,11 +49,9 @@ export const addTryoutRoute = Effect.fn("sync.addTryoutRoute")(function* (
   const identity = JSON.stringify([source.locale, source.publicPath]);
 
   if (routes.has(identity)) {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Duplicate try-out route: ${source.locale}:${source.publicPath}.`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Duplicate try-out route: ${source.locale}:${source.publicPath}.`,
+    });
   }
 
   const sourcePath = source.publicPath;

--- a/packages/backend/scripts/sync-content/content/tryouts.ts
+++ b/packages/backend/scripts/sync-content/content/tryouts.ts
@@ -338,11 +338,9 @@ const readSectionQuestions = Effect.fn("sync.readSectionQuestions")(
         logError(error);
       }
 
-      return yield* Effect.fail(
-        new ScriptFailureError({
-          message: `Failed to parse ${errors.length} try-out question source(s).`,
-        })
-      );
+      return yield* new ScriptFailureError({
+        message: `Failed to parse ${errors.length} try-out question source(s).`,
+      });
     }
 
     return questions;
@@ -373,11 +371,9 @@ const readQuestion = Effect.fn("sync.readQuestion")(function* (
   ]);
 
   if (!choices) {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Missing or invalid choices.ts for ${questionSourcePath}.`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Missing or invalid choices.ts for ${questionSourcePath}.`,
+    });
   }
 
   const localeChoices = choices[source.locale];

--- a/packages/backend/scripts/sync-content/content/validate.ts
+++ b/packages/backend/scripts/sync-content/content/validate.ts
@@ -126,11 +126,9 @@ const validateTryoutQuestions = Effect.fn("sync.validateTryoutQuestions")(
           const choices = yield* readQuestionChoices(path.dirname(file));
 
           if (!choices) {
-            return yield* Effect.fail(
-              new ScriptFailureError({
-                message: `Missing or invalid try-out choices for ${file}. Add exactly one correct option for every supported locale in choices.ts.`,
-              })
-            );
+            return yield* new ScriptFailureError({
+              message: `Missing or invalid try-out choices for ${file}. Add exactly one correct option for every supported locale in choices.ts.`,
+            });
           }
         })
       );
@@ -291,7 +289,7 @@ export const validate = Effect.fn("sync.validate")(function* () {
   if (allErrors.length > 20) {
     log(`... and ${allErrors.length - 20} more errors`);
   }
-  return yield* Effect.fail(
-    new ScriptFailureError({ message: "Content validation failed." })
-  );
+  return yield* new ScriptFailureError({
+    message: "Content validation failed.",
+  });
 });

--- a/packages/backend/scripts/sync-content/convex/client.ts
+++ b/packages/backend/scripts/sync-content/convex/client.ts
@@ -99,11 +99,9 @@ const parseConvexResponse = <A, I>(
     );
 
     if (response.status === "error") {
-      return yield* Effect.fail(
-        new ConvexResponseError({
-          message: `${functionPath}: ${response.errorMessage || "Unknown Convex error"}`,
-        })
-      );
+      return yield* new ConvexResponseError({
+        message: `${functionPath}: ${response.errorMessage || "Unknown Convex error"}`,
+      });
     }
 
     return yield* Schema.decodeUnknown(valueSchema)(response.value).pipe(
@@ -180,11 +178,9 @@ const callConvexFunction = Effect.fn("scripts.callConvexFunction")(function* <
 
   if (!response.ok) {
     const body = yield* readFailedResponseBody(response);
-    return yield* Effect.fail(
-      new ConvexRequestError({
-        message: `${functionPath}: HTTP ${response.status} ${body}`,
-      })
-    );
+    return yield* new ConvexRequestError({
+      message: `${functionPath}: HTTP ${response.status} ${body}`,
+    });
   }
 
   const json = yield* Effect.tryPromise({
@@ -237,11 +233,9 @@ export const getConvexConfig = Effect.fn("scripts.getConvexConfig")(function* (
   );
 
   if (!parsed.accessToken) {
-    return yield* Effect.fail(
-      new ConvexAuthError({
-        message: "No access token. Run: npx convex dev",
-      })
-    );
+    return yield* new ConvexAuthError({
+      message: "No access token. Run: npx convex dev",
+    });
   }
 
   if (options.prod) {

--- a/packages/backend/scripts/sync-content/convex/counts.ts
+++ b/packages/backend/scripts/sync-content/convex/counts.ts
@@ -55,7 +55,7 @@ export const getContentCounts = Effect.fn("sync.getContentCounts")(function* (
     ]);
   }
 
-  return Schema.decodeUnknownSync(ContentCountsSchema)(
+  return yield* Schema.decodeUnknown(ContentCountsSchema)(
     Object.fromEntries(entries)
   );
 });

--- a/packages/backend/scripts/sync-content/convex/inspection.ts
+++ b/packages/backend/scripts/sync-content/convex/inspection.ts
@@ -292,7 +292,7 @@ export const getStaleContent = Effect.fn("sync.getStaleContent")(function* (
     ),
   ]);
 
-  return Schema.decodeUnknownSync(StaleContentSchema)({
+  return yield* Schema.decodeUnknown(StaleContentSchema)({
     staleArticles: articles.filter(
       (item) => !articleSlugSet.has(item.sourcePath)
     ),
@@ -395,7 +395,7 @@ export const getDataIntegrity = Effect.fn("sync.getDataIntegrity")(function* (
     references.map((reference) => reference.articleId)
   );
 
-  return Schema.decodeUnknownSync(DataIntegritySchema)({
+  return yield* Schema.decodeUnknown(DataIntegritySchema)({
     orphanQuestionChoiceIds: Array.from(
       new Set(
         choices
@@ -447,7 +447,7 @@ export const getGraphIdentityIntegrity = Effect.fn(
     );
   }
 
-  return Schema.decodeUnknownSync(GraphIdentityIntegritySchema)(total);
+  return yield* Schema.decodeUnknown(GraphIdentityIntegritySchema)(total);
 });
 
 /** Returns authors that have no content-author links after sync. */
@@ -472,7 +472,7 @@ export const getUnusedAuthors = Effect.fn("sync.getUnusedAuthors")(function* (
     contentAuthors.map((authorLink) => authorLink.authorId)
   );
 
-  return Schema.decodeUnknownSync(UnusedAuthorsSchema)({
+  return yield* Schema.decodeUnknown(UnusedAuthorsSchema)({
     unusedAuthors: authors.filter(
       (author) => !authorIdsWithContent.has(author.id)
     ),

--- a/packages/backend/scripts/sync-content/routes/public.ts
+++ b/packages/backend/scripts/sync-content/routes/public.ts
@@ -18,11 +18,9 @@ export const readPublicContentRoute = Effect.fn("sync.readPublicContentRoute")(
       return routeOption.value;
     }
 
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Missing public route projection for ${locale}:${sourcePath}.`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Missing public route projection for ${locale}:${sourcePath}.`,
+    });
   }
 );
 

--- a/packages/backend/scripts/sync-content/routes/rows.ts
+++ b/packages/backend/scripts/sync-content/routes/rows.ts
@@ -57,11 +57,9 @@ export const buildPublicRouteProjection = Effect.fn(
     const identity = getRouteIdentity(values);
 
     if (identities.has(identity)) {
-      return yield* Effect.fail(
-        new PublicRouteProjectionError({
-          message: `Duplicate public route identity: ${identity}.`,
-        })
-      );
+      return yield* new PublicRouteProjectionError({
+        message: `Duplicate public route identity: ${identity}.`,
+      });
     }
 
     identities.add(identity);
@@ -78,22 +76,18 @@ export const buildPublicRouteProjection = Effect.fn(
         values.materialContextPublicPath
       )
     ) {
-      return yield* Effect.fail(
-        new PublicRouteProjectionError({
-          message: `Incomplete material context ownership: ${identity}.`,
-        })
-      );
+      return yield* new PublicRouteProjectionError({
+        message: `Incomplete material context ownership: ${identity}.`,
+      });
     }
 
     if (
       materialContextIdentity &&
       materialContextIdentities.has(materialContextIdentity)
     ) {
-      return yield* Effect.fail(
-        new PublicRouteProjectionError({
-          message: `Duplicate material context identity: ${materialContextIdentity}.`,
-        })
-      );
+      return yield* new PublicRouteProjectionError({
+        message: `Duplicate material context identity: ${materialContextIdentity}.`,
+      });
     }
 
     if (materialContextIdentity) {

--- a/packages/backend/scripts/sync-content/routes/sitemap.ts
+++ b/packages/backend/scripts/sync-content/routes/sitemap.ts
@@ -125,11 +125,9 @@ export const buildPublicSitemapArtifacts = Effect.fn(
       const pagePaths = paths.slice(offset, offset + PUBLIC_SITEMAP_PAGE_SIZE);
 
       if (pagePaths.length === 0) {
-        return yield* Effect.fail(
-          new PublicSitemapProjectionError({
-            message: `Public sitemap page ${locale}/${pages.length} has no paths.`,
-          })
-        );
+        return yield* new PublicSitemapProjectionError({
+          message: `Public sitemap page ${locale}/${pages.length} has no paths.`,
+        });
       }
 
       pages.push({

--- a/packages/backend/scripts/sync-content/routes/sync.ts
+++ b/packages/backend/scripts/sync-content/routes/sync.ts
@@ -175,11 +175,9 @@ const buildShardBatches = Effect.fn("sync.buildPublicRouteShardBatches")(
 
     for (const shard of shards) {
       if (shard.routes.length > CONTENT_SYNC_BATCH_LIMITS.publicRouteRows) {
-        return yield* Effect.fail(
-          new PublicRouteShardOverflowError({
-            message: `Public route shard ${shard.shard} has ${shard.routes.length} rows; limit is ${CONTENT_SYNC_BATCH_LIMITS.publicRouteRows}.`,
-          })
-        );
+        return yield* new PublicRouteShardOverflowError({
+          message: `Public route shard ${shard.shard} has ${shard.routes.length} rows; limit is ${CONTENT_SYNC_BATCH_LIMITS.publicRouteRows}.`,
+        });
       }
 
       const exceedsRows =

--- a/packages/backend/scripts/sync-content/runtime/cache.ts
+++ b/packages/backend/scripts/sync-content/runtime/cache.ts
@@ -85,11 +85,9 @@ export const invalidateContentRuntimeCache = Effect.fn(
   const endpoint = getContentRuntimeCacheRevalidationUrl(siteUrl);
 
   if (!endpoint) {
-    return yield* Effect.fail(
-      new ContentRuntimeCacheConfigError({
-        message: `SITE_URL must be a valid URL: ${siteUrl}`,
-      })
-    );
+    return yield* new ContentRuntimeCacheConfigError({
+      message: `SITE_URL must be a valid URL: ${siteUrl}`,
+    });
   }
 
   const response = yield* Effect.either(
@@ -117,7 +115,7 @@ export const invalidateContentRuntimeCache = Effect.fn(
       return;
     }
 
-    return yield* Effect.fail(response.left);
+    return yield* response.left;
   }
 
   if (response.right.ok) {
@@ -136,9 +134,7 @@ export const invalidateContentRuntimeCache = Effect.fn(
   );
   const responseBody = body._tag === "Right" ? body.right : "";
 
-  return yield* Effect.fail(
-    new ContentRuntimeCacheInvalidationError({
-      message: `Content runtime cache invalidation failed with ${response.right.status}: ${responseBody}`,
-    })
-  );
+  return yield* new ContentRuntimeCacheInvalidationError({
+    message: `Content runtime cache invalidation failed with ${response.right.status}: ${responseBody}`,
+  });
 });

--- a/packages/backend/scripts/sync-content/verify/sync.ts
+++ b/packages/backend/scripts/sync-content/verify/sync.ts
@@ -168,11 +168,9 @@ export const verify = Effect.fn("sync.verify")(function* (
 
   const countsResult = yield* Effect.either(getContentCounts(config));
   if (countsResult._tag === "Left") {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Failed to query database: ${getUnknownMessage(countsResult.left)}`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Failed to query database: ${getUnknownMessage(countsResult.left)}`,
+    });
   }
 
   const counts = countsResult.right;
@@ -301,11 +299,9 @@ export const verify = Effect.fn("sync.verify")(function* (
   log("\n=== DATA INTEGRITY ===\n");
   const integrityResult = yield* Effect.either(getDataIntegrity(config));
   if (integrityResult._tag === "Left") {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Failed to query database: ${getUnknownMessage(integrityResult.left)}`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Failed to query database: ${getUnknownMessage(integrityResult.left)}`,
+    });
   }
 
   const integrity = integrityResult.right;
@@ -352,11 +348,9 @@ export const verify = Effect.fn("sync.verify")(function* (
     verifyGraphIdentity(config, options)
   );
   if (graphIdentityResult._tag === "Left") {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Failed to verify graph identity: ${getUnknownMessage(graphIdentityResult.left)}`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Failed to verify graph identity: ${getUnknownMessage(graphIdentityResult.left)}`,
+    });
   }
 
   allMatch = graphIdentityResult.right && allMatch;
@@ -366,11 +360,9 @@ export const verify = Effect.fn("sync.verify")(function* (
     verifyQuranRuntime(config, options)
   );
   if (quranRuntimeResult._tag === "Left") {
-    return yield* Effect.fail(
-      new ScriptFailureError({
-        message: `Failed to verify Quran runtime: ${getUnknownMessage(quranRuntimeResult.left)}`,
-      })
-    );
+    return yield* new ScriptFailureError({
+      message: `Failed to verify Quran runtime: ${getUnknownMessage(quranRuntimeResult.left)}`,
+    });
   }
   allMatch = quranRuntimeResult.right && allMatch;
 
@@ -386,7 +378,7 @@ export const verify = Effect.fn("sync.verify")(function* (
   } else {
     log("\nRun 'pnpm --filter @repo/backend sync' to fix");
   }
-  return yield* Effect.fail(
-    new ScriptFailureError({ message: "Content verification failed." })
-  );
+  return yield* new ScriptFailureError({
+    message: "Content verification failed.",
+  });
 });

--- a/packages/backend/scripts/sync-content/workflow/fixture.ts
+++ b/packages/backend/scripts/sync-content/workflow/fixture.ts
@@ -1,5 +1,6 @@
 import { NAKAFA_CONTENT_SECTIONS } from "@repo/backend/convex/contents/constants";
 import type { NakafaSection } from "@repo/backend/convex/lib/validators/contents";
+import { ScriptFailureError } from "@repo/backend/scripts/lib/errors";
 import type {
   ConvexConfig,
   SyncMetrics,
@@ -85,7 +86,11 @@ export async function loadWorkflow(
   vi.doMock("@repo/backend/scripts/sync-content/convex/client", () => ({
     /** Fails if direct incremental-only mutation calls are reached by this workflow test. */
     callConvexMutation: () =>
-      Effect.fail(new Error("Unexpected Convex mutation call.")),
+      Effect.fail(
+        new ScriptFailureError({
+          message: "Unexpected Convex mutation call.",
+        })
+      ),
   }));
   vi.doMock("@repo/backend/scripts/sync-content/cli/logging", () => ({
     /** Suppresses duration formatting noise in workflow tests. */
@@ -192,7 +197,9 @@ export async function loadWorkflow(
     verify: () => {
       events.push("verify");
       if (options.verifyFails) {
-        return Effect.fail(new Error("verify failed"));
+        return Effect.fail(
+          new ScriptFailureError({ message: "verify failed" })
+        );
       }
 
       return Effect.void;

--- a/packages/backend/scripts/sync-content/workflow/full.ts
+++ b/packages/backend/scripts/sync-content/workflow/full.ts
@@ -63,9 +63,7 @@ export const syncFull = Effect.fn("sync.full")(function* (
 
   if (result._tag === "Left") {
     logError(`Full sync failed: ${getUnknownMessage(result.left)}`);
-    return yield* Effect.fail(
-      new ScriptFailureError({ message: "Full sync failed." })
-    );
+    return yield* new ScriptFailureError({ message: "Full sync failed." });
   }
 
   log("\n=== FULL SYNC COMPLETE ===");

--- a/packages/backend/scripts/sync-content/workflow/run.ts
+++ b/packages/backend/scripts/sync-content/workflow/run.ts
@@ -64,12 +64,10 @@ export const validateIncrementalSyncOptions = Effect.fn(
     return;
   }
 
-  return yield* Effect.fail(
-    new ScriptFailureError({
-      message:
-        "Incremental sync does not support --locale because sync state is shared across locales",
-    })
-  );
+  return yield* new ScriptFailureError({
+    message:
+      "Incremental sync does not support --locale because sync state is shared across locales",
+  });
 });
 
 /** Runs the complete content sync in dependency-safe phases. */

--- a/packages/backend/test/quran-snapshot.ts
+++ b/packages/backend/test/quran-snapshot.ts
@@ -24,7 +24,7 @@ import { Effect, Schema } from "effect";
 export const makeQuranSnapshotRow = Effect.fn(
   "backendTest.makeQuranSnapshotRow"
 )(function* (snapshotId: Sha256Hash) {
-  const payload = Schema.decodeUnknownSync(QuranSearchRowSchema)({
+  const payload = yield* Schema.decodeUnknown(QuranSearchRowSchema)({
     description: "Technical Quran search row",
     graph: {
       alignmentId: "alignment:quran:quran-surah:1",

--- a/packages/contents/_lib/fs/folder-scan.test.ts
+++ b/packages/contents/_lib/fs/folder-scan.test.ts
@@ -16,11 +16,7 @@ vi.mock("@repo/contents/_lib/io/content", async () => {
       readDirectory: (
         directoryPath: string,
         options?: { recursive?: boolean }
-      ) =>
-        Effect.try({
-          catch: (cause) => cause,
-          try: () => mockReadDirectory(directoryPath, options),
-        }),
+      ) => Effect.try(() => mockReadDirectory(directoryPath, options)),
     },
   };
 });

--- a/packages/contents/_lib/mdx-slugs/source.ts
+++ b/packages/contents/_lib/mdx-slugs/source.ts
@@ -80,14 +80,12 @@ const validateMdxSlugParity = Effect.fn("contents.mdxSlugs.validateParity")(
         continue;
       }
 
-      return yield* Effect.fail(
-        new MdxLocaleParityError({
-          locale,
-          message: `MDX paths for ${locale} do not match ${defaultLocale}.`,
-          missingSlugs,
-          unexpectedSlugs,
-        })
-      );
+      return yield* new MdxLocaleParityError({
+        locale,
+        message: `MDX paths for ${locale} do not match ${defaultLocale}.`,
+        missingSlugs,
+        unexpectedSlugs,
+      });
     }
   }
 );

--- a/packages/contents/_lib/quran.ts
+++ b/packages/contents/_lib/quran.ts
@@ -25,23 +25,19 @@ function isPositiveInteger(value: number) {
 export function getSurah(id: number): Effect.Effect<Surah, SurahNotFoundError> {
   return Effect.gen(function* () {
     if (!isPositiveInteger(id)) {
-      return yield* Effect.fail(
-        new SurahNotFoundError({
-          message: "Surah number must be a positive integer.",
-          surahNumber: id,
-        })
-      );
+      return yield* new SurahNotFoundError({
+        message: "Surah number must be a positive integer.",
+        surahNumber: id,
+      });
     }
 
     const surah = quran.find((item) => item.number === id);
     const result = Schema.decodeUnknownOption(SurahSchema)(surah);
     if (Option.isNone(result)) {
-      return yield* Effect.fail(
-        new SurahNotFoundError({
-          message: "Surah was not found.",
-          surahNumber: id,
-        })
-      );
+      return yield* new SurahNotFoundError({
+        message: "Surah was not found.",
+        surahNumber: id,
+      });
     }
 
     return result.value;

--- a/packages/contents/_types/curriculum/projection.ts
+++ b/packages/contents/_types/curriculum/projection.ts
@@ -48,7 +48,7 @@ export const projectCurriculumNodes = Effect.fn(
   const result = projectCurricula({ curricula, materials });
 
   if (result.failures.length > 0) {
-    return yield* Effect.fail(toProjectionError(result.failures));
+    return yield* toProjectionError(result.failures);
   }
 
   return result.nodes;

--- a/packages/contents/_types/route/path.ts
+++ b/packages/contents/_types/route/path.ts
@@ -35,13 +35,11 @@ export function lookupNamespaceSegment(
     const segment = readNamespaceSegment(namespace, locale);
 
     if (!segment) {
-      return yield* Effect.fail(
-        new MissingPublicSlugError({
-          locale,
-          source: "route-surface",
-          value: namespace,
-        })
-      );
+      return yield* new MissingPublicSlugError({
+        locale,
+        source: "route-surface",
+        value: namespace,
+      });
     }
 
     return segment;
@@ -68,13 +66,11 @@ export function lookupDomainSlug(
     const slug = readDomainSlug(domains, kind, domain, locale);
 
     if (!slug) {
-      return yield* Effect.fail(
-        new MissingPublicSlugError({
-          locale,
-          source: `${kind}-domain`,
-          value: domain,
-        })
-      );
+      return yield* new MissingPublicSlugError({
+        locale,
+        source: `${kind}-domain`,
+        value: domain,
+      });
     }
 
     return slug;
@@ -183,14 +179,12 @@ export function uniqueRoutes<TRoute extends PublicRoute>(
       const existing = byPath.get(key);
 
       if (existing) {
-        return yield* Effect.fail(
-          new DuplicatePublicRouteError({
-            duplicateKind: route.kind,
-            existingKind: existing.kind,
-            locale: route.locale,
-            publicPath: route.publicPath,
-          })
-        );
+        return yield* new DuplicatePublicRouteError({
+          duplicateKind: route.kind,
+          existingKind: existing.kind,
+          locale: route.locale,
+          publicPath: route.publicPath,
+        });
       }
 
       byPath.set(key, route);

--- a/packages/contents/_types/route/program.ts
+++ b/packages/contents/_types/route/program.ts
@@ -13,13 +13,11 @@ export function findProgram(
     const program = programs.find((candidate) => candidate.key === programKey);
 
     if (!program) {
-      return yield* Effect.fail(
-        new MissingPublicSlugError({
-          locale: "en",
-          source: "program",
-          value: programKey,
-        })
-      );
+      return yield* new MissingPublicSlugError({
+        locale: "en",
+        source: "program",
+        value: programKey,
+      });
     }
 
     return program;

--- a/packages/design-system/components/code-block/copy-button.tsx
+++ b/packages/design-system/components/code-block/copy-button.tsx
@@ -4,6 +4,10 @@ import { Copy01Icon, Tick01Icon } from "@hugeicons/core-free-icons";
 import { captureException } from "@repo/analytics/posthog";
 import { Button } from "@repo/design-system/components/ui/button";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
+import type {
+  CodeClipboardUnavailableError,
+  CodeClipboardWriteError,
+} from "@repo/design-system/lib/code-block/clipboard";
 import { writeCodeToClipboard } from "@repo/design-system/lib/code-block/clipboard";
 import { useCodeBlock } from "@repo/design-system/lib/code-block/context";
 import { cn } from "@repo/design-system/lib/utils";
@@ -50,6 +54,20 @@ export const CodeBlockCopyButton = ({
       return;
     }
 
+    const handleUnavailableError = (error: CodeClipboardUnavailableError) =>
+      Effect.sync(() => {
+        setIsCopied(false);
+        captureException(error, { source: "code-block-copy" });
+        onError?.(error);
+      });
+    const handleWriteError = (error: CodeClipboardWriteError) =>
+      Effect.sync(() => {
+        const cause = error.cause instanceof Error ? error.cause : error;
+
+        setIsCopied(false);
+        captureException(cause, { source: "code-block-copy" });
+        onError?.(cause);
+      });
     const copyProgram = Effect.gen(function* () {
       yield* writeCodeToClipboard(navigator.clipboard, code);
       yield* Effect.sync(() => {
@@ -59,22 +77,10 @@ export const CodeBlockCopyButton = ({
       yield* Effect.sleep(Duration.millis(timeout));
       yield* Effect.sync(() => setIsCopied(false));
     }).pipe(
-      Effect.catchTag("CodeClipboardUnavailableError", (error) =>
-        Effect.sync(() => {
-          setIsCopied(false);
-          captureException(error, { source: "code-block-copy" });
-          onError?.(error);
-        })
-      ),
-      Effect.catchTag("CodeClipboardWriteError", (error) =>
-        Effect.sync(() => {
-          const cause = error.cause instanceof Error ? error.cause : error;
-
-          setIsCopied(false);
-          captureException(cause, { source: "code-block-copy" });
-          onError?.(cause);
-        })
-      )
+      Effect.catchTags({
+        CodeClipboardUnavailableError: handleUnavailableError,
+        CodeClipboardWriteError: handleWriteError,
+      })
     );
     const previousFiber = copyFiberRef.current;
     const nextProgram = previousFiber

--- a/packages/design-system/lib/audio-player/runtime.test.ts
+++ b/packages/design-system/lib/audio-player/runtime.test.ts
@@ -14,7 +14,7 @@ import {
   setAudioPlayerPlaybackRate,
   stabilizeAudioPlayerSnapshot,
 } from "@repo/design-system/lib/audio-player/runtime";
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const TEST_ITEM = {
@@ -195,9 +195,14 @@ describe("audio player commands", () => {
       throw synchronousCause;
     });
 
-    const synchronousError = Effect.runSync(
-      beginAudioPlayerPlayback(synchronous.audio).pipe(Effect.flip)
+    const synchronousResult = Effect.runSync(
+      Effect.either(beginAudioPlayerPlayback(synchronous.audio))
     );
+    expect(Either.isLeft(synchronousResult)).toBe(true);
+    if (Either.isRight(synchronousResult)) {
+      throw new Error("Expected synchronous playback preparation to fail.");
+    }
+    const synchronousError = synchronousResult.left;
     expect(synchronousError).toMatchObject({
       cause: synchronousCause,
       operation: "play",

--- a/packages/design-system/lib/audio-player/runtime.ts
+++ b/packages/design-system/lib/audio-player/runtime.ts
@@ -210,17 +210,19 @@ export const prepareAudioPlayerItem = Effect.fn(
 /** Starts playback once and returns an Effect that awaits that exact request. */
 export const beginAudioPlayerPlayback = Effect.fn(
   "designSystem.audioPlayer.beginPlayback"
-)(function* (audio: HTMLAudioElement) {
-  const playback = yield* Effect.try({
+)((audio: HTMLAudioElement) =>
+  Effect.try({
     try: () => audio.play(),
     catch: (cause) => operationError("play", cause),
-  });
-
-  return Effect.tryPromise({
-    try: () => playback,
-    catch: (cause) => operationError("play", cause),
-  });
-});
+  }).pipe(
+    Effect.map((playback) =>
+      Effect.tryPromise({
+        try: () => playback,
+        catch: (cause) => operationError("play", cause),
+      })
+    )
+  )
+);
 
 /** Pauses the browser media element through the typed error channel. */
 export const pauseAudioPlayer = Effect.fn("designSystem.audioPlayer.pause")(

--- a/packages/design-system/lib/files/download.ts
+++ b/packages/design-system/lib/files/download.ts
@@ -43,22 +43,22 @@ export const downloadFile = Effect.fn("designSystem.files.download")(
 
         return { anchor, objectUrl: URL.createObjectURL(blob) };
       },
-      catch: (cause) => cause,
+      catch: (cause) => downloadError(filename, cause),
     }).pipe(Effect.either);
 
     if (Either.isLeft(preparation)) {
-      return yield* Effect.fail(downloadError(filename, preparation.left));
+      return yield* preparation.left;
     }
 
     const { anchor, objectUrl } = preparation.right;
-    const failures: unknown[] = [];
+    const failures: BrowserFileDownloadError[] = [];
     const attachment = yield* Effect.try({
       try: () => {
         anchor.href = objectUrl;
         anchor.download = filename;
         document.body.append(anchor);
       },
-      catch: (cause) => cause,
+      catch: (cause) => downloadError(filename, cause),
     }).pipe(Effect.either);
 
     if (Either.isLeft(attachment)) {
@@ -66,7 +66,7 @@ export const downloadFile = Effect.fn("designSystem.files.download")(
     } else {
       const activation = yield* Effect.try({
         try: () => anchor.click(),
-        catch: (cause) => cause,
+        catch: (cause) => downloadError(filename, cause),
       }).pipe(Effect.either);
 
       if (Either.isLeft(activation)) {
@@ -76,11 +76,11 @@ export const downloadFile = Effect.fn("designSystem.files.download")(
 
     const anchorCleanup = yield* Effect.try({
       try: () => anchor.remove(),
-      catch: (cause) => cause,
+      catch: (cause) => downloadError(filename, cause),
     }).pipe(Effect.either);
     const objectUrlCleanup = yield* Effect.try({
       try: () => URL.revokeObjectURL(objectUrl),
-      catch: (cause) => cause,
+      catch: (cause) => downloadError(filename, cause),
     }).pipe(Effect.either);
 
     if (Either.isLeft(anchorCleanup)) {
@@ -89,8 +89,9 @@ export const downloadFile = Effect.fn("designSystem.files.download")(
     if (Either.isLeft(objectUrlCleanup)) {
       failures.push(objectUrlCleanup.left);
     }
-    if (failures.length > 0) {
-      return yield* Effect.fail(downloadError(filename, failures[0]));
+    const firstFailure = failures[0];
+    if (firstFailure) {
+      return yield* firstFailure;
     }
   }
 );

--- a/packages/math/errors.ts
+++ b/packages/math/errors.ts
@@ -1,16 +1,18 @@
 import { Schema } from "effect";
 
 /** Raised when the configured CAS endpoint cannot be reached or rejects a call. */
-export class MathCasRequestError extends Schema.TaggedError<MathCasRequestError>(
-  "MathCasRequestError"
-)("MathCasRequestError", {
-  message: Schema.String,
-  status: Schema.optional(Schema.Number),
-}) {}
+export class MathCasRequestError extends Schema.TaggedError<MathCasRequestError>()(
+  "MathCasRequestError",
+  {
+    message: Schema.String,
+    status: Schema.optional(Schema.Number),
+  }
+) {}
 
 /** Raised when the CAS response does not match the shared math contract. */
-export class MathCasResponseError extends Schema.TaggedError<MathCasResponseError>(
-  "MathCasResponseError"
-)("MathCasResponseError", {
-  message: Schema.String,
-}) {}
+export class MathCasResponseError extends Schema.TaggedError<MathCasResponseError>()(
+  "MathCasResponseError",
+  {
+    message: Schema.String,
+  }
+) {}

--- a/packages/math/schema/shared.ts
+++ b/packages/math/schema/shared.ts
@@ -153,9 +153,7 @@ const matrixRowSchema = Schema.Array(valueInputSchema).pipe(
 );
 
 export const matrixSchema = Schema.Array(matrixRowSchema)
-  .pipe(Schema.mutable)
-  .pipe(Schema.minItems(1))
-  .pipe(Schema.mutable)
+  .pipe(Schema.mutable, Schema.minItems(1), Schema.mutable)
   .annotations({
     description:
       "Matrix rows as nested arrays of exact string values, for example [[1, 2], [3, 4]].",

--- a/packages/math/schema/tool/calculus.ts
+++ b/packages/math/schema/tool/calculus.ts
@@ -51,7 +51,6 @@ export const MathCalculusInputSchema = MathCalculusStructSchema.pipe(
   }),
   Schema.filter((value) => hasValidCalculusOrder(value), {
     message: () => "Expected derivative order only for differentiate.",
-  })
-)
-  .pipe(Schema.mutable)
-  .annotations({ description: "Calculus tool input." });
+  }),
+  Schema.mutable
+).annotations({ description: "Calculus tool input." });

--- a/packages/math/schema/tool/equation.ts
+++ b/packages/math/schema/tool/equation.ts
@@ -134,15 +134,13 @@ const MathEquationSystemInputSchema = MathEquationSystemStructSchema.pipe(
   Schema.filter((value) => hasBoundedDomainVariable(value), {
     message: () =>
       "Expected bounded system solves to include the bounded variable in variables.",
-  })
-)
-  .pipe(
-    Schema.filter((value) => hasSolvedVariableInEveryBoundedExpression(value), {
-      message: () =>
-        "Expected every bounded-system expression to include a solved variable.",
-    })
-  )
-  .pipe(Schema.mutable);
+  }),
+  Schema.filter((value) => hasSolvedVariableInEveryBoundedExpression(value), {
+    message: () =>
+      "Expected every bounded-system expression to include a solved variable.",
+  }),
+  Schema.mutable
+);
 
 export const MathEquationInputSchema = Schema.Union(
   MathEquationRootInputSchema,

--- a/packages/math/schema/tool/probability.ts
+++ b/packages/math/schema/tool/probability.ts
@@ -113,9 +113,9 @@ const MathProbabilityDistributionInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({ description: "Named distribution summary input." });
 
 const MathProbabilityMomentInputSchema = Schema.extend(
@@ -140,15 +140,13 @@ const MathProbabilityMomentInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
-  )
-  .pipe(
+    }),
     Schema.filter((value) => hasConsistentMomentExpression(value), {
       message: () =>
         "Expected the moment expression to contain exactly one random variable, matching variable when provided.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({
     description: "Named distribution expected value or variance input.",
   });
@@ -168,9 +166,9 @@ const MathProbabilityPointInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({ description: "Exact-value probability input." });
 
 const MathProbabilityCumulativeInputSchema = Schema.extend(
@@ -189,9 +187,9 @@ const MathProbabilityCumulativeInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({ description: "Cumulative probability input." });
 
 const MathProbabilityTailInputSchema = Schema.extend(
@@ -210,9 +208,9 @@ const MathProbabilityTailInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({ description: "Tail probability input." });
 
 const MathProbabilityIntervalInputSchema = Schema.extend(
@@ -236,9 +234,9 @@ const MathProbabilityIntervalInputSchema = Schema.extend(
     Schema.filter((value) => hasRequiredProbabilityParameters(value), {
       message: () =>
         "Expected required distribution parameters for the selected probability distribution.",
-    })
+    }),
+    Schema.mutable
   )
-  .pipe(Schema.mutable)
   .annotations({ description: "Interval probability input." });
 
 export const MathProbabilityInputSchema = Schema.Union(

--- a/packages/math/service.ts
+++ b/packages/math/service.ts
@@ -56,12 +56,10 @@ export class MathService extends Effect.Service<MathService>()(
             });
 
             if (!response.ok) {
-              return yield* Effect.fail(
-                new MathCasRequestError({
-                  message: yield* readResponseError(response),
-                  status: response.status,
-                })
-              );
+              return yield* new MathCasRequestError({
+                message: yield* readResponseError(response),
+                status: response.status,
+              });
             }
 
             const payload = yield* Effect.tryPromise({

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/gateway@3.0.118'
   - '@ai-sdk/google@3.0.78'
   - '@ai-sdk/react@3.0.190'
-  - '@effect/language-service@0.86.2'
+  - '@effect/language-service@0.87.1'
   - '@posthog/convex'
   - '@posthog/core'
   - '@posthog/types'


### PR DESCRIPTION
## Summary

- align touched application, backend, content, AI, design-system, MCP, and CLI seams with Effect-native typed failures and named programs
- preserve the surrounding Effect runtime when third-party callbacks re-enter Effect programs
- keep the installed stable Effect 3.22.0 source reference, agent guidance, and Zed/vtsls setup synchronized and explicitly exclude the vendored source from editor/dependency scanning
- update the Effect language-service exception to the installed 0.87.1 release while keeping Effect v4 beta and the alpha native tsgo toolchain out of production

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm lint`
- `pnpm effect:source:check`
- affected workspace typechecks: www, mcp, backend, contents, design-system, AI, math
- `pnpm test` (12/12 workspaces)
- `pnpm build` (5/5 tasks; WWW generated 1,306 pages)
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (63 files, zero diagnostics)
- Effect language-service diagnostics across every real project
- Effect native tsgo 0.24.3 diagnostics across every real project from an isolated executable copy; no dependency or repository workaround retained
- `codex review --base origin/main` (no findings)
- touched TypeScript/TSX files over 500 LOC: none
