### PR TITLE
docs(effect): align service guidance

### DIFF
--- a/.agents/skills/effect-best-practices/SKILL.md
+++ b/.agents/skills/effect-best-practices/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: effect-best-practices
-description: Enforces Effect-TS patterns for services, errors, layers, and atoms. Use when writing code with Effect.Service, Schema.TaggedError, Layer composition, or effect-atom React components.
-metadata:
-  version: 1.0.0
+description: Enforces Effect-TS patterns for services, errors, layers, and atoms. Use when writing code with Context.Tag, Effect.Service, Schema.TaggedError, Layer composition, or effect-atom React components.
 ---
 
 # Effect-TS Best Practices
 
 This skill enforces opinionated, consistent patterns for Effect-TS codebases. These patterns optimize for type safety, testability, observability, and maintainability.
+
+## Version And Source Gate
+
+- Run the repository's Effect source/version check before relying on an API.
+- For Effect 3.22, `Context.Tag` plus `Layer` is the documented stable service pattern.
+- `Effect.Service` is marked experimental in the pinned 3.22 source. Use it only when the
+  repository deliberately adopts it and the module genuinely owns a default implementation.
+- Do not turn `Context.Tag` versus `Effect.Service` into a business-versus-infrastructure rule.
 
 ## Effect Language Server (Required)
 
@@ -47,28 +53,16 @@ stable editor path or CI compiler with it automatically. Re-evaluate it as an ex
 toolchain migration after its release status, executable packaging, editor integration,
 and full repository gates are verified.
 
-### Features
-
-- **Diagnostics**: Detects 30+ Effect-specific issues (floating Effects, missing requirements, incorrect yield patterns)
-- **Quick Info**: Hover to see Effect type parameters (Success, Error, Requirements)
-- **Completions**: Auto-complete `Self`, Duration strings, Schema brands
-- **Refactors**: Convert async → Effect.gen, auto-compose Layers, transform to Schema
-
-### Build-Time Diagnostics
-
-For CI enforcement:
-```bash
-npx effect-language-service patch
-```
-
-See `references/language-server.md` for configuration options and CLI tools.
+The plugin adds Effect-specific diagnostics, quick info, completions, and
+refactors. For CI enforcement, run `npx effect-language-service patch`. See
+`references/language-server.md` for configuration options and CLI tools.
 
 ## Quick Reference: Critical Rules
 
 | Category | DO | DON'T |
 |----------|-----|-------|
-| Services | `Effect.Service` with `accessors: true` | `Context.Tag` for business logic |
-| Dependencies | `dependencies: [Dep.Default]` in service | Manual `Layer.provide` at usage sites |
+| Services | `Context.Tag` plus an owning `Layer` | Unversioned `Effect.Service` mandates |
+| Dependencies | Compose requirements once at the layer root | Re-providing dependencies at usage sites |
 | Layers | `Layer.mergeAll` for flat composition | Deeply nested `Layer.provide` chains |
 | Layer Chaining | `Layer.provideMerge` for incremental composition | Multiple `Layer.provide` (creates nested types) |
 | Errors | `Schema.TaggedError` with `message` field | Plain classes or generic Error |
@@ -88,50 +82,48 @@ See `references/language-server.md` for configuration options and CLI tools.
 
 ## Service Definition Pattern
 
-**Always use `Effect.Service`** for business logic services. This provides automatic accessors, built-in `Default` layer, and proper dependency declaration.
+Use `Context.Tag` plus `Layer` as the stable default. The tag owns the contract and the
+layer owns one implementation, so callers can substitute implementations without importing
+a module-selected default.
 
 ```typescript
-import { Effect } from "effect"
+import { Context, Effect, Layer, Option } from "effect"
 
-export class UserService extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
-    dependencies: [UserRepo.Default, CacheService.Default],
-    effect: Effect.gen(function* () {
+export class UserService extends Context.Tag("UserService")<
+    UserService,
+    {
+        readonly register: (
+            input: CreateUserInput,
+        ) => Effect.Effect<User, EmailAlreadyRegisteredError | UserCreateError>
+    }
+>() {}
+
+export const UserServiceLive = Layer.effect(
+    UserService,
+    Effect.gen(function* () {
         const repo = yield* UserRepo
-        const cache = yield* CacheService
 
-        const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-            const cached = yield* cache.get(id)
-            if (Option.isSome(cached)) return cached.value
-
-            const user = yield* repo.findById(id)
-            yield* cache.set(id, user)
-            return user
+        const register = Effect.fn("UserService.register")(function* (
+            input: CreateUserInput,
+        ) {
+            const existing = yield* repo.findByEmail(input.email)
+            if (Option.isSome(existing)) {
+                return yield* new EmailAlreadyRegisteredError({
+                    email: input.email,
+                    message: "Email is already registered",
+                })
+            }
+            return yield* repo.create(input)
         })
 
-        const create = Effect.fn("UserService.create")(function* (data: CreateUserInput) {
-            const user = yield* repo.create(data)
-            yield* Effect.log("User created", { userId: user.id })
-            return user
-        })
-
-        return { findById, create }
+        return UserService.of({ register })
     }),
-}) {}
-
-// Usage - dependencies are already wired
-const program = Effect.gen(function* () {
-    const user = yield* UserService.findById(userId)
-    return user
-})
-
-// At app root
-const MainLive = Layer.mergeAll(UserService.Default, OtherService.Default)
+)
 ```
 
-**When `Context.Tag` is acceptable:**
-- Infrastructure with runtime injection (Cloudflare KV, worker bindings)
-- Factory patterns where resources are provided externally
+`Effect.Service` may remove boilerplate when the same module genuinely owns a canonical
+default implementation and the repository deliberately opts into its experimental 3.22 API.
+When it is used, declare its default-layer dependencies in `dependencies`.
 
 See `references/service-patterns.md` for detailed patterns.
 
@@ -298,31 +290,13 @@ const transfer = Effect.fn("AccountService.transfer")(
 
 ## Layer Composition
 
-**Declare dependencies in the service**, not at usage sites:
+Compose dependency layers once at the application boundary, not repeatedly at usage sites:
 
 ```typescript
-// CORRECT - dependencies in service definition
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
-    accessors: true,
-    dependencies: [
-        UserService.Default,
-        ProductService.Default,
-        PaymentService.Default,
-    ],
-    effect: Effect.gen(function* () {
-        const users = yield* UserService
-        const products = yield* ProductService
-        const payments = yield* PaymentService
-        // ...
-    }),
-}) {}
-
-// At app root - simple merge
 const AppLive = Layer.mergeAll(
-    OrderService.Default,
-    // Infrastructure layers (intentionally not in dependencies)
-    DatabaseLive,
-    RedisLive,
+    UserServiceLive.pipe(Layer.provide(UserRepoLive)),
+    OrderServiceLive.pipe(Layer.provide(OrderRepoLive)),
+    NotificationServiceLive,
 )
 ```
 
@@ -331,9 +305,9 @@ const AppLive = Layer.mergeAll(
 ```typescript
 // Use Layer.mergeAll for flat composition of same-level layers
 const RepoLive = Layer.mergeAll(
-    UserRepo.Default,
-    OrderRepo.Default,
-    ProductRepo.Default,
+    UserRepoLive,
+    OrderRepoLive,
+    ProductRepoLive,
 )
 
 // Use Layer.provideMerge for incremental chaining (flatter types than Layer.provide)
@@ -457,11 +431,6 @@ const isLoading = result.waiting // Updates automatically, no useState/finally n
 
 See `references/effect-atom-patterns.md` for complete patterns including families, localStorage, mutations, and anti-patterns.
 
-## RPC & Cluster Patterns
-
-For RPC contracts and cluster workflows, see:
-- `references/rpc-cluster-patterns.md` - RpcGroup, Workflow.make, Activity patterns
-
 ## Anti-Patterns (Forbidden)
 
 These patterns are **never acceptable**:
@@ -517,7 +486,7 @@ See `references/observability-patterns.md` for metrics and tracing patterns.
 For detailed patterns, consult these reference files in the `references/` directory:
 
 - `language-server.md` - Effect Language Service setup, diagnostics, refactors, CLI tools
-- `service-patterns.md` - Service definition, Effect.fn, Context.Tag exceptions
+- `service-patterns.md` - Service contracts, implementation ownership, Effect.fn
 - `error-patterns.md` - Schema.TaggedError, error remapping, retry patterns
 - `schema-patterns.md` - Branded types, transforms, Schema.Class
 - `layer-patterns.md` - Dependency composition, testing layers

--- a/.agents/skills/effect-best-practices/references/anti-patterns.md
+++ b/.agents/skills/effect-best-practices/references/anti-patterns.md
@@ -2,6 +2,25 @@
 
 These patterns are **never acceptable** in Effect-TS code. Each is listed with rationale and the correct alternative.
 
+## Contents
+
+- [Boundary runners inside services](#forbidden-effectrunsyncrunpromise-inside-services)
+- [Thrown errors in generators](#forbidden-throw-inside-effectgen)
+- [Lost error types](#forbidden-catchall-losing-type-information)
+- [Unsafe casts](#forbidden-anyunknown-casts)
+- [Promise signatures](#forbidden-promise-in-service-signatures)
+- [Console logging](#forbidden-consolelog)
+- [Direct environment reads](#forbidden-processenv-directly)
+- [Deprecated Config.secret](#forbidden-configsecret-deprecated)
+- [Nullable domain types](#forbidden-nullundefined-in-domain-types)
+- [Throwing Option access](#forbidden-optiongetorthrow)
+- [Unjustified service defaults](#forbidden-unjustified-effectservice-defaults)
+- [Discarded error channels](#forbidden-ignoring-errors-with-ordie)
+- [Generic error remapping](#forbidden-maperror-instead-of-catchtag)
+- [Mixed Promise chains](#forbidden-mixing-effect-and-promise-chains)
+- [Unmanaged mutable state](#forbidden-mutable-state-without-ref)
+- [Direct wall-clock reads](#forbidden-using-datenow-or-new-date-directly)
+
 ## FORBIDDEN: Effect.runSync/runPromise Inside Services
 
 ```typescript
@@ -236,28 +255,32 @@ const name = Option.getOrElse(maybeName, () => "Anonymous")
 const upperName = Option.map(maybeName, (n) => n.toUpperCase())
 ```
 
-## FORBIDDEN: Context.Tag for Business Services
+## FORBIDDEN: Unjustified Effect.Service Defaults
 
 ```typescript
-// FORBIDDEN
-export class UserService extends Context.Tag("UserService")<
-    UserService,
-    { findById: (id: UserId) => Effect.Effect<User, UserNotFoundError> }
->() {
-    static Default = Layer.effect(this, Effect.gen(function* () { ... }))
-}
-```
-
-**Why:** Requires manual layer creation, no built-in accessors, more boilerplate.
-
-**Correct:**
-```typescript
+// FORBIDDEN when the module should not own a canonical default implementation
 export class UserService extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
     dependencies: [...],
     effect: Effect.gen(function* () { ... }),
 }) {}
 ```
+
+**Why:** Effect 3.22 marks `Effect.Service` experimental, and it couples the
+contract to a module-owned default layer. Do not make that ownership decision
+just to save layer boilerplate.
+
+**Correct:**
+```typescript
+export class UserService extends Context.Tag("UserService")<
+    UserService,
+    { readonly findById: (id: UserId) => Effect.Effect<User, UserNotFoundError> }
+>() {}
+
+export const UserServiceLive = Layer.succeed(UserService, { findById })
+```
+
+`Effect.Service` remains allowed when the repository deliberately accepts its
+experimental API and the same module genuinely owns the canonical default.
 
 ## FORBIDDEN: Ignoring Errors with orDie
 

--- a/.agents/skills/effect-best-practices/references/language-server.md
+++ b/.agents/skills/effect-best-practices/references/language-server.md
@@ -254,7 +254,7 @@ await Effect.runPromise(Effect.succeed(42))
 // ERROR: UserService is required but not provided
 const program = UserService.findById(id)
 // FIX: Add to Layer composition
-const MainLive = Layer.provide(program, UserService.Default)
+const runnable = Effect.provide(program, UserServiceLive)
 ```
 
 ### Yield Non-Effect

--- a/.agents/skills/effect-best-practices/references/layer-patterns.md
+++ b/.agents/skills/effect-best-practices/references/layer-patterns.md
@@ -1,74 +1,77 @@
 # Layer Patterns
 
-## Dependencies in Effect.Service
+## Contents
 
-**Critical rule:** Always declare dependencies in the `dependencies` array of `Effect.Service`. This ensures proper composition and avoids "leaked dependencies" that require manual wiring at usage sites.
+- [Dependency requirements](#dependency-requirements)
+- [Infrastructure layers](#infrastructure-layers)
+- [Flat composition](#layermergeall-over-nested-provides)
+- [Sequential composition](#layerprovidemerge-for-sequential-composition)
+- [Deduplication](#layer-deduplication-benefits)
+- [TypeScript performance](#typescript-lsp-performance)
+- [Configuration](#layerconfig-pattern)
+- [Naming](#layer-naming-conventions)
+- [Config-dependent layers](#layerunwrapeffect-for-config-dependent-layers)
+- [Scoped layers](#scoped-layers)
+- [Testing](#testing-layer-composition)
+- [Constructors](#layereffect-vs-layersucceed)
+- [Lazy layers](#lazy-layers)
+
+## Dependency Requirements
+
+Use `Context.Tag` plus `Layer` as the stable Effect 3.22 default. Keep each
+service contract separate from its implementations. A consuming layer exposes
+dependencies in its `RIn` type, and the composition root chooses the
+implementations once.
 
 ### Correct Pattern
 
 ```typescript
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
-    accessors: true,
-    dependencies: [
-        UserService.Default,
-        ProductService.Default,
-        InventoryService.Default,
-        PaymentService.Default,
-    ],
-    effect: Effect.gen(function* () {
+export class OrderService extends Context.Tag("OrderService")<
+    OrderService,
+    {
+        readonly place: (input: PlaceOrderInput) => Effect.Effect<Order, PlaceOrderError>
+    }
+>() {}
+
+export const OrderServiceLive = Layer.effect(
+    OrderService,
+    Effect.gen(function* () {
         const users = yield* UserService
         const products = yield* ProductService
         const inventory = yield* InventoryService
         const payments = yield* PaymentService
 
-        // Service implementation...
-        return { /* methods */ }
+        const place = makePlaceOrder({ users, products, inventory, payments })
+        return OrderService.of({ place })
     }),
-}) {}
+)
 
-// At app root - simple, flat composition
+const OrderDependenciesLive = Layer.mergeAll(
+    UserServiceLive,
+    ProductServiceLive,
+    InventoryServiceLive,
+    PaymentServiceLive,
+)
+
 const AppLive = Layer.mergeAll(
-    OrderService.Default,
-    // Other top-level services
-    NotificationService.Default,
-    AnalyticsService.Default,
+    OrderServiceLive.pipe(Layer.provide(OrderDependenciesLive)),
+    NotificationServiceLive,
+    AnalyticsServiceLive,
 )
 ```
 
-### Wrong Pattern (Leaked Dependencies)
-
-```typescript
-// WRONG - Dependencies not declared
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
-    accessors: true,
-    effect: Effect.gen(function* () {
-        const users = yield* UserService // Not in dependencies!
-        // ...
-    }),
-}) {}
-
-// Now every usage requires manual wiring
-const program = OrderService.create(input).pipe(
-    Effect.provide(
-        OrderService.Default.pipe(
-            Layer.provide(UserService.Default),
-            Layer.provide(ProductService.Default),
-            // Easy to forget one, causes runtime errors
-        )
-    ),
-)
-```
+Do not rebuild this dependency graph with repeated `Effect.provide` calls at
+each usage site.
 
 ## Infrastructure Layers
 
-Infrastructure layers (Database, Redis, HTTP clients) are **acceptable** to leave as "leaked" dependencies because:
-
-1. They're provided once at the application root
-2. They don't change between test/production (different implementations, same interface)
-3. They're true infrastructure, not business logic
+Dependency ownership does not change because a requirement is infrastructure.
+Database, cache, and HTTP services may be supplied once at the application
+boundary, but the layer that consumes them must still expose those requirements
+in its `RIn` type. Tests can then replace the same requirements without hidden
+wiring.
 
 ```typescript
-// Infrastructure can be provided at app root
 import { PgClient } from "@effect/sql-pg"
 
 const DatabaseLive = PgClient.layer({
@@ -79,29 +82,33 @@ const DatabaseLive = PgClient.layer({
     password: Config.redacted("DB_PASSWORD"),
 })
 
-// Services use database but don't declare it in dependencies
-export class UserRepo extends Effect.Service<UserRepo>()("UserRepo", {
-    accessors: true,
-    // No dependencies array - PgClient provided at app root
-    effect: Effect.gen(function* () {
+export class UserRepo extends Context.Tag("UserRepo")<
+    UserRepo,
+    {
+        readonly findById: (id: UserId) => Effect.Effect<Option.Option<User>, SqlError>
+    }
+>() {}
+
+// UserRepoLive declares PgClient as an input requirement through Layer's RIn.
+const UserRepoLive = Layer.effect(
+    UserRepo,
+    Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
 
         const findById = Effect.fn("UserRepo.findById")(function* (id: UserId) {
-            const rows = yield* sql`SELECT * FROM users WHERE id = ${id}`.pipe(Effect.orDie)
-            return rows[0] as User | undefined
+            // Query and decode through the repository's schemas.
+            return yield* loadUser(sql, id)
         })
 
-        return { findById }
+        return UserRepo.of({ findById })
     }),
-}) {}
+)
 
-// App root provides infrastructure once
 const AppLive = Layer.mergeAll(
-    OrderService.Default,
-    UserService.Default,
+    OrderServiceLive,
+    UserRepoLive,
 ).pipe(
-    Layer.provide(DatabaseLive), // Infrastructure provided here
-    Layer.provide(RedisLive),
+    Layer.provide(DatabaseLive),
 )
 ```
 
@@ -112,10 +119,10 @@ const AppLive = Layer.mergeAll(
 ```typescript
 // CORRECT - Flat composition
 const ServicesLive = Layer.mergeAll(
-    UserService.Default,
-    OrderService.Default,
-    ProductService.Default,
-    NotificationService.Default,
+    UserServiceLive,
+    OrderServiceLive,
+    ProductServiceLive,
+    NotificationServiceLive,
 )
 
 const InfrastructureLive = Layer.mergeAll(
@@ -131,11 +138,11 @@ const AppLive = ServicesLive.pipe(
 
 ```typescript
 // WRONG - Deeply nested, hard to read
-const AppLive = UserService.Default.pipe(
+const AppLive = UserServiceLive.pipe(
     Layer.provide(
-        OrderService.Default.pipe(
+        OrderServiceLive.pipe(
             Layer.provide(
-                ProductService.Default.pipe(
+                ProductServiceLive.pipe(
                     Layer.provide(DatabaseLive),
                 ),
             ),
@@ -151,7 +158,7 @@ const AppLive = UserService.Default.pipe(
 ```typescript
 // CORRECT - Layer.provideMerge chains for incremental composition
 const MainLive = DatabaseLive.pipe(
-    Layer.provideMerge(ProxyConfigService.Default),
+    Layer.provideMerge(ProxyConfigServiceLive),
     Layer.provideMerge(LoggerLive),
     Layer.provideMerge(CacheLive),
     Layer.provideMerge(TracerLive),
@@ -159,7 +166,7 @@ const MainLive = DatabaseLive.pipe(
 
 // WRONG - Multiple Layer.provide calls create nested types
 const MainLive = DatabaseLive.pipe(
-    Layer.provide(ProxyConfigService.Default),
+    Layer.provide(ProxyConfigServiceLive),
     Layer.provide(LoggerLive),  // Each provide creates deeper nesting
     Layer.provide(CacheLive),
 )
@@ -174,8 +181,8 @@ Layers automatically memoize construction - the same service is instantiated onl
 ```typescript
 // Both UserRepo and OrderRepo depend on DatabaseLive
 const RepoLive = Layer.mergeAll(
-    UserRepo.Default,   // requires DatabaseLive
-    OrderRepo.Default,  // requires DatabaseLive
+    UserRepoLive,   // requires DatabaseLive
+    OrderRepoLive,  // requires DatabaseLive
 )
 
 // With Layer.mergeAll, DatabaseLive is constructed ONCE
@@ -184,18 +191,9 @@ const AppLive = RepoLive.pipe(
 )
 ```
 
-**`Effect.provide` does NOT deduplicate:**
+Use the composed layer rather than separately providing each repository:
 
 ```typescript
-// WRONG - Each provide creates a new instance
-const program = myEffect.pipe(
-    Effect.provide(UserRepo.Default),
-    Effect.provide(OrderRepo.Default),
-    // If both repos need DatabaseLive, and you provide it separately,
-    // you may get TWO database connections!
-)
-
-// CORRECT - Use layers for deduplication
 const program = myEffect.pipe(
     Effect.provide(AppLive), // Single composed layer
 )
@@ -236,10 +234,11 @@ const AppLive = Layer.mergeAll(Layer1, Layer2).pipe(
 
 ## layerConfig Pattern
 
-For services that need configuration at construction time, use the `layerConfig` static method pattern:
+For services that need configuration at construction time, expose a
+configuration-driven layer factory:
 
 ```typescript
-import { Config, ConfigError, Effect, Layer } from "effect"
+import { Config, ConfigError, Context, Effect, Layer } from "effect"
 
 interface EventQueueConfig {
     readonly maxRetries: number
@@ -247,34 +246,30 @@ interface EventQueueConfig {
     readonly pollInterval: number
 }
 
-export class ElectricEventQueue extends Effect.Service<ElectricEventQueue>()(
-    "ElectricEventQueue",
+export class ElectricEventQueue extends Context.Tag("ElectricEventQueue")<
+    ElectricEventQueue,
     {
-        accessors: true,
-        effect: Effect.gen(function* () {
-            // Default implementation
-            return { /* methods */ }
-        }),
+        readonly publish: (
+            events: ReadonlyArray<Event>,
+        ) => Effect.Effect<void, EventQueueError>
     }
-) {
-    // Static method for config-driven layer
-    static readonly layerConfig = (
-        config: Config.Config.Wrap<EventQueueConfig>,
-    ): Layer.Layer<ElectricEventQueue, ConfigError.ConfigError> =>
-        Layer.unwrapEffect(
-            Config.unwrap(config).pipe(
-                Effect.map((cfg) =>
-                    Layer.succeed(
-                        ElectricEventQueue,
-                        new ElectricEventQueueImpl(cfg)
-                    )
-                )
+>() {}
+
+export const makeEventQueueLive = (
+    config: Config.Config.Wrap<EventQueueConfig>,
+): Layer.Layer<ElectricEventQueue, ConfigError.ConfigError> =>
+    Layer.unwrapEffect(
+        Config.unwrap(config).pipe(
+            Effect.map((value) =>
+                Layer.succeed(
+                    ElectricEventQueue,
+                    ElectricEventQueue.of(makeElectricEventQueue(value)),
+                ),
             )
         )
-}
+    )
 
-// Usage
-const EventQueueLive = ElectricEventQueue.layerConfig({
+const EventQueueLive = makeEventQueueLive({
     maxRetries: Config.integer("EVENT_QUEUE_MAX_RETRIES").pipe(
         Config.withDefault(3)
     ),
@@ -303,7 +298,10 @@ Use suffixes to indicate layer type:
 
 ```typescript
 // Production
-export const UserServiceLive = UserService.Default
+export const UserServiceLive = Layer.effect(
+    UserService,
+    makeUserService,
+)
 
 // Test with mocks
 export const UserServiceTest = Layer.succeed(
@@ -315,25 +313,25 @@ export const UserServiceTest = Layer.succeed(
 )
 
 // Test with in-memory state
-export class UserServiceInMemory extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
-    effect: Effect.gen(function* () {
+export const UserServiceInMemory = Layer.effect(
+    UserService,
+    Effect.sync(() => {
         const store = new Map<string, User>()
 
-        return {
+        return UserService.of({
             findById: Effect.fn("UserService.findById")(function* (id) {
                 const user = store.get(id)
                 if (!user) return yield* Effect.fail(new UserNotFoundError({ userId: id }))
                 return user
             }),
             create: Effect.fn("UserService.create")(function* (input) {
-                const user = { id: UserId.make(crypto.randomUUID()), ...input }
+                const user = makeTestUser(store.size, input)
                 store.set(user.id, user)
                 return user
             }),
-        }
+        })
     }),
-}) {}
+)
 ```
 
 ## Layer.unwrapEffect for Config-Dependent Layers
@@ -402,19 +400,28 @@ const DatabaseConnectionLive = Layer.scoped(
     )
 )
 
-// Service using scoped resource
-export class UserRepo extends Effect.Service<UserRepo>()("UserRepo", {
-    accessors: true,
-    effect: Effect.gen(function* () {
+// Repository layer exposes DatabaseConnection in its RIn type.
+export class UserRepo extends Context.Tag("UserRepo")<
+    UserRepo,
+    {
+        readonly findById: (
+            id: UserId,
+        ) => Effect.Effect<Option.Option<User>, DatabaseError>
+    }
+>() {}
+
+export const UserRepoLive = Layer.effect(
+    UserRepo,
+    Effect.gen(function* () {
         const db = yield* DatabaseConnection
 
-        return {
+        return UserRepo.of({
             findById: Effect.fn("UserRepo.findById")(function* (id) {
-                return yield* db.query("SELECT * FROM users WHERE id = $1", [id])
+                return yield* loadUser(db, id)
             }),
-        }
+        })
     }),
-}) {}
+)
 ```
 
 ## Testing Layer Composition

--- a/.agents/skills/effect-best-practices/references/rpc-cluster-patterns.md
+++ b/.agents/skills/effect-best-practices/references/rpc-cluster-patterns.md
@@ -365,10 +365,18 @@ const createOrderHandler = Effect.gen(function* () {
 ### From Backend Service
 
 ```typescript
-export class MessageService extends Effect.Service<MessageService>()("MessageService", {
-    accessors: true,
-    dependencies: [MessageRepo.Default, WorkflowClient.Default],
-    effect: Effect.gen(function* () {
+export class MessageService extends Context.Tag("MessageService")<
+    MessageService,
+    {
+        readonly create: (
+            input: CreateMessageInput,
+        ) => Effect.Effect<Message, MessageCreateError>
+    }
+>() {}
+
+export const MessageServiceLive = Layer.effect(
+    MessageService,
+    Effect.gen(function* () {
         const repo = yield* MessageRepo
         const workflows = yield* WorkflowClient
 
@@ -386,9 +394,13 @@ export class MessageService extends Effect.Service<MessageService>()("MessageSer
             return message
         })
 
-        return { create }
+        return MessageService.of({ create })
     }),
-}) {}
+)
+
+export const MessageServiceAppLive = MessageServiceLive.pipe(
+    Layer.provide(Layer.mergeAll(MessageRepoLive, WorkflowClientLive)),
+)
 ```
 
 ## Workflow HTTP API

--- a/.agents/skills/effect-best-practices/references/service-patterns.md
+++ b/.agents/skills/effect-best-practices/references/service-patterns.md
@@ -1,100 +1,84 @@
 # Service Patterns
 
-## Effect.Service Over Context.Tag
+## Contents
 
-**Always prefer `Effect.Service`** for defining business logic services. This is the modern, recommended approach that provides:
+- [Stable contracts](#stable-contracts-with-contexttag-and-layer)
+- [Deliberate Effect.Service adoption](#deliberate-effectservice-adoption)
+- [Effect.fn tracing](#effectfn-for-tracing)
+- [Runtime-injected tags](#runtime-injected-contexttag-examples)
+- [Single responsibility](#single-responsibility)
+- [Service interfaces](#service-interface-patterns)
+- [Testing](#testing-services)
 
-1. **Built-in `Default` layer** - No manual layer creation needed
-2. **Automatic accessors** - Direct method calls via `ServiceName.method()`
-3. **Proper dependency declaration** - Dependencies are explicit and type-checked
-4. **Consistent structure** - All services follow the same pattern
+## Stable Contracts With Context.Tag And Layer
 
-### Basic Service Definition
+Effect 3.22 documents `Context.Tag` plus `Layer` as the stable service pattern.
+The pinned source marks `Effect.Service` experimental, so it is not a universal
+replacement for `Context.Tag`.
 
-```typescript
-import { Effect, Layer } from "effect"
+Keep ownership explicit:
 
-export class UserService extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
-    effect: Effect.gen(function* () {
-        const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-            // Implementation
-        })
-
-        const findByEmail = Effect.fn("UserService.findByEmail")(function* (email: string) {
-            // Implementation
-        })
-
-        const create = Effect.fn("UserService.create")(function* (input: CreateUserInput) {
-            // Implementation
-        })
-
-        return { findById, findByEmail, create }
-    }),
-}) {}
-```
-
-### Service with Dependencies
-
-**Critical:** Always declare dependencies using the `dependencies` array. This ensures:
-- Dependencies are automatically provided when using `ServiceName.Default`
-- Type errors if dependencies are missing
-- No manual `Layer.provide` at usage sites
+- The tag owns the contract.
+- A layer owns one implementation.
+- The application composition root chooses the implementation.
+- Effect requirements keep missing dependencies visible in the type.
 
 ```typescript
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
-    accessors: true,
-    dependencies: [
-        UserService.Default,
-        ProductService.Default,
-        InventoryService.Default,
-    ],
-    effect: Effect.gen(function* () {
-        // Dependencies are automatically available
-        const users = yield* UserService
-        const products = yield* ProductService
-        const inventory = yield* InventoryService
+import { Context, Effect, Layer, Option } from "effect"
 
-        const create = Effect.fn("OrderService.create")(function* (input: CreateOrderInput) {
-            // Validate user exists
-            const user = yield* users.findById(input.userId)
+export class UserService extends Context.Tag("UserService")<
+    UserService,
+    {
+        readonly register: (
+            input: CreateUserInput,
+        ) => Effect.Effect<User, EmailAlreadyRegisteredError | UserCreateError>
+    }
+>() {}
 
-            // Check product availability
-            const product = yield* products.findById(input.productId)
-            const available = yield* inventory.checkAvailability(input.productId, input.quantity)
+export const UserServiceLive = Layer.effect(
+    UserService,
+    Effect.gen(function* () {
+        const repo = yield* UserRepo
 
-            if (!available) {
-                return yield* Effect.fail(new InsufficientInventoryError({
-                    productId: input.productId,
-                    message: "Not enough inventory",
-                }))
+        const register = Effect.fn("UserService.register")(function* (
+            input: CreateUserInput,
+        ) {
+            const existing = yield* repo.findByEmail(input.email)
+            if (Option.isSome(existing)) {
+                return yield* new EmailAlreadyRegisteredError({
+                    email: input.email,
+                    message: "Email is already registered",
+                })
             }
-
-            // Create order...
+            return yield* repo.create(input)
         })
 
-        return { create }
+        return UserService.of({ register })
     }),
-}) {}
-```
-
-### Wrong: Leaking Dependencies
-
-```typescript
-// WRONG - Dependencies not declared, must be provided manually
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
-    accessors: true,
-    effect: Effect.gen(function* () {
-        const users = yield* UserService  // Dependency not in `dependencies` array!
-        // ...
-    }),
-}) {}
-
-// Now every usage site must do this:
-const program = OrderService.create(input).pipe(
-    Effect.provide(UserService.Default),  // Annoying and error-prone
 )
 ```
+
+Provide requirements once when composing layers:
+
+```typescript
+const AppLive = Layer.mergeAll(
+    UserServiceLive.pipe(Layer.provide(UserRepoLive)),
+    OrderServiceLive.pipe(Layer.provide(OrderRepoLive)),
+)
+```
+
+## Deliberate Effect.Service Adoption
+
+`Effect.Service` may combine a tag with a module-owned default layer when all of
+these conditions hold:
+
+- The repository deliberately accepts its experimental Effect 3.22 status.
+- The module genuinely owns a canonical default implementation.
+- Importing the contract may intentionally expose that default.
+- Alternate implementations remain easy to provide in tests and other runtimes.
+
+When those conditions hold, declare default-layer requirements in the
+`dependencies` array. Otherwise use `Context.Tag` plus a separately owned layer.
 
 ## Effect.fn for Tracing
 
@@ -139,9 +123,9 @@ yield* Effect.annotateCurrentSpan("step", "processing")
 yield* Effect.annotateCurrentSpan("step", "completing")
 ```
 
-## When Context.Tag is Acceptable
+## Runtime-Injected Context.Tag Examples
 
-`Context.Tag` is appropriate **only** for infrastructure that's injected at runtime:
+Runtime-injected infrastructure is another clear use of the stable tag pattern:
 
 ### Cloudflare Worker Bindings
 
@@ -195,25 +179,24 @@ Each service should have a focused responsibility:
 
 ```typescript
 // CORRECT - Focused services
-export class UserService extends Effect.Service<UserService>()("UserService", { /* user operations */ }) {}
-export class AuthService extends Effect.Service<AuthService>()("AuthService", { /* auth operations */ }) {}
-export class NotificationService extends Effect.Service<NotificationService>()("NotificationService", { /* notifications */ }) {}
+export class UserService extends Context.Tag("UserService")<
+    UserService,
+    UserOperations
+>() {}
+export class AuthService extends Context.Tag("AuthService")<
+    AuthService,
+    AuthOperations
+>() {}
+export class NotificationService extends Context.Tag("NotificationService")<
+    NotificationService,
+    NotificationOperations
+>() {}
 
 // WRONG - God service doing everything
-export class AppService extends Effect.Service<AppService>()("AppService", {
-    effect: Effect.gen(function* () {
-        return {
-            createUser,
-            deleteUser,
-            login,
-            logout,
-            sendEmail,
-            sendPush,
-            processPayment,
-            // ... 50 more methods
-        }
-    }),
-}) {}
+export class AppService extends Context.Tag("AppService")<
+    AppService,
+    UserOperations & AuthOperations & NotificationOperations & PaymentOperations
+>() {}
 ```
 
 ## Service Interface Patterns
@@ -266,30 +249,31 @@ Create test implementations using the same pattern:
 export const UserServiceTest = Layer.succeed(
     UserService,
     UserService.of({
-        findById: (id) => Effect.succeed(mockUser),
-        create: (input) => Effect.succeed({ ...mockUser, ...input }),
+        register: (input) => Effect.succeed({ ...mockUser, ...input }),
     })
 )
 
-// Or with Effect.Service for stateful mocks
-export class UserServiceTest extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
-    effect: Effect.gen(function* () {
-        const users = new Map<string, User>()
+// Stateful test implementation with the same stable tag contract
+export const UserServiceInMemory = Layer.effect(
+    UserService,
+    Effect.sync(() => {
+        const usersByEmail = new Map<string, User>()
 
-        const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-            const user = users.get(id)
-            if (!user) return yield* Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" }))
+        const register = Effect.fn("UserService.register")(function* (
+            input: CreateUserInput,
+        ) {
+            if (usersByEmail.has(input.email)) {
+                return yield* new EmailAlreadyRegisteredError({
+                    email: input.email,
+                    message: "Email is already registered",
+                })
+            }
+            const user = makeTestUser(usersByEmail.size, input)
+            usersByEmail.set(user.email, user)
             return user
         })
 
-        const create = Effect.fn("UserService.create")(function* (input: CreateUserInput) {
-            const user = { id: UserId.make(crypto.randomUUID()), ...input }
-            users.set(user.id, user)
-            return user
-        })
-
-        return { findById, create }
+        return UserService.of({ register })
     }),
-}) {}
+)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 
 - This is an Effect-native TypeScript codebase. Effect is the decomposition and composition architecture, not a wrapper around raw TypeScript.
 - Effect-native architecture gives Nakafa decomposable, composable, traceable, and type-safe behavior end to end. It prevents fragmented helper chains, duplicated maps, hidden failure paths, and source-of-truth drift.
-- Every new or touched TypeScript domain capability must start from Effect-native design: Schema contracts, branded values, tagged errors, small named `Effect.fn` programs, and `Effect.Service`/`Context.Tag` plus `Layer` only where there is a real dependency seam.
+- Every new or touched TypeScript domain capability must start from Effect-native design: Schema contracts, branded values, tagged errors, small named `Effect.fn` programs, and `Context.Tag` plus `Layer` only where there is a real dependency seam. `Effect.Service` is an optional convenience only when a module genuinely owns a default implementation and the repository deliberately accepts its experimental Effect 3.22 API.
 - Public module Interfaces must expose schema-derived data contracts and Effect-native operations for fallible, effectful, cross-source, or cross-module work. Do not build a raw TypeScript module and sprinkle Schema decoding, `Effect.succeed`, or a boundary runner around it later.
 - Source registries must decode through schemas and produce typed/branded rows. Projection modules must compose those rows through typed Effects, not raw loops with hidden failure or fallback paths.
 - Missing source data, duplicate routes, invalid slugs, invalid source rows, mismatched mappings, and route collisions are expected domain failures in the Effect error channel. Model them with `Schema.TaggedError` or `Data.TaggedError`, not `null`, generic `Error`, thrown parser errors, silent filtering, or fallback strings.
@@ -194,7 +194,7 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 - Effect-native means effectful work is modeled with Effect; pure deterministic helpers should stay pure.
 - Model expected failures with `Schema.TaggedError` and specific domain error names.
 - Prefer `Effect.fn("scope.name")` for effectful exported functions and service methods so traces are named.
-- Use `Effect.Service` with declared dependencies for business services; reserve `Context.Tag` for runtime-injected infrastructure boundaries.
+- Use the documented stable `Context.Tag` plus `Layer` pattern for dependency contracts. `Effect.Service` may combine that contract with a default layer only when the module genuinely owns the default implementation and the repository deliberately accepts its experimental Effect 3.22 API; do not choose between them based only on whether a dependency is “business” or “infrastructure.”
 - Use `@effect/platform` and `@effect/platform-node` for Node filesystem and HTTP boundaries when those packages own the IO seam.
 - Prefer `Effect.Cache` or Effect cached effects for shared effectful cache state. Plain `Map` is acceptable inside one pure algorithm for grouping, deduplication, or indexing.
 - Use `Effect.try`, `Effect.tryPromise`, `Effect.acquireRelease`, and `Effect.sync` instead of raw `try/catch`, raw async wrappers, or hidden side effects.


### PR DESCRIPTION
## Summary

- make `Context.Tag` plus `Layer` the stable Effect 3.22 service default across root agent rules and the older best-practices skill
- keep `Effect.Service` available only when the repository deliberately accepts its experimental status and a module genuinely owns the default implementation
- remove the contradictory business-versus-infrastructure rule and add navigable reference tables of contents
- reduce the main skill from 527 to 496 lines

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm effect:source:check`
- official `skill-creator/scripts/quick_validate.py` (`Skill is valid!`)
- `git diff --check`

The standalone `pnpm agent-docs` command requires a running site; the hosted Agent-Friendly Docs workflow provides that server and remains the authoritative gate.
