### PR TITLE
fix(cas): preserve FastAPI request paths

### DIFF
--- a/apps/cas/vercel.ts
+++ b/apps/cas/vercel.ts
@@ -10,10 +10,4 @@ export const config: VercelConfig = {
       main: true,
     },
   },
-  rewrites: [
-    {
-      source: "/(.*)",
-      destination: "/api/index",
-    },
-  ],
 };


### PR DESCRIPTION
## What changed

- removes the obsolete catch-all rewrite from the Vercel FastAPI project config
- lets the current Vercel Python runtime pass the original public request path directly to FastAPI

## Why

The exact production deployment for `07220aae86c3c297858f536f7b8a7966c3e5efea` warned that internal backend rewrites now pass the rewritten destination path to the application. The old `/(.*)` to `/api/index` rewrite therefore made `/`, `/health`, and `/api/math` reach FastAPI as `/api/index`, and the production alias returned 404. Current Vercel FastAPI handling exposes the app routes directly and does not require this rewrite.

## Verification

- CAS lint
- CAS 233 tests at 100% coverage
- CAS basedpyright: 0 errors, 0 warnings, 0 notes
- root lint
- git diff check
- exact-head Vercel preview `dpl_4aU7R7p2g9HWauPzhbrzZg15FJ4h` READY with no alias error
- preview `/` returned 200
- preview `/health` returned 200 with `{"status":"ok"}`
- authenticated preview `POST /api/math` returned 200 and evaluated `2 + 2` to `4`

Production acceptance will repeat the three endpoint checks against `cas.nakafa.com` after the reviewed commit merges.