### PR TITLE
fix(settings): remove curriculum card flicker

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/user/settings/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/user/settings/page.tsx
@@ -1,6 +1,9 @@
+import { api } from "@repo/backend/convex/_generated/api";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { UserSettingsCurriculum } from "@/components/user/settings/curriculum";
 import { UserSettingsProfilePage } from "@/components/user/settings/profile-page";
+import { preloadAuthQuery } from "@/lib/auth/server";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 
 export async function generateMetadata({
@@ -17,6 +20,23 @@ export async function generateMetadata({
   };
 }
 
-export default function Page() {
-  return <UserSettingsProfilePage />;
+export default async function Page({
+  params,
+}: PageProps<"/[locale]/user/settings">) {
+  const locale = getLocaleOrThrow((await params).locale);
+  const [preloadedPrograms, preloadedPreference] = await Promise.all([
+    preloadAuthQuery(api.learningPreferences.queries.listCurriculumPrograms, {
+      locale,
+    }),
+    preloadAuthQuery(api.learningPreferences.queries.getCurrent, { locale }),
+  ]);
+
+  return (
+    <UserSettingsProfilePage>
+      <UserSettingsCurriculum
+        preloadedPreference={preloadedPreference}
+        preloadedPrograms={preloadedPrograms}
+      />
+    </UserSettingsProfilePage>
+  );
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/user/settings/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/user/settings/page.tsx
@@ -1,9 +1,12 @@
 import { api } from "@repo/backend/convex/_generated/api";
+import { redirect } from "@repo/internationalization/src/navigation";
+import { Effect, Option } from "effect";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { UserSettingsCurriculum } from "@/components/user/settings/curriculum";
 import { UserSettingsProfilePage } from "@/components/user/settings/profile-page";
-import { preloadAuthQuery } from "@/lib/auth/server";
+import { scheduleCurrentServerExceptionCapture } from "@/lib/analytics/server";
+import { getToken, preloadAuthQuery } from "@/lib/auth/server";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 
 export async function generateMetadata({
@@ -23,20 +26,56 @@ export async function generateMetadata({
 export default async function Page({
   params,
 }: PageProps<"/[locale]/user/settings">) {
-  const locale = getLocaleOrThrow((await params).locale);
-  const [preloadedPrograms, preloadedPreference] = await Promise.all([
-    preloadAuthQuery(api.learningPreferences.queries.listCurriculumPrograms, {
-      locale,
-    }),
-    preloadAuthQuery(api.learningPreferences.queries.getCurrent, { locale }),
+  const [{ locale: rawLocale }, token] = await Promise.all([
+    params,
+    getToken(),
   ]);
+  const locale = getLocaleOrThrow(rawLocale);
+
+  if (!token) {
+    redirect({ href: "/auth", locale });
+    return null;
+  }
+
+  const curriculum = await Effect.runPromise(
+    Effect.all(
+      {
+        preloadedPreference: Effect.tryPromise(() =>
+          preloadAuthQuery(api.learningPreferences.queries.getCurrent, {
+            locale,
+          })
+        ),
+        preloadedPrograms: Effect.tryPromise(() =>
+          preloadAuthQuery(
+            api.learningPreferences.queries.listCurriculumPrograms,
+            { locale }
+          )
+        ),
+      },
+      { concurrency: "unbounded" }
+    ).pipe(
+      Effect.map(Option.some),
+      Effect.catchTag("UnknownException", (error) =>
+        Effect.sync(() =>
+          scheduleCurrentServerExceptionCapture(error.error, {
+            source: "user-settings-curriculum-preload",
+          })
+        ).pipe(Effect.as(Option.none()))
+      )
+    )
+  );
 
   return (
     <UserSettingsProfilePage>
-      <UserSettingsCurriculum
-        preloadedPreference={preloadedPreference}
-        preloadedPrograms={preloadedPrograms}
-      />
+      {Option.match(curriculum, {
+        onNone: () => null,
+        onSome: ({ preloadedPreference, preloadedPrograms }) => (
+          <UserSettingsCurriculum
+            preloadedPreference={preloadedPreference}
+            preloadedPrograms={preloadedPrograms}
+          />
+        ),
+      })}
     </UserSettingsProfilePage>
   );
 }

--- a/apps/www/components/user/settings/curriculum.tsx
+++ b/apps/www/components/user/settings/curriculum.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { api } from "@repo/backend/convex/_generated/api";
-import { useQueryWithStatus } from "@repo/backend/helpers/react";
+import type { api } from "@repo/backend/convex/_generated/api";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Field, FieldLabel } from "@repo/design-system/components/ui/field";
 import {
@@ -13,6 +12,7 @@ import {
   SelectValue,
 } from "@repo/design-system/components/ui/select";
 import { useForm } from "@tanstack/react-form";
+import { type Preloaded, usePreloadedQuery } from "convex/react";
 import type { FunctionArgs, FunctionReturnType } from "convex/server";
 import { Effect, Schema } from "effect";
 import type { Locale } from "next-intl";
@@ -59,27 +59,28 @@ class CurriculumPreferenceMutationError extends Schema.TaggedError<CurriculumPre
   }
 ) {}
 
-/** Renders the settings form that saves the user's preferred curriculum. */
-export function UserSettingsCurriculum() {
-  const locale = useLocale();
-  const programs = useQueryWithStatus(
-    api.learningPreferences.queries.listCurriculumPrograms,
-    { locale }
-  );
-  const preference = useQueryWithStatus(
-    api.learningPreferences.queries.getCurrent,
-    { locale }
-  );
+interface UserSettingsCurriculumProps {
+  preloadedPreference: Preloaded<
+    typeof api.learningPreferences.queries.getCurrent
+  >;
+  preloadedPrograms: Preloaded<
+    typeof api.learningPreferences.queries.listCurriculumPrograms
+  >;
+}
 
-  if (!(programs.isSuccess && preference.isSuccess)) {
-    return null;
-  }
+/** Renders the settings form that saves the user's preferred curriculum. */
+export function UserSettingsCurriculum({
+  preloadedPreference,
+  preloadedPrograms,
+}: UserSettingsCurriculumProps) {
+  const preference = usePreloadedQuery(preloadedPreference);
+  const programs = usePreloadedQuery(preloadedPrograms);
 
   return (
     <UserSettingsCurriculumForm
-      initialProgramKey={preference.data?.preferredCurriculumProgramKey ?? ""}
-      key={preference.data?.preferredCurriculumProgramKey ?? "empty"}
-      programs={programs.data}
+      initialProgramKey={preference?.preferredCurriculumProgramKey ?? ""}
+      key={preference?.preferredCurriculumProgramKey ?? "empty"}
+      programs={programs}
     />
   );
 }

--- a/apps/www/components/user/settings/profile-page.tsx
+++ b/apps/www/components/user/settings/profile-page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { UserSettingsCurriculum } from "@/components/user/settings/curriculum";
+import type { ReactNode } from "react";
 import { UserSettingsDeleteAccount } from "@/components/user/settings/delete-account";
 import { UserSettingsName } from "@/components/user/settings/name";
 import { UserSettingsRole } from "@/components/user/settings/role";
 import { useUser } from "@/lib/context/use-user";
 
-export function UserSettingsProfilePage() {
+export function UserSettingsProfilePage({ children }: { children: ReactNode }) {
   const user = useUser((state) => state.user);
 
   if (!user) {
@@ -17,7 +17,7 @@ export function UserSettingsProfilePage() {
     <>
       <UserSettingsName user={user} />
       <UserSettingsRole user={user} />
-      <UserSettingsCurriculum />
+      {children}
       <UserSettingsDeleteAccount userId={user.appUser._id} />
     </>
   );


### PR DESCRIPTION
## Description

- Preload the curriculum program list and current preference from the settings Server Component.
- Hydrate the client form from those preloaded Convex results while keeping its live reactive subscription.
- Compose the curriculum card into the profile shell through `children`, keeping data loading owned by the page.
- Redirect guests before curriculum reads and isolate curriculum-specific preload failures from the other account controls.

## Root cause

The curriculum component returned `null` until two additional client-side Convex queries completed. The name and role cards only depended on the already-resolved user context, so the curriculum card entered the layout later and visibly shifted the page.

## Architecture

- Personalized data remains request-time dynamic under the existing authenticated Suspense boundary. It is intentionally not placed in a shared Cache Components cache.
- The page resolves the cached Better Auth token before starting authenticated reads.
- Both independent reads run concurrently through `Effect.all`.
- A rejected curriculum preload is reported server-side and omits only that card. Name, role, and account deletion remain available.
- The RSC boundary passes only the two preloaded payloads consumed by the curriculum form.
- The profile shell stays data-agnostic and composes the domain-owned card through `children`.
- Production Convex already exposes both typed queries with locale argument and return validators. This PR changes no Convex function, schema, generated API, migration, or data.
- No React page or component test was added. Browser acceptance and the existing suites own this UI behavior.

## Review resolutions

- Fixed the valid preload isolation finding in `b024260a93`.
- Fixed the valid unauthenticated preload finding in `b024260a93`.
- Both review threads have concise evidence replies and are resolved.
- Fresh exact-head Codex review found no major issue.

## Type

- Bug fix
- Performance

## Testing

Exact reviewed head: `b024260a93534f7d84fe6df2b2b8006b07f0f8cf`

- `pnpm --filter www typecheck`
- `pnpm --filter www test`: 153 files, 946 tests, 100% coverage
- `pnpm lint`: passed repository lint, Effect source, and test-ownership checks
- `pnpm build`: all 5 build tasks passed, including 1,306 WWW pages
- Focused Ultracite check for all three changed files
- `git diff --check`
- Hosted Agent Docs: passed tests, production build, server start, and AFDocs in 11m36s
- React Doctor: 100/100 at exact head
- Production Convex function-spec verification for `listCurriculumPrograms` and `getCurrent`

## Production closure

- Rebase-merged to exact `main` commit `8b653c19533f7db801174ee80b9b525e9e05dcda`.
- Reviewed-head tree and merged-main tree are byte-identical at `a01a81683ac35eb592dc0f62a657514d54d6002e`.
- Vercel production deployment `dpl_AQxY5sbJnE7wB8huFP4kSYTrBsWT` is READY and aliases `nakafa.com` from the exact merged commit.
- Vercel production build passed compilation, TypeScript, and all 1,306 pages with no build error.
- Authenticated production requests to `/id/user/settings` and `/id/user/settings/subscriptions` returned 200.
- On a production client navigation from Subscriptions to Account, 5 ms sampling observed `Nama`, `Peran`, `Kurikulum`, and `Hapus akun` entering together. No intermediate state contained the other account cards without `Kurikulum`.
- The production curriculum form resolved to `Kurikulum Merdeka` and remained reactive through `usePreloadedQuery`.
- Browser console logs were empty. Deployment-scoped Vercel warning, error, and fatal logs were empty after acceptance.
- Convex production insights contained no error-severity item. The remaining warnings are unrelated historical OCC retries.
- No Convex deployment was performed because this PR has no backend or schema delta.
- The merged feature worktree, local branch, and remote branch were removed after exact tree-equivalence and clean-worktree proof.