### PR TITLE
feat(www): add curriculum discovery section

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(site)/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(site)/page.tsx
@@ -5,6 +5,7 @@ import type { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { use } from "react";
 import { Community } from "@/components/marketing/about/community";
+import { Curricula } from "@/components/marketing/about/curricula";
 import { Faq } from "@/components/marketing/about/faq";
 import { Features } from "@/components/marketing/about/features";
 import { Hero } from "@/components/marketing/about/hero";
@@ -138,6 +139,7 @@ async function MarketingHomePageContent({ locale }: { locale: Locale }) {
         <Hero />
         <Logos />
         <Features />
+        <Curricula locale={locale} />
         <Trust locale={locale} />
         <Pricing />
         <Schools />

--- a/apps/www/components/marketing/about/curricula-art.tsx
+++ b/apps/www/components/marketing/about/curricula-art.tsx
@@ -1,74 +1,18 @@
 "use client";
 
 import { useIntersection } from "@mantine/hooks";
-import { ColorPanels } from "@paper-design/shaders-react";
-import {
-  getThemeAppearance,
-  getThemeShaderColor,
-} from "@repo/design-system/lib/theme/registry";
+import { Warp } from "@paper-design/shaders-react";
+import { getThemeShaderColor } from "@repo/design-system/lib/theme/registry";
 import { useReducedMotion } from "motion/react";
 import { useTheme } from "next-themes";
 
-/** Adds an alpha channel to an RGB shader color. */
+/** Adds an alpha channel to a theme registry RGB color. */
 function withAlpha(color: string, alpha: number) {
   return color.replace("rgb(", "rgba(").replace(")", `, ${alpha})`);
 }
 
-/** Returns country-informed shader colors for one curriculum program. */
-function getCurriculumColors({
-  appearance,
-  programKey,
-  themeColor,
-}: {
-  appearance: "dark" | "light";
-  programKey: string;
-  themeColor: string;
-}) {
-  const paperColor =
-    appearance === "dark"
-      ? "rgba(255, 255, 255, 0.58)"
-      : "rgba(255, 255, 255, 0.82)";
-
-  switch (programKey) {
-    case "merdeka":
-      return [
-        withAlpha(themeColor, 0.72),
-        "rgba(206, 17, 38, 0.88)",
-        paperColor,
-      ];
-    case "cambridge-international":
-      return [
-        withAlpha(themeColor, 0.7),
-        "rgba(1, 33, 105, 0.86)",
-        "rgba(200, 16, 46, 0.76)",
-        paperColor,
-      ];
-    case "singapore-moe":
-      return [
-        withAlpha(themeColor, 0.72),
-        "rgba(239, 51, 64, 0.86)",
-        paperColor,
-      ];
-    case "united-states":
-      return [
-        withAlpha(themeColor, 0.7),
-        "rgba(60, 59, 110, 0.84)",
-        "rgba(178, 34, 52, 0.76)",
-        paperColor,
-      ];
-    default:
-      return [withAlpha(themeColor, 0.76), paperColor];
-  }
-}
-
-/** Renders one theme-aware curriculum color field that pauses outside view. */
-export function CurriculaArt({
-  maxPixelCount,
-  programKey,
-}: {
-  maxPixelCount: number;
-  programKey: string;
-}) {
+/** Renders one shared curriculum field that pauses outside view. */
+export function CurriculaArt({ maxPixelCount }: { maxPixelCount: number }) {
   const { resolvedTheme } = useTheme();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const { ref, entry } = useIntersection({
@@ -76,41 +20,41 @@ export function CurriculaArt({
     rootMargin: "240px",
     threshold: 0.05,
   });
-  const appearance = getThemeAppearance(resolvedTheme);
   const themeColor = getThemeShaderColor(resolvedTheme);
-  const colors = getCurriculumColors({
-    appearance,
-    programKey,
-    themeColor,
-  });
   const isMoving = entry?.isIntersecting && !shouldReduceMotion;
 
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 opacity-90 [mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_48%,black_76%,rgba(0,0,0,0.72)_90%,transparent_100%)] dark:opacity-80"
+      className="pointer-events-none absolute inset-0 opacity-90 [mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.12)_12%,rgba(0,0,0,0.56)_36%,black_72%,black_100%)] dark:opacity-80"
       ref={ref}
     >
-      <ColorPanels
-        angle1={0.34}
-        angle2={0.28}
-        blur={0.36}
+      <Warp
         className="size-full"
-        colorBack="rgba(0, 0, 0, 0)"
-        colors={colors}
-        density={1.45}
-        edges={false}
-        fadeIn={0.9}
-        fadeOut={0.48}
+        colors={[
+          withAlpha(themeColor, 0.18),
+          "#ee0000",
+          "#ffffff",
+          "#012169",
+          "#c8102e",
+          "#ed2939",
+          "#2e52b2",
+          "#d80027",
+        ]}
+        distortion={0.38}
         fit="cover"
-        gradient={0.84}
-        length={2.4}
         maxPixelCount={maxPixelCount}
         minPixelRatio={1.2}
-        offsetY={0.2}
-        rotation={270}
-        scale={1.38}
-        speed={isMoving ? 0.14 : 0}
+        offsetY={0.68}
+        proportion={0.36}
+        rotation={0}
+        scale={1.42}
+        shape="edge"
+        shapeScale={0.86}
+        softness={0.82}
+        speed={isMoving ? 2.5 : 0}
+        swirl={0.44}
+        swirlIterations={6}
       />
     </div>
   );

--- a/apps/www/components/marketing/about/curricula-art.tsx
+++ b/apps/www/components/marketing/about/curricula-art.tsx
@@ -26,7 +26,7 @@ export function CurriculaArt({ maxPixelCount }: { maxPixelCount: number }) {
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 opacity-90 [mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.12)_12%,rgba(0,0,0,0.56)_36%,black_72%,black_100%)] dark:opacity-80"
+      className="pointer-events-none absolute inset-0 opacity-90 [mask-image:linear-gradient(to_bottom,black_0%,black_28%,rgba(0,0,0,0.78)_50%,rgba(0,0,0,0.28)_78%,transparent_100%)] dark:opacity-80"
       ref={ref}
     >
       <Warp

--- a/apps/www/components/marketing/about/curricula-art.tsx
+++ b/apps/www/components/marketing/about/curricula-art.tsx
@@ -2,25 +2,16 @@
 
 import { useIntersection } from "@mantine/hooks";
 import { Warp } from "@paper-design/shaders-react";
-import { getThemeShaderColor } from "@repo/design-system/lib/theme/registry";
 import { useReducedMotion } from "motion/react";
-import { useTheme } from "next-themes";
-
-/** Adds an alpha channel to a theme registry RGB color. */
-function withAlpha(color: string, alpha: number) {
-  return color.replace("rgb(", "rgba(").replace(")", `, ${alpha})`);
-}
 
 /** Renders one shared curriculum field that pauses outside view. */
 export function CurriculaArt({ maxPixelCount }: { maxPixelCount: number }) {
-  const { resolvedTheme } = useTheme();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const { ref, entry } = useIntersection({
     root: null,
     rootMargin: "240px",
     threshold: 0.05,
   });
-  const themeColor = getThemeShaderColor(resolvedTheme);
   const isMoving = entry?.isIntersecting && !shouldReduceMotion;
 
   return (
@@ -32,7 +23,7 @@ export function CurriculaArt({ maxPixelCount }: { maxPixelCount: number }) {
       <Warp
         className="size-full"
         colors={[
-          withAlpha(themeColor, 0.18),
+          "rgba(0, 0, 0, 0)",
           "#ee0000",
           "#ffffff",
           "#012169",

--- a/apps/www/components/marketing/about/curricula-art.tsx
+++ b/apps/www/components/marketing/about/curricula-art.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useIntersection } from "@mantine/hooks";
+import { ColorPanels } from "@paper-design/shaders-react";
+import {
+  getThemeAppearance,
+  getThemeShaderColor,
+} from "@repo/design-system/lib/theme/registry";
+import { useReducedMotion } from "motion/react";
+import { useTheme } from "next-themes";
+
+/** Adds an alpha channel to an RGB shader color. */
+function withAlpha(color: string, alpha: number) {
+  return color.replace("rgb(", "rgba(").replace(")", `, ${alpha})`);
+}
+
+/** Returns country-informed shader colors for one curriculum program. */
+function getCurriculumColors({
+  appearance,
+  programKey,
+  themeColor,
+}: {
+  appearance: "dark" | "light";
+  programKey: string;
+  themeColor: string;
+}) {
+  const paperColor =
+    appearance === "dark"
+      ? "rgba(255, 255, 255, 0.58)"
+      : "rgba(255, 255, 255, 0.82)";
+
+  switch (programKey) {
+    case "merdeka":
+      return [
+        withAlpha(themeColor, 0.72),
+        "rgba(206, 17, 38, 0.88)",
+        paperColor,
+      ];
+    case "cambridge-international":
+      return [
+        withAlpha(themeColor, 0.7),
+        "rgba(1, 33, 105, 0.86)",
+        "rgba(200, 16, 46, 0.76)",
+        paperColor,
+      ];
+    case "singapore-moe":
+      return [
+        withAlpha(themeColor, 0.72),
+        "rgba(239, 51, 64, 0.86)",
+        paperColor,
+      ];
+    case "united-states":
+      return [
+        withAlpha(themeColor, 0.7),
+        "rgba(60, 59, 110, 0.84)",
+        "rgba(178, 34, 52, 0.76)",
+        paperColor,
+      ];
+    default:
+      return [withAlpha(themeColor, 0.76), paperColor];
+  }
+}
+
+/** Renders one theme-aware curriculum color field that pauses outside view. */
+export function CurriculaArt({
+  maxPixelCount,
+  programKey,
+}: {
+  maxPixelCount: number;
+  programKey: string;
+}) {
+  const { resolvedTheme } = useTheme();
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const { ref, entry } = useIntersection({
+    root: null,
+    rootMargin: "240px",
+    threshold: 0.05,
+  });
+  const appearance = getThemeAppearance(resolvedTheme);
+  const themeColor = getThemeShaderColor(resolvedTheme);
+  const colors = getCurriculumColors({
+    appearance,
+    programKey,
+    themeColor,
+  });
+  const isMoving = entry?.isIntersecting && !shouldReduceMotion;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 opacity-90 [mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_48%,black_76%,rgba(0,0,0,0.72)_90%,transparent_100%)] dark:opacity-80"
+      ref={ref}
+    >
+      <ColorPanels
+        angle1={0.34}
+        angle2={0.28}
+        blur={0.36}
+        className="size-full"
+        colorBack="rgba(0, 0, 0, 0)"
+        colors={colors}
+        density={1.45}
+        edges={false}
+        fadeIn={0.9}
+        fadeOut={0.48}
+        fit="cover"
+        gradient={0.84}
+        length={2.4}
+        maxPixelCount={maxPixelCount}
+        minPixelRatio={1.2}
+        offsetY={0.2}
+        rotation={270}
+        scale={1.38}
+        speed={isMoving ? 0.14 : 0}
+      />
+    </div>
+  );
+}

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -35,10 +35,7 @@ export async function Curricula({ locale }: { locale: Locale }) {
   const curricula = readRuntimeCurriculumOptions(catalog, locale);
 
   return (
-    <section
-      className="relative isolate z-0 border-b bg-background"
-      id="curricula"
-    >
+    <section className="relative isolate z-0 bg-background" id="curricula">
       <div className="mx-auto w-full max-w-7xl border-x">
         <div className="px-6 py-24 sm:py-28 lg:px-10 lg:py-32">
           <h2 className="max-w-4xl text-pretty text-3xl tracking-tight sm:text-4xl">

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -2,6 +2,7 @@ import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
+import { cn } from "@repo/design-system/lib/utils";
 import type { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import {
@@ -21,9 +22,6 @@ export async function Curricula({ locale }: { locale: Locale }) {
     readRuntimeCurriculumCatalog(locale),
   ]);
   const curricula = readRuntimeCurriculumOptions(catalog, locale);
-  const cardPixelBudget = Math.floor(
-    CURRICULA_SHADER_PIXEL_BUDGET / Math.max(curricula.length, 1)
-  );
 
   return (
     <section
@@ -56,28 +54,31 @@ export async function Curricula({ locale }: { locale: Locale }) {
           aria-label={t("navigation")}
           className="grid grid-cols-2 border-t lg:grid-cols-4"
         >
-          {curricula.map((curriculum) => (
+          {curricula.map((curriculum, index) => (
             <NavigationLink
-              className="group relative min-h-64 overflow-hidden border-r border-b p-5 outline-none even:border-r-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-72 sm:p-6 lg:min-h-80 lg:border-r lg:p-8 lg:last:border-r-0"
+              className={cn(
+                "group relative flex min-h-40 flex-col items-start justify-between p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-44 sm:p-6 lg:min-h-48 lg:p-8",
+                index % 2 === 0 && "border-r",
+                index < 2 && "border-b lg:border-b-0",
+                index < curricula.length - 1 && "lg:border-r"
+              )}
               href={curriculum.href}
               key={curriculum.programKey}
             >
-              <CurriculaArt
-                maxPixelCount={cardPixelBudget}
-                programKey={curriculum.programKey}
+              <CountryFlagIcon
+                className="h-auto w-6 rounded-xs ring-1 ring-foreground/10"
+                countryCode={curriculum.countryCode}
               />
-              <span className="relative z-1 flex flex-col items-start gap-4">
-                <CountryFlagIcon
-                  className="h-auto w-6 rounded-xs ring-1 ring-foreground/10"
-                  countryCode={curriculum.countryCode}
-                />
-                <span className="max-w-52 text-pretty text-lg tracking-tight sm:text-xl">
-                  {curriculum.title}
-                </span>
+              <span className="max-w-52 text-pretty text-lg tracking-tight sm:text-xl">
+                {curriculum.title}
               </span>
             </NavigationLink>
           ))}
         </nav>
+
+        <div className="relative min-h-64 overflow-hidden border-t sm:min-h-72 lg:min-h-80">
+          <CurriculaArt maxPixelCount={CURRICULA_SHADER_PIXEL_BUDGET} />
+        </div>
       </div>
     </section>
   );

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -2,6 +2,7 @@ import { ArrowUpRight01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
+import { cn } from "@repo/design-system/lib/utils";
 import type { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import {
@@ -62,11 +63,17 @@ export async function Curricula({ locale }: { locale: Locale }) {
 
         <nav
           aria-label={t("navigation")}
-          className="grid grid-cols-2 gap-px border-t bg-border lg:grid-cols-4"
+          className="grid grid-cols-2 border-t lg:grid-cols-4"
         >
-          {curricula.map((curriculum) => (
+          {curricula.map((curriculum, index) => (
             <NavigationLink
-              className="group relative flex min-h-40 flex-col items-start justify-between bg-background p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-44 sm:p-6 lg:min-h-48 lg:p-8"
+              className={cn(
+                "group relative flex min-h-40 flex-col items-start justify-between bg-background p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-44 sm:p-6 lg:min-h-48 lg:p-8",
+                index % 2 === 1 && "border-l",
+                index >= 2 && "border-t",
+                index % 4 === 0 ? "lg:border-l-0" : "lg:border-l",
+                index >= 4 ? "lg:border-t" : "lg:border-t-0"
+              )}
               href={curriculum.href}
               key={curriculum.programKey}
             >

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -85,7 +85,7 @@ export async function Curricula({ locale }: { locale: Locale }) {
           ))}
         </nav>
 
-        <div className="relative min-h-64 overflow-hidden border-t sm:min-h-72 lg:min-h-80">
+        <div className="relative min-h-80 overflow-hidden border-t sm:min-h-96 lg:min-h-[28rem]">
           <CurriculaArt maxPixelCount={CURRICULA_SHADER_PIXEL_BUDGET} />
         </div>
       </div>

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -1,0 +1,84 @@
+import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@repo/design-system/components/ui/button";
+import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
+import NavigationLink from "@repo/design-system/components/ui/navigation-link";
+import type { Locale } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import {
+  readRuntimeCurriculumCatalog,
+  readRuntimeCurriculumOptions,
+} from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime";
+import { CurriculaArt } from "@/components/marketing/about/curricula-art";
+import { CountryFlagIcon } from "@/components/shared/country-flag";
+import { getCurriculumIndexHref } from "@/lib/curriculum/routes";
+
+const CURRICULA_SHADER_PIXEL_BUDGET = 720_000;
+
+/** Lets learners enter Nakafa through the curriculum they already use. */
+export async function Curricula({ locale }: { locale: Locale }) {
+  const [t, catalog] = await Promise.all([
+    getTranslations({ locale, namespace: "CurriculaSection" }),
+    readRuntimeCurriculumCatalog(locale),
+  ]);
+  const curricula = readRuntimeCurriculumOptions(catalog, locale);
+  const cardPixelBudget = Math.floor(
+    CURRICULA_SHADER_PIXEL_BUDGET / Math.max(curricula.length, 1)
+  );
+
+  return (
+    <section
+      className="relative isolate z-0 border-b bg-background"
+      id="curricula"
+    >
+      <div className="mx-auto w-full max-w-7xl border-x">
+        <div className="px-6 py-24 sm:py-28 lg:px-10 lg:py-32">
+          <h2 className="max-w-4xl text-pretty text-3xl tracking-tight sm:text-4xl">
+            {t.rich("headline", {
+              mark: (chunks) => <mark>{chunks}</mark>,
+            })}
+          </h2>
+          <p className="mt-6 max-w-2xl text-pretty text-foreground/70 text-lg">
+            {t("description")}
+          </p>
+          <Button
+            className="mt-8"
+            nativeButton={false}
+            render={
+              <NavigationLink href={getCurriculumIndexHref(locale)}>
+                {t("cta")}
+                <HugeIcons icon={ArrowUpRight01Icon} />
+              </NavigationLink>
+            }
+          />
+        </div>
+
+        <nav
+          aria-label={t("navigation")}
+          className="grid grid-cols-2 border-t lg:grid-cols-4"
+        >
+          {curricula.map((curriculum) => (
+            <NavigationLink
+              className="group relative min-h-64 overflow-hidden border-r border-b p-5 outline-none even:border-r-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-72 sm:p-6 lg:min-h-80 lg:border-r lg:p-8 lg:last:border-r-0"
+              href={curriculum.href}
+              key={curriculum.programKey}
+            >
+              <CurriculaArt
+                maxPixelCount={cardPixelBudget}
+                programKey={curriculum.programKey}
+              />
+              <span className="relative z-1 flex flex-col items-start gap-4">
+                <CountryFlagIcon
+                  className="h-auto w-6 rounded-xs ring-1 ring-foreground/10"
+                  countryCode={curriculum.countryCode}
+                />
+                <span className="max-w-52 text-pretty text-lg tracking-tight sm:text-xl">
+                  {curriculum.title}
+                </span>
+              </span>
+            </NavigationLink>
+          ))}
+        </nav>
+      </div>
+    </section>
+  );
+}

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -1,8 +1,7 @@
-import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { ArrowUpRight01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
-import { cn } from "@repo/design-system/lib/utils";
 import type { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import {
@@ -14,6 +13,17 @@ import { CountryFlagIcon } from "@/components/shared/country-flag";
 import { getCurriculumIndexHref } from "@/lib/curriculum/routes";
 
 const CURRICULA_SHADER_PIXEL_BUDGET = 720_000;
+
+/** Renders a country flag when available and a global curriculum mark otherwise. */
+function CurriculumCountryMark({ countryCode }: { countryCode?: string }) {
+  return (
+    <CountryFlagIcon
+      className="h-auto w-6 rounded-xs ring-1 ring-foreground/10"
+      countryCode={countryCode}
+      fallback={<HugeIcons className="size-5 shrink-0" icon={Globe02Icon} />}
+    />
+  );
+}
 
 /** Lets learners enter Nakafa through the curriculum they already use. */
 export async function Curricula({ locale }: { locale: Locale }) {
@@ -52,23 +62,15 @@ export async function Curricula({ locale }: { locale: Locale }) {
 
         <nav
           aria-label={t("navigation")}
-          className="grid grid-cols-2 border-t lg:grid-cols-4"
+          className="grid grid-cols-2 gap-px border-t bg-border lg:grid-cols-4"
         >
-          {curricula.map((curriculum, index) => (
+          {curricula.map((curriculum) => (
             <NavigationLink
-              className={cn(
-                "group relative flex min-h-40 flex-col items-start justify-between p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-44 sm:p-6 lg:min-h-48 lg:p-8",
-                index % 2 === 0 && "border-r",
-                index < 2 && "border-b lg:border-b-0",
-                index < curricula.length - 1 && "lg:border-r"
-              )}
+              className="group relative flex min-h-40 flex-col items-start justify-between bg-background p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:min-h-44 sm:p-6 lg:min-h-48 lg:p-8"
               href={curriculum.href}
               key={curriculum.programKey}
             >
-              <CountryFlagIcon
-                className="h-auto w-6 rounded-xs ring-1 ring-foreground/10"
-                countryCode={curriculum.countryCode}
-              />
+              <CurriculumCountryMark countryCode={curriculum.countryCode} />
               <span className="max-w-52 text-pretty text-lg tracking-tight sm:text-xl">
                 {curriculum.title}
               </span>

--- a/apps/www/components/shared/country-flag.tsx
+++ b/apps/www/components/shared/country-flag.tsx
@@ -4,14 +4,17 @@ import GB from "country-flag-icons/react/3x2/GB";
 import ID from "country-flag-icons/react/3x2/ID";
 import SG from "country-flag-icons/react/3x2/SG";
 import US from "country-flag-icons/react/3x2/US";
+import type { ReactNode } from "react";
 
 /** Renders one supported country flag without dynamic component lookup. */
 export function CountryFlagIcon({
   className,
   countryCode,
+  fallback = null,
 }: {
   className?: string;
   countryCode?: string;
+  fallback?: ReactNode;
 }) {
   const flagClassName = cn("size-4 shrink-0", className);
 
@@ -27,6 +30,6 @@ export function CountryFlagIcon({
     case "US":
       return <US aria-hidden className={flagClassName} />;
     default:
-      return null;
+      return fallback;
   }
 }

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -821,6 +821,12 @@
     "projectile-range": "Range",
     "projectile-instantaneous-velocity": "Velocity at two seconds"
   },
+  "CurriculaSection": {
+    "headline": "Your curriculum may differ. <mark>Your learning still stays connected.</mark>",
+    "description": "Start from your school pathway. Lessons, Tryout, and Nina follow the curriculum you use.",
+    "cta": "Explore all curricula",
+    "navigation": "Available curricula"
+  },
   "SchoolsSection": {
     "badge": "For Schools",
     "headline": "Every school has <mark>different</mark> needs. We <mark>get it</mark>.",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -821,6 +821,12 @@
     "projectile-range": "Jangkauan",
     "projectile-instantaneous-velocity": "Kecepatan pada dua detik"
   },
+  "CurriculaSection": {
+    "headline": "Kurikulummu boleh berbeda. <mark>Alur belajarmu tetap menyatu.</mark>",
+    "description": "Mulai dari jalur sekolahmu. Materi, Tryout, dan Nina mengikuti kurikulum yang kamu gunakan.",
+    "cta": "Lihat semua kurikulum",
+    "navigation": "Kurikulum yang tersedia"
+  },
   "SchoolsSection": {
     "badge": "Untuk Sekolah",
     "headline": "Setiap sekolah punya kebutuhan <mark>berbeda</mark>. Kami <mark>mengerti</mark>.",


### PR DESCRIPTION
## Summary

- add a localized curriculum discovery chapter between Features and Trust
- derive curriculum flags, names, and links from the same active published-or-source runtime catalog as the curriculum index
- render equal flat curriculum choices in a 2 by 2 mobile grid and 4-column desktop grid with explicit shared dividers
- follow the choices with one shared full-width Paper Warp field that blends Nakafa's theme color with the exact installed flag palette
- preserve one 720,000-pixel canvas budget, pause animation offscreen, and stop motion when reduced motion is enabled
- provide a 320 to 448 pixel visual pause whose color stays present below the curriculum grid and fades downward into the next storytelling chapter

## Verification

- `pnpm --filter www test` (182 files, 1,160 tests, 100% coverage)
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (100/100)
- `pnpm --filter www build` (1,303/1,303 pages)
- production browser QA on desktop and mobile layouts
- verified responsive shader heights of 320, 384, and 448 pixels, a top-to-bottom fade, one Trust boundary, and no horizontal overflow
- verified Indonesian and English copy plus localized curriculum index destinations returning HTTP 200

## Scope

Frontend and localization only. No backend, Convex, schema, dependency, manifest, or lockfile changes.
