### PR TITLE
fix(marketing): preserve landing navigation

### DIFF
--- a/apps/www/components/marketing/shared/footer.tsx
+++ b/apps/www/components/marketing/shared/footer.tsx
@@ -92,12 +92,17 @@ export function Footer() {
               </span>
               <ul className="flex flex-col gap-2">
                 <li>
-                  <LinkItem href="/" label={t("about-us")} />
+                  <LinkItem
+                    href={`/${locale}`}
+                    label={t("about-us")}
+                    nativeAnchor
+                  />
                 </li>
                 <li>
                   <LinkItem
-                    href={{ pathname: "/", hash: "pricing" }}
+                    href={`/${locale}#pricing`}
                     label={tMarketing("pricing")}
+                    nativeAnchor
                   />
                 </li>
                 <li>
@@ -138,14 +143,14 @@ export function Footer() {
         </div>
       </div>
 
-      <NavigationLink
+      <a
         className="mx-auto flex w-full max-w-7xl px-6 py-16 transition-colors ease-out hover:text-primary"
-        href="/"
+        href={`/${locale}`}
       >
         <span className="mx-auto font-bold text-7xl transition-colors duration-300 ease-out hover:text-primary sm:text-8xl md:text-9xl lg:text-[12rem] xl:text-[18rem]">
           Nakafa
         </span>
-      </NavigationLink>
+      </a>
 
       <section className="w-full border-t">
         <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-4 p-6 lg:flex-row">
@@ -184,21 +189,34 @@ export function Footer() {
   );
 }
 
+type LinkItemProps =
+  | {
+      href: ComponentProps<typeof NavigationLink>["href"];
+      label: string;
+      nativeAnchor?: false;
+    }
+  | {
+      href: string;
+      label: string;
+      nativeAnchor: true;
+    };
+
 /**
  * Renders one locale-aware footer destination with the shared text treatment.
  */
-function LinkItem({
-  href,
-  label,
-}: {
-  href: ComponentProps<typeof NavigationLink>["href"];
-  label: string;
-}) {
+function LinkItem({ href, label, nativeAnchor }: LinkItemProps) {
+  const className = "text-sm transition-colors ease-out hover:text-primary";
+
+  if (nativeAnchor) {
+    return (
+      <a className={className} href={href}>
+        {label}
+      </a>
+    );
+  }
+
   return (
-    <NavigationLink
-      className="text-sm transition-colors ease-out hover:text-primary"
-      href={href}
-    >
+    <NavigationLink className={className} href={href}>
       {label}
     </NavigationLink>
   );

--- a/apps/www/components/marketing/shared/header-cta.tsx
+++ b/apps/www/components/marketing/shared/header-cta.tsx
@@ -4,17 +4,18 @@ import { Button } from "@repo/design-system/components/ui/button";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
 import { Link } from "@repo/internationalization/src/navigation";
 import Image from "next/image";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useUser } from "@/lib/context/use-user";
 
+/**
+ * Routes authenticated users home and clears stale marketing fragments for
+ * signed-out visitors.
+ */
 export function LogoCta() {
   const currentUser = useUser((state) => state.user);
-
-  return (
-    <Link
-      className="flex items-center gap-2"
-      href={currentUser ? "/home" : "/"}
-    >
+  const locale = useLocale();
+  const content = (
+    <>
       <Image
         alt="Nakafa"
         className="size-8 rounded-full border"
@@ -23,6 +24,20 @@ export function LogoCta() {
         width={32}
       />
       <span className="font-medium">Nakafa</span>
+    </>
+  );
+
+  if (!currentUser) {
+    return (
+      <a className="flex items-center gap-2" href={`/${locale}`}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link className="flex items-center gap-2" href="/home">
+      {content}
     </Link>
   );
 }

--- a/apps/www/components/marketing/shared/header.tsx
+++ b/apps/www/components/marketing/shared/header.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@repo/design-system/components/ui/button";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { HeaderContainer } from "@/components/marketing/shared/header-container";
 import { HeaderCta, LogoCta } from "@/components/marketing/shared/header-cta";
 import { Language } from "@/components/marketing/shared/language";
 
 export function Header() {
   const t = useTranslations("Marketing");
+  const locale = useLocale();
 
   return (
     <HeaderContainer>
@@ -16,7 +17,7 @@ export function Header() {
         <nav className="hidden items-center md:flex">
           <Button
             nativeButton={false}
-            render={<NavigationLink href="/">{t("about")}</NavigationLink>}
+            render={<a href={`/${locale}`}>{t("about")}</a>}
             variant="ghost"
           />
           <Button


### PR DESCRIPTION
## Summary

- use localized native anchors for marketing root and hash navigation that must reset or reposition scroll
- keep authenticated home navigation on the existing localized app link
- preserve the existing header, footer, responsive layout, and design-system styling

## Root cause

Next client navigation preserved the current scroll position when the destination remained visible on the same marketing page. This left footer Pricing and root About links at the wrong section even after the URL changed.

## Verification

- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`
- `pnpm --filter www build` with 1,303 of 1,303 static pages
- production-mode browser checks for English and Indonesian header, footer, hero, curriculum, and Tryout destinations
- first-party production landing destinations audited for successful HTML responses
- `.md` lesson endpoints and `llms.txt` verified with 200 text responses