### PR TITLE
refactor(http): replace Ky with Effect HttpClient

### DIFF
--- a/apps/www/app/api/weather/route.ts
+++ b/apps/www/app/api/weather/route.ts
@@ -1,3 +1,4 @@
+import { FetchHttpClient } from "@effect/platform";
 import {
   DEFAULT_LATITUDE,
   DEFAULT_LONGITUDE,
@@ -102,7 +103,8 @@ export function POST(req: Request) {
             { status: 500 }
           );
         })
-      )
+      ),
+      Effect.provide(FetchHttpClient.layer)
     )
   );
 }

--- a/apps/www/components/school/classes/forum/conversation/input.tsx
+++ b/apps/www/components/school/classes/forum/conversation/input.tsx
@@ -1,3 +1,4 @@
+import { FetchHttpClient } from "@effect/platform";
 import { ArrowUp01Icon } from "@hugeicons/core-free-icons";
 import { useDisclosure, useOs, useResizeObserver } from "@mantine/hooks";
 import { captureException } from "@repo/analytics/posthog";
@@ -184,7 +185,7 @@ export function ForumPostInput() {
           forumId,
           parentId: replyTarget?.postId,
         },
-      });
+      }).pipe(Effect.provide(FetchHttpClient.layer));
 
       if (isTextOnlyPost) {
         Effect.runSync(clearSubmittedDraft());

--- a/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
@@ -1,62 +1,95 @@
 // @vitest-environment node
 
+import { HttpClient, HttpClientResponse } from "@effect/platform";
+import type { HttpClientRequest } from "@effect/platform/HttpClientRequest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { FileWithPreview } from "@repo/design-system/hooks/use-file-upload";
-import { Effect, Either } from "effect";
+import { Effect, Either, FiberRef, Layer } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { submitForumPost } from "./submit";
 
 const mocks = vi.hoisted(() => ({
   captureException: vi.fn(),
-  post: vi.fn(),
+  request: vi.fn<(request: HttpClientRequest) => void>(),
+  response: vi.fn<() => Response>(),
+  tracingDisabled: vi.fn<(disabled: boolean) => void>(),
 }));
 
 vi.mock("@repo/analytics/posthog", () => ({
   captureException: mocks.captureException,
 }));
 
-vi.mock("ky", () => ({
-  default: {
-    post: mocks.post,
-  },
-}));
-
 const forumId = "forum_1" as Id<"schoolClassForums">;
 const postId = "post_1" as Id<"schoolClassForumPosts">;
 const storageId = "storage_1" as Id<"_storage">;
-const uploadUrl = "https://upload.example.test/file";
+const uploadUrl = "https://upload.example.test/file?token=signed-upload-secret";
 
 type SubmitForumPostInput = Parameters<typeof submitForumPost>[0];
+
+const TestHttpClient = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.gen(function* () {
+      const tracerDisabledWhen = yield* FiberRef.get(
+        HttpClient.currentTracerDisabledWhen
+      );
+      mocks.tracingDisabled(tracerDisabledWhen(request));
+      mocks.request(request);
+      return HttpClientResponse.fromWeb(request, mocks.response());
+    })
+  )
+);
+
+/** Runs a forum submission with the deterministic test HTTP client. */
+function runSubmit(input: SubmitForumPostInput) {
+  return Effect.runPromise(
+    submitForumPost(input).pipe(Effect.provide(TestHttpClient), Effect.either)
+  );
+}
+
+/** Builds the default successful Convex mutation set for one submit test. */
+function makeMutations(
+  overrides: Partial<SubmitForumPostInput["mutations"]> = {}
+) {
+  return {
+    createPost: vi.fn(async () => postId),
+    discardForumUploads: vi.fn(async () => null),
+    generateUploadUrl: vi.fn(),
+    saveForumUpload: vi.fn(),
+    ...overrides,
+  } satisfies SubmitForumPostInput["mutations"];
+}
+
+/** Builds one browser attachment fixture. */
+function makeFile(id: string) {
+  return {
+    file: new File([id], `${id}.txt`, { type: "text/plain" }),
+    id,
+  } satisfies FileWithPreview;
+}
 
 describe("submitForumPost", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.post.mockReturnValue({
-      json: vi.fn(async () => ({ storageId })),
-    });
+    mocks.response.mockReturnValue(
+      Response.json({
+        storageId,
+      })
+    );
   });
 
   it("creates a text-only post without upload mutations", async () => {
-    const mutations = {
-      createPost: vi.fn(async () => postId),
-      discardForumUploads: vi.fn(async () => null),
-      generateUploadUrl: vi.fn(),
-      saveForumUpload: vi.fn(),
-    } satisfies SubmitForumPostInput["mutations"];
+    const mutations = makeMutations();
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files: [],
-          mutations,
-          post: {
-            body: "hello",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files: [],
+      mutations,
+      post: {
+        body: "hello",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isRight(result)).toBe(true);
     expect(mutations.createPost).toHaveBeenCalledWith({
@@ -70,26 +103,19 @@ describe("submitForumPost", () => {
   });
 
   it("does not discard pending uploads when a text-only post fails", async () => {
-    const mutations = {
+    const mutations = makeMutations({
       createPost: vi.fn(() => Promise.reject(new Error("post failed"))),
-      discardForumUploads: vi.fn(async () => null),
-      generateUploadUrl: vi.fn(),
-      saveForumUpload: vi.fn(),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files: [],
-          mutations,
-          post: {
-            body: "hello",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files: [],
+      mutations,
+      post: {
+        body: "hello",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isLeft(result)).toBe(true);
     expect(mutations.discardForumUploads).not.toHaveBeenCalled();
@@ -108,37 +134,42 @@ describe("submitForumPost", () => {
         },
         id: "existing",
       },
-      {
-        file: new File(["fresh"], "fresh.txt", { type: "text/plain" }),
-        id: "fresh",
-      },
+      makeFile("fresh"),
     ] satisfies FileWithPreview[];
-    const mutations = {
-      createPost: vi.fn(async () => postId),
-      discardForumUploads: vi.fn(async () => null),
+    const mutations = makeMutations({
       generateUploadUrl: vi.fn(async () => ({
         uploadId,
         uploadUrl,
       })),
       saveForumUpload: vi.fn(async () => uploadId),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files,
-          mutations,
-          post: {
-            body: "with attachment",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files,
+      mutations,
+      post: {
+        body: "with attachment",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isRight(result)).toBe(true);
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          _tag: "Raw",
+          body: files[1]?.file,
+        }),
+        headers: expect.objectContaining({
+          "content-type": "text/plain",
+        }),
+        method: "POST",
+        url: uploadUrl,
+      })
+    );
     expect(mutations.generateUploadUrl).toHaveBeenCalledTimes(1);
+    expect(mocks.tracingDisabled).toHaveBeenCalledWith(true);
     expect(mutations.createPost).toHaveBeenCalledWith({
       attachmentUploadIds: [uploadId],
       body: "with attachment",
@@ -150,19 +181,8 @@ describe("submitForumPost", () => {
   it("discards successful uploads when another attachment upload fails", async () => {
     const successfulUploadId =
       "upload_success" as Id<"schoolClassForumPendingUploads">;
-    const files = [
-      {
-        file: new File(["first"], "first.txt", { type: "text/plain" }),
-        id: "first",
-      },
-      {
-        file: new File(["second"], "second.txt", { type: "text/plain" }),
-        id: "second",
-      },
-    ] satisfies FileWithPreview[];
-    const mutations = {
-      createPost: vi.fn(async () => postId),
-      discardForumUploads: vi.fn(async () => null),
+    const files = [makeFile("first"), makeFile("second")];
+    const mutations = makeMutations({
       generateUploadUrl: vi
         .fn()
         .mockResolvedValueOnce({
@@ -171,21 +191,17 @@ describe("submitForumPost", () => {
         })
         .mockRejectedValueOnce(new Error("upload URL failed")),
       saveForumUpload: vi.fn(async () => successfulUploadId),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files,
-          mutations,
-          post: {
-            body: "",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files,
+      mutations,
+      post: {
+        body: "",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isLeft(result)).toBe(true);
     expect(mutations.createPost).not.toHaveBeenCalled();
@@ -196,40 +212,35 @@ describe("submitForumPost", () => {
 
   it("captures cleanup failures without masking storage upload errors", async () => {
     const uploadId = "upload_storage" as Id<"schoolClassForumPendingUploads">;
-    const files = [
-      {
-        file: new File(["storage"], "storage.txt", { type: "text/plain" }),
-        id: "storage",
-      },
-    ] satisfies FileWithPreview[];
-    mocks.post.mockReturnValue({
-      json: vi.fn(() => Promise.reject("storage failed")),
-    });
-    const mutations = {
-      createPost: vi.fn(async () => postId),
+    const files = [makeFile("storage")];
+    mocks.response.mockReturnValue(
+      new Response("storage failed", { status: 500 })
+    );
+    const mutations = makeMutations({
       discardForumUploads: vi.fn(() => Promise.reject("cleanup failed")),
       generateUploadUrl: vi.fn(async () => ({
         uploadId,
         uploadUrl,
       })),
       saveForumUpload: vi.fn(async () => uploadId),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files,
-          mutations,
-          post: {
-            body: "",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files,
+      mutations,
+      post: {
+        body: "",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isLeft(result)).toBe(true);
+    if (Either.isRight(result)) {
+      return;
+    }
+    expect(JSON.stringify(result.left)).not.toContain("signed-upload-secret");
+    expect(JSON.stringify(result.left)).not.toContain(uploadUrl);
     expect(mutations.saveForumUpload).not.toHaveBeenCalled();
     expect(mocks.captureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -242,35 +253,24 @@ describe("submitForumPost", () => {
 
   it("discards the pending upload when metadata save fails", async () => {
     const uploadId = "upload_metadata" as Id<"schoolClassForumPendingUploads">;
-    const files = [
-      {
-        file: new File(["metadata"], "metadata.txt", { type: "text/plain" }),
-        id: "metadata",
-      },
-    ] satisfies FileWithPreview[];
-    const mutations = {
-      createPost: vi.fn(async () => postId),
-      discardForumUploads: vi.fn(async () => null),
+    const files = [makeFile("metadata")];
+    const mutations = makeMutations({
       generateUploadUrl: vi.fn(async () => ({
         uploadId,
         uploadUrl,
       })),
       saveForumUpload: vi.fn(() => Promise.reject(new Error("save failed"))),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files,
-          mutations,
-          post: {
-            body: "",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files,
+      mutations,
+      post: {
+        body: "",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isLeft(result)).toBe(true);
     expect(mutations.discardForumUploads).toHaveBeenCalledWith({
@@ -281,37 +281,25 @@ describe("submitForumPost", () => {
 
   it("discards uploaded attachments when creating the post fails", async () => {
     const uploadId = "upload_for_post" as Id<"schoolClassForumPendingUploads">;
-    const files = [
-      {
-        file: new File(["attachment"], "attachment.txt", {
-          type: "text/plain",
-        }),
-        id: "attachment",
-      },
-    ] satisfies FileWithPreview[];
-    const mutations = {
+    const files = [makeFile("attachment")];
+    const mutations = makeMutations({
       createPost: vi.fn(() => Promise.reject(new Error("post failed"))),
-      discardForumUploads: vi.fn(async () => null),
       generateUploadUrl: vi.fn(async () => ({
         uploadId,
         uploadUrl,
       })),
       saveForumUpload: vi.fn(async () => uploadId),
-    } satisfies SubmitForumPostInput["mutations"];
+    });
 
-    const result = await Effect.runPromise(
-      Effect.either(
-        submitForumPost({
-          files,
-          mutations,
-          post: {
-            body: "attachment",
-            forumId,
-            parentId: undefined,
-          },
-        })
-      )
-    );
+    const result = await runSubmit({
+      files,
+      mutations,
+      post: {
+        body: "attachment",
+        forumId,
+        parentId: undefined,
+      },
+    });
 
     expect(Either.isLeft(result)).toBe(true);
     expect(mutations.discardForumUploads).toHaveBeenCalledWith({

--- a/apps/www/components/school/classes/forum/conversation/input/submit.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/submit.ts
@@ -1,10 +1,27 @@
+import {
+  HttpBody,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "@effect/platform";
 import { captureException } from "@repo/analytics/posthog";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { FileWithPreview } from "@repo/design-system/hooks/use-file-upload";
 import type { FunctionArgs, FunctionReturnType } from "convex/server";
 import { Effect, Either, Schema } from "effect";
-import ky from "ky";
+
+const STORAGE_UPLOAD_TIMEOUT = "10 seconds";
+
+const StorageIdSchema = Schema.declare(
+  (input): input is Id<"_storage"> =>
+    typeof input === "string" && input.length > 0,
+  { identifier: "ConvexStorageId" }
+);
+
+const StorageUploadResponseSchema = Schema.Struct({
+  storageId: StorageIdSchema,
+});
 
 type GenerateUploadUrlMutation = (
   args: FunctionArgs<
@@ -157,21 +174,29 @@ const uploadAttachmentFile = Effect.fn("www.forum.uploadAttachmentFile")(
           cause: getErrorCause(cause),
         }),
     });
+    const client = (yield* HttpClient.HttpClient).pipe(
+      // Convex upload URLs are short-lived capabilities and must not enter traces.
+      HttpClient.withTracerDisabledWhen(() => true)
+    );
 
-    const { storageId } = yield* Effect.tryPromise({
-      try: () =>
-        ky
-          .post(uploadUrl, {
-            headers: { "Content-Type": file.type },
-            body: file,
+    const { storageId } = yield* HttpClientRequest.post(uploadUrl).pipe(
+      HttpClientRequest.setBody(
+        HttpBody.raw(file, {
+          contentType: file.type,
+        })
+      ),
+      client.execute,
+      Effect.flatMap(HttpClientResponse.filterStatusOk),
+      Effect.flatMap(
+        HttpClientResponse.schemaBodyJson(StorageUploadResponseSchema)
+      ),
+      Effect.timeout(STORAGE_UPLOAD_TIMEOUT),
+      Effect.mapError(
+        () =>
+          new ForumAttachmentUploadError({
+            message: "Forum attachment storage upload failed.",
           })
-          .json<{ storageId: Id<"_storage"> }>(),
-      catch: (cause) =>
-        new ForumAttachmentUploadError({
-          message: "Forum attachment storage upload failed.",
-          cause: getErrorCause(cause),
-        }),
-    }).pipe(
+      ),
       Effect.tapError(() =>
         discardPendingUploads({
           mutations,

--- a/apps/www/lib/react-query/use-weather.tsx
+++ b/apps/www/lib/react-query/use-weather.tsx
@@ -1,14 +1,20 @@
-import type { getWeather } from "@repo/ai/clients/weather/client";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientResponse,
+} from "@effect/platform";
+import { WeatherDataSchema } from "@repo/ai/clients/weather/schema";
 import { useQuery } from "@tanstack/react-query";
 import { Effect } from "effect";
-import ky from "ky";
 
-type Weather = Effect.Effect.Success<ReturnType<typeof getWeather>>;
+const WEATHER_REQUEST_TIMEOUT = "10 seconds";
 
 /** Load the current weather summary through the app API route. */
 const fetchWeather = Effect.fn("www.weather.fetch")(function* () {
-  return yield* Effect.tryPromise(() =>
-    ky.post<Weather>("/api/weather").json()
+  return yield* HttpClient.post("/api/weather").pipe(
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(WeatherDataSchema)),
+    Effect.timeout(WEATHER_REQUEST_TIMEOUT)
   );
 });
 
@@ -16,6 +22,9 @@ const fetchWeather = Effect.fn("www.weather.fetch")(function* () {
 export function useWeather() {
   return useQuery({
     queryKey: ["weather"],
-    queryFn: () => Effect.runPromise(fetchWeather()),
+    queryFn: () =>
+      Effect.runPromise(
+        fetchWeather().pipe(Effect.provide(FetchHttpClient.layer))
+      ),
   });
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -17,6 +17,7 @@
     "google-index": "node --env-file=.env.local --import tsx scripts/google-index.ts"
   },
   "dependencies": {
+    "@effect/platform": "0.97.0",
     "@ai-sdk/react": "^4.0.40",
     "@convex-dev/better-auth": "^0.12.5",
     "@hugeicons/core-free-icons": "^4.2.2",
@@ -56,7 +57,6 @@
     "effect": "catalog:",
     "feed": "^6.0.0",
     "immer": "^11.1.11",
-    "ky": "^2.0.2",
     "motion": "^12.42.2",
     "nanoid": "^6.0.0",
     "next": "16.2.11",

--- a/packages/ai/clients/weather/client.test.ts
+++ b/packages/ai/clients/weather/client.test.ts
@@ -1,0 +1,263 @@
+import { HttpClient, HttpClientResponse } from "@effect/platform";
+import { getWeather } from "@repo/ai/clients/weather/client";
+import { Effect, Either, Layer } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const latitude = "-6.2088";
+const longitude = "106.8456";
+const coordinates = { lat: -6.2088, lon: 106.8456 };
+
+const weatherResponse = {
+  city: {
+    coord: coordinates,
+    country: "ID",
+    id: 1,
+    name: "Jakarta",
+    sunrise: 1,
+    sunset: 2,
+    timezone: 25_200,
+  },
+  cnt: 1,
+  cod: "200",
+  list: [
+    {
+      clouds: { all: 10 },
+      dt: 1,
+      dt_txt: "2026-07-27 09:00:00",
+      main: {
+        feels_like: 301,
+        humidity: 70,
+        pressure: 1009,
+        temp: 302,
+        temp_max: 303,
+        temp_min: 301,
+      },
+      pop: 0.1,
+      sys: { pod: "d" },
+      weather: [
+        {
+          description: "clear sky",
+          icon: "01d",
+          id: 800,
+          main: "Clear",
+        },
+      ],
+      wind: { deg: 90, speed: 2 },
+    },
+  ],
+  message: 0,
+};
+
+const airPollutionResponse = {
+  coord: coordinates,
+  list: [],
+};
+
+const geocodeResponse = [
+  {
+    country: "ID",
+    lat: coordinates.lat,
+    lon: coordinates.lon,
+    name: "Jakarta",
+  },
+];
+
+type WeatherEndpoint =
+  | "air-pollution"
+  | "air-pollution-forecast"
+  | "geocode"
+  | "weather";
+
+type ResponseOverrides = Partial<
+  Record<WeatherEndpoint, () => globalThis.Response>
+>;
+
+/** Resolves the OpenWeather endpoint represented by one client request. */
+function getEndpoint(url: string): WeatherEndpoint {
+  if (url.endsWith("/geo/1.0/reverse")) {
+    return "geocode";
+  }
+  if (url.endsWith("/data/2.5/forecast")) {
+    return "weather";
+  }
+  if (url.endsWith("/air_pollution/forecast")) {
+    return "air-pollution-forecast";
+  }
+  return "air-pollution";
+}
+
+/** Builds an Effect HTTP client with deterministic endpoint responses. */
+function makeWeatherClient(overrides: ResponseOverrides = {}) {
+  const defaults = {
+    "air-pollution": () => Response.json(airPollutionResponse),
+    "air-pollution-forecast": () => Response.json(airPollutionResponse),
+    geocode: () => Response.json(geocodeResponse),
+    weather: () => Response.json(weatherResponse),
+  } satisfies Record<WeatherEndpoint, () => globalThis.Response>;
+
+  return Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.sync(() => {
+        const endpoint = getEndpoint(request.url);
+        const response = overrides[endpoint]?.() ?? defaults[endpoint]();
+        return HttpClientResponse.fromWeb(request, response);
+      })
+    )
+  );
+}
+
+/** Runs the public weather program with a deterministic HTTP layer. */
+function runWeather(overrides?: ResponseOverrides) {
+  return Effect.runPromise(
+    getWeather({ latitude, longitude }).pipe(
+      Effect.provide(makeWeatherClient(overrides)),
+      Effect.either
+    )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getWeather", () => {
+  it("returns the complete decoded weather payload", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+
+    const result = await runWeather();
+
+    expect(result).toEqual(
+      Either.right({
+        ...weatherResponse,
+        air_pollution: airPollutionResponse,
+        air_pollution_forecast: airPollutionResponse,
+        geocoding: {
+          city: "Jakarta",
+          country: "ID",
+          latitude,
+          longitude,
+        },
+      })
+    );
+  });
+
+  it("keeps an unavailable required forecast in the typed error channel", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+
+    const result = await runWeather({
+      weather: () => new Response("unauthorized", { status: 401 }),
+    });
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isRight(result)) {
+      return;
+    }
+    expect(result.left).toMatchObject({
+      _tag: "WeatherClientRequestError",
+      endpoint: "weather-forecast",
+    });
+  });
+
+  it("keeps an invalid required forecast in the schema error channel", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+
+    const result = await runWeather({
+      weather: () => Response.json({ cod: "200" }),
+    });
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isRight(result)) {
+      return;
+    }
+    expect(result.left).toMatchObject({ _tag: "ParseError" });
+  });
+
+  it("uses logged defaults when optional requests fail", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+    const unavailable = () =>
+      new Response("unavailable", {
+        status: 401,
+      });
+
+    const result = await runWeather({
+      "air-pollution": unavailable,
+      "air-pollution-forecast": unavailable,
+      geocode: unavailable,
+    });
+
+    expect(result).toEqual(
+      Either.right(
+        expect.objectContaining({
+          air_pollution: {
+            coord: coordinates,
+            list: [],
+          },
+          air_pollution_forecast: {
+            coord: coordinates,
+            list: [],
+          },
+          geocoding: {
+            city: "",
+            country: "",
+            latitude,
+            longitude,
+          },
+        })
+      )
+    );
+  });
+
+  it("uses logged defaults when optional payloads are invalid", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+    const invalid = () => Response.json({ invalid: true });
+
+    const result = await runWeather({
+      "air-pollution": invalid,
+      "air-pollution-forecast": invalid,
+      geocode: invalid,
+    });
+
+    expect(result).toEqual(
+      Either.right(
+        expect.objectContaining({
+          air_pollution: {
+            coord: coordinates,
+            list: [],
+          },
+          air_pollution_forecast: {
+            coord: coordinates,
+            list: [],
+          },
+          geocoding: {
+            city: "",
+            country: "",
+            latitude,
+            longitude,
+          },
+        })
+      )
+    );
+  });
+
+  it("uses the default location when geocoding has no match", async () => {
+    vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
+
+    const result = await runWeather({
+      geocode: () => Response.json([]),
+    });
+
+    expect(result).toEqual(
+      Either.right(
+        expect.objectContaining({
+          geocoding: {
+            city: "",
+            country: "",
+            latitude,
+            longitude,
+          },
+        })
+      )
+    );
+  });
+});

--- a/packages/ai/clients/weather/client.ts
+++ b/packages/ai/clients/weather/client.ts
@@ -4,10 +4,10 @@ import {
   ReverseGeocodeSchema,
   WeatherResponseSchema,
 } from "@repo/ai/clients/weather/schema";
+import { requestWeatherJson } from "@repo/ai/clients/weather/transport";
 import { weatherKeys } from "@repo/ai/keys";
 import { logError, timeOperation } from "@repo/utilities/logging/effect";
 import { Effect, Schema } from "effect";
-import ky from "ky";
 
 const GEO_BASE_URL = "https://api.openweathermap.org/geo/1.0";
 const WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5";
@@ -17,16 +17,6 @@ export const DEFAULT_LONGITUDE = "106.8456";
 type AirPollutionResponse = Schema.Schema.Type<
   typeof AirPollutionResponseSchema
 >;
-
-/** OpenWeather failed before returning usable JSON. */
-export class WeatherClientRequestError extends Schema.TaggedError<WeatherClientRequestError>()(
-  "WeatherClientRequestError",
-  {
-    cause: Schema.optional(Schema.String),
-    endpoint: Schema.String,
-    message: Schema.String,
-  }
-) {}
 
 /** Fetches comprehensive weather data for given coordinates. */
 export const getWeather = Effect.fn("weather.getWeather")(function* ({
@@ -102,7 +92,7 @@ const fetchGeoData = Effect.fn("weather.fetchGeoData")(function* (
     Effect.annotateLogs(context)
   );
 
-  const locations = yield* requestJson({
+  const locations = yield* requestWeatherJson({
     endpoint: "reverse-geocode",
     searchParams: {
       appid: apiKey,
@@ -115,7 +105,7 @@ const fetchGeoData = Effect.fn("weather.fetchGeoData")(function* (
     Effect.flatMap(Schema.decodeUnknown(ReverseGeocodeSchema)),
     Effect.catchTags({
       WeatherClientRequestError: (error) =>
-        logError(new Error(error.message), {
+        logError(error, {
           ...context,
           operation: "fetchGeoData",
         }).pipe(Effect.as([])),
@@ -154,7 +144,7 @@ const fetchWeatherForecast = Effect.fn("weather.fetchWeatherForecast")(
       Effect.annotateLogs(context)
     );
 
-    return yield* requestJson({
+    return yield* requestWeatherJson({
       endpoint: "weather-forecast",
       searchParams: {
         appid: apiKey,
@@ -162,21 +152,7 @@ const fetchWeatherForecast = Effect.fn("weather.fetchWeatherForecast")(
         lon: longitude,
       },
       url: `${WEATHER_BASE_URL}/forecast`,
-    }).pipe(
-      Effect.flatMap(Schema.decodeUnknown(WeatherResponseSchema)),
-      Effect.catchTags({
-        WeatherClientRequestError: (error) =>
-          logError(new Error(error.message), {
-            ...context,
-            operation: "fetchWeatherForecast",
-          }).pipe(Effect.as(null)),
-        ParseError: (error) =>
-          Effect.logWarning("Weather forecast validation failed").pipe(
-            Effect.annotateLogs({ ...context, cause: error.message }),
-            Effect.as(null)
-          ),
-      })
-    );
+    }).pipe(Effect.flatMap(Schema.decodeUnknown(WeatherResponseSchema)));
   }
 );
 
@@ -192,7 +168,7 @@ const fetchAirPollution = Effect.fn("weather.fetchAirPollution")(function* (
     Effect.annotateLogs(context)
   );
 
-  return yield* requestJson({
+  return yield* requestWeatherJson({
     endpoint: "air-pollution",
     searchParams: {
       appid: apiKey,
@@ -204,7 +180,7 @@ const fetchAirPollution = Effect.fn("weather.fetchAirPollution")(function* (
     Effect.flatMap(Schema.decodeUnknown(AirPollutionResponseSchema)),
     Effect.catchTags({
       WeatherClientRequestError: (error) =>
-        logError(new Error(error.message), {
+        logError(error, {
           ...context,
           operation: "fetchAirPollution",
         }).pipe(Effect.as(emptyAirPollution(latitude, longitude))),
@@ -227,7 +203,7 @@ const fetchAirPollutionForecast = Effect.fn(
     Effect.annotateLogs(context)
   );
 
-  return yield* requestJson({
+  return yield* requestWeatherJson({
     endpoint: "air-pollution-forecast",
     searchParams: {
       appid: apiKey,
@@ -239,7 +215,7 @@ const fetchAirPollutionForecast = Effect.fn(
     Effect.flatMap(Schema.decodeUnknown(AirPollutionResponseSchema)),
     Effect.catchTags({
       WeatherClientRequestError: (error) =>
-        logError(new Error(error.message), {
+        logError(error, {
           ...context,
           operation: "fetchAirPollutionForecast",
         }).pipe(Effect.as(emptyAirPollution(latitude, longitude))),
@@ -250,27 +226,6 @@ const fetchAirPollutionForecast = Effect.fn(
         ),
     })
   );
-});
-
-/** Requests JSON from OpenWeather through an Effect boundary. */
-const requestJson = Effect.fn("weather.requestJson")(function* ({
-  endpoint,
-  searchParams,
-  url,
-}: {
-  endpoint: string;
-  searchParams: Record<string, string>;
-  url: string;
-}) {
-  return yield* Effect.tryPromise({
-    try: () => ky.get(url, { searchParams }).json(),
-    catch: (error) =>
-      new WeatherClientRequestError({
-        cause: String(error),
-        endpoint,
-        message: `OpenWeather request failed for ${endpoint}.`,
-      }),
-  });
 });
 
 /** Builds an empty location when reverse geocoding is unavailable. */

--- a/packages/ai/clients/weather/schema.test.ts
+++ b/packages/ai/clients/weather/schema.test.ts
@@ -1,60 +1,91 @@
-import { WeatherResponseSchema } from "@repo/ai/clients/weather/schema";
+import {
+  WeatherDataSchema,
+  WeatherResponseSchema,
+} from "@repo/ai/clients/weather/schema";
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
-describe("WeatherResponseSchema", () => {
-  it("accepts forecast items without visibility", () => {
-    const decoded = Schema.decodeUnknownSync(WeatherResponseSchema)({
-      city: {
-        coord: {
-          lat: -6.2088,
-          lon: 106.8456,
-        },
-        country: "ID",
-        id: 1_642_911,
-        name: "Jakarta",
-        sunrise: 1_779_309_600,
-        sunset: 1_779_352_800,
-        timezone: 25_200,
+const weatherResponse = {
+  city: {
+    coord: {
+      lat: -6.2088,
+      lon: 106.8456,
+    },
+    country: "ID",
+    id: 1_642_911,
+    name: "Jakarta",
+    sunrise: 1_779_309_600,
+    sunset: 1_779_352_800,
+    timezone: 25_200,
+  },
+  cnt: 1,
+  cod: "200",
+  list: [
+    {
+      clouds: {
+        all: 75,
       },
-      cnt: 1,
-      cod: "200",
-      list: [
+      dt: 1_779_321_600,
+      dt_txt: "2026-05-21 12:00:00",
+      main: {
+        feels_like: 305.2,
+        humidity: 78,
+        pressure: 1010,
+        temp: 300.4,
+        temp_max: 301,
+        temp_min: 300,
+      },
+      pop: 0.42,
+      sys: {
+        pod: "d",
+      },
+      weather: [
         {
-          clouds: {
-            all: 75,
-          },
-          dt: 1_779_321_600,
-          dt_txt: "2026-05-21 12:00:00",
-          main: {
-            feels_like: 305.2,
-            humidity: 78,
-            pressure: 1010,
-            temp: 300.4,
-            temp_max: 301,
-            temp_min: 300,
-          },
-          pop: 0.42,
-          sys: {
-            pod: "d",
-          },
-          weather: [
-            {
-              description: "light rain",
-              icon: "10d",
-              id: 500,
-              main: "Rain",
-            },
-          ],
-          wind: {
-            deg: 160,
-            speed: 2.5,
-          },
+          description: "light rain",
+          icon: "10d",
+          id: 500,
+          main: "Rain",
         },
       ],
-      message: 0,
-    });
+      wind: {
+        deg: 160,
+        speed: 2.5,
+      },
+    },
+  ],
+  message: 0,
+};
+
+const airPollution = {
+  coord: {
+    lat: -6.2088,
+    lon: 106.8456,
+  },
+  list: [],
+};
+
+describe("WeatherResponseSchema", () => {
+  it("accepts forecast items without visibility", () => {
+    const decoded = Schema.decodeUnknownSync(WeatherResponseSchema)(
+      weatherResponse
+    );
 
     expect(decoded.list[0]?.visibility).toBeUndefined();
+  });
+
+  it("accepts the complete app weather payload", () => {
+    const decoded = Schema.decodeUnknownSync(WeatherDataSchema)({
+      ...weatherResponse,
+      air_pollution: airPollution,
+      air_pollution_forecast: airPollution,
+      geocoding: {
+        city: "Jakarta",
+        country: "ID",
+        latitude: "-6.2088",
+        longitude: "106.8456",
+      },
+    });
+
+    expect(decoded.geocoding.city).toBe("Jakarta");
   });
 });

--- a/packages/ai/clients/weather/schema.ts
+++ b/packages/ai/clients/weather/schema.ts
@@ -138,5 +138,17 @@ export const GeoDataSchema = Schema.Struct({
   longitude: Schema.String,
 });
 
+/** Weather payload returned by the Nakafa weather route. */
+export const WeatherDataSchema = WeatherResponseSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      air_pollution: AirPollutionResponseSchema,
+      air_pollution_forecast: AirPollutionResponseSchema,
+      geocoding: GeoDataSchema,
+    })
+  ),
+  Schema.mutable
+);
+
 /** Geographic data used by Nina weather context. */
 export type GeoData = Schema.Schema.Type<typeof GeoDataSchema>;

--- a/packages/ai/clients/weather/transport.test.ts
+++ b/packages/ai/clients/weather/transport.test.ts
@@ -1,0 +1,122 @@
+import {
+  HttpClient,
+  type HttpClientRequest,
+  HttpClientResponse,
+} from "@effect/platform";
+import { requestWeatherJson } from "@repo/ai/clients/weather/transport";
+import { Effect, Either, Layer } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+interface TestClientInput {
+  makeResponse: (request: HttpClientRequest.HttpClientRequest) => Response;
+  observeRequest?: (request: HttpClientRequest.HttpClientRequest) => void;
+}
+
+/** Builds a deterministic Effect HTTP client for transport tests. */
+function makeTestClient({
+  makeResponse,
+  observeRequest = () => undefined,
+}: TestClientInput) {
+  return Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.sync(() => {
+        observeRequest(request);
+        return HttpClientResponse.fromWeb(request, makeResponse(request));
+      })
+    )
+  );
+}
+
+describe("requestWeatherJson", () => {
+  it("sends query parameters and returns decoded JSON", async () => {
+    const observeRequest =
+      vi.fn<(request: HttpClientRequest.HttpClientRequest) => void>();
+    const result = await Effect.runPromise(
+      requestWeatherJson({
+        endpoint: "forecast",
+        searchParams: {
+          appid: "weather-key",
+          lat: "-6.2088",
+        },
+        url: "https://weather.example.test/forecast",
+      }).pipe(
+        Effect.provide(
+          makeTestClient({
+            makeResponse: () => Response.json({ cod: "200" }),
+            observeRequest,
+          })
+        )
+      )
+    );
+
+    expect(result).toEqual({ cod: "200" });
+    expect(observeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: "https://weather.example.test/forecast",
+        urlParams: [
+          ["appid", "weather-key"],
+          ["lat", "-6.2088"],
+        ],
+      })
+    );
+    const request = observeRequest.mock.calls[0]?.[0];
+    expect(request?.headers).not.toHaveProperty("b3");
+    expect(request?.headers).not.toHaveProperty("traceparent");
+  });
+
+  it("maps rejected HTTP status into the weather error contract", async () => {
+    const result = await Effect.runPromise(
+      requestWeatherJson({
+        endpoint: "forecast",
+        searchParams: {
+          appid: "weather-secret",
+        },
+        url: "https://weather.example.test/forecast",
+      }).pipe(
+        Effect.provide(
+          makeTestClient({
+            makeResponse: () =>
+              new Response("unauthorized", {
+                status: 401,
+              }),
+          })
+        ),
+        Effect.either
+      )
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isRight(result)) {
+      return;
+    }
+    expect(result.left).toMatchObject({
+      _tag: "WeatherClientRequestError",
+      endpoint: "forecast",
+      message: "OpenWeather request failed for forecast.",
+    });
+    expect(JSON.stringify(result.left)).not.toContain("weather-secret");
+    expect(JSON.stringify(result.left)).not.toContain(
+      "https://weather.example.test/forecast"
+    );
+  });
+
+  it("retries transient HTTP failures before returning JSON", async () => {
+    const makeResponse = vi
+      .fn<(request: HttpClientRequest.HttpClientRequest) => Response>()
+      .mockReturnValueOnce(new Response("unavailable", { status: 503 }))
+      .mockReturnValueOnce(Response.json({ cod: "200" }));
+
+    const result = await Effect.runPromise(
+      requestWeatherJson({
+        endpoint: "forecast",
+        searchParams: {},
+        url: "https://weather.example.test/forecast",
+      }).pipe(Effect.provide(makeTestClient({ makeResponse })))
+    );
+
+    expect(result).toEqual({ cod: "200" });
+    expect(makeResponse).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ai/clients/weather/transport.ts
+++ b/packages/ai/clients/weather/transport.ts
@@ -1,0 +1,51 @@
+import {
+  HttpClient,
+  HttpClientResponse,
+  type UrlParams,
+} from "@effect/platform";
+import { Effect, Schedule, Schema } from "effect";
+
+const WEATHER_REQUEST_TIMEOUT = "10 seconds";
+
+class WeatherClientRequestError extends Schema.TaggedError<WeatherClientRequestError>()(
+  "WeatherClientRequestError",
+  {
+    endpoint: Schema.String,
+    message: Schema.String,
+  }
+) {}
+
+interface WeatherRequestInput {
+  endpoint: string;
+  searchParams: UrlParams.Input;
+  url: string;
+}
+
+/** Requests OpenWeather JSON through the injected Effect HTTP client. */
+export const requestWeatherJson = Effect.fn("weather.requestJson")(function* ({
+  endpoint,
+  searchParams,
+  url,
+}: WeatherRequestInput) {
+  const client = (yield* HttpClient.HttpClient).pipe(
+    // OpenWeather requires `appid` in the query, so its URL must not enter telemetry.
+    HttpClient.withTracerDisabledWhen(() => true),
+    HttpClient.retryTransient({
+      schedule: Schedule.exponential("300 millis"),
+      times: 2,
+    })
+  );
+
+  return yield* client.get(url, { urlParams: searchParams }).pipe(
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
+    Effect.flatMap((response) => response.json),
+    Effect.timeout(WEATHER_REQUEST_TIMEOUT),
+    Effect.mapError(
+      () =>
+        new WeatherClientRequestError({
+          endpoint,
+          message: `OpenWeather request failed for ${endpoint}.`,
+        })
+    )
+  );
+});

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@effect/platform": "0.97.0",
     "@ai-sdk/devtools": "^1.0.7",
     "@ai-sdk/elevenlabs": "^3.0.13",
     "@ai-sdk/gateway": "^4.0.28",
@@ -26,7 +27,6 @@
     "effect": "catalog:",
     "gpt-tokenizer": "^3.4.0",
     "ipaddr.js": "^2.4.0",
-    "ky": "^2.0.2",
     "parse-domain": "^8.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@convex-dev/better-auth':
         specifier: ^0.12.5
         version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.42.3(react@19.2.8))(hono@4.12.32)(react@19.2.8)(typescript@6.0.3)
+      '@effect/platform':
+        specifier: 0.97.0
+        version: 0.97.0(effect@3.22.0)
       '@hugeicons/core-free-icons':
         specifier: ^4.2.2
         version: 4.2.3
@@ -358,9 +361,6 @@ importers:
       immer:
         specifier: ^11.1.11
         version: 11.1.15
-      ky:
-        specifier: ^2.0.2
-        version: 2.0.2
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -461,6 +461,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^4.0.40
         version: 4.0.40(react@19.2.8)(zod@4.4.3)
+      '@effect/platform':
+        specifier: 0.97.0
+        version: 0.97.0(effect@3.22.0)
       '@mendable/firecrawl-js':
         specifier: ^4.30.1
         version: 4.30.1
@@ -494,9 +497,6 @@ importers:
       ipaddr.js:
         specifier: ^2.4.0
         version: 2.4.0
-      ky:
-        specifier: ^2.0.2
-        version: 2.0.2
       parse-domain:
         specifier: ^8.3.1
         version: 8.3.1
@@ -5903,10 +5903,6 @@ packages:
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
-
-  ky@2.0.2:
-    resolution: {integrity: sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg==}
-    engines: {node: '>=22'}
 
   kysely@0.28.17:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
@@ -12881,8 +12877,6 @@ snapshots:
   kleur@3.0.3: {}
 
   kubernetes-types@1.30.0: {}
-
-  ky@2.0.2: {}
 
   kysely@0.28.17: {}
 


### PR DESCRIPTION
## Summary

- remove Ky from every Nakafa dependency and HTTP call site
- model weather and forum upload requests with Effect HttpClient, typed domain errors, schema decoding, status filtering, retries, and timeouts
- inject HttpClient at domain seams and provide FetchHttpClient only at Next, React, and browser boundaries
- prevent OpenWeather API keys and signed Convex upload URLs from entering Effect HTTP spans or surfaced/logged error payloads; regression tests use sentinel secrets
- keep Effect 3.22.0 and @effect/platform 0.97.0 on current stable releases; Effect 4 remains beta

## Verification

- pnpm install --frozen-lockfile
- @repo/ai: 59 files / 383 tests / 100% coverage
- www: 149 files / 909 tests / 100% coverage
- @repo/ai and www typechecks
- lint, test ownership, boundaries, Effect source alignment
- React Doctor changed scope: 100/100
- API production build: 20/20 pages
- no Ky source, manifest, lockfile, or dependency-graph references
- all touched TypeScript modules are under 500 LOC

Local WWW compilation and TypeScript completed repeatedly. Final prerender was blocked only by external Convex and Google Fonts fetch timeouts over the current mobile hotspot; exact-main Vercel production readiness is therefore the deployment gate.

No Convex schema or function changes are included, so no Convex deployment is required.