### PR TITLE
docs: refresh agent and production guidance

### DIFF
--- a/.agents/skills/vercel-react-best-practices/AGENTS.md
+++ b/.agents/skills/vercel-react-best-practices/AGENTS.md
@@ -20,21 +20,21 @@ Comprehensive performance optimization guide for React and Next.js applications,
 
 ## Table of Contents
 
-1. [Eliminating Waterfalls](#1-eliminating-waterfalls) — **CRITICAL**
+1. [Eliminating Waterfalls](#1-eliminating-waterfalls): **CRITICAL**
    - 1.1 [Check Cheap Conditions Before Async Flags](#11-check-cheap-conditions-before-async-flags)
    - 1.2 [Defer Await Until Needed](#12-defer-await-until-needed)
    - 1.3 [Dependency-Based Parallelization](#13-dependency-based-parallelization)
    - 1.4 [Prevent Waterfall Chains in API Routes](#14-prevent-waterfall-chains-in-api-routes)
    - 1.5 [Promise.all() for Independent Operations](#15-promiseall-for-independent-operations)
    - 1.6 [Strategic Suspense Boundaries](#16-strategic-suspense-boundaries)
-2. [Bundle Size Optimization](#2-bundle-size-optimization) — **CRITICAL**
+2. [Bundle Size Optimization](#2-bundle-size-optimization): **CRITICAL**
    - 2.1 [Avoid Barrel File Imports](#21-avoid-barrel-file-imports)
    - 2.2 [Conditional Module Loading](#22-conditional-module-loading)
    - 2.3 [Defer Non-Critical Third-Party Libraries](#23-defer-non-critical-third-party-libraries)
    - 2.4 [Dynamic Imports for Heavy Components](#24-dynamic-imports-for-heavy-components)
    - 2.5 [Prefer Statically Analyzable Paths](#25-prefer-statically-analyzable-paths)
    - 2.6 [Preload Based on User Intent](#26-preload-based-on-user-intent)
-3. [Server-Side Performance](#3-server-side-performance) — **HIGH**
+3. [Server-Side Performance](#3-server-side-performance): **HIGH**
    - 3.1 [Authenticate Server Actions Like API Routes](#31-authenticate-server-actions-like-api-routes)
    - 3.2 [Avoid Duplicate Serialization in RSC Props](#32-avoid-duplicate-serialization-in-rsc-props)
    - 3.3 [Avoid Shared Module State for Request Data](#33-avoid-shared-module-state-for-request-data)
@@ -45,12 +45,12 @@ Comprehensive performance optimization guide for React and Next.js applications,
    - 3.8 [Parallel Nested Data Fetching](#38-parallel-nested-data-fetching)
    - 3.9 [Per-Request Deduplication with React.cache()](#39-per-request-deduplication-with-reactcache)
    - 3.10 [Use after() for Non-Blocking Operations](#310-use-after-for-non-blocking-operations)
-4. [Client-Side Data Fetching](#4-client-side-data-fetching) — **MEDIUM-HIGH**
+4. [Client-Side Data Fetching](#4-client-side-data-fetching): **MEDIUM-HIGH**
    - 4.1 [Deduplicate Global Event Listeners](#41-deduplicate-global-event-listeners)
    - 4.2 [Use Passive Event Listeners for Scrolling Performance](#42-use-passive-event-listeners-for-scrolling-performance)
    - 4.3 [Use SWR for Automatic Deduplication](#43-use-swr-for-automatic-deduplication)
    - 4.4 [Version and Minimize localStorage Data](#44-version-and-minimize-localstorage-data)
-5. [Re-render Optimization](#5-re-render-optimization) — **MEDIUM**
+5. [Re-render Optimization](#5-re-render-optimization): **MEDIUM**
    - 5.1 [Calculate Derived State During Rendering](#51-calculate-derived-state-during-rendering)
    - 5.2 [Defer State Reads to Usage Point](#52-defer-state-reads-to-usage-point)
    - 5.3 [Do not wrap a simple expression with a primitive result type in useMemo](#53-do-not-wrap-a-simple-expression-with-a-primitive-result-type-in-usememo)
@@ -66,7 +66,7 @@ Comprehensive performance optimization guide for React and Next.js applications,
    - 5.13 [Use Transitions for Non-Urgent Updates](#513-use-transitions-for-non-urgent-updates)
    - 5.14 [Use useDeferredValue for Expensive Derived Renders](#514-use-usedeferredvalue-for-expensive-derived-renders)
    - 5.15 [Use useRef for Transient Values](#515-use-useref-for-transient-values)
-6. [Rendering Performance](#6-rendering-performance) — **MEDIUM**
+6. [Rendering Performance](#6-rendering-performance): **MEDIUM**
    - 6.1 [Animate SVG Wrapper Instead of SVG Element](#61-animate-svg-wrapper-instead-of-svg-element)
    - 6.2 [CSS content-visibility for Long Lists](#62-css-content-visibility-for-long-lists)
    - 6.3 [Hoist Static JSX Elements](#63-hoist-static-jsx-elements)
@@ -78,7 +78,7 @@ Comprehensive performance optimization guide for React and Next.js applications,
    - 6.9 [Use Explicit Conditional Rendering](#69-use-explicit-conditional-rendering)
    - 6.10 [Use React DOM Resource Hints](#610-use-react-dom-resource-hints)
    - 6.11 [Use useTransition Over Manual Loading States](#611-use-usetransition-over-manual-loading-states)
-7. [JavaScript Performance](#7-javascript-performance) — **LOW-MEDIUM**
+7. [JavaScript Performance](#7-javascript-performance): **LOW-MEDIUM**
    - 7.1 [Avoid Layout Thrashing](#71-avoid-layout-thrashing)
    - 7.2 [Build Index Maps for Repeated Lookups](#72-build-index-maps-for-repeated-lookups)
    - 7.3 [Cache Property Access in Loops](#73-cache-property-access-in-loops)
@@ -93,7 +93,7 @@ Comprehensive performance optimization guide for React and Next.js applications,
    - 7.12 [Use Loop for Min/Max Instead of Sort](#712-use-loop-for-minmax-instead-of-sort)
    - 7.13 [Use Set/Map for O(1) Lookups](#713-use-setmap-for-o1-lookups)
    - 7.14 [Use toSorted() Instead of sort() for Immutability](#714-use-tosorted-instead-of-sort-for-immutability)
-8. [Advanced Patterns](#8-advanced-patterns) — **LOW**
+8. [Advanced Patterns](#8-advanced-patterns): **LOW**
    - 8.1 [Do Not Put Effect Events in Dependency Arrays](#81-do-not-put-effect-events-in-dependency-arrays)
    - 8.2 [Initialize App Once, Not Per Mount](#82-initialize-app-once-not-per-mount)
    - 8.3 [Store Event Handlers in Refs](#83-store-event-handlers-in-refs)
@@ -113,7 +113,7 @@ Waterfalls are the #1 performance killer. Each sequential await adds full networ
 
 When a branch uses `await` for a flag or remote value and also requires a **cheap synchronous** condition (local props, request metadata, already-loaded state), evaluate the cheap condition **first**. Otherwise you pay for the async call even when the compound condition can never be true.
 
-This is a specialization of [Defer Await Until Needed](./async-defer-await.md) for `flag && cheapCondition` style checks.
+This is a specialization of [Defer Await Until Needed](#12-defer-await-until-needed) for `flag && cheapCondition` style checks.
 
 **Incorrect:**
 
@@ -216,7 +216,7 @@ async function updateResource(resourceId: string, userId: string) {
 
 This optimization is especially valuable when the skipped branch is frequently taken, or when the deferred operation is expensive.
 
-For `await getFlag()` combined with a cheap synchronous guard (`flag && someCondition`), see [Check Cheap Conditions Before Async Flags](./async-cheap-condition-before-await.md).
+For `await getFlag()` combined with a cheap synchronous guard (`flag && someCondition`), see [Check Cheap Conditions Before Async Flags](#11-check-cheap-conditions-before-async-flags).
 
 ### 1.3 Dependency-Based Parallelization
 
@@ -696,7 +696,7 @@ Optimizing server-side rendering and data fetching eliminates server-side waterf
 
 **Impact: CRITICAL (prevents unauthorized access to server mutations)**
 
-Server Actions (functions with `"use server"`) are exposed as public endpoints, just like API routes. Always verify authentication and authorization **inside** each Server Action—do not rely solely on middleware, layout guards, or page-level checks, as Server Actions can be invoked directly.
+Server Actions (functions with `"use server"`) are exposed as public endpoints, just like API routes. Always verify authentication and authorization **inside** each Server Action; do not rely solely on middleware, layout guards, or page-level checks, as Server Actions can be invoked directly.
 
 Next.js documentation explicitly states: "Treat Server Actions with the same security considerations as public-facing API endpoints, and verify if the user is allowed to perform a mutation."
 
@@ -889,7 +889,7 @@ Safe exceptions:
 
 - Process-wide singletons that do not store request- or user-specific mutable data
 
-For static assets and config, see [Hoist Static I/O to Module Level](./server-hoist-static-io.md).
+For static assets and config, see [Hoist Static I/O to Module Level](#35-hoist-static-io-to-module-level).
 
 ### 3.4 Cross-Request LRU Caching
 
@@ -2058,7 +2058,7 @@ function TodoList() {
 }
 ```
 
-The first callback is recreated every time `items` changes, which can cause child components to re-render unnecessarily. The second callback has a stale closure bug—it will always reference the initial `items` value.
+The first callback is recreated every time `items` changes, which can cause child components to re-render unnecessarily. The second callback has a stale closure bug; it will always reference the initial `items` value.
 
 **Correct: stable callbacks, no stale closures**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,5 @@
 # Contributing to nakafa.com
 
-Thank you for contributing! Every contribution helps improve educational content for millions of learners.
-
-## Contribution License
-
 Nakafa is source-available, not open source. Read `LICENSE`,
 `CONTENT_LICENSE.md`, and `TRADEMARKS.md` before contributing.
 
@@ -11,79 +7,94 @@ You may create a GitHub fork only to prepare and submit contributions back to
 Nakafa. The fork must not be used as a standalone project, hosted service,
 mirror, product, rebrand, or distribution channel.
 
-By submitting a pull request, patch, issue attachment, content correction,
-translation, design, dataset, documentation change, or any other contribution,
-you certify that:
+By submitting code, content, data, designs, or another contribution, you
+certify that:
 
-- You have the right to submit the contribution.
-- The contribution is your original work, or you have permission to submit it.
-- The contribution does not include secrets, private data, copied proprietary
-  material, or material with license terms that conflict with Nakafa.
+- You have the right to submit it.
+- It is your original work, or you have permission to submit it.
+- It contains no secrets, private data, copied proprietary material, or
+  conflicting license terms.
 - You grant PT. Nakafa Tekno Kreatif a perpetual, worldwide, non-exclusive,
   royalty-free, sublicensable, and transferable license to use, reproduce,
   modify, distribute, publicly display, publicly perform, create derivative
-  works from, and relicense the contribution as part of Nakafa.
-- PT. Nakafa Tekno Kreatif may use the contribution in source-available,
-  commercial, proprietary, hosted, educational, and internal versions of Nakafa
-  without owing you payment.
+  works from, and relicense it as part of Nakafa.
+- PT. Nakafa Tekno Kreatif may use it in source-available, commercial,
+  proprietary, hosted, educational, and internal versions of Nakafa without
+  owing you payment.
 
 Do not submit a contribution if you cannot grant these rights.
 
-## Getting Started
+## Setup
 
-### Prerequisites
-- Node.js 22+
-- pnpm
+The supported toolchain is declared in `package.json`:
+
+- Node.js 24
+- pnpm 10.34.1
 - Git
 
-### Development Setup
-```bash
-# Clone and install
+```sh
 git clone https://github.com/YOUR-USERNAME/nakafa.com.git
 cd nakafa.com
-pnpm install
-
-# Start development
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 
-Visit http://localhost:3000
+The main web app is available at [http://localhost:3000](http://localhost:3000).
 
-## Project Structure
-- apps/www - Main Next.js application
-- packages/contents - Educational content & MDX files
-- packages/design-system - UI components & design tokens
-- packages/internationalization - i18n configuration
-- packages/analytics - Analytics utilities
+## Before editing
 
-## Making Changes
+- Read root `AGENTS.md` and the nearest nested `AGENTS.md`.
+- Inspect recent history, the owning package, its config, and nearby tests.
+- Verify whether a content scope is owned by Aksara or by the remaining local
+  `packages/contents` source.
+- For Effect work, inspect the pinned read-only `repos/effect` source.
+- For Convex work, follow `packages/backend/AGENTS.md` and use an isolated Agent
+  Mode deployment.
 
-### Development Commands
-```bash
-pnpm test         # Run tests
-pnpm lint         # Check code quality
-pnpm format       # Format code
-pnpm --filter www typecheck # Type check the web app
+## Code standards
+
+- Use TypeScript and existing package or app aliases.
+- Design effectful domain work as typed Effect programs with schema-derived
+  contracts and tagged expected errors.
+- Prefer direct, readable control flow, early returns, and small domain-owned
+  modules.
+- Do not add workaround casts, generic errors, wrapper chains, compatibility
+  layers, duplicate sources of truth, or dead migration code.
+- Keep tests colocated as `name.test.ts` or `name.test.tsx` and use
+  `vitest.config.ts`.
+- Use MDX for authored educational content and the existing math components for
+  mathematical notation.
+
+## Verification
+
+Run the smallest relevant checks while developing, then the complete affected
+workspace gates before opening a pull request:
+
+```sh
+pnpm lint
+pnpm test
+pnpm boundaries
+pnpm --filter www typecheck
+pnpm build
 ```
 
-### Code Standards
-- TypeScript strict mode enabled
-- Use functional components with hooks
-- Export as named exports
-- No type assertions
-- MDX for educational content with InlineMath for math
-- Import from @repo/* for internal packages, @/ for app-level
+Run typechecks and tests for every other changed workspace. For production-mode
+runtime verification, run `pnpm start` after a successful root build.
 
-### Submitting Changes
-1. Branch from main: `git checkout -b feature/change-name`
-2. Make changes with clear commit messages
-3. Ensure tests pass and no linting errors
-4. Push and create a pull request
+## Pull requests
 
-## Finding Issues
-Look for labels: `good first issue`, `help wanted`, or browse open issues.
+1. Branch from current `main`.
+2. Keep commits small and cohesive.
+3. Open a ready pull request with an accurate title and body.
+4. Wait for exact-head CI and review.
+5. Reply concisely to each review finding, fix valid findings, and resolve every
+   conversation.
+6. Re-run affected checks after the final change.
 
-## Get Help
-- Discord: https://discord.gg/CPCSfKhvfQ
-- GitHub Discussions: https://github.com/nakafaai/nakafa.com/discussions
-- Security: https://github.com/nakafaai/nakafa.com/security/advisories/new
+Protected `main` accepts linear squash or rebase merges and rejects merge
+commits, force pushes, and unresolved required checks.
+
+## Help
+
+- [GitHub Discussions](https://github.com/nakafaai/nakafa.com/discussions)
+- [Security advisories](https://github.com/nakafaai/nakafa.com/security/advisories/new)

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -32,21 +32,21 @@ jobs:
       SITE_URL: http://localhost:3000
       TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: apps/cas/uv.lock

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,9 +20,9 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@v2
+      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2
         with:
           blocking: warning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,6 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 ## Source Of Truth
 
 - Use retrieval-led reasoning first. Read the repo, configs, docs, and generated files before changing code.
-- No Cursor rules were found in `.cursor/rules/` or `.cursorrules` when this guide was updated.
-- No Copilot instructions were found in `.github/copilot-instructions.md` when this guide was updated.
 - This root `AGENTS.md` is the baseline for the repo.
 - Also read any nested `AGENTS.md` files in the area you touch.
 - For Convex work, `packages/backend/AGENTS.md` is mandatory.
@@ -29,14 +27,19 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 - Main packages: `packages/backend`, `packages/design-system`, `packages/contents`, `packages/ai`, `packages/testing`
 - App-local alias: `@/*`
 - Cross-package alias: `@repo/*`
-- Educational MDX content lives in `packages/contents/`
+- Aksara owns authored content and publication for every explicitly activated
+  scope. During the migration, `packages/contents/` still contains source for
+  unactivated scopes plus copies awaiting coordinated deletion after cutover.
 
 ## Package Ownership
 
 - `packages/utilities` is for generic cross-domain primitives only. Do not put Nakafa content-domain constants, taxonomy, schemas, MDX/content metadata, or content-specific helpers there.
-- Content taxonomy constants and domain types live in `packages/contents/_types/taxonomy.ts`; callers import taxonomy constants and types directly from that module.
-- Content schema modules may derive Effect schemas from taxonomy values, but they must not re-export taxonomy constants or domain types.
-- `packages/contents` is the source of truth for content-domain types, taxonomy, metadata schemas, and authoring contracts. Backend/Convex may import only narrow pure modules from `packages/contents/_types` when runtime validators must share the same taxonomy.
+- For scopes still owned locally, content taxonomy constants and domain types live in `packages/contents/_types/taxonomy.ts`; callers import them directly from that module.
+- Local content schema modules may derive Effect schemas from taxonomy values, but they must not re-export taxonomy constants or domain types.
+- Aksara contracts and signed snapshots are authoritative for activated content
+  scopes. Filesystem copies for those scopes are deletion work, not editable or
+  publishable source. Do not create a second source of truth across both
+  repositories.
 
 ## Effect-Native Standard
 
@@ -67,10 +70,11 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 - Convex Helpers README: `https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md`
 - Convex Aggregate: `https://www.convex.dev/components/aggregate`
 - Convex pagination: `https://docs.convex.dev/database/pagination`
+- Convex Agent Mode: `https://docs.convex.dev/cli/agent-mode`
 - Confect spec/impl model: `https://confect.dev/concepts/spec-impl-model`
 - Confect file naming conventions: `https://confect.dev/concepts/file-naming-conventions`
 - Effect docs: `https://effect.website/docs`
-- Effect LLM reference: `https://effect.website/llms.txt`
+- Effect source-vendoring guidance: `https://www.effect.website/blog/the-one-weird-git-trick-that-makes-coding-agents-more-effect-ive`
 - Effect Cache: `https://effect.website/docs/caching/cache/`
 - Effect Platform filesystem: `https://effect.website/docs/platform/file-system/`
 - React effects guidance: `https://react.dev/learn/you-might-not-need-an-effect`
@@ -82,7 +86,8 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 ## Vendored References
 
 - External source references live under `repos/` as read-only Git subtrees.
-- `repos/effect` is pinned to the installed `effect` package version. Before writing or reviewing Effect code, read its `AGENTS.md`, then inspect the relevant implementation, tests, and type-level tests under `packages/effect`.
+- Follow the official Effect guidance on [vendoring source for coding agents](https://www.effect.website/blog/the-one-weird-git-trick-that-makes-coding-agents-more-effect-ive).
+- `repos/effect` is pinned to the installed `effect` package version. Before writing or reviewing Effect code, read its `AGENTS.md`, then inspect the relevant implementation, tests, type-level tests, module structure, and API design under `packages/effect`.
 - Prefer the matching vendored source for Effect API shape and idioms instead of guessing from memory, generated declarations, or examples for another major version.
 - Never edit, import from, build, lint, or test `repos/effect` as Nakafa application code.
 - `pnpm effect:source:check` verifies that the installed and vendored Effect versions match. After committing an Effect dependency update, run `pnpm effect:source:update`; it pulls the matching release tag and creates one linear reference update commit.
@@ -194,7 +199,7 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 - Effect-native means effectful work is modeled with Effect; pure deterministic helpers should stay pure.
 - Model expected failures with `Schema.TaggedError` and specific domain error names.
 - Prefer `Effect.fn("scope.name")` for effectful exported functions and service methods so traces are named.
-- Use the documented stable `Context.Tag` plus `Layer` pattern for dependency contracts. `Effect.Service` may combine that contract with a default layer only when the module genuinely owns the default implementation and the repository deliberately accepts its experimental Effect 3.22 API; do not choose between them based only on whether a dependency is “business” or “infrastructure.”
+- Use the documented stable `Context.Tag` plus `Layer` pattern for dependency contracts. `Effect.Service` may combine that contract with a default layer only when the module genuinely owns the default implementation and the repository deliberately accepts its experimental Effect 3.22 API; do not choose between them based only on whether a dependency is "business" or "infrastructure."
 - Use `@effect/platform` and `@effect/platform-node` for Node filesystem and HTTP boundaries when those packages own the IO seam.
 - Prefer `Effect.Cache` or Effect cached effects for shared effectful cache state. Plain `Map` is acceptable inside one pure algorithm for grouping, deduplication, or indexing.
 - Use `Effect.try`, `Effect.tryPromise`, `Effect.acquireRelease`, and `Effect.sync` instead of raw `try/catch`, raw async wrappers, or hidden side effects.
@@ -224,7 +229,7 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
  
 ### Next.js: ALWAYS read docs before coding
  
-Before any Next.js work, find and read the relevant installed Next.js doc. With pnpm, resolve it with `find . -path '*/node_modules/next/dist/docs' -type d -print`; do not assume it exists at direct `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+Before any Next.js work, find and read the relevant installed Next.js doc. With pnpm, resolve it with `find . -path '*/node_modules/next/dist/docs' -type d -print`; do not assume it exists at direct `node_modules/next/dist/docs/`. Your training data is outdated; the docs are the source of truth.
  
 <!-- END:nextjs-agent-rules -->
 
@@ -243,6 +248,7 @@ Before any Next.js work, find and read the relevant installed Next.js doc. With 
 ## Convex Rules
 
 - Follow official Convex docs and the generated AI guidelines exactly.
+- Every concurrent Convex task must use an isolated deployment through Agent Mode as documented in `packages/backend/AGENTS.md`. Never use the shared personal dev deployment for new work.
 - Prefer Convex-first app-data mutations and queries. Do not add Next Server Actions or Route Handlers that only wrap Convex functions; use them only for real Next/framework boundaries such as cookies, headers, cache invalidation, or non-Convex integrations, and document that reason at the seam.
 - Use shared helpers and validators in `packages/backend/convex/lib/`.
 - Use auth helpers from `packages/backend/convex/lib/helpers/auth.ts`; do not reach for raw `ctx.auth` patterns first.

--- a/README.md
+++ b/README.md
@@ -2,260 +2,141 @@
 
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nakafaai/nakafa.com)
 
-## Overview
+Nakafa is a source-available educational platform for structured learning,
+assessments, Quran study, and political analysis. The production site is
+[nakafa.com](https://nakafa.com).
 
-**Nakafa** is a source-available educational platform providing structured learning content across multiple educational levels (elementary, middle, high school, university) with political analysis articles.
+This repository owns the React and Next.js applications, design system,
+transactional Convex backend, renderer implementations, user state, and
+product integrations. The separate
+[Aksara repository](https://github.com/nakafaai/aksara) owns authored content
+and signed publication artifacts for every scope that has completed cutover.
+During the migration, `packages/contents` still contains source for scopes that
+have not completed cutover and copies awaiting coordinated deletion for scopes
+already served from Aksara. Those copies are not active publication sources.
 
-Nakafa is **not open source** under the Open Source Definition because commercial,
-hosted, redistribution, modification, white-label, rebrand, and AI-training uses
-require prior written permission from PT. Nakafa Tekno Kreatif.
+## Toolchain
 
-**Live Site**: [nakafa.com](https://nakafa.com)
+`package.json` is the toolchain source of truth:
 
-## Quick Start
+- Node.js 24
+- pnpm 10.34.1
+- Turborepo
+- Next.js 16 and React 19
+- TypeScript 7 CLI with TypeScript 6 API compatibility
+- Convex
+- Vitest
+- Biome through Ultracite
 
-### Prerequisites
+Do not add `.npmrc`, `.node-version`, `.nvmrc`, or another package-manager
+contract unless the repository gains a measured need that `package.json`
+cannot express.
 
-- Node.js 22+
-- pnpm
-- Git
+## Setup
 
-### Installation
-
-```bash
-# Clone & install
+```sh
 git clone https://github.com/nakafaai/nakafa.com.git
 cd nakafa.com
-pnpm install
-
-# Start development
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000)
+The main web app is available at [http://localhost:3000](http://localhost:3000).
 
-### Available Scripts
+For production-mode local verification:
 
-```bash
-pnpm dev          # Development server (Turbopack)
-pnpm build        # Production build
-pnpm start        # Production server
-pnpm lint         # Lint & format check
-pnpm test         # Run tests
-pnpm clean        # Clean dependencies
+```sh
+pnpm build
+pnpm start
 ```
 
-## Architecture
+## Repository layout
 
-### Customer Sync Flow (Convex + Polar)
+- `apps/www`: main Next.js application on port 3000
+- `apps/mcp`: MCP application on port 3001
+- `apps/api`: API application on port 3002
+- `apps/cas`: Python CAS service on port 3003
+- `apps/email`: email preview application on port 3004
+- `packages/backend`: Convex schema, functions, workflows, and integrations
+- `packages/design-system`: shared React components and renderer implementations
+- `packages/ai`: Effect-native AI capabilities
+- `packages/contents`: unactivated content source plus cutover copies awaiting
+  coordinated deletion
+- `packages/testing`: shared Vitest configuration
+- `packages/utilities`: generic cross-domain primitives
+- `repos/effect`: read-only Effect source pinned to the installed version
 
-The platform uses [Polar](https://polar.sh) for payments with bidirectional sync to Convex database.
+Read the nearest `AGENTS.md` before working. Convex changes also require
+`packages/backend/AGENTS.md` and the generated Convex guidelines. Effect work
+requires reading `repos/effect/AGENTS.md` plus the relevant implementation,
+tests, type-level tests, module structure, and API design in the vendored source.
 
-#### Signup Flow
+## Commands
 
-```mermaid
-flowchart LR
-    A[User Signup] --> B[Auth Trigger]
-    B --> C[syncCustomer]
-    C --> D[ensureCustomer]
-    D <--> E[(Polar API)]
-    D --> F[upsertCustomer]
-    F --> G[(Convex DB)]
-```
-
-#### Checkout Flow
-
-```mermaid
-flowchart LR
-    A[User Click] --> B[createProCheckoutUrl]
-    B --> C[Read Vercel request IP]
-    C --> D[generateCheckoutLink]
-    D --> E[requireCustomer]
-    E --> F[ensureCustomer]
-    F <--> G[(Polar API)]
-    E --> H[upsertCustomer]
-    H --> I[(Convex DB)]
-    D --> J[createCheckoutSession with customerIpAddress]
-    J --> G
-    G --> K[Checkout URL]
-```
-
-#### Webhook Flow
-
-```mermaid
-flowchart LR
-    A[(Polar API)] -->|webhook| B[Webhook Handler]
-    B -->|created/updated| C[upsertCustomer]
-    B -->|deleted| D[deleteCustomerById]
-    C --> E[(Convex DB)]
-    D --> E
-```
-
-#### Flow Summary
-
-| Flow | Trigger | Steps |
-| ------ | --------- | ------- |
-| **Signup** | User registers | Auth trigger → `syncCustomer` → `ensureCustomer` → `upsertCustomer` |
-| **Checkout** | User clicks buy | `requireCustomer` → `createCheckoutSession` → Redirect to Polar |
-| **Portal** | User opens settings | `requireCustomer` → `createCustomerPortalSession` → Redirect |
-| **Webhook** | Polar event | `upsertCustomer` or `deleteCustomerById` |
-
-#### Key Design Decisions
-
-- **Polar is source of truth** - Local DB is cache for fast queries
-- **Idempotent operations** - All mutations safe to retry
-- **Race condition handling** - `ensureCustomer` retries on create failure
-- **Edge case recovery** - Deleted from Polar → recreated on next checkout
-
-## Development
-
-### Project Documentation
-
-Detailed technical documentation available on [DeepWiki](https://deepwiki.com/nakafaai/nakafa.com) - covers architecture, design decisions, and development patterns.
-
-### Adding Content
-
-1. Navigate to appropriate level in `packages/contents/subject/`
-2. Create MDX files following existing structure
-3. Update data files in `_data/` directories
-4. Test locally with `pnpm dev`
-
-### Testing
-
-All tests use **Vitest** with jsdom environment and **global test functions** (no imports needed).
-
-#### Getting Started
-
-```bash
-# Run all tests
+```sh
+pnpm dev
+pnpm dev:all
+pnpm build
+pnpm start
 pnpm test
-
-# Test specific app
-pnpm --filter www test
+pnpm test:coverage
+pnpm lint
+pnpm format
+pnpm boundaries
+pnpm effect:source:check
 ```
 
-#### Test Commands
+There is no root typecheck script. Run the typecheck owned by each changed
+workspace, for example:
 
-| Command | Description |
-| --------- | ------------- |
-| `pnpm test` | Run all tests across all apps/packages |
-| `pnpm --filter www test` | Run tests for www app only |
-| `pnpm --filter www test:watch` | Watch mode - re-run on file changes |
-| `pnpm --filter www test:ui` | Open Vitest UI in browser |
-| `pnpm --filter www test:coverage` | Run tests with coverage report |
-
-#### Coverage
-
-Coverage reports are generated in terminal and HTML format:
-
-- Thresholds: 60% lines/functions, 50% branches, 60% statements
-- HTML report: `apps/www/coverage/index.html`
-- View locally after running `pnpm --filter www test:coverage`
-
-#### Writing Tests
-
-Tests are located in `**/__tests__/` or `**/*.test.ts|tsx` files.
-
-**Example test file:**
-
-```typescript
-import { describe, expect, it } from "vitest";
-import { getInitialName } from "./helper";
-
-describe("getInitialName", () => {
-  it("returns 'NF' for undefined", () => {
-    expect(getInitialName()).toBe("NF");
-  });
-
-  it("returns initials for full name", () => {
-    expect(getInitialName("John Doe")).toBe("JD");
-  });
-});
+```sh
+pnpm --filter www typecheck
+pnpm --filter @repo/backend typecheck
+pnpm --filter @repo/design-system typecheck
 ```
 
-#### Best Practices
+Tests use Vitest config files owned by each workspace. Keep tests colocated as
+`name.test.ts` or `name.test.tsx`, import the Vitest APIs they use, and preserve
+the workspace's configured per-file coverage gate. Do not create `__tests__`
+folders or duplicate test-only source modules.
 
-- **Test location**: Place tests next to source files in `__tests__/` directory
-- **One test file per source file**: Use descriptive names matching the source
-- **Arrange-Act-Assert**: Structure each test clearly
-- **Test behavior, not implementation**: Focus on what the function does
-- **Use globals**: No need to import `describe`, `it`, `expect` from vitest
-- **Mock external dependencies**: Use setup file for common mocks
+## Content ownership
 
-#### Test Setup
+Do not add substitute content or duplicate Aksara-owned source to this
+repository. Before changing educational content, verify the active ownership
+scope. Aksara-owned changes belong in `nakafaai/aksara`; remaining local scopes
+must follow `packages/contents` contracts until their coordinated cutover.
 
-Common mocks for Next.js routing, i18n, and browser APIs are pre-configured in `packages/testing/setup.ts`:
+Renderer and component implementations remain in Nakafa. Aksara content refers
+to reviewed renderer contracts and never carries duplicate React or TSX
+implementations.
 
-- `useRouter()` - Mocked router with all methods
-- `usePathname()` - Returns `/`
-- `useSearchParams()` - Returns empty URLSearchParams
-- `useTranslations()` - Returns key as translation
-- `matchMedia()` - Mocked MediaQueryList
+## Contributing
 
-### Contributing
-
-By submitting a contribution, you agree to the contribution terms in
-[`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md). Do not submit code,
-content, data, designs, or other materials unless you have the right to grant
-those contribution rights.
-
-1. Fork repository
-2. Create feature branch: `git checkout -b feature/name`
-3. Make changes following established patterns
-4. Run `pnpm lint` and `pnpm test`
-5. Submit pull request
+Read [`AGENTS.md`](AGENTS.md) and
+[`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md). Submit a ready pull request
+from a branch, keep it current with `main`, resolve review conversations, and
+run the relevant exact-head checks before merge.
 
 ## License
 
-Nakafa uses a source-available license model.
+Nakafa uses a source-available license model and is not open source under the
+Open Source Definition.
 
 | Area | License or policy |
-| ------ | ------------------- |
-| Software source code | [Nakafa Source Available License 1.0](./LICENSE) |
-| Educational content, articles, exercises, datasets, and media | [Nakafa Content License 1.0](./CONTENT_LICENSE.md) |
-| Nakafa names, logos, domains, product names, UI identity, and brand assets | [Nakafa Trademark and Brand Policy](./TRADEMARKS.md) |
+| --- | --- |
+| Software source code | [Nakafa Source Available License 1.0](LICENSE) |
+| Educational content, articles, exercises, datasets, and media | [Nakafa Content License 1.0](CONTENT_LICENSE.md) |
+| Names, logos, domains, product names, UI identity, and brand assets | [Nakafa Trademark and Brand Policy](TRADEMARKS.md) |
 
-Allowed without written permission:
+Commercial, hosted, redistribution, modification, white-label, rebrand, and
+AI-training uses require prior written permission from PT. Nakafa Tekno
+Kreatif. See the license files for the complete terms.
 
-- View, inspect, and audit the source code.
-- Clone one copy for personal review.
-- Create a GitHub fork only to submit contributions back to Nakafa.
-- Run the unmodified software locally for personal, non-commercial learning,
-  research, testing, security review, or hobby evaluation.
-- Read Nakafa content for personal, non-commercial learning.
-- Submit contributions under [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md).
+Reference material:
 
-Not allowed without prior written permission:
-
-- Commercial or revenue-generating use.
-- Any hosted deployment outside your own local machine.
-- Use by a company, school, institution, nonprofit organization, government
-  organization, team, or client.
-- Redistribution, mirroring, packaging, resale, sublicensing, or publishing
-  copies.
-- Modification, derivative products, forked products, white-label use,
-  private-label use, or rebranding.
-- Scraping, bulk extraction, dataset creation, embeddings, AI training,
-  fine-tuning, benchmarking, or competing educational products.
-- Use of the Nakafa name, logos, domains, screenshots, UI identity, or brand
-  assets as your own brand.
+- [Open Source Definition](https://opensource.org/definition-annotated)
+- [GitHub licensing documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository)
+- [PolyForm licenses](https://polyformproject.org/licenses)
 
 For commercial licensing inquiries: <nakafaai@gmail.com>
-
-Reference sources behind this license model:
-
-- [Open Source Definition](https://opensource.org/definition-annotated) requires
-  free redistribution, derived works, and no field-of-use restrictions.
-- [GitHub licensing docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository)
-  explain that public source visibility does not automatically grant copyright
-  permissions beyond viewing and forking on GitHub.
-- [PolyForm licenses](https://polyformproject.org/licenses/) document common
-  source-available patterns for limited source-code rights.
-
-## Contact
-
-**Nabil Fatih** - [@nabilfatih](https://twitter.com/nabilfatih_) - <nakafaai@gmail.com>
-
----
-
-Built with ❤️ for learners everywhere

--- a/agent-docs.config.yml
+++ b/agent-docs.config.yml
@@ -10,5 +10,13 @@ options:
   parityExclusions:
     - .katex
     - .katex-mathml
+  # The check targets a dedicated local server, so remote-site throttling only
+  # delays complete sitemap coverage across immutable content buckets.
+  requestDelay: 0
   requestTimeout: 20000
   samplingStrategy: deterministic
+  # Quran Markdown keeps one complete surah together. The largest sampled page
+  # is 58,115 characters after HTML conversion and remains below the 100K cap.
+  thresholds:
+    fail: 100000
+    pass: 60000

--- a/apps/www/agent-docs.check.ts
+++ b/apps/www/agent-docs.check.ts
@@ -4,7 +4,7 @@ import { type CheckResult, getChecksSorted, runChecks } from "afdocs";
 import { loadConfig } from "afdocs/helpers";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const AGENT_DOCS_TIMEOUT_MS = 300_000;
+const AGENT_DOCS_TIMEOUT_MS = 600_000;
 const ALLOWED_SKIP_CHECKS = new Set(["auth-alternative-access"]);
 
 describe("Agent-Friendly Documentation", () => {

--- a/docs/adr/0005-forum-viewport.md
+++ b/docs/adr/0005-forum-viewport.md
@@ -1,4 +1,4 @@
-# ADR 0002: Effect-Owned Forum Conversation Viewport
+# ADR 0005: Effect-Owned Forum Conversation Viewport
 
 ## Status
 

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -9,7 +9,7 @@
 - Use `catchTag` or `catchTags` when the error type is known.
 - Avoid raw `try/catch`; use `Effect.try`, `Effect.tryPromise`, or safe platform APIs like `URL.canParse`.
 - Avoid raw `async` business logic. Use `Effect.runPromise` only at external framework boundaries such as AI SDK tool `execute` handlers.
-- Use `Context.Tag` only for runtime-injected infrastructure adapters. Use `Effect.Service` for business services with dependencies.
+- Use the stable `Context.Tag` plus `Layer` pattern for real dependency seams. Use `Effect.Service` only when the module owns a default implementation and deliberately accepts its experimental Effect 3.22 API.
 - Keep provider configuration and environment access inside config/env boundary modules.
 - Prefer direct imports. Do not add barrels or wrapper chains.
 

--- a/packages/backend/AGENTS.md
+++ b/packages/backend/AGENTS.md
@@ -7,8 +7,8 @@ When working on Convex code, **always read
 how to correctly use Convex APIs and patterns. The file contains rules that
 override what you may have learned about Convex from training data.
 
-Convex agent skills for common tasks can be installed by running
-`npx convex ai-files install`.
+Nakafa keeps one canonical Convex skill surface in root `.agents/skills`.
+Do not install package-local skill copies.
 
 <!-- convex-ai-end -->
 
@@ -27,6 +27,34 @@ Agent Mode isolates new development only. Existing workflows and scheduled
 functions remain on the deployment where they started, and shared-dev or
 production data/deploy windows still require explicit read-only proof and
 coordination.
+
+Nakafa is pnpm-only. From the repository root, create and select one expiring
+cloud dev deployment for a worktree with:
+
+```sh
+worktree_name=$(basename "$PWD")
+pnpm --dir packages/backend exec convex deployment create \
+  "dev/$USER-codex/$worktree_name" \
+  --type dev \
+  --select \
+  --expiration "in 5 days"
+pnpm --dir packages/backend exec convex deployment token create agent-token --save-env
+pnpm --dir packages/backend exec convex dev --once
+```
+
+Use a local deployment instead when HTTP ingress, project environment values,
+and hosted integrations are unnecessary:
+
+```sh
+pnpm --dir packages/backend exec convex deployment create local --select
+pnpm --dir packages/backend exec convex dev --once
+```
+
+The deployment selection and URLs are worktree-owned. Never copy
+`CONVEX_DEPLOYMENT`, `CONVEX_DEPLOY_KEY`, or generated Convex URL values from
+another worktree. Copy other ignored application environment files only when
+the task needs them, byte-for-byte from the canonical checkout, without
+printing secrets.
 
 ## Nakafa Convex Architecture Rules
 
@@ -57,8 +85,10 @@ obsolete Convex function and its tests before considering the work complete.
 ## Type And Convex Source Of Truth
 
 Convex is the typed transactional source for app state and graph read models.
-`packages/contents` is the authoring and source-registry input that feeds those
-read models; do not make path/corpus layout the app-state identity.
+Aksara signed snapshots feed activated content scopes. During migration,
+`packages/contents` still feeds unactivated scopes and contains cutover copies
+awaiting deletion. Those copies are not authoritative and must not be edited or
+republished. Do not make either corpus path layout the app-state identity.
 
 Domain validators and schema modules own backend value sets. Derive types from
 Convex `Infer<typeof validator>`, generated `Doc<>` and `Id<>` types, or

--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -1,13 +1,7 @@
-<!-- convex-ai-start -->
+# Backend agent guide
 
-This project uses [Convex](https://convex.dev) as its backend.
-
-When working on Convex code, **always read
-`convex/_generated/ai/guidelines.md` first** for important guidelines on
-how to correctly use Convex APIs and patterns. The file contains rules that
-override what you may have learned about Convex from training data.
-
-Convex agent skills for common tasks can be installed by running
-`npx convex ai-files install`.
-
-<!-- convex-ai-end -->
+Read [`AGENTS.md`](AGENTS.md) and
+[`convex/_generated/ai/guidelines.md`](convex/_generated/ai/guidelines.md)
+before changing this package. Root `.agents/skills` is the canonical skill
+surface. Use pnpm and an isolated Convex Agent Mode deployment exactly as
+documented in `AGENTS.md`; do not install package-local skill copies.

--- a/packages/backend/scripts/README.md
+++ b/packages/backend/scripts/README.md
@@ -1,380 +1,127 @@
-# Backend Scripts
+# Backend scripts
 
-Sync MDX content and run backend integrity checks for Convex state.
+These scripts operate filesystem content projections and verify customer
+state. Package scripts in `packages/backend/package.json` are the command
+source of truth.
 
-## Quick Start
+## Content ownership
 
-```bash
-# Development (syncs all content, cleans stale, verifies)
+Aksara owns the activated article, material, and learning-program scopes.
+The current full and incremental orchestrators still traverse their local
+copies while final repository cleanup is pending. Those writes do not own the
+active Aksara runtime and must not be used to publish or repair an activated
+scope.
+
+Until their coordinated cutovers complete, Nakafa still owns:
+
+- try-out catalogs, question prompts, answers, choices, and IRT projections;
+- Quran source, search, Tafsir, and related read models.
+
+After each remaining scope moves to Aksara, delete its sync implementation,
+reset commands, tests, and documentation in the same migration.
+
+## Development setup
+
+Read [`../AGENTS.md`](../AGENTS.md) and use an isolated Agent Mode deployment.
+From the repository root:
+
+```sh
+worktree_name=$(basename "$PWD")
+pnpm --dir packages/backend exec convex deployment create \
+  "dev/$USER-codex/$worktree_name" \
+  --type dev \
+  --select \
+  --expiration "in 5 days"
+pnpm --dir packages/backend exec convex deployment token create agent-token --save-env
+pnpm --dir packages/backend exec convex dev --once
+```
+
+The selected deployment and its generated URLs belong only to that worktree.
+Do not copy Convex deployment identity from another task.
+
+## Validation and sync
+
+Use the scope command for content that Nakafa still owns:
+
+```sh
+pnpm --filter @repo/backend exec tsx scripts/sync-content.ts quran
+pnpm --filter @repo/backend exec tsx scripts/sync-content.ts tryouts
+```
+
+The broad commands below still include cutover copies and exist only until the
+remaining scope cutovers and final sync deletion finish:
+
+```sh
+pnpm --filter @repo/backend sync:validate
+pnpm --filter @repo/backend sync:verify
 pnpm --filter @repo/backend sync
-
-# Production
-pnpm --filter @repo/backend sync:prod
-```
-
-## Setup
-
-### 1. Authenticate with Convex
-
-```bash
-cd packages/backend
-npx convex dev
-```
-
-This stores your access token in `~/.convex/config.json`.
-
-### 2. Configure Environment
-
-Add to `packages/backend/.env.local`:
-
-```bash
-# Development (created by npx convex dev)
-CONVEX_URL=https://your-dev-project.convex.cloud
-
-# Production (find in Convex Dashboard -> Settings -> Deployment URL)
-CONVEX_PROD_URL=https://your-prod-project.convex.cloud
-```
-
-### 3. Deploy Functions to Production
-
-Before syncing to production, deploy the sync functions:
-
-```bash
-npx convex deploy
-```
-
-## Commands
-
-### Development
-
-| Command | Description |
-|---------|-------------|
-| `sync` | Full sync + clean + verify (recommended) |
-| `sync:incremental` | Sync only changed files since last sync (fast) |
-| `sync:validate` | Validate content without syncing (for CI) |
-| `sync:verify` | Verify database matches filesystem |
-| `sync:clean` | Find and remove stale content |
-| `sync:reset` | Delete synced content/runtime rows (authors optional, requires --force) |
-| `sync:reset:analytics` | Delete rebuildable analytics projections |
-| `sync:reset:audio` | Delete rebuildable audio projections |
-| `sync:reset:tryouts` | Delete tryout content/read models, access rows, entitlements, and IRT scale data, then run a full sync |
-
-### Production
-
-| Command | Description |
-|---------|-------------|
-| `sync:prod` | Full sync + clean + verify to production |
-| `sync:prod:incremental` | Incremental sync to production |
-| `sync:prod:verify` | Verify production database |
-| `sync:prod:clean` | Clean stale content in production |
-| `sync:prod:reset` | Delete synced content/runtime rows in production (authors optional, requires --force) |
-| `sync:prod:reset:analytics` | Delete production analytics projections |
-| `sync:prod:reset:audio` | Delete production audio source, generated audio, and audio queue rows |
-| `sync:prod:reset:tryouts` | Delete tryout content/read models, access rows, entitlements, and IRT scale data in production, then run a full sync |
-
-### Integrity
-
-| Command | Description |
-|---------|-------------|
-| `customers:verify` | Verify user/customer/subscription cohesion in development |
-| `customers:verify:prod` | Verify user/customer/subscription cohesion in production |
-
-### Options
-
-| Flag | Description |
-|------|-------------|
-| `--locale en\|id` | Sync specific locale only (not supported by incremental sync) |
-| `--force` | Actually delete content (for clean/reset) |
-| `--authors` | Also delete authors (for clean/reset) |
-| `--sequential` | Run phases sequentially (debugging) |
-
-## Workflows
-
-### Development
-
-```bash
-# First time or after major changes
-pnpm --filter @repo/backend sync
-
-# Daily (only syncs changed files)
 pnpm --filter @repo/backend sync:incremental
-
-# Before commit (validates without syncing)
-pnpm --filter @repo/backend sync:validate
 ```
 
-### Production
+- `sync:validate` checks authored source without writing Convex.
+- `sync:verify` compares filesystem projections with the selected deployment.
+- `sync` performs a full clean, sync, verification, and cache invalidation pass.
+- `sync:incremental` uses the last successful Git revision and does not accept
+  `--locale` because its state is shared across locales.
 
-```bash
-# 1. Validate content
+Use `--locale en` or `--locale id` only with full, validate, verify, or clean
+operations. Use `--sequential` only for debugging one full sync.
+
+## Production
+
+Production commands require an approved deployment and data window. Re-run the
+read-only validation and dry-run gates immediately before any write:
+
+```sh
 pnpm --filter @repo/backend sync:validate
-
-# 2. Deploy functions to production
-cd packages/backend && npx convex deploy
-
-# 3. Sync content to production
+pnpm --filter @repo/backend sync:prod:verify
+pnpm --filter @repo/backend deploy
 pnpm --filter @repo/backend sync:prod
-
-# 4. Verify production data
 pnpm --filter @repo/backend sync:prod:verify
 ```
 
-### Reset (Start Fresh)
+Never deploy a worktree that would remove another task's active schema or
+indexes. Use the Convex CLI deletion guard and inspect the exact diff first.
 
-This rebuilds synced content and resettable runtime projections. Durable learning
-views and Continue Learning recents are preserved across the reset and rejoin the
-current content routes after sync.
+## Destructive operations
 
-```bash
-# See what would be deleted (dry run)
+Reset and clean commands are dry-run unless `--force` is present:
+
+```sh
+pnpm --filter @repo/backend sync:clean
 pnpm --filter @repo/backend sync:reset
-
-# Actually delete all content
-pnpm --filter @repo/backend sync:reset --force
-
-# Delete including authors
-pnpm --filter @repo/backend sync:reset --force --authors
-
-# Re-sync after reset
-pnpm --filter @repo/backend sync
-```
-
-For production (use with caution):
-
-```bash
-# Preview deletion
-pnpm --filter @repo/backend sync:prod:reset
-
-# Actually delete production content
-pnpm --filter @repo/backend sync:prod:reset --force
-```
-
-### Reset Content Analytics
-
-Use this when rebuildable analytics projections must be restarted, such as after
-an analytics projection shape change. It clears analytics queue rows, partition
-leases, popularity counts, and trending buckets. Durable learning views and the
-Continue Learning read model are preserved. If their identity contract changes,
-use an explicit backed-up migration instead of this generic reset.
-
-```bash
-# Preview deletion
 pnpm --filter @repo/backend sync:reset:analytics
-
-# Actually delete analytics rows
-pnpm --filter @repo/backend sync:reset:analytics --force
-```
-
-For production, run the reset only during an approved Convex write/deploy
-window. This command calls internal mutations from the deployed Convex bundle, so
-it is operational read-model reset tooling after those mutations are available.
-For a strict schema projection cutover where old production rows block deploying
-the current bundle, first use an approved deployment-compatible data cutover path
-to clear or migrate the analytics rows. Then deploy strict code, run this reset
-only if analytics rows still remain, and verify:
-
-```bash
-pnpm --filter @repo/backend deploy
-pnpm --filter @repo/backend sync:prod:reset:analytics --force
-pnpm --filter @repo/backend sync:prod:verify
-```
-
-### Reset Audio Read Models
-
-Use this when derived audio read models must be discarded and rebuilt from the
-content graph, such as after audio projection shape changes or generated audio
-storage corruption. It clears only audio source, generated audio, and audio queue
-rows; then a full sync rebuilds audio source projections.
-
-```bash
-# Preview deletion
 pnpm --filter @repo/backend sync:reset:audio
-
-# Actually delete audio read models
-pnpm --filter @repo/backend sync:reset:audio --force
-
-# Rebuild audio source projections
-pnpm --filter @repo/backend sync
-```
-
-For production, run the reset only during an approved Convex write/deploy
-window. This command calls internal mutations from the deployed Convex bundle, so
-it is operational read-model reset tooling after those mutations are available.
-For a strict schema projection cutover where old production rows block deploying
-the current bundle, first use an approved deployment-compatible data cutover path
-to clear or migrate the audio read-model rows, then deploy strict code, rebuild,
-and verify:
-
-```bash
-pnpm --filter @repo/backend sync:prod:reset:audio --force
-pnpm --filter @repo/backend deploy
-pnpm --filter @repo/backend sync:prod
-pnpm --filter @repo/backend sync:prod:verify
-```
-
-### Reset Tryouts + IRT Only
-
-```bash
-# Preview the tryout/IRT wipe
 pnpm --filter @repo/backend sync:reset:tryouts
-
-# Actually delete tryout definitions, access rows, entitlements, and IRT scale data
-pnpm --filter @repo/backend sync:reset:tryouts --force
-
-# Then rebuild the deleted tables with a full sync
-pnpm --filter @repo/backend sync
 ```
 
-`sync:reset:tryouts` clears incremental sync state on purpose. Do not follow it
-with `sync:incremental`; run a full sync so Convex rebuilds the deleted tryout
-and IRT tables coherently. It intentionally preserves
-`tryoutFreeAttemptClaims`: the one-free-tryout allowance belongs to the account,
-not to rebuildable try-out content or runtime rows.
+Production variants use the `sync:prod:*` scripts. Do not run them without an
+approved window, exact row-count proof, a recovery plan, and post-write
+verification. `--authors` extends a full reset to authors. Try-out and audio
+resets deliberately clear incremental state and must be followed by a full
+sync, never an incremental sync.
 
-For production (use with caution):
+`tryoutFreeAttemptClaims` is durable account state and is not reset with
+try-out content.
 
-```bash
-pnpm --filter @repo/backend sync:prod:reset:tryouts --force
-pnpm --filter @repo/backend sync:prod
+## Customer verification
+
+```sh
+pnpm --filter @repo/backend customers:verify
+pnpm --filter @repo/backend customers:verify:prod
 ```
 
-## Content Structure
-
-### Articles
-
-```
-packages/contents/articles/{category}/{slug}/
-  en.mdx       # English
-  id.mdx       # Indonesian
-  ref.ts       # References
-```
-
-### Materials
-
-```
-packages/contents/material/lesson/{subject}/{material}/
-  source.ts
-  {lesson}/
-    en.mdx
-    id.mdx
-```
-
-### Question Bank
-
-```
-packages/contents/question-bank/tryout/{country}/{exam}/{section}/{set}/
-  question-{number}/
-    question.en.mdx
-    question.id.mdx
-    answer.en.mdx
-    answer.id.mdx
-    choices.ts
-```
-
-**⚠️ IMPORTANT**: When adding new try-out questions, you MUST attach the question-bank source to the typed try-out source:
-
-1. Create question directories under `question-bank/tryout/{country}/{exam}/{section}/{set}/question-{number}/`
-2. Add MDX files and choices
-3. **Add track, set, and section placement** to `packages/contents/tryout/{country}/{exam}/source.ts`:
-
-```typescript
-{
-  key: "2027",
-  kind: "year",
-  order: 1,
-  routeSlugs: { en: "2027", id: "2027" },
-  translations: {
-    en: { title: "Year 2027" },
-    id: { title: "Tahun 2027" },
-  },
-  sets: [
-    {
-      key: "set-2",
-      order: 2,
-      routeSlugs: { en: "set-2", id: "set-2" },
-      translations: {
-        en: { title: "Set 2" },
-        id: { title: "Set 2" },
-      },
-      sections: [
-        {
-          key: "quantitative-knowledge",
-          order: 1,
-          questionCount: 20,
-          questionSourcePath:
-            "question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-2",
-          routeSlugs: {
-            en: "quantitative-knowledge",
-            id: "pengetahuan-kuantitatif",
-          },
-          timeLimitSeconds: 1800,
-          translations: {
-            en: { title: "Quantitative Knowledge" },
-            id: { title: "Pengetahuan Kuantitatif" },
-          },
-        },
-      ],
-    },
-  ],
-}
-```
-
-If you forget step 3, sync verification reports missing question-bank source paths. Add the missing paths to the typed try-out source before syncing.
-
-## Troubleshooting
-
-### "CONVEX_URL not set"
-Run `npx convex dev` to create `.env.local`.
-
-### "CONVEX_PROD_URL not set"
-Add production URL from Convex Dashboard -> Settings -> Deployment URL.
-
-### "No access token"
-Run `npx convex dev` to authenticate.
-
-### "Could not find function"
-Deploy functions first: `npx convex deploy`
-
-### Sync shows 0 changes
-Content hash unchanged. This is normal for `sync:incremental`.
-
-## Scripts
-
-| Script | Purpose |
-|--------|---------|
-| `sync-content.ts` | Sync MDX content to Convex database |
-| `customers/verify.ts` | Verify user/customer/subscription cohesion |
+These commands verify user, customer, and subscription cohesion without
+changing content ownership.
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `sync-content.ts` | Main sync script |
-| `sync-content/` | Shared sync-content helpers, validation, and workflows |
-| `customers/` | Customer cohesion verification scripts |
-| `customers/verify.ts` | Dev/prod verification for user/customer/subscription cohesion |
-| `../convex/contentSync/mutations/` | Convex sync mutations split by concern |
-| `../convex/contentSync/queries/` | Convex verification queries split by concern |
-| `../.sync-state.json` | Dev incremental sync state (gitignored) |
-| `../.sync-state.prod.json` | Prod incremental sync state (gitignored) |
+- `sync-content.ts` is the CLI boundary.
+- `sync-content/` owns validation, projection, Convex calls, cleanup, and
+  verification until final filesystem sync deletion.
+- `customers/verify.ts` verifies customer state.
+- `.sync-state.json` and `.sync-state.prod.json` are ignored incremental state.
 
-## How Incremental Sync Works
-
-The incremental sync tracks the last successful sync using separate state files:
-- **Dev**: `.sync-state.json` - tracks dev database syncs
-- **Prod**: `.sync-state.prod.json` - tracks prod database syncs
-
-This ensures syncing to dev doesn't affect prod's incremental state and vice versa.
-
-Each state file contains:
-- `lastSyncTimestamp` - when the last sync completed
-- `lastSyncCommit` - git commit hash at last sync
-
-When you run `sync:incremental`, it:
-1. Loads the state file for the target environment
-2. Uses `git diff` to find files changed since `lastSyncCommit`
-3. Syncs affected article, curriculum, and tryout rows
-4. Runs the global stale-content cleanup only when a changed source path was deleted or renamed
-5. Rebuilds route artifacts only for affected locale and section targets
-6. Syncs Quran, public routes, and learning programs only when their sources changed
-7. Saves the new commit hash after successful sync
+Authored source paths remain under `packages/contents/question-bank`,
+`packages/contents/tryout`, and the Quran source modules until their Aksara
+cutovers complete.


### PR DESCRIPTION
## Summary

- make activated Aksara ownership and remaining tryout/Quran ownership explicit
- require Effect work to trace the pinned read-only `repos/effect` implementation, tests, type tests, module structure, and API design
- document Convex Agent Mode as the mandatory concurrent-work boundary
- replace stale setup, test, sync, and contribution guidance with current pnpm-only commands
- pin current GitHub Actions and resolve the duplicate ADR number
- retain all 23 strict AFDocs checks while scaling deterministic full-sitemap coverage for the dedicated local server
- set an explicit 100,000-character hard cap that keeps complete Quran surah pages intact

## Verification

- `pnpm lint`
- `pnpm effect:source:check`, installed and vendored Effect 3.22.0 aligned
- `pnpm test`, 12 Turbo tasks with workspace coverage gates
- `pnpm boundaries`, 3,698 files across 19 packages
- `pnpm build`, all 5 tasks and WWW 1,303 pages
- production-mode root `pnpm start`, WWW, MCP, API, and CAS returned HTTP 200
- `pnpm agent-docs`, 23 of 23 checks completed in 421.72 seconds with 0 failures and only the intentional public-docs auth skip
- external documentation links: 71 checked, 0 failures
- hosted exact-head Agent-Friendly Docs is running; React Doctor is green
