### PR TITLE
fix(design-system): preserve 3D canvas radius

### DIFF
--- a/packages/design-system/components/three/canvas.tsx
+++ b/packages/design-system/components/three/canvas.tsx
@@ -121,7 +121,10 @@ function ThreeCanvasComponent({
       }}
     >
       <Canvas
-        className={cn("size-full [&_canvas]:size-full", className)}
+        className={cn(
+          "size-full overflow-hidden rounded-[inherit] [&>div]:rounded-[inherit] [&_canvas]:size-full [&_canvas]:rounded-[inherit]",
+          className
+        )}
         dpr={[1, 2]}
         fallback={
           <div className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
## Summary

- make the shared ThreeCanvas root inherit and clip to its scene frame radius
- pass the inherited radius through the internal React Three Fiber wrapper
- apply the same radius to the actual WebGL canvas so compositing cannot expose square corners

## Root cause

The scene frame already had the correct theme-driven radius and overflow clipping. React Three Fiber inserts an internal wrapper before the canvas, so the visible WebGL surface still computed to a zero radius and could appear square depending on compositing.

## Scope

- one shared design-system module
- no marketing-only override
- no backend, schema, environment, manifest, dependency, or lockfile changes

## Verification

- design system typecheck
- design system tests: 332 passed, 100% coverage
- www typecheck
- www tests: 1,160 passed, 100% coverage
- lint
- boundaries
- changed-scope React Doctor: 100/100
- production www build: 1,303/1,303 static pages
- production browser QA at 1440x900, 1024x768, 390x844, and 320x844
- Indonesian and English computed styles confirm the frame, R3F wrappers, and canvas share the same nonzero radius