### PR TITLE
ci: pin React Doctor runtime

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -26,3 +26,5 @@ jobs:
       - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
         with:
           blocking: warning
+          scope: changed
+          version: 0.9.3


### PR DESCRIPTION
## Summary

- pin the React Doctor action runtime to the same `0.9.3` version used by the repository CLI
- make the intended changed-file scope explicit while preserving the warning blocking policy

## Why

The action source is pinned, but its `version` input otherwise defaults to `latest`. Explicit version parity keeps local and hosted diagnostics reproducible.

## Verification

- parsed `.github/workflows/react-doctor.yml` as YAML
- asserted local and workflow React Doctor versions both resolve to `0.9.3`
- asserted `scope: changed` and `blocking: warning`
- `git diff --check`
