### PR TITLE
build(tryouts): stage runtime indexes

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -285,6 +285,8 @@ import type * as contentRelease_tryout_facts from "../contentRelease/tryout/fact
 import type * as contentRelease_tryout_limits from "../contentRelease/tryout/limits.js";
 import type * as contentRelease_tryout_owner from "../contentRelease/tryout/owner.js";
 import type * as contentRelease_tryout_section from "../contentRelease/tryout/section.js";
+import type * as contentRelease_tryout_setIdentity from "../contentRelease/tryout/setIdentity.js";
+import type * as contentRelease_tryout_setIdentity_impl from "../contentRelease/tryout/setIdentity/impl.js";
 import type * as contentRelease_tryout_verify from "../contentRelease/tryout/verify.js";
 import type * as contentRelease_verify from "../contentRelease/verify.js";
 import type * as contentRelease_verify_delete from "../contentRelease/verify/delete.js";
@@ -827,6 +829,8 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/tryout/limits": typeof contentRelease_tryout_limits;
   "contentRelease/tryout/owner": typeof contentRelease_tryout_owner;
   "contentRelease/tryout/section": typeof contentRelease_tryout_section;
+  "contentRelease/tryout/setIdentity": typeof contentRelease_tryout_setIdentity;
+  "contentRelease/tryout/setIdentity/impl": typeof contentRelease_tryout_setIdentity_impl;
   "contentRelease/tryout/verify": typeof contentRelease_tryout_verify;
   "contentRelease/verify": typeof contentRelease_verify;
   "contentRelease/verify/delete": typeof contentRelease_verify_delete;

--- a/packages/backend/convex/contentRelease/snapshot/schema.ts
+++ b/packages/backend/convex/contentRelease/snapshot/schema.ts
@@ -176,6 +176,7 @@ const tables = {
     publicPath: v.optional(v.string()),
     rowHash: v.string(),
     rowJson: v.string(),
+    setIdentity: v.optional(v.string()),
     snapshotId: v.string(),
   })
     .index("by_snapshotId_and_index", ["snapshotId", "index"])
@@ -184,7 +185,11 @@ const tables = {
       "snapshotId",
       "locale",
       "publicPath",
-    ]),
+    ])
+    .index("by_snapshotId_and_setIdentity_and_kind_and_order", {
+      fields: ["snapshotId", "setIdentity", "kind", "order"],
+      staged: true,
+    }),
 
   /** Immutable attempt placements with terminal answer-artifact bindings. */
   tryoutPlacements: defineTable({
@@ -215,6 +220,14 @@ const tables = {
       "sectionKey",
       "questionOrder",
     ])
+    .index("by_snapshotId_and_questionArtifactHash", {
+      fields: ["snapshotId", "questionArtifactHash"],
+      staged: true,
+    })
+    .index("by_snapshotId_and_answerArtifactHash", {
+      fields: ["snapshotId", "answerArtifactHash"],
+      staged: true,
+    })
     .index("by_questionArtifactHash", ["questionArtifactHash"])
     .index("by_answerArtifactHash", ["answerArtifactHash"]),
 };

--- a/packages/backend/convex/contentRelease/tryout/facts.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/facts.test.ts
@@ -1,0 +1,72 @@
+import { makeTryoutCatalogRecord } from "@nakafa/aksara-contracts/tryout/row-hash";
+import { TryoutCatalogRowSchema } from "@nakafa/aksara-contracts/tryout/spec";
+import {
+  tryoutCatalogFacts,
+  tryoutCatalogSetIdentity,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
+import { makeTryoutCatalogRow } from "@repo/backend/test/tryout-snapshot";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+/** Creates one schema-decoded technical set or section row. */
+function makeSetChild(kind: "section" | "set") {
+  const common = {
+    countryKey: "indonesia",
+    examKey: "snbt",
+    graph: {
+      alignmentId: `alignment:tryout:technical:${kind}`,
+      assetId: `asset:en:tryout:technical:${kind}`,
+      conceptId: `concept:tryout:technical:${kind}`,
+      learningObjectId: `lo:tryout-technical-${kind}`,
+      lensId: "lens:tryout:technical",
+    },
+    locale: "en",
+    order: 1,
+    publicPath: `try-out/indonesia/snbt/2027/set-1/${kind}`,
+    questionCount: 1,
+    setKey: "set-1",
+    sourceRevision: "technical-revision",
+    title: `Technical ${kind}`,
+    trackKey: "2027",
+  };
+
+  if (kind === "set") {
+    return Schema.decodeUnknownSync(TryoutCatalogRowSchema)({
+      ...common,
+      kind,
+      scoringStrategy: "irt",
+      sectionCount: 1,
+      visibleSectionCount: 1,
+    });
+  }
+
+  return Schema.decodeUnknownSync(TryoutCatalogRowSchema)({
+    ...common,
+    kind,
+    questionSourcePath:
+      "packages/corpus/question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1",
+    sectionKey: "quantitative-knowledge",
+    timeLimitSeconds: 60,
+    visibility: "visible",
+  });
+}
+
+describe("contentRelease/tryout/facts", () => {
+  it("derives one stable set identity for set and section rows", () => {
+    const set = makeSetChild("set");
+    const section = makeSetChild("section");
+    const setIdentity = tryoutCatalogSetIdentity(set);
+
+    expect(tryoutCatalogFacts(makeTryoutCatalogRecord(set)).setIdentity).toBe(
+      setIdentity
+    );
+    expect(tryoutCatalogSetIdentity(section)).toBe(setIdentity);
+  });
+
+  it("stores no set identity for rows outside a set", () => {
+    const country = makeTryoutCatalogRow().record;
+
+    expect(tryoutCatalogFacts(country).setIdentity).toBeUndefined();
+    expect(tryoutCatalogSetIdentity(country.row)).toBeUndefined();
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/facts.ts
+++ b/packages/backend/convex/contentRelease/tryout/facts.ts
@@ -4,8 +4,25 @@ import {
 } from "@nakafa/aksara-contracts/tryout/identity";
 import type {
   TryoutCatalogRecord,
+  TryoutCatalogRow,
   TryoutPlacementRecord,
 } from "@nakafa/aksara-contracts/tryout/spec";
+
+/** Derives the canonical set identity shared by set and section rows. */
+export function tryoutCatalogSetIdentity(row: TryoutCatalogRow) {
+  if (row.kind !== "set" && row.kind !== "section") {
+    return;
+  }
+
+  return tryoutCatalogIdentity({
+    countryKey: row.countryKey,
+    examKey: row.examKey,
+    kind: "set",
+    locale: row.locale,
+    setKey: row.setKey,
+    trackKey: row.trackKey,
+  });
+}
 
 /** Derives the exact indexed facts stored beside one signed catalog row. */
 export function tryoutCatalogFacts(record: TryoutCatalogRecord) {
@@ -16,6 +33,7 @@ export function tryoutCatalogFacts(record: TryoutCatalogRecord) {
     locale: row.locale,
     order: row.kind === "country" || row.kind === "exam" ? 0 : row.order,
     publicPath: row.publicPath,
+    setIdentity: tryoutCatalogSetIdentity(row),
   };
 }
 

--- a/packages/backend/convex/contentRelease/tryout/setIdentity.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/setIdentity.test.ts
@@ -1,0 +1,229 @@
+import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot-data";
+import { makeTryoutCatalogRecord } from "@nakafa/aksara-contracts/tryout/row-hash";
+import {
+  type TryoutCatalogRow,
+  TryoutCatalogRowSchema,
+} from "@nakafa/aksara-contracts/tryout/spec";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import {
+  tryoutCatalogFacts,
+  tryoutCatalogSetIdentity,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
+import { migrateTryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/setIdentity/impl";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeTryoutCatalogRow } from "@repo/backend/test/tryout-snapshot";
+import { convexTest } from "convex-test";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+const snapshotId = `sha256:${"5".repeat(64)}`;
+
+/** Creates one signed technical section with a unique catalog identity. */
+function makeSection(index = 0) {
+  return Schema.decodeUnknownSync(TryoutCatalogRowSchema)({
+    countryKey: "indonesia",
+    examKey: "snbt",
+    graph: {
+      alignmentId: `alignment:tryout:technical:section-${index}`,
+      assetId: `asset:en:tryout:technical:section-${index}`,
+      conceptId: `concept:tryout:technical:section-${index}`,
+      learningObjectId: `lo:tryout-technical-section-${index}`,
+      lensId: "lens:tryout:technical",
+    },
+    kind: "section",
+    locale: "en",
+    order: index + 1,
+    publicPath: `try-out/indonesia/snbt/2027/set-1/section-${index}`,
+    questionCount: 1,
+    questionSourcePath: `packages/corpus/question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1/section-${index}`,
+    sectionKey: `section-${index}`,
+    setKey: "set-1",
+    sourceRevision: "technical-revision",
+    timeLimitSeconds: 60,
+    title: `Technical section ${index}`,
+    trackKey: "2027",
+    visibility: "visible",
+  });
+}
+
+/** Inserts one signed catalog row in the exact pre-migration shape. */
+function insertOldCatalog(ctx: MutationCtx, row: TryoutCatalogRow) {
+  const record = makeTryoutCatalogRecord(row);
+  const facts = tryoutCatalogFacts(record);
+  return ctx.db.insert("tryoutCatalog", {
+    identity: facts.identity,
+    index: row.order,
+    kind: facts.kind,
+    locale: facts.locale,
+    order: facts.order,
+    publicPath: facts.publicPath,
+    rowHash: record.rowHash,
+    rowJson: canonicalizeContentSnapshotRow({
+      family: "tryout",
+      record,
+      rowKind: "catalog",
+    }),
+    snapshotId,
+  });
+}
+
+describe("contentRelease/tryout/setIdentity", () => {
+  it("previews, applies, and verifies the exact signed catalog migration", async () => {
+    const target = convexTest(schema, convexModules);
+    const section = makeSection();
+    const country = makeTryoutCatalogRow().record.row;
+    await target.mutation(async (ctx) => {
+      await insertOldCatalog(ctx, section);
+      await insertOldCatalog(ctx, country);
+    });
+
+    await expect(
+      target.mutation(internal.contentRelease.tryout.setIdentity.migrate, {
+        apply: false,
+        expectedMissing: 1,
+      })
+    ).resolves.toEqual({ candidates: 1, updated: 0 });
+    await expect(
+      target.mutation(internal.contentRelease.tryout.setIdentity.migrate, {
+        apply: true,
+        expectedMissing: 1,
+      })
+    ).resolves.toEqual({ candidates: 1, updated: 1 });
+    await expect(
+      target.mutation(internal.contentRelease.tryout.setIdentity.migrate, {
+        apply: false,
+        expectedMissing: 0,
+      })
+    ).resolves.toEqual({ candidates: 0, updated: 0 });
+
+    const migrated = await target.run((ctx) =>
+      ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_identity", (query) =>
+          query
+            .eq("snapshotId", snapshotId)
+            .eq(
+              "identity",
+              tryoutCatalogFacts(makeTryoutCatalogRecord(section)).identity
+            )
+        )
+        .unique()
+    );
+    expect(migrated?.setIdentity).toBe(tryoutCatalogSetIdentity(section));
+  });
+
+  it("rejects count drift and invalid operator bounds", async () => {
+    const target = convexTest(schema, convexModules);
+    await target.mutation((ctx) => insertOldCatalog(ctx, makeSection()));
+
+    await expect(
+      target.mutation((ctx) =>
+        runConvexProgram(
+          migrateTryoutSetIdentity(ctx, {
+            apply: false,
+            expectedMissing: 0,
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+
+    for (const expectedMissing of [-1, 1.5, 101]) {
+      await expect(
+        target.mutation((ctx) =>
+          runConvexProgram(
+            migrateTryoutSetIdentity(ctx, {
+              apply: false,
+              expectedMissing,
+            })
+          )
+        )
+      ).rejects.toMatchObject({
+        data: { code: "CONTENT_RELEASE_LIMIT" },
+      });
+    }
+  });
+
+  it("rejects corrupt, unexpected, and invalid stored identities", async () => {
+    const corrupt = convexTest(schema, convexModules);
+    await corrupt.mutation(async (ctx) => {
+      const id = await insertOldCatalog(ctx, makeSection());
+      await ctx.db.patch("tryoutCatalog", id, { rowHash: "invalid" });
+    });
+    await expect(
+      corrupt.mutation((ctx) =>
+        runConvexProgram(
+          migrateTryoutSetIdentity(ctx, {
+            apply: false,
+            expectedMissing: 1,
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const unexpected = convexTest(schema, convexModules);
+    await unexpected.mutation(async (ctx) => {
+      const country = makeTryoutCatalogRow().record.row;
+      const id = await insertOldCatalog(ctx, country);
+      await ctx.db.patch("tryoutCatalog", id, { setIdentity: "unexpected" });
+    });
+    await expect(
+      unexpected.mutation((ctx) =>
+        runConvexProgram(
+          migrateTryoutSetIdentity(ctx, {
+            apply: false,
+            expectedMissing: 0,
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const invalid = convexTest(schema, convexModules);
+    await invalid.mutation(async (ctx) => {
+      const id = await insertOldCatalog(ctx, makeSection());
+      await ctx.db.patch("tryoutCatalog", id, { setIdentity: "invalid" });
+    });
+    await expect(
+      invalid.mutation((ctx) =>
+        runConvexProgram(
+          migrateTryoutSetIdentity(ctx, {
+            apply: false,
+            expectedMissing: 0,
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it("rejects catalogs beyond the guarded migration scope", async () => {
+    const target = convexTest(schema, convexModules);
+    await target.mutation(async (ctx) => {
+      for (let index = 0; index <= 100; index += 1) {
+        await insertOldCatalog(ctx, makeSection(index));
+      }
+    });
+
+    await expect(
+      target.mutation((ctx) =>
+        runConvexProgram(
+          migrateTryoutSetIdentity(ctx, {
+            apply: false,
+            expectedMissing: 100,
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_LIMIT" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/tryout/setIdentity.ts
+++ b/packages/backend/convex/contentRelease/tryout/setIdentity.ts
@@ -1,0 +1,18 @@
+import { internalMutation } from "@repo/backend/convex/_generated/server";
+import { migrateTryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/setIdentity/impl";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { v } from "convex/values";
+
+/** Audits or applies the bounded signed try-out set-identity migration. */
+export const migrate = internalMutation({
+  args: {
+    apply: v.boolean(),
+    expectedMissing: v.number(),
+  },
+  returns: v.object({
+    candidates: v.number(),
+    updated: v.number(),
+  }),
+  handler: (ctx, input) =>
+    runConvexProgram(migrateTryoutSetIdentity(ctx, input)),
+});

--- a/packages/backend/convex/contentRelease/tryout/setIdentity/impl.ts
+++ b/packages/backend/convex/contentRelease/tryout/setIdentity/impl.ts
@@ -1,0 +1,109 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { tryoutCatalogSetIdentity } from "@repo/backend/convex/contentRelease/tryout/facts";
+import { verifyTryoutCatalog } from "@repo/backend/convex/contentRelease/tryout/verify";
+import { Effect } from "effect";
+
+const TRYOUT_SET_IDENTITY_LIMIT = 100;
+
+type CatalogRow = Doc<"tryoutCatalog">;
+
+interface MigrationCandidate {
+  readonly row: CatalogRow;
+  readonly setIdentity: string;
+}
+
+/** Validates the operator-provided migration bound. */
+function validateExpectedMissing(expectedMissing: number) {
+  if (
+    !Number.isInteger(expectedMissing) ||
+    expectedMissing < 0 ||
+    expectedMissing > TRYOUT_SET_IDENTITY_LIMIT
+  ) {
+    return releaseFail(
+      "CONTENT_RELEASE_LIMIT",
+      `Try-out set-identity migration expects between 0 and ${TRYOUT_SET_IDENTITY_LIMIT} missing rows.`
+    );
+  }
+
+  return Effect.void;
+}
+
+/** Authenticates one catalog row and classifies its migration state. */
+const classifyCatalogRow = Effect.fn(
+  "contentRelease.classifyTryoutSetIdentity"
+)(function* (row: CatalogRow) {
+  const verified = yield* verifyTryoutCatalog(row, row.snapshotId);
+  const setIdentity = tryoutCatalogSetIdentity(verified);
+
+  if (setIdentity === undefined) {
+    if (row.setIdentity !== undefined) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Try-out catalog row ${row.identity} has an unexpected set identity.`
+      );
+    }
+
+    return;
+  }
+
+  if (row.setIdentity === undefined) {
+    return { row, setIdentity };
+  }
+
+  if (row.setIdentity !== setIdentity) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Try-out catalog row ${row.identity} has an invalid set identity.`
+    );
+  }
+});
+
+/** Audits or migrates the bounded signed try-out catalog set identities. */
+export const migrateTryoutSetIdentity = Effect.fn(
+  "contentRelease.migrateTryoutSetIdentity"
+)(function* (
+  ctx: MutationCtx,
+  input: { readonly apply: boolean; readonly expectedMissing: number }
+) {
+  yield* validateExpectedMissing(input.expectedMissing);
+
+  const rows = yield* Effect.promise(() =>
+    ctx.db.query("tryoutCatalog").take(TRYOUT_SET_IDENTITY_LIMIT + 1)
+  );
+  if (rows.length > TRYOUT_SET_IDENTITY_LIMIT) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_LIMIT",
+      `Try-out set-identity migration exceeds ${TRYOUT_SET_IDENTITY_LIMIT} catalog rows.`
+    );
+  }
+
+  const candidates: MigrationCandidate[] = [];
+  for (const row of rows) {
+    const candidate = yield* classifyCatalogRow(row);
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  if (candidates.length !== input.expectedMissing) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_CONFLICT",
+      `Try-out set-identity migration found ${candidates.length} missing rows instead of ${input.expectedMissing}.`
+    );
+  }
+
+  if (input.apply) {
+    for (const { row, setIdentity } of candidates) {
+      yield* Effect.promise(() =>
+        ctx.db.patch("tryoutCatalog", row._id, { setIdentity })
+      );
+    }
+  }
+
+  return {
+    candidates: candidates.length,
+    updated: input.apply ? candidates.length : 0,
+  };
+});

--- a/packages/backend/convex/irt/schema.ts
+++ b/packages/backend/convex/irt/schema.ts
@@ -105,6 +105,14 @@ const tables = {
     publishedAt: v.number(),
   })
     .index("by_tryoutSetId_and_publishedAt", ["tryoutSetId", "publishedAt"])
+    .index("by_tryoutSetId_and_tryoutSnapshotId_and_publishedAt", {
+      fields: ["tryoutSetId", "tryoutSnapshotId", "publishedAt"],
+      staged: true,
+    })
+    .index("by_setIdentity_and_publishedAt", {
+      fields: ["setIdentity", "publishedAt"],
+      staged: true,
+    })
     .index("by_tryoutSnapshotId_and_setIdentity_and_publishedAt", [
       "tryoutSnapshotId",
       "setIdentity",
@@ -136,6 +144,10 @@ const tables = {
       "questionSourceKey",
       "sourceRevision",
     ])
+    .index("by_calibrationRunId", {
+      fields: ["calibrationRunId"],
+      staged: true,
+    })
     .index("by_calibrationStatus", ["calibrationStatus"])
     .index("by_scaleVersionId_and_placementIdentity", [
       "scaleVersionId",

--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -69,6 +69,10 @@ const tables = {
     endReason: v.union(attemptEndReasonValidator, v.null()),
   })
     .index("by_status_and_expiresAt", ["status", "expiresAt"])
+    .index("by_tryoutSnapshotId", {
+      fields: ["tryoutSnapshotId"],
+      staged: true,
+    })
     .index("by_userId_and_startedAt", ["userId", "startedAt"])
     .index("by_userId_and_status_and_expiresAt", [
       "userId",


### PR DESCRIPTION
## Summary

- stage seven exact indexes required by the signed try-out runtime
- derive and write the canonical set identity for every new signed set or section row
- add one temporary internal migration that authenticates and backfills exactly 44 existing signed rows
- remove two redundant response indexes because the existing compound indexes already own those prefixes
- keep all runtime queries unchanged until every staged index is ready

## Verification

- focused migration and fact tests: 2 files, 6 tests, changed implementation files at 100% coverage
- backend TypeScript 7 typecheck
- ordinary Convex code generation and TypeScript 6 compatibility check
- backend full suite: 288 files, 1,300 tests
- root lint, test ownership, boundaries, and Effect source alignment
- exact-head production Convex dry-run
- exactly seven staged indexes added; zero root or component index deletions

## Rollout

1. Merge and deploy this prerequisite.
2. Preview, apply, and re-preview the guarded production migration with expected counts 44, 44, then 0.
3. Wait until all seven staged indexes finish backfilling.
4. Rebase PR #242, enable and consume the ready indexes, and remove the temporary migration before its final merge.