### PR TITLE
fix(content): purge sitemap CDN cache

### DIFF
--- a/apps/www/app/api/internal/content/cache/route.test.ts
+++ b/apps/www/app/api/internal/content/cache/route.test.ts
@@ -11,6 +11,10 @@ import {
 import { Effect } from "effect";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ContentCacheInvalidationError,
+  type invalidateContentCache,
+} from "@/lib/content/cache";
 
 const releaseId = ReleaseIdSchema.make("release-cache-test");
 const artifactHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
@@ -22,8 +26,8 @@ const exactRequest = makeContentCacheRequest({
 });
 const exactTags = exactRequest.tags;
 const readActiveContentIdentityMock = vi.hoisted(() => vi.fn());
-const revalidateContentCacheMock = vi.hoisted(() =>
-  vi.fn((tags: readonly string[]) => tags)
+const invalidateContentCacheMock = vi.hoisted(() =>
+  vi.fn<typeof invalidateContentCache>()
 );
 
 vi.mock("@/env", () => ({
@@ -34,7 +38,7 @@ vi.mock("@/env", () => ({
 vi.mock("@/lib/content/cache", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/content/cache")>()),
   /** Records content runtime cache invalidation calls. */
-  revalidateContentCache: revalidateContentCacheMock,
+  invalidateContentCache: invalidateContentCacheMock,
 }));
 
 vi.mock("@/lib/content/published/active", () => ({
@@ -49,7 +53,9 @@ beforeEach(() => {
       sequence: 1,
     })
   );
-  revalidateContentCacheMock.mockClear();
+  invalidateContentCacheMock
+    .mockReset()
+    .mockImplementation((tags) => Effect.succeed(tags));
 });
 
 /** Creates one Next POST request for the cache route. */
@@ -112,7 +118,7 @@ describe("content runtime cache revalidation route", () => {
     expect(missing.headers.get("Cache-Control")).toBe("private, no-store");
     expect(invalid.headers.get("Cache-Control")).toBe("private, no-store");
     expect(malformed.headers.get("Cache-Control")).toBe("private, no-store");
-    expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+    expect(invalidateContentCacheMock).not.toHaveBeenCalled();
   });
 
   it("rejects an authenticated request without an exact release body", async () => {
@@ -126,7 +132,7 @@ describe("content runtime cache revalidation route", () => {
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(readActiveContentIdentityMock).not.toHaveBeenCalled();
-    expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+    expect(invalidateContentCacheMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -157,7 +163,7 @@ describe("content runtime cache revalidation route", () => {
       error: "Content release is not active.",
     });
     expect(readActiveContentIdentityMock).toHaveBeenCalledTimes(1);
-    expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+    expect(invalidateContentCacheMock).not.toHaveBeenCalled();
   });
 
   it("rejects a declared body that is absent", async () => {
@@ -170,7 +176,7 @@ describe("content runtime cache revalidation route", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Invalid cache invalidation request.",
     });
-    expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+    expect(invalidateContentCacheMock).not.toHaveBeenCalled();
   });
 
   it("invalidates and echoes the exact release artifact tags", async () => {
@@ -191,7 +197,23 @@ describe("content runtime cache revalidation route", () => {
     });
     expect(response.status).toBe(200);
     expect(readActiveContentIdentityMock).toHaveBeenCalledTimes(1);
-    expect(revalidateContentCacheMock).toHaveBeenCalledWith(exactTags);
+    expect(invalidateContentCacheMock).toHaveBeenCalledWith(exactTags);
+  });
+
+  it("reports a typed cache invalidation failure without a false receipt", async () => {
+    invalidateContentCacheMock.mockReturnValueOnce(
+      Effect.fail(new ContentCacheInvalidationError({ layer: "sitemap" }))
+    );
+    const { POST } = await import("@/app/api/internal/content/cache/route");
+    const response = await POST(
+      createBodyRequest(JSON.stringify(exactRequest))
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Content cache invalidation failed.",
+    });
+    expect(invalidateContentCacheMock).toHaveBeenCalledWith(exactTags);
   });
 
   it.each([
@@ -274,7 +296,7 @@ describe("content runtime cache revalidation route", () => {
       await expect(response.json()).resolves.toEqual({
         error: "Invalid cache invalidation request.",
       });
-      expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+      expect(invalidateContentCacheMock).not.toHaveBeenCalled();
     }
   );
 
@@ -293,6 +315,6 @@ describe("content runtime cache revalidation route", () => {
 
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
-    expect(revalidateContentCacheMock).not.toHaveBeenCalled();
+    expect(invalidateContentCacheMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/www/app/api/internal/content/cache/route.ts
+++ b/apps/www/app/api/internal/content/cache/route.ts
@@ -8,7 +8,7 @@ import { Effect, Schema } from "effect";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { env } from "@/env";
-import { revalidateContentCache } from "@/lib/content/cache";
+import { invalidateContentCache } from "@/lib/content/cache";
 import { isInternalContentAuthorized } from "@/lib/content/internal/authorization";
 import { readActiveContentIdentity } from "@/lib/content/published/active";
 
@@ -111,14 +111,22 @@ export const POST = (request: NextRequest) =>
           { headers: PRIVATE_RESPONSE_HEADERS, status: 409 }
         );
       }
-      const tags = revalidateContentCache(decoded.right.tags);
+      const invalidation = yield* invalidateContentCache(
+        decoded.right.tags
+      ).pipe(Effect.either);
+      if (invalidation._tag === "Left") {
+        return NextResponse.json(
+          { error: "Content cache invalidation failed." },
+          { headers: PRIVATE_RESPONSE_HEADERS, status: 503 }
+        );
+      }
 
       return NextResponse.json(
         ContentCacheReceiptSchema.make({
           family: decoded.right.family,
           releaseId: decoded.right.releaseId,
           revalidated: true,
-          tags,
+          tags: invalidation.right,
         }),
         { headers: PRIVATE_RESPONSE_HEADERS }
       );

--- a/apps/www/app/sitemap.xml/route.test.ts
+++ b/apps/www/app/sitemap.xml/route.test.ts
@@ -34,6 +34,7 @@ describe("sitemap index route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("application/xml");
+    expect(response.headers.get("Vercel-Cache-Tag")).toBe("content-sitemap");
     expect(text).toContain("<sitemapindex");
     expect(text).toContain("https://nakafa.com/sitemap/base.xml");
     expect(text).toContain("https://nakafa.com/sitemap/content_id_quran_0.xml");

--- a/apps/www/app/sitemap/[id]/route.test.ts
+++ b/apps/www/app/sitemap/[id]/route.test.ts
@@ -59,6 +59,7 @@ describe("sitemap page route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("application/xml");
+    expect(response.headers.get("Vercel-Cache-Tag")).toBe("content-sitemap");
     expect(text).toContain("<urlset");
     expect(text).toContain("<loc>https://nakafa.com/en</loc>");
     expect(mockGetSitemapEntries).toHaveBeenCalledWith({ pageId: "base" });

--- a/apps/www/lib/content/cache.test.ts
+++ b/apps/www/lib/content/cache.test.ts
@@ -4,7 +4,7 @@ import {
   makeArtifactCacheTag,
 } from "@nakafa/aksara-contracts/cache/content";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
-import { Schema } from "effect";
+import { Effect, Either, Schema } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const artifactHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
@@ -12,6 +12,12 @@ const artifactTag = makeArtifactCacheTag(artifactHash);
 const cacheLifeMock = vi.hoisted(() => vi.fn());
 const cacheTagMock = vi.hoisted(() => vi.fn());
 const revalidateTagMock = vi.hoisted(() => vi.fn());
+const dangerouslyDeleteByTagMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@vercel/functions", () => ({
+  /** Records immediate CDN deletion without calling Vercel. */
+  dangerouslyDeleteByTag: dangerouslyDeleteByTagMock,
+}));
 
 vi.mock("next/cache", () => ({
   /** Records cache profile usage without touching Next internals. */
@@ -27,6 +33,7 @@ describe("content runtime cache", () => {
     cacheLifeMock.mockClear();
     cacheTagMock.mockClear();
     revalidateTagMock.mockClear();
+    dangerouslyDeleteByTagMock.mockReset().mockResolvedValue(undefined);
   });
 
   it("applies the shared tag and cache profile", async () => {
@@ -63,7 +70,7 @@ describe("content runtime cache", () => {
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
 
-  it("invalidates only the decoded exact artifact tags requested", async () => {
+  it("invalidates exact Next tags and the sitemap CDN tag", async () => {
     const cache = await import("@/lib/content/cache");
     const tags = Schema.decodeUnknownSync(ContentCacheTagsSchema)([
       "content-runtime",
@@ -71,12 +78,60 @@ describe("content runtime cache", () => {
       artifactTag,
     ]);
 
-    expect(cache.revalidateContentCache(tags)).toEqual(tags);
+    await expect(
+      Effect.runPromise(cache.invalidateContentCache(tags))
+    ).resolves.toEqual(tags);
     expect(revalidateTagMock.mock.calls).toEqual([
       ["content-runtime", { expire: 0 }],
       ["content-family:material", { expire: 0 }],
       [artifactTag, { expire: 0 }],
     ]);
+    expect(dangerouslyDeleteByTagMock).toHaveBeenCalledWith("content-sitemap", {
+      revalidationDeadlineSeconds: 0,
+    });
+  });
+
+  it("keeps a failed CDN purge in the typed error channel", async () => {
+    dangerouslyDeleteByTagMock.mockRejectedValueOnce(new Error("unavailable"));
+    const cache = await import("@/lib/content/cache");
+    const tags = Schema.decodeUnknownSync(ContentCacheTagsSchema)([
+      "content-runtime",
+      "content-family:material",
+    ]);
+
+    const result = await Effect.runPromise(
+      cache.invalidateContentCache(tags).pipe(Effect.either)
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toEqual(
+        new cache.ContentCacheInvalidationError({ layer: "sitemap" })
+      );
+    }
+  });
+
+  it("keeps a failed Next invalidation in the typed error channel", async () => {
+    revalidateTagMock.mockImplementationOnce(() => {
+      throw new Error("unavailable");
+    });
+    const cache = await import("@/lib/content/cache");
+    const tags = Schema.decodeUnknownSync(ContentCacheTagsSchema)([
+      "content-runtime",
+      "content-family:material",
+    ]);
+
+    const result = await Effect.runPromise(
+      cache.invalidateContentCache(tags).pipe(Effect.either)
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toEqual(
+        new cache.ContentCacheInvalidationError({ layer: "next" })
+      );
+    }
+    expect(dangerouslyDeleteByTagMock).not.toHaveBeenCalled();
   });
 
   it("rejects an artifact tag without a canonical signed hash", async () => {

--- a/apps/www/lib/content/cache.ts
+++ b/apps/www/lib/content/cache.ts
@@ -6,10 +6,18 @@ import {
 } from "@nakafa/aksara-contracts/cache/content";
 import type { ContentFamily } from "@nakafa/aksara-contracts/content";
 import type { Sha256Hash } from "@nakafa/aksara-contracts/ids";
+import { Effect, Schema } from "effect";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
+import { purgeSitemapCache } from "@/lib/sitemap/cache";
 
 const CONTENT_RUNTIME_CACHE_PROFILE = "contentRuntime";
 const CONTENT_RUNTIME_REVALIDATION = { expire: 0 };
+
+/** One content cache layer could not be invalidated after publication. */
+export class ContentCacheInvalidationError extends Schema.TaggedError<ContentCacheInvalidationError>()(
+  "ContentCacheInvalidationError",
+  { layer: Schema.Literal("next", "sitemap") }
+) {}
 
 /**
  * Applies the content runtime cache profile and invalidation tags to one cached read.
@@ -38,11 +46,23 @@ export function applyPublishedContentCache(
   cacheLife(CONTENT_RUNTIME_CACHE_PROFILE);
 }
 
-/** Immediately invalidates one exact decoded content-family cache request. */
-export function revalidateContentCache(tags: ContentCacheTags) {
-  for (const tag of tags) {
-    revalidateTag(tag, CONTENT_RUNTIME_REVALIDATION);
-  }
+/** Immediately invalidates Next runtime data and the sitemap CDN response. */
+export const invalidateContentCache = Effect.fn("www.content.cache.invalidate")(
+  function* (tags: ContentCacheTags) {
+    yield* Effect.try({
+      catch: () => new ContentCacheInvalidationError({ layer: "next" }),
+      try: () => {
+        for (const tag of tags) {
+          revalidateTag(tag, CONTENT_RUNTIME_REVALIDATION);
+        }
+      },
+    });
+    yield* purgeSitemapCache().pipe(
+      Effect.mapError(
+        () => new ContentCacheInvalidationError({ layer: "sitemap" })
+      )
+    );
 
-  return tags;
-}
+    return tags;
+  }
+);

--- a/apps/www/lib/sitemap/cache.ts
+++ b/apps/www/lib/sitemap/cache.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { dangerouslyDeleteByTag } from "@vercel/functions";
+import { Effect, Schema } from "effect";
+
+/** One CDN-only tag shared by every bounded sitemap response. */
+export const CONTENT_SITEMAP_CACHE_TAG = "content-sitemap";
+
+/** Vercel could not remove the stale sitemap response from its CDN cache. */
+export class SitemapCachePurgeError extends Schema.TaggedError<SitemapCachePurgeError>()(
+  "SitemapCachePurgeError",
+  {}
+) {}
+
+/** Deletes every sitemap response so the next crawler receives active content. */
+export const purgeSitemapCache = Effect.fn("www.sitemap.cache.purge")(() =>
+  Effect.tryPromise({
+    catch: () => new SitemapCachePurgeError(),
+    try: () =>
+      dangerouslyDeleteByTag(CONTENT_SITEMAP_CACHE_TAG, {
+        revalidationDeadlineSeconds: 0,
+      }),
+  })
+);

--- a/apps/www/lib/sitemap/xml.ts
+++ b/apps/www/lib/sitemap/xml.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { CONTENT_SITEMAP_CACHE_TAG } from "@/lib/sitemap/cache";
 
 type SitemapEntry = MetadataRoute.Sitemap[number];
 
@@ -6,6 +7,7 @@ export const sitemapXmlHeaders = {
   "Cache-Control":
     "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
   "Content-Type": "application/xml; charset=utf-8",
+  "Vercel-Cache-Tag": CONTENT_SITEMAP_CACHE_TAG,
 } as const;
 
 const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';


### PR DESCRIPTION
## Outcome

- tags every sitemap response with one dedicated Vercel CDN cache tag
- invalidates Next content tags and deletes stale sitemap CDN responses after a signed content activation
- fails closed with HTTP 503 when either cache layer cannot be invalidated

## Why

The material and program release activated 745 material sitemap buckets, but the normal sitemap URL could still serve its prior one-hour CDN response. Next tag invalidation does not purge a response cached through manual CDN headers, so release acceptance could observe stale route inventory.

## Verification

- exact-commit local Codex review: no actionable regressions
- pnpm --filter www typecheck
- full WWW suite: 182 files, 1,160 tests, 100% statements, branches, functions, and lines
- pnpm lint
- pnpm boundaries
- React Doctor changed scope: 100/100
- root pnpm build: 5/5 tasks, WWW 1,303/1,303 pages
- root pnpm start: WWW, API, MCP, and CAS smoke endpoints returned HTTP 200

Production CDN behavior will be verified on the exact merged deployment before the retained recovery release is accepted.