### PR TITLE
Respect system theme preferences by default

### DIFF
--- a/packages/design-system/lib/theme/bootstrap.test.ts
+++ b/packages/design-system/lib/theme/bootstrap.test.ts
@@ -4,20 +4,23 @@ import vm from "node:vm";
 import { createThemeBootstrapScript } from "@repo/design-system/lib/theme/bootstrap";
 import {
   concreteThemeValues,
+  DEFAULT_THEME,
+  type ThemeValue,
   themes,
 } from "@repo/design-system/lib/theme/registry";
 import { describe, expect, it } from "vitest";
 
 interface BootstrapScenario {
-  defaultTheme?: "light" | "system";
+  defaultTheme?: ThemeValue;
   matchMediaFails?: boolean;
   storageFails?: boolean;
   storedTheme?: string;
   systemDark?: boolean;
 }
 
+/** Runs the document bootstrap against a controlled browser environment. */
 function runBootstrap({
-  defaultTheme = "light",
+  defaultTheme = DEFAULT_THEME,
   matchMediaFails = false,
   storageFails = false,
   storedTheme,
@@ -68,11 +71,14 @@ function runBootstrap({
 }
 
 describe("theme bootstrap", () => {
-  it("applies the official light default while preserving unrelated classes", () => {
-    const result = runBootstrap();
+  it("resolves the official system default while preserving unrelated classes", () => {
+    const light = runBootstrap();
+    const dark = runBootstrap({ systemDark: true });
 
-    expect(result.classes).toEqual(new Set(["font-variable", "light"]));
-    expect(result.colorScheme).toBe("light");
+    expect(light.classes).toEqual(new Set(["font-variable", "light"]));
+    expect(light.colorScheme).toBe("light");
+    expect(dark.classes).toEqual(new Set(["font-variable", "dark"]));
+    expect(dark.colorScheme).toBe("dark");
   });
 
   it("applies every persisted concrete theme with its owned appearance", () => {
@@ -97,13 +103,6 @@ describe("theme bootstrap", () => {
     expect(light.colorScheme).toBe("light");
     expect(dark.classes).toEqual(new Set(["font-variable", "dark"]));
     expect(dark.colorScheme).toBe("dark");
-  });
-
-  it("resolves a system first-visit default", () => {
-    const result = runBootstrap({ defaultTheme: "system", systemDark: true });
-
-    expect(result.classes).toEqual(new Set(["font-variable", "dark"]));
-    expect(result.colorScheme).toBe("dark");
   });
 
   it("falls back safely when browser preference APIs are unavailable", () => {

--- a/packages/design-system/lib/theme/registry.test.ts
+++ b/packages/design-system/lib/theme/registry.test.ts
@@ -9,6 +9,7 @@ import {
   toRgbProjection,
 } from "@repo/design-system/lib/theme/contract";
 import {
+  DEFAULT_THEME,
   getThemeAppearance,
   getThemeShaderColor,
   themes,
@@ -21,6 +22,10 @@ const sources = await Effect.runPromise(
 );
 
 describe("theme registry", () => {
+  it("uses the browser preference for first-time visitors", () => {
+    expect(DEFAULT_THEME).toBe("system");
+  });
+
   it("defines every selectable theme exactly once", () => {
     const values = themes.map((theme) => theme.value);
 

--- a/packages/design-system/lib/theme/registry.ts
+++ b/packages/design-system/lib/theme/registry.ts
@@ -183,7 +183,7 @@ export type ThemeValue = (typeof themes)[number]["value"];
 export const THEME_STORAGE_KEY = "theme";
 
 /** First-visit theme shared by the localized document and next-themes. */
-export const DEFAULT_THEME = "light" satisfies ThemeValue;
+export const DEFAULT_THEME = "system" satisfies ThemeValue;
 
 /** Concrete class names managed on the document root. */
 export const concreteThemeValues = themes.flatMap((theme) =>

--- a/packages/design-system/styles/globals.css
+++ b/packages/design-system/styles/globals.css
@@ -278,6 +278,10 @@
     @apply border-border outline-ring/50;
   }
 
+  html {
+    scrollbar-gutter: stable both-edges;
+  }
+
   body {
     @apply bg-background text-foreground selection:bg-primary selection:text-primary-foreground overscroll-y-none;
   }


### PR DESCRIPTION
## Summary

- use the browser color-scheme preference for first-time visitors
- keep persisted Nakafa theme choices authoritative
- keep the pre-paint bootstrap and React theme provider on one shared default
- reserve symmetric scrollbar gutters so dropdown and dialog scroll locking does not shift centered layouts

## Why

Nakafa explicitly overrode `next-themes` with a light first-visit default. That prevented new visitors from receiving their operating-system theme until they manually selected System.

Nakafa also released the viewport scrollbar gutter when overlays locked scrolling, which moved centered page content horizontally. The shared root now reserves both gutter edges without duplicating layout compensation in individual overlays.

## Verification

- `pnpm --filter @repo/design-system test` (332 tests, 100% coverage)
- `pnpm --filter @repo/design-system typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (100/100)
- `pnpm --filter www build` (1,303/1,303 pages)
