### PR TITLE
feat(content): read signed tryout snapshots

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -279,6 +279,13 @@ import type * as contentRelease_snapshot_tryout from "../contentRelease/snapshot
 import type * as contentRelease_spec from "../contentRelease/spec.js";
 import type * as contentRelease_status from "../contentRelease/status.js";
 import type * as contentRelease_sync from "../contentRelease/sync.js";
+import type * as contentRelease_tryout from "../contentRelease/tryout.js";
+import type * as contentRelease_tryout_catalog from "../contentRelease/tryout/catalog.js";
+import type * as contentRelease_tryout_facts from "../contentRelease/tryout/facts.js";
+import type * as contentRelease_tryout_limits from "../contentRelease/tryout/limits.js";
+import type * as contentRelease_tryout_owner from "../contentRelease/tryout/owner.js";
+import type * as contentRelease_tryout_section from "../contentRelease/tryout/section.js";
+import type * as contentRelease_tryout_verify from "../contentRelease/tryout/verify.js";
 import type * as contentRelease_verify from "../contentRelease/verify.js";
 import type * as contentRelease_verify_delete from "../contentRelease/verify/delete.js";
 import type * as contentRelease_verify_item from "../contentRelease/verify/item.js";
@@ -814,6 +821,13 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/spec": typeof contentRelease_spec;
   "contentRelease/status": typeof contentRelease_status;
   "contentRelease/sync": typeof contentRelease_sync;
+  "contentRelease/tryout": typeof contentRelease_tryout;
+  "contentRelease/tryout/catalog": typeof contentRelease_tryout_catalog;
+  "contentRelease/tryout/facts": typeof contentRelease_tryout_facts;
+  "contentRelease/tryout/limits": typeof contentRelease_tryout_limits;
+  "contentRelease/tryout/owner": typeof contentRelease_tryout_owner;
+  "contentRelease/tryout/section": typeof contentRelease_tryout_section;
+  "contentRelease/tryout/verify": typeof contentRelease_tryout_verify;
   "contentRelease/verify": typeof contentRelease_verify;
   "contentRelease/verify/delete": typeof contentRelease_verify_delete;
   "contentRelease/verify/item": typeof contentRelease_verify_item;

--- a/packages/backend/convex/contentRelease/snapshot/cleanup.test.ts
+++ b/packages/backend/convex/contentRelease/snapshot/cleanup.test.ts
@@ -183,6 +183,8 @@ describe("contentRelease/snapshot/cleanup", () => {
       for (const index of [1]) {
         await ctx.db.insert("tryoutPlacements", {
           answerArtifactHash: `sha256:${"a".repeat(64)}`,
+          countryKey: "indonesia",
+          examKey: "snbt",
           identity: `placement-${index}`,
           index,
           locale: "en",
@@ -191,6 +193,9 @@ describe("contentRelease/snapshot/cleanup", () => {
           rowHash: `sha256:${index.toString(16).padStart(64, "0")}`,
           rowJson: "{}",
           snapshotId,
+          sectionKey: "quantitative-knowledge",
+          setKey: "set-1",
+          trackKey: "2027",
         });
       }
     });

--- a/packages/backend/convex/contentRelease/snapshot/retention.test.ts
+++ b/packages/backend/convex/contentRelease/snapshot/retention.test.ts
@@ -1,8 +1,8 @@
-import { tryoutPlacementIdentity } from "@nakafa/aksara-contracts/tryout/identity";
 import {
   hasSnapshotArtifactReference,
   isSnapshotReferenced,
 } from "@repo/backend/convex/contentRelease/snapshot/retention";
+import { tryoutPlacementFacts } from "@repo/backend/convex/contentRelease/tryout/facts";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
@@ -65,12 +65,10 @@ describe("contentRelease/snapshot/retention", () => {
     const placement = makeTryoutPlacementRow().record;
     await t.mutation((ctx) =>
       ctx.db.insert("tryoutPlacements", {
+        ...tryoutPlacementFacts(placement),
         answerArtifactHash: answerHash,
-        identity: tryoutPlacementIdentity(placement.row),
         index: 0,
-        locale: placement.row.locale,
         questionArtifactHash: TEST_ARTIFACT_HASH,
-        questionOrder: placement.row.questionOrder,
         rowHash: placement.rowHash,
         rowJson: "{}",
         snapshotId: `sha256:${"5".repeat(64)}`,

--- a/packages/backend/convex/contentRelease/snapshot/schema.ts
+++ b/packages/backend/convex/contentRelease/snapshot/schema.ts
@@ -189,6 +189,8 @@ const tables = {
   /** Immutable attempt placements with terminal answer-artifact bindings. */
   tryoutPlacements: defineTable({
     answerArtifactHash: v.string(),
+    countryKey: v.string(),
+    examKey: v.string(),
     identity: v.string(),
     index: v.number(),
     locale: localeValidator,
@@ -197,9 +199,22 @@ const tables = {
     rowHash: v.string(),
     rowJson: v.string(),
     snapshotId: v.string(),
+    sectionKey: v.string(),
+    setKey: v.string(),
+    trackKey: v.string(),
   })
     .index("by_snapshotId_and_index", ["snapshotId", "index"])
     .index("by_snapshotId_and_identity", ["snapshotId", "identity"])
+    .index("by_snapshotId_and_section_and_questionOrder", [
+      "snapshotId",
+      "locale",
+      "countryKey",
+      "examKey",
+      "trackKey",
+      "setKey",
+      "sectionKey",
+      "questionOrder",
+    ])
     .index("by_questionArtifactHash", ["questionArtifactHash"])
     .index("by_answerArtifactHash", ["answerArtifactHash"]),
 };

--- a/packages/backend/convex/contentRelease/snapshot/tryout.test.ts
+++ b/packages/backend/convex/contentRelease/snapshot/tryout.test.ts
@@ -13,6 +13,10 @@ import {
   stageTryoutPlacement,
 } from "@repo/backend/convex/contentRelease/snapshot/tryout";
 import {
+  tryoutCatalogFacts,
+  tryoutPlacementFacts,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
+import {
   TRYOUT_CATALOG_DOCUMENT_LIMIT,
   TRYOUT_PLACEMENT_DOCUMENT_LIMIT,
 } from "@repo/backend/convex/contentRelease/tryout/limits";
@@ -91,7 +95,7 @@ describe("contentRelease/snapshot/tryout", () => {
     ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_CONFLICT" } });
   });
 
-  it("rejects rows that could exceed aggregate runtime read budgets", async () => {
+  it("rejects new or replayed rows beyond aggregate read budgets", async () => {
     const catalogSource = makeTryoutCatalogRow();
     const catalog = {
       ...catalogSource,
@@ -109,30 +113,52 @@ describe("contentRelease/snapshot/tryout", () => {
       }),
     };
     const t = convexTest(schema, convexModules);
+    const catalogJson = canonicalizeContentSnapshotRow(catalog);
+    const placementJson = canonicalizeContentSnapshotRow(placement);
 
     await expect(
       t.mutation((ctx) =>
         runConvexProgram(
-          stageTryoutCatalog(
-            ctx,
-            snapshotId,
-            0,
-            catalog,
-            canonicalizeContentSnapshotRow(catalog)
-          )
+          stageTryoutCatalog(ctx, snapshotId, 0, catalog, catalogJson)
         )
       )
     ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });
     await expect(
       t.mutation((ctx) =>
         runConvexProgram(
-          stageTryoutPlacement(
-            ctx,
-            snapshotId,
-            1,
-            placement,
-            canonicalizeContentSnapshotRow(placement)
-          )
+          stageTryoutPlacement(ctx, snapshotId, 1, placement, placementJson)
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });
+
+    await t.mutation(async (ctx) => {
+      await ctx.db.insert("tryoutCatalog", {
+        ...tryoutCatalogFacts(catalog.record),
+        index: 0,
+        rowHash: catalog.record.rowHash,
+        rowJson: catalogJson,
+        snapshotId,
+      });
+      await ctx.db.insert("tryoutPlacements", {
+        ...tryoutPlacementFacts(placement.record),
+        index: 1,
+        rowHash: placement.record.rowHash,
+        rowJson: placementJson,
+        snapshotId,
+      });
+    });
+
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          stageTryoutCatalog(ctx, snapshotId, 0, catalog, catalogJson)
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          stageTryoutPlacement(ctx, snapshotId, 1, placement, placementJson)
         )
       )
     ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });

--- a/packages/backend/convex/contentRelease/snapshot/tryout.test.ts
+++ b/packages/backend/convex/contentRelease/snapshot/tryout.test.ts
@@ -5,9 +5,17 @@ import {
   tryoutPlacementIdentity,
 } from "@nakafa/aksara-contracts/tryout/identity";
 import {
+  makeTryoutCatalogRecord,
+  makeTryoutPlacementRecord,
+} from "@nakafa/aksara-contracts/tryout/row-hash";
+import {
   stageTryoutCatalog,
   stageTryoutPlacement,
 } from "@repo/backend/convex/contentRelease/snapshot/tryout";
+import {
+  TRYOUT_CATALOG_DOCUMENT_LIMIT,
+  TRYOUT_PLACEMENT_DOCUMENT_LIMIT,
+} from "@repo/backend/convex/contentRelease/tryout/limits";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
@@ -81,5 +89,52 @@ describe("contentRelease/snapshot/tryout", () => {
         )
       )
     ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_CONFLICT" } });
+  });
+
+  it("rejects rows that could exceed aggregate runtime read budgets", async () => {
+    const catalogSource = makeTryoutCatalogRow();
+    const catalog = {
+      ...catalogSource,
+      record: makeTryoutCatalogRecord({
+        ...catalogSource.record.row,
+        description: "x".repeat(TRYOUT_CATALOG_DOCUMENT_LIMIT),
+      }),
+    };
+    const placementSource = makeTryoutPlacementRow();
+    const placement = {
+      ...placementSource,
+      record: makeTryoutPlacementRecord({
+        ...placementSource.record.row,
+        title: "x".repeat(TRYOUT_PLACEMENT_DOCUMENT_LIMIT),
+      }),
+    };
+    const t = convexTest(schema, convexModules);
+
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          stageTryoutCatalog(
+            ctx,
+            snapshotId,
+            0,
+            catalog,
+            canonicalizeContentSnapshotRow(catalog)
+          )
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          stageTryoutPlacement(
+            ctx,
+            snapshotId,
+            1,
+            placement,
+            canonicalizeContentSnapshotRow(placement)
+          )
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_SIZE" } });
   });
 });

--- a/packages/backend/convex/contentRelease/snapshot/tryout.ts
+++ b/packages/backend/convex/contentRelease/snapshot/tryout.ts
@@ -6,6 +6,10 @@ import {
   tryoutCatalogFacts,
   tryoutPlacementFacts,
 } from "@repo/backend/convex/contentRelease/tryout/facts";
+import {
+  TRYOUT_CATALOG_DOCUMENT_LIMIT,
+  TRYOUT_PLACEMENT_DOCUMENT_LIMIT,
+} from "@repo/backend/convex/contentRelease/tryout/limits";
 import { Effect } from "effect";
 
 type TryoutRow = Extract<ContentSnapshotRow, { readonly family: "tryout" }>;
@@ -62,7 +66,8 @@ export const stageTryoutCatalog = Effect.fn(
   };
   yield* ensureDocumentSize(
     `Try-out snapshot ${snapshotId} row ${index}`,
-    stored
+    stored,
+    TRYOUT_CATALOG_DOCUMENT_LIMIT
   );
   yield* Effect.promise(() => ctx.db.insert("tryoutCatalog", stored));
   return false;
@@ -118,7 +123,8 @@ export const stageTryoutPlacement = Effect.fn(
   };
   yield* ensureDocumentSize(
     `Try-out snapshot ${snapshotId} placement ${index}`,
-    stored
+    stored,
+    TRYOUT_PLACEMENT_DOCUMENT_LIMIT
   );
   yield* Effect.promise(() => ctx.db.insert("tryoutPlacements", stored));
   return false;

--- a/packages/backend/convex/contentRelease/snapshot/tryout.ts
+++ b/packages/backend/convex/contentRelease/snapshot/tryout.ts
@@ -27,6 +27,18 @@ export const stageTryoutCatalog = Effect.fn(
   rowJson: string
 ) {
   const facts = tryoutCatalogFacts(source.record);
+  const stored = {
+    ...facts,
+    index,
+    rowHash: source.record.rowHash,
+    rowJson,
+    snapshotId,
+  };
+  yield* ensureDocumentSize(
+    `Try-out snapshot ${snapshotId} row ${index}`,
+    stored,
+    TRYOUT_CATALOG_DOCUMENT_LIMIT
+  );
   const byIndex = yield* Effect.promise(() =>
     ctx.db
       .query("tryoutCatalog")
@@ -57,18 +69,6 @@ export const stageTryoutCatalog = Effect.fn(
     }
     return true;
   }
-  const stored = {
-    ...facts,
-    index,
-    rowHash: source.record.rowHash,
-    rowJson,
-    snapshotId,
-  };
-  yield* ensureDocumentSize(
-    `Try-out snapshot ${snapshotId} row ${index}`,
-    stored,
-    TRYOUT_CATALOG_DOCUMENT_LIMIT
-  );
   yield* Effect.promise(() => ctx.db.insert("tryoutCatalog", stored));
   return false;
 });
@@ -84,6 +84,18 @@ export const stageTryoutPlacement = Effect.fn(
   rowJson: string
 ) {
   const facts = tryoutPlacementFacts(source.record);
+  const stored = {
+    ...facts,
+    index,
+    rowHash: source.record.rowHash,
+    rowJson,
+    snapshotId,
+  };
+  yield* ensureDocumentSize(
+    `Try-out snapshot ${snapshotId} placement ${index}`,
+    stored,
+    TRYOUT_PLACEMENT_DOCUMENT_LIMIT
+  );
   const byIndex = yield* Effect.promise(() =>
     ctx.db
       .query("tryoutPlacements")
@@ -114,18 +126,6 @@ export const stageTryoutPlacement = Effect.fn(
     }
     return true;
   }
-  const stored = {
-    ...facts,
-    index,
-    rowHash: source.record.rowHash,
-    rowJson,
-    snapshotId,
-  };
-  yield* ensureDocumentSize(
-    `Try-out snapshot ${snapshotId} placement ${index}`,
-    stored,
-    TRYOUT_PLACEMENT_DOCUMENT_LIMIT
-  );
   yield* Effect.promise(() => ctx.db.insert("tryoutPlacements", stored));
   return false;
 });

--- a/packages/backend/convex/contentRelease/snapshot/tryout.ts
+++ b/packages/backend/convex/contentRelease/snapshot/tryout.ts
@@ -1,25 +1,16 @@
 import type { ContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot-data";
-import {
-  tryoutCatalogIdentity,
-  tryoutPlacementIdentity,
-} from "@nakafa/aksara-contracts/tryout/identity";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  tryoutCatalogFacts,
+  tryoutPlacementFacts,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
 import { Effect } from "effect";
 
 type TryoutRow = Extract<ContentSnapshotRow, { readonly family: "tryout" }>;
 type CatalogRow = Extract<TryoutRow, { readonly rowKind: "catalog" }>;
 type PlacementRow = Extract<TryoutRow, { readonly rowKind: "placement" }>;
-
-/** Derives one localized hierarchy identity and display order. */
-function catalogIdentity(source: CatalogRow) {
-  const row = source.record.row;
-  return {
-    identity: tryoutCatalogIdentity(row),
-    order: row.kind === "country" || row.kind === "exam" ? 0 : row.order,
-  };
-}
 
 /** Stores one immutable try-out hierarchy row without flattening its body. */
 export const stageTryoutCatalog = Effect.fn(
@@ -31,8 +22,7 @@ export const stageTryoutCatalog = Effect.fn(
   source: CatalogRow,
   rowJson: string
 ) {
-  const row = source.record.row;
-  const identity = catalogIdentity(source);
+  const facts = tryoutCatalogFacts(source.record);
   const byIndex = yield* Effect.promise(() =>
     ctx.db
       .query("tryoutCatalog")
@@ -45,7 +35,7 @@ export const stageTryoutCatalog = Effect.fn(
     ctx.db
       .query("tryoutCatalog")
       .withIndex("by_snapshotId_and_identity", (query) =>
-        query.eq("snapshotId", snapshotId).eq("identity", identity.identity)
+        query.eq("snapshotId", snapshotId).eq("identity", facts.identity)
       )
       .unique()
   );
@@ -64,11 +54,8 @@ export const stageTryoutCatalog = Effect.fn(
     return true;
   }
   const stored = {
-    ...identity,
+    ...facts,
     index,
-    kind: row.kind,
-    locale: row.locale,
-    publicPath: row.publicPath,
     rowHash: source.record.rowHash,
     rowJson,
     snapshotId,
@@ -91,8 +78,7 @@ export const stageTryoutPlacement = Effect.fn(
   source: PlacementRow,
   rowJson: string
 ) {
-  const row = source.record.row;
-  const identity = tryoutPlacementIdentity(row);
+  const facts = tryoutPlacementFacts(source.record);
   const byIndex = yield* Effect.promise(() =>
     ctx.db
       .query("tryoutPlacements")
@@ -105,7 +91,7 @@ export const stageTryoutPlacement = Effect.fn(
     ctx.db
       .query("tryoutPlacements")
       .withIndex("by_snapshotId_and_identity", (query) =>
-        query.eq("snapshotId", snapshotId).eq("identity", identity)
+        query.eq("snapshotId", snapshotId).eq("identity", facts.identity)
       )
       .unique()
   );
@@ -124,12 +110,8 @@ export const stageTryoutPlacement = Effect.fn(
     return true;
   }
   const stored = {
-    answerArtifactHash: row.answerArtifactHash,
-    identity,
+    ...facts,
     index,
-    locale: row.locale,
-    questionArtifactHash: row.questionArtifactHash,
-    questionOrder: row.questionOrder,
     rowHash: source.record.rowHash,
     rowJson,
     snapshotId,

--- a/packages/backend/convex/contentRelease/tryout.ts
+++ b/packages/backend/convex/contentRelease/tryout.ts
@@ -1,0 +1,22 @@
+import { query } from "@repo/backend/convex/_generated/server";
+import { localeValidator } from "@repo/backend/convex/contentRelease/spec";
+import { readTryoutCatalog } from "@repo/backend/convex/contentRelease/tryout/catalog";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { v } from "convex/values";
+
+const tryoutCatalogValidator = v.object({
+  activeManifestHash: v.union(v.string(), v.null()),
+  activeReleaseId: v.union(v.string(), v.null()),
+  managed: v.boolean(),
+  rowJson: v.array(v.string()),
+  snapshotId: v.union(v.string(), v.null()),
+  sourceRevision: v.union(v.string(), v.null()),
+});
+
+/** Returns the verified active try-out hierarchy for one locale. */
+export const catalog = query({
+  args: { locale: localeValidator },
+  returns: tryoutCatalogValidator,
+  handler: (ctx, { locale }) =>
+    runConvexProgram(readTryoutCatalog(ctx, locale)),
+});

--- a/packages/backend/convex/contentRelease/tryout/catalog.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/catalog.test.ts
@@ -1,0 +1,167 @@
+import { TryoutCatalogRowSchema } from "@nakafa/aksara-contracts/tryout/spec";
+import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
+import { readTryoutCatalog } from "@repo/backend/convex/contentRelease/tryout/catalog";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  activateTryoutSnapshot,
+  makeTryoutCatalogRow,
+  makeTryoutPlacementRow,
+} from "@repo/backend/test/tryout-snapshot";
+import { convexTest } from "convex-test";
+import { Effect, Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+/** Creates one technical track used to break localized count symmetry. */
+function makeTechnicalTrack() {
+  return Schema.decodeUnknownSync(TryoutCatalogRowSchema)({
+    countryKey: "indonesia",
+    description: "Technical track",
+    examKey: "snbt",
+    graph: {
+      alignmentId: "alignment:tryout:technical:track",
+      assetId: "asset:en:tryout:technical:track",
+      conceptId: "concept:tryout:technical:track",
+      learningObjectId: "lo:tryout-technical-track",
+      lensId: "lens:tryout:technical",
+    },
+    kind: "track",
+    locale: "en",
+    order: 1,
+    publicPath: "try-out/indonesia/snbt/2027",
+    questionCount: 1,
+    sectionCount: 1,
+    setCount: 1,
+    sourceRevision: "technical-revision",
+    title: "Technical track",
+    trackKey: "2027",
+    trackKind: "year",
+    visibleSectionCount: 1,
+  });
+}
+
+/** Activates the smallest coherent two-locale catalog. */
+async function activateCatalog() {
+  const t = convexTest(schema, convexModules);
+  const catalog = [
+    makeTryoutCatalogRow("en").record.row,
+    makeTryoutCatalogRow("id").record.row,
+  ];
+  const placements = [
+    makeTryoutPlacementRow("en").record.row,
+    makeTryoutPlacementRow("id").record.row,
+  ];
+  const snapshotId = await t.mutation((ctx) =>
+    activateTryoutSnapshot(ctx, { catalog, placements })
+  );
+  return { snapshotId, t };
+}
+
+describe("contentRelease/tryout/catalog", () => {
+  it("returns an unmanaged catalog before try-out publication", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutCatalog(ctx, "en")))
+    ).resolves.toMatchObject({ managed: false, rowJson: [] });
+  });
+
+  it("returns one verified localized hierarchy from the active snapshot", async () => {
+    const { snapshotId, t } = await activateCatalog();
+    const result = await t.query((ctx) =>
+      runConvexProgram(readTryoutCatalog(ctx, "id"))
+    );
+    const rows = await Effect.runPromise(
+      Effect.forEach(result.rowJson, decodeSnapshotRowJson)
+    );
+
+    expect(result).toMatchObject({ managed: true, snapshotId });
+    expect(rows).toMatchObject([
+      {
+        family: "tryout",
+        record: { row: { kind: "country", locale: "id" } },
+        rowKind: "catalog",
+      },
+    ]);
+  });
+
+  it("waits for active question ownership before exposing the catalog", async () => {
+    const { t } = await activateCatalog();
+    await t.mutation(async (ctx) => {
+      const release = await ctx.db.query("contentReleases").unique();
+      if (!release) {
+        throw new Error("Expected one technical release.");
+      }
+      await ctx.db.patch("contentReleases", release._id, {
+        resultFamilies: ["material"],
+      });
+    });
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutCatalog(ctx, "en")))
+    ).resolves.toMatchObject({ managed: false, rowJson: [] });
+  });
+
+  it("rejects asymmetric localized hierarchy counts", async () => {
+    const asymmetric = convexTest(schema, convexModules);
+    await asymmetric.mutation((ctx) =>
+      activateTryoutSnapshot(ctx, {
+        catalog: [
+          makeTryoutCatalogRow("en").record.row,
+          makeTryoutCatalogRow("id").record.row,
+          makeTechnicalTrack(),
+        ],
+        placements: [
+          makeTryoutPlacementRow("en").record.row,
+          makeTryoutPlacementRow("id").record.row,
+        ],
+      })
+    );
+    await expect(
+      asymmetric.query((ctx) => runConvexProgram(readTryoutCatalog(ctx, "en")))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it("fails closed when one signed row disappears or changes indexed facts", async () => {
+    const missing = await activateCatalog();
+    await missing.t.mutation(async (ctx) => {
+      const row = await ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_locale_and_publicPath", (index) =>
+          index.eq("snapshotId", missing.snapshotId).eq("locale", "en")
+        )
+        .unique();
+      if (!row) {
+        throw new Error("Expected one English catalog row.");
+      }
+      await ctx.db.delete(row._id);
+    });
+    await expect(
+      missing.t.query((ctx) => runConvexProgram(readTryoutCatalog(ctx, "en")))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const changed = await activateCatalog();
+    await changed.t.mutation(async (ctx) => {
+      const row = await ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_locale_and_publicPath", (index) =>
+          index.eq("snapshotId", changed.snapshotId).eq("locale", "en")
+        )
+        .unique();
+      if (!row) {
+        throw new Error("Expected one English catalog row.");
+      }
+      await ctx.db.patch("tryoutCatalog", row._id, { order: 10 });
+    });
+    await expect(
+      changed.t.query((ctx) => runConvexProgram(readTryoutCatalog(ctx, "en")))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/catalog.ts
+++ b/packages/backend/convex/contentRelease/tryout/catalog.ts
@@ -1,0 +1,112 @@
+import type { ContentLocale } from "@nakafa/aksara-contracts/content";
+import type { TryoutCatalogCounts } from "@nakafa/aksara-contracts/tryout/snapshot";
+import type { TryoutCatalogRow } from "@nakafa/aksara-contracts/tryout/spec";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { readSourceRevision } from "@repo/backend/convex/contentRelease/runtime/origin";
+import { TRYOUT_CATALOG_LIMIT } from "@repo/backend/convex/contentRelease/tryout/limits";
+import { loadTryoutOwner } from "@repo/backend/convex/contentRelease/tryout/owner";
+import { verifyTryoutCatalog } from "@repo/backend/convex/contentRelease/tryout/verify";
+import { Effect } from "effect";
+
+/** Counts each hierarchy kind in one verified localized catalog. */
+function countCatalog(rows: readonly TryoutCatalogRow[]) {
+  return {
+    country: rows.filter(({ kind }) => kind === "country").length,
+    exam: rows.filter(({ kind }) => kind === "exam").length,
+    section: rows.filter(({ kind }) => kind === "section").length,
+    set: rows.filter(({ kind }) => kind === "set").length,
+    track: rows.filter(({ kind }) => kind === "track").length,
+  };
+}
+
+/** Divides signed global counts into the exact expected locale inventory. */
+function localizedCounts(
+  counts: TryoutCatalogCounts,
+  localeCount: number
+): TryoutCatalogCounts | undefined {
+  const entries = Object.entries(counts);
+  if (entries.some(([, count]) => count % localeCount !== 0)) {
+    return;
+  }
+  return {
+    country: counts.country / localeCount,
+    exam: counts.exam / localeCount,
+    section: counts.section / localeCount,
+    set: counts.set / localeCount,
+    track: counts.track / localeCount,
+  };
+}
+
+/** Reads the complete verified hierarchy for one active try-out locale. */
+export const readTryoutCatalog = Effect.fn("contentRelease.readTryoutCatalog")(
+  function* (ctx: QueryCtx, locale: ContentLocale) {
+    const owner = yield* loadTryoutOwner(ctx);
+    if (!(owner.managed && owner.selected)) {
+      return {
+        activeManifestHash: owner.selected?.active.manifestHash ?? null,
+        activeReleaseId: owner.selected?.active.releaseId ?? null,
+        managed: false,
+        rowJson: [],
+        snapshotId: owner.selected?.snapshotId ?? null,
+        sourceRevision: null,
+      };
+    }
+    const { active, snapshot, snapshotId } = owner.selected;
+    if (snapshot.family !== "tryout") {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Active try-out owner selected another snapshot family."
+      );
+    }
+    const { counts, locales } = snapshot.manifest;
+    const expected = localizedCounts(counts, locales.length);
+    if (!expected) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Active try-out catalog counts do not divide across its locales."
+      );
+    }
+    const total = Object.values(expected).reduce(
+      (count, value) => count + value,
+      0
+    );
+    if (total > TRYOUT_CATALOG_LIMIT) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_LIMIT",
+        `Try-out catalog exceeds ${TRYOUT_CATALOG_LIMIT} rows per locale.`
+      );
+    }
+    const stored = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_locale_and_publicPath", (index) =>
+          index.eq("snapshotId", snapshotId).eq("locale", locale)
+        )
+        .take(total + 1)
+    );
+    if (stored.length !== total) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Try-out catalog for ${locale} does not match its signed count.`
+      );
+    }
+    const rows = yield* Effect.forEach(stored, (row) =>
+      verifyTryoutCatalog(row, snapshotId)
+    );
+    if (JSON.stringify(countCatalog(rows)) !== JSON.stringify(expected)) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Try-out catalog for ${locale} changed its hierarchy counts.`
+      );
+    }
+    return {
+      activeManifestHash: active.manifestHash,
+      activeReleaseId: active.releaseId,
+      managed: true,
+      rowJson: stored.map(({ rowJson }) => rowJson),
+      snapshotId,
+      sourceRevision: readSourceRevision(active),
+    };
+  }
+);

--- a/packages/backend/convex/contentRelease/tryout/facts.ts
+++ b/packages/backend/convex/contentRelease/tryout/facts.ts
@@ -1,0 +1,37 @@
+import {
+  tryoutCatalogIdentity,
+  tryoutPlacementIdentity,
+} from "@nakafa/aksara-contracts/tryout/identity";
+import type {
+  TryoutCatalogRecord,
+  TryoutPlacementRecord,
+} from "@nakafa/aksara-contracts/tryout/spec";
+
+/** Derives the exact indexed facts stored beside one signed catalog row. */
+export function tryoutCatalogFacts(record: TryoutCatalogRecord) {
+  const { row } = record;
+  return {
+    identity: tryoutCatalogIdentity(row),
+    kind: row.kind,
+    locale: row.locale,
+    order: row.kind === "country" || row.kind === "exam" ? 0 : row.order,
+    publicPath: row.publicPath,
+  };
+}
+
+/** Derives the exact server-only facts stored beside one signed placement. */
+export function tryoutPlacementFacts(record: TryoutPlacementRecord) {
+  const { row } = record;
+  return {
+    answerArtifactHash: row.answerArtifactHash,
+    countryKey: row.countryKey,
+    examKey: row.examKey,
+    identity: tryoutPlacementIdentity(row),
+    locale: row.locale,
+    questionArtifactHash: row.questionArtifactHash,
+    questionOrder: row.questionOrder,
+    sectionKey: row.sectionKey,
+    setKey: row.setKey,
+    trackKey: row.trackKey,
+  };
+}

--- a/packages/backend/convex/contentRelease/tryout/limits.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/limits.test.ts
@@ -1,0 +1,22 @@
+import {
+  TRANSACTION_READ_HEADROOM,
+  TRANSACTION_READ_LIMIT,
+} from "@repo/backend/convex/contentRelease/spec";
+import {
+  TRYOUT_CATALOG_DOCUMENT_LIMIT,
+  TRYOUT_CATALOG_LIMIT,
+  TRYOUT_PLACEMENT_DOCUMENT_LIMIT,
+  TRYOUT_SECTION_LIMIT,
+} from "@repo/backend/convex/contentRelease/tryout/limits";
+import { describe, expect, it } from "vitest";
+
+describe("contentRelease/tryout/limits", () => {
+  it.each([
+    [TRYOUT_CATALOG_LIMIT, TRYOUT_CATALOG_DOCUMENT_LIMIT],
+    [TRYOUT_SECTION_LIMIT, TRYOUT_PLACEMENT_DOCUMENT_LIMIT],
+  ])("reserves transaction headroom for %i maximum rows", (count, bytes) => {
+    expect(count * bytes).toBeLessThanOrEqual(
+      TRANSACTION_READ_LIMIT - TRANSACTION_READ_HEADROOM
+    );
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/limits.ts
+++ b/packages/backend/convex/contentRelease/tryout/limits.ts
@@ -1,5 +1,22 @@
+import {
+  TRANSACTION_READ_HEADROOM,
+  TRANSACTION_READ_LIMIT,
+} from "@repo/backend/convex/contentRelease/spec";
+
 /** Maximum immutable hierarchy rows accepted by one runtime catalog read. */
 export const TRYOUT_CATALOG_LIMIT = 1000;
 
 /** Maximum question placements accepted within one authored section. */
 export const TRYOUT_SECTION_LIMIT = 256;
+
+const TRYOUT_READ_BUDGET = TRANSACTION_READ_LIMIT - TRANSACTION_READ_HEADROOM;
+
+/** Per-row ceiling that keeps a maximum catalog read within its byte budget. */
+export const TRYOUT_CATALOG_DOCUMENT_LIMIT = Math.floor(
+  TRYOUT_READ_BUDGET / TRYOUT_CATALOG_LIMIT
+);
+
+/** Per-row ceiling that keeps a maximum section read within its byte budget. */
+export const TRYOUT_PLACEMENT_DOCUMENT_LIMIT = Math.floor(
+  TRYOUT_READ_BUDGET / TRYOUT_SECTION_LIMIT
+);

--- a/packages/backend/convex/contentRelease/tryout/limits.ts
+++ b/packages/backend/convex/contentRelease/tryout/limits.ts
@@ -1,0 +1,5 @@
+/** Maximum immutable hierarchy rows accepted by one runtime catalog read. */
+export const TRYOUT_CATALOG_LIMIT = 1000;
+
+/** Maximum question placements accepted within one authored section. */
+export const TRYOUT_SECTION_LIMIT = 256;

--- a/packages/backend/convex/contentRelease/tryout/owner.ts
+++ b/packages/backend/convex/contentRelease/tryout/owner.ts
@@ -1,0 +1,19 @@
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { loadActiveSnapshot } from "@repo/backend/convex/contentRelease/runtime/snapshot";
+import { loadReleaseFamilies } from "@repo/backend/convex/contentRelease/scope/family";
+import { Effect } from "effect";
+
+/** Selects one active try-out snapshot whose question bodies are also active. */
+export const loadTryoutOwner = Effect.fn("contentRelease.loadTryoutOwner")(
+  function* (ctx: QueryCtx) {
+    const selected = yield* loadActiveSnapshot(ctx, "tryout");
+    if (!selected) {
+      return { managed: false, selected: null };
+    }
+    const families = yield* loadReleaseFamilies(selected.active.release);
+    if (!families.result.includes("question")) {
+      return { managed: false, selected };
+    }
+    return { managed: true, selected };
+  }
+);

--- a/packages/backend/convex/contentRelease/tryout/section.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/section.test.ts
@@ -1,0 +1,166 @@
+import {
+  TryoutCatalogRowSchema,
+  TryoutPlacementSchema,
+} from "@nakafa/aksara-contracts/tryout/spec";
+import { readTryoutSection } from "@repo/backend/convex/contentRelease/tryout/section";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  activateTryoutSnapshot,
+  makeTryoutCatalogRow,
+  makeTryoutPlacementRow,
+} from "@repo/backend/test/tryout-snapshot";
+import { convexTest } from "convex-test";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+const identity = {
+  countryKey: "indonesia",
+  examKey: "snbt",
+  locale: "en",
+  sectionKey: "quantitative-knowledge",
+  setKey: "set-1",
+  trackKey: "2027",
+} as const;
+
+/** Creates one technical section with an explicit signed question count. */
+function makeTechnicalSection(locale: "en" | "id", questionCount = 1) {
+  return Schema.decodeUnknownSync(TryoutCatalogRowSchema)({
+    ...identity,
+    graph: {
+      alignmentId: "alignment:tryout:technical:section",
+      assetId: `asset:${locale}:tryout:technical:section`,
+      conceptId: "concept:tryout:technical:section",
+      learningObjectId: "lo:tryout-technical-section",
+      lensId: "lens:tryout:technical",
+    },
+    kind: "section",
+    locale,
+    order: 1,
+    publicPath: "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge",
+    questionCount,
+    questionSourcePath:
+      "packages/corpus/question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1",
+    sourceRevision: "technical-revision",
+    timeLimitSeconds: 60,
+    title: locale === "en" ? "Technical section" : "Bagian teknis",
+    visibility: "visible",
+  });
+}
+
+/** Moves one technical placement to another valid authored order. */
+function makeTechnicalPlacement(locale: "en" | "id", questionOrder: number) {
+  const placement = makeTryoutPlacementRow(locale).record.row;
+  const questionRoot = `question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1/question-${questionOrder}`;
+  return Schema.decodeUnknownSync(TryoutPlacementSchema)({
+    ...placement,
+    answerContentKey: `${questionRoot}/answer`,
+    questionContentKey: `${questionRoot}/question`,
+    questionOrder,
+    questionSourcePath: `packages/corpus/${questionRoot}`,
+  });
+}
+
+/** Activates one complete technical section in both supported locales. */
+async function activateSection(questionCount = 1) {
+  const t = convexTest(schema, convexModules);
+  const snapshotId = await t.mutation((ctx) =>
+    activateTryoutSnapshot(ctx, {
+      catalog: [
+        makeTryoutCatalogRow("en").record.row,
+        makeTryoutCatalogRow("id").record.row,
+        makeTechnicalSection("en", questionCount),
+        makeTechnicalSection("id", questionCount),
+      ],
+      placements: [
+        makeTryoutPlacementRow("en").record.row,
+        makeTryoutPlacementRow("id").record.row,
+      ],
+    })
+  );
+  return { snapshotId, t };
+}
+
+describe("contentRelease/tryout/section", () => {
+  it("returns one verified server-only section with signed placements", async () => {
+    const { snapshotId, t } = await activateSection();
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutSection(ctx, identity)))
+    ).resolves.toMatchObject({
+      placements: [
+        {
+          countryKey: "indonesia",
+          questionOrder: 1,
+          scope: "server",
+        },
+      ],
+      section: { kind: "section", questionCount: 1 },
+      snapshotId,
+    });
+  });
+
+  it("returns null until try-out ownership becomes active", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutSection(ctx, identity)))
+    ).resolves.toBeNull();
+  });
+
+  it("fails closed for a missing section or placement", async () => {
+    const missingSection = await activateSection();
+    await expect(
+      missingSection.t.query((ctx) =>
+        runConvexProgram(
+          readTryoutSection(ctx, { ...identity, sectionKey: "missing" })
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_MISSING" } });
+
+    const missingPlacement = await activateSection();
+    await missingPlacement.t.mutation(async (ctx) => {
+      const placement = await ctx.db.query("tryoutPlacements").first();
+      if (!placement) {
+        throw new Error("Expected one technical placement.");
+      }
+      await ctx.db.delete(placement._id);
+    });
+    await expect(
+      missingPlacement.t.query((ctx) =>
+        runConvexProgram(readTryoutSection(ctx, identity))
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_INTEGRITY" } });
+  });
+
+  it("rejects a section above the bounded placement limit", async () => {
+    const { t } = await activateSection(257);
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutSection(ctx, identity)))
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_LIMIT" } });
+  });
+
+  it("rejects a signed placement that breaks contiguous section order", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation((ctx) =>
+      activateTryoutSnapshot(ctx, {
+        catalog: [
+          makeTryoutCatalogRow("en").record.row,
+          makeTryoutCatalogRow("id").record.row,
+          makeTechnicalSection("en"),
+          makeTechnicalSection("id"),
+        ],
+        placements: [
+          makeTechnicalPlacement("en", 2),
+          makeTryoutPlacementRow("id").record.row,
+        ],
+      })
+    );
+
+    await expect(
+      t.query((ctx) => runConvexProgram(readTryoutSection(ctx, identity)))
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_INTEGRITY" } });
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/section.ts
+++ b/packages/backend/convex/contentRelease/tryout/section.ts
@@ -1,0 +1,110 @@
+import { tryoutCatalogIdentity } from "@nakafa/aksara-contracts/tryout/identity";
+import {
+  type TryoutSection,
+  TryoutSectionSchema,
+} from "@nakafa/aksara-contracts/tryout/spec";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import {
+  ReleaseError,
+  releaseFail,
+} from "@repo/backend/convex/contentRelease/error";
+import { TRYOUT_SECTION_LIMIT } from "@repo/backend/convex/contentRelease/tryout/limits";
+import { loadTryoutOwner } from "@repo/backend/convex/contentRelease/tryout/owner";
+import {
+  verifyTryoutCatalog,
+  verifyTryoutPlacement,
+} from "@repo/backend/convex/contentRelease/tryout/verify";
+import { Effect, Schema } from "effect";
+
+/** Stable authored keys that select one localized try-out section. */
+export type TryoutSectionIdentity = Pick<
+  TryoutSection,
+  "countryKey" | "examKey" | "locale" | "sectionKey" | "setKey" | "trackKey"
+>;
+
+/** Reads one verified server-only section and all signed placements. */
+export const readTryoutSection = Effect.fn("contentRelease.readTryoutSection")(
+  function* (ctx: QueryCtx, identity: TryoutSectionIdentity) {
+    const owner = yield* loadTryoutOwner(ctx);
+    if (!(owner.managed && owner.selected)) {
+      return null;
+    }
+
+    const { snapshotId } = owner.selected;
+
+    const catalogIdentity = tryoutCatalogIdentity({
+      ...identity,
+      kind: "section",
+    });
+    const storedSection = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_identity", (index) =>
+          index.eq("snapshotId", snapshotId).eq("identity", catalogIdentity)
+        )
+        .unique()
+    );
+    if (!storedSection) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_MISSING",
+        `Try-out section ${catalogIdentity} is unavailable.`
+      );
+    }
+
+    const catalogRow = yield* verifyTryoutCatalog(storedSection, snapshotId);
+    const section = yield* Schema.decodeUnknown(TryoutSectionSchema)(
+      catalogRow
+    ).pipe(
+      Effect.mapError(
+        () =>
+          new ReleaseError({
+            code: "CONTENT_RELEASE_INTEGRITY",
+            message: `Try-out section ${catalogIdentity} changed its row kind.`,
+          })
+      )
+    );
+    if (section.questionCount > TRYOUT_SECTION_LIMIT) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_LIMIT",
+        `Try-out section ${catalogIdentity} exceeds ${TRYOUT_SECTION_LIMIT} placements.`
+      );
+    }
+
+    const storedPlacements = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutPlacements")
+        .withIndex("by_snapshotId_and_section_and_questionOrder", (index) =>
+          index
+            .eq("snapshotId", snapshotId)
+            .eq("locale", identity.locale)
+            .eq("countryKey", identity.countryKey)
+            .eq("examKey", identity.examKey)
+            .eq("trackKey", identity.trackKey)
+            .eq("setKey", identity.setKey)
+            .eq("sectionKey", identity.sectionKey)
+        )
+        .take(section.questionCount + 1)
+    );
+    if (storedPlacements.length !== section.questionCount) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Try-out section ${catalogIdentity} lost its signed placements.`
+      );
+    }
+
+    const placements = yield* Effect.forEach(storedPlacements, (placement) =>
+      verifyTryoutPlacement(placement, snapshotId)
+    );
+    const hasChangedOrder = placements.some(
+      ({ questionOrder }, index) => questionOrder !== index + 1
+    );
+    if (hasChangedOrder) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Try-out section ${catalogIdentity} changed its placement order.`
+      );
+    }
+
+    return { placements, section, snapshotId };
+  }
+);

--- a/packages/backend/convex/contentRelease/tryout/verify.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/verify.test.ts
@@ -1,0 +1,97 @@
+import { verifyTryoutPlacement } from "@repo/backend/convex/contentRelease/tryout/verify";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  activateTryoutSnapshot,
+  makeTryoutCatalogRow,
+  makeTryoutPlacementRow,
+} from "@repo/backend/test/tryout-snapshot";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+/** Activates and returns one exact technical placement row. */
+async function activatePlacement() {
+  const t = convexTest(schema, convexModules);
+  const snapshotId = await t.mutation((ctx) =>
+    activateTryoutSnapshot(ctx, {
+      catalog: [
+        makeTryoutCatalogRow("en").record.row,
+        makeTryoutCatalogRow("id").record.row,
+      ],
+      placements: [
+        makeTryoutPlacementRow("en").record.row,
+        makeTryoutPlacementRow("id").record.row,
+      ],
+    })
+  );
+  const placement = await t.run((ctx) =>
+    ctx.db
+      .query("tryoutPlacements")
+      .withIndex("by_snapshotId_and_section_and_questionOrder", (index) =>
+        index
+          .eq("snapshotId", snapshotId)
+          .eq("locale", "en")
+          .eq("countryKey", "indonesia")
+          .eq("examKey", "snbt")
+          .eq("trackKey", "2027")
+          .eq("setKey", "set-1")
+          .eq("sectionKey", "quantitative-knowledge")
+          .eq("questionOrder", 1)
+      )
+      .unique()
+  );
+  if (!placement) {
+    throw new Error("Expected one technical placement.");
+  }
+  return { placement, snapshotId, t };
+}
+
+describe("contentRelease/tryout/verify", () => {
+  it("authenticates one exact server-only placement", async () => {
+    const { placement, snapshotId, t } = await activatePlacement();
+
+    await expect(
+      t.query(() =>
+        runConvexProgram(verifyTryoutPlacement(placement, snapshotId))
+      )
+    ).resolves.toMatchObject({
+      countryKey: "indonesia",
+      questionOrder: 1,
+      sectionKey: "quantitative-knowledge",
+    });
+  });
+
+  it("rejects a placement with lost signed or indexed facts", async () => {
+    const lost = await activatePlacement();
+    await expect(
+      lost.t.query(() =>
+        runConvexProgram(
+          verifyTryoutPlacement(lost.placement, `sha256:${"0".repeat(64)}`)
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const changed = await activatePlacement();
+    await changed.t.mutation((ctx) =>
+      ctx.db.patch("tryoutPlacements", changed.placement._id, {
+        sectionKey: "changed-section",
+      })
+    );
+    const tampered = await changed.t.run((ctx) =>
+      ctx.db.get(changed.placement._id)
+    );
+    if (!tampered) {
+      throw new Error("Expected one tampered placement.");
+    }
+    await expect(
+      changed.t.query(() =>
+        runConvexProgram(verifyTryoutPlacement(tampered, changed.snapshotId))
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/verify.ts
+++ b/packages/backend/convex/contentRelease/tryout/verify.ts
@@ -1,0 +1,77 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
+import {
+  tryoutCatalogFacts,
+  tryoutPlacementFacts,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
+import { Effect } from "effect";
+
+/** Authenticates one immutable catalog row and every indexed fact. */
+export const verifyTryoutCatalog = Effect.fn(
+  "contentRelease.verifyTryoutCatalog"
+)(function* (row: Doc<"tryoutCatalog">, snapshotId: string) {
+  const decoded = yield* decodeSnapshotRowJson(row.rowJson);
+  if (
+    decoded.family !== "tryout" ||
+    decoded.rowKind !== "catalog" ||
+    decoded.record.rowHash !== row.rowHash ||
+    row.snapshotId !== snapshotId
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Try-out catalog row ${row.identity} lost its signed snapshot.`
+    );
+  }
+  const facts = tryoutCatalogFacts(decoded.record);
+  if (
+    facts.identity !== row.identity ||
+    facts.kind !== row.kind ||
+    facts.locale !== row.locale ||
+    facts.order !== row.order ||
+    facts.publicPath !== row.publicPath
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Try-out catalog row ${row.identity} changed its indexed facts.`
+    );
+  }
+  return decoded.record.row;
+});
+
+/** Authenticates one server-only placement and every indexed fact. */
+export const verifyTryoutPlacement = Effect.fn(
+  "contentRelease.verifyTryoutPlacement"
+)(function* (row: Doc<"tryoutPlacements">, snapshotId: string) {
+  const decoded = yield* decodeSnapshotRowJson(row.rowJson);
+  if (
+    decoded.family !== "tryout" ||
+    decoded.rowKind !== "placement" ||
+    decoded.record.rowHash !== row.rowHash ||
+    row.snapshotId !== snapshotId
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Try-out placement ${row.identity} lost its signed snapshot.`
+    );
+  }
+  const facts = tryoutPlacementFacts(decoded.record);
+  if (
+    facts.answerArtifactHash !== row.answerArtifactHash ||
+    facts.countryKey !== row.countryKey ||
+    facts.examKey !== row.examKey ||
+    facts.identity !== row.identity ||
+    facts.locale !== row.locale ||
+    facts.questionArtifactHash !== row.questionArtifactHash ||
+    facts.questionOrder !== row.questionOrder ||
+    facts.sectionKey !== row.sectionKey ||
+    facts.setKey !== row.setKey ||
+    facts.trackKey !== row.trackKey
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Try-out placement ${row.identity} changed its indexed facts.`
+    );
+  }
+  return decoded.record.row;
+});

--- a/packages/backend/test/tryout-snapshot.ts
+++ b/packages/backend/test/tryout-snapshot.ts
@@ -1,3 +1,4 @@
+import type { ContentLocale } from "@nakafa/aksara-contracts/content";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import {
   inheritContentSnapshots,
@@ -11,8 +12,6 @@ import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release
 import {
   compareTryoutCatalog,
   compareTryoutPlacements,
-  tryoutCatalogIdentity,
-  tryoutPlacementIdentity,
 } from "@nakafa/aksara-contracts/tryout/identity";
 import {
   digestTryoutCatalog,
@@ -28,6 +27,10 @@ import {
   TryoutPlacementSchema,
 } from "@nakafa/aksara-contracts/tryout/spec";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import {
+  tryoutCatalogFacts,
+  tryoutPlacementFacts,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
 import { encodeSnapshotJson } from "@repo/backend/convex/contentRelease/wire";
 import {
   TEST_MANIFEST_HASH,
@@ -39,7 +42,9 @@ import { Effect, Schema, Stream } from "effect";
 const artifactHash = Sha256HashSchema.make(`sha256:${"8".repeat(64)}`);
 
 /** Creates one hashed technical try-out country row. */
-export function makeTryoutCatalogRow(): Extract<
+export function makeTryoutCatalogRow(
+  locale: ContentLocale = "en"
+): Extract<
   ContentSnapshotRow,
   { readonly family: "tryout"; readonly rowKind: "catalog" }
 > {
@@ -48,17 +53,17 @@ export function makeTryoutCatalogRow(): Extract<
     countryKey: "indonesia",
     graph: {
       alignmentId: "alignment:tryout:technical:country",
-      assetId: "asset:en:tryout:technical:country",
+      assetId: `asset:${locale}:tryout:technical:country`,
       conceptId: "concept:tryout:technical:country",
       learningObjectId: "lo:tryout-technical-country",
       lensId: "lens:tryout:technical",
     },
     kind: "country",
-    locale: "en",
+    locale,
     order: 1,
     publicPath: "try-out/indonesia",
     sourceRevision: "technical-revision",
-    title: "Technical country",
+    title: locale === "en" ? "Technical country" : "Negara teknis",
   });
   return {
     family: "tryout",
@@ -68,7 +73,9 @@ export function makeTryoutCatalogRow(): Extract<
 }
 
 /** Creates one hashed technical try-out question placement. */
-export function makeTryoutPlacementRow(): Extract<
+export function makeTryoutPlacementRow(
+  locale: ContentLocale = "en"
+): Extract<
   ContentSnapshotRow,
   { readonly family: "tryout"; readonly rowKind: "placement" }
 > {
@@ -79,14 +86,14 @@ export function makeTryoutPlacementRow(): Extract<
     choices: [
       {
         isCorrect: true,
-        label: "Technical choice",
+        label: locale === "en" ? "Technical choice" : "Pilihan teknis",
         optionKey: "option-1",
         order: 1,
       },
     ],
     countryKey: "indonesia",
     examKey: "snbt",
-    locale: "en",
+    locale,
     questionArtifactHash: artifactHash,
     questionContentKey:
       "question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1/question-1/question",
@@ -98,7 +105,7 @@ export function makeTryoutPlacementRow(): Extract<
     sectionKey: "quantitative-knowledge",
     setKey: "set-1",
     sourceRevision: "technical-revision",
-    title: "Technical question",
+    title: locale === "en" ? "Technical question" : "Pertanyaan teknis",
     trackKey: "2027",
   });
   return {
@@ -112,22 +119,25 @@ export function makeTryoutPlacementRow(): Extract<
 export const makeTryoutSnapshotManifest = Effect.fn(
   "backendTest.makeTryoutSnapshotManifest"
 )(function* () {
-  const catalog = makeTryoutCatalogRow();
-  const placement = makeTryoutPlacementRow();
+  const catalog = [makeTryoutCatalogRow("en"), makeTryoutCatalogRow("id")];
+  const placements = [
+    makeTryoutPlacementRow("en"),
+    makeTryoutPlacementRow("id"),
+  ];
   const catalogEvidence = yield* digestTryoutCatalog(
-    Stream.make(catalog.record)
+    Stream.fromIterable(catalog.map(({ record }) => record))
   );
   const placementEvidence = yield* digestTryoutPlacements(
-    Stream.make(placement.record)
+    Stream.fromIterable(placements.map(({ record }) => record))
   );
   const manifest = makeTryoutSnapshot({
     catalogDigest: catalogEvidence.digest,
-    counts: { country: 1, exam: 0, section: 0, set: 0, track: 0 },
+    counts: { country: 2, exam: 0, section: 0, set: 0, track: 0 },
     format: "tryout-v1",
     locales: ["en", "id"],
     placementCount: placementEvidence.count,
     placementDigest: placementEvidence.digest,
-    routeCount: 1,
+    routeCount: 2,
   });
   return {
     family: "tryout",
@@ -244,14 +254,9 @@ function insertCatalogRecord(
   index: number,
   record: ReturnType<typeof makeTryoutCatalogRecord>
 ) {
-  const { row } = record;
   return ctx.db.insert("tryoutCatalog", {
-    identity: tryoutCatalogIdentity(row),
+    ...tryoutCatalogFacts(record),
     index,
-    kind: row.kind,
-    locale: row.locale,
-    order: row.kind === "set" || row.kind === "section" ? row.order : 0,
-    publicPath: row.publicPath,
     rowHash: record.rowHash,
     rowJson: canonicalizeContentSnapshotRow({
       family: "tryout",
@@ -269,14 +274,9 @@ function insertPlacementRecord(
   index: number,
   record: ReturnType<typeof makeTryoutPlacementRecord>
 ) {
-  const { row } = record;
   return ctx.db.insert("tryoutPlacements", {
-    answerArtifactHash: row.answerArtifactHash,
-    identity: tryoutPlacementIdentity(row),
+    ...tryoutPlacementFacts(record),
     index,
-    locale: row.locale,
-    questionArtifactHash: row.questionArtifactHash,
-    questionOrder: row.questionOrder,
     rowHash: record.rowHash,
     rowJson: canonicalizeContentSnapshotRow({
       family: "tryout",


### PR DESCRIPTION
## Summary

- add signed immutable tryout snapshot storage and indexed runtime reads
- verify catalog and placement hashes, snapshot identity, indexed facts, locale symmetry, and renderer compatibility
- bound catalog and section reads below the Convex transaction read ceiling
- retain snapshot-owned artifact references during cleanup

This PR is additive. It does not switch production tryout routes or remove legacy ownership yet.

## Real corpus proof

- 3,360 localized question and answer bodies
- 840 localized placements
- 54 catalog rows
- 420 unique questions
- largest catalog row: 1,062 bytes
- largest locale catalog read: 24,413 bytes
- largest placement row: 3,301 bytes
- largest section read: 72,687 bytes across 40 rows

## Migration safety

- production `tryoutPlacements` rows: 0
- shared development `tryoutPlacements` rows: 0
- no optional compatibility schema is required
- no shared development or production deployment was performed
- strict codegen and deployment passed only on Agent Mode deployment `ceaseless-mallard-896`

## Verification

- focused snapshot, catalog, section, retention, cleanup, and integrity tests: 25 passed
- full backend: 286 files, 1,294 tests
- backend TypeScript 7 typecheck
- root lint
- workspace boundaries
- Effect source alignment
- root production build: 5 of 5 tasks, WWW 1,303 of 1,303 pages
- root production start: WWW, API, MCP, and CAS returned HTTP 200
- exact full local Codex review: no actionable correctness finding
- hosted Agent-Friendly Docs: passed in 17m11s
- hosted React Doctor: passed
- unresolved review threads: 0
- worktree and diff checks clean

## Review dispositions

- rejected the optional migration suggestion after direct development and production zero-row proof
- accepted and fixed the aggregate read-budget finding
- accepted and fixed the immutable replay size-bypass finding
- GitHub Codex returned its usage-limit response instead of a new exact-head review, so the independent exact-head local review is the review gate

After this seam merges, the next governed step is to deploy the additive storage, publish the real question and tryout snapshot release, migrate attempt ownership, switch without fallback, and delete the legacy tryout content path.
