### PR TITLE
Align marketing typography and responsive gutters

### DIFF
--- a/apps/www/components/marketing/about/community.tsx
+++ b/apps/www/components/marketing/about/community.tsx
@@ -11,7 +11,7 @@ export function Community() {
   return (
     <section className="scroll-mt-28" id="community">
       <div className="mx-auto w-full max-w-7xl border-x">
-        <div className="grid gap-12 px-6 py-48">
+        <div className="grid gap-12 px-6 py-48 lg:px-10">
           <div className="grid gap-8 lg:grid-cols-2 lg:gap-12">
             <div className="grid content-start gap-6">
               <h2 className="max-w-xl text-balance text-3xl tracking-tight sm:text-4xl">

--- a/apps/www/components/marketing/about/curricula.tsx
+++ b/apps/www/components/marketing/about/curricula.tsx
@@ -38,7 +38,7 @@ export async function Curricula({ locale }: { locale: Locale }) {
     <section className="relative isolate z-0 bg-background" id="curricula">
       <div className="mx-auto w-full max-w-7xl border-x">
         <div className="px-6 py-24 sm:py-28 lg:px-10 lg:py-32">
-          <h2 className="max-w-4xl text-pretty text-3xl tracking-tight sm:text-4xl">
+          <h2 className="max-w-4xl text-balance text-3xl tracking-tight sm:text-4xl">
             {t.rich("headline", {
               mark: (chunks) => <mark>{chunks}</mark>,
             })}
@@ -75,7 +75,7 @@ export async function Curricula({ locale }: { locale: Locale }) {
               key={curriculum.programKey}
             >
               <CurriculumCountryMark countryCode={curriculum.countryCode} />
-              <span className="max-w-52 text-pretty text-lg tracking-tight sm:text-xl">
+              <span className="max-w-52 text-balance text-lg tracking-tight sm:text-xl">
                 {curriculum.title}
               </span>
             </NavigationLink>

--- a/apps/www/components/marketing/about/faq.tsx
+++ b/apps/www/components/marketing/about/faq.tsx
@@ -25,7 +25,7 @@ export function Faq() {
   return (
     <section className="border-b">
       <div className="mx-auto w-full max-w-7xl border-x">
-        <div className="scroll-mt-28 px-6 py-48" id="faq">
+        <div className="scroll-mt-28 px-6 py-48 lg:px-10" id="faq">
           <div className="grid gap-12 lg:grid-cols-3">
             <div className="grid content-start gap-6 lg:col-span-1">
               <div className="flex items-center gap-2">

--- a/apps/www/components/marketing/about/features.tsx
+++ b/apps/www/components/marketing/about/features.tsx
@@ -40,7 +40,7 @@ export function Features() {
     >
       <div className="mx-auto w-full max-w-7xl border-x">
         <div className="px-6 py-24 sm:py-28 lg:px-10 lg:py-32">
-          <h2 className="max-w-4xl text-pretty text-3xl tracking-tight sm:text-4xl">
+          <h2 className="max-w-4xl text-balance text-3xl tracking-tight sm:text-4xl">
             {t.rich("story", {
               mark: (chunks) => <mark>{chunks}</mark>,
             })}

--- a/apps/www/components/marketing/about/hero.tsx
+++ b/apps/www/components/marketing/about/hero.tsx
@@ -22,9 +22,9 @@ export function Hero() {
         <HeroArt />
       </div>
 
-      <div className="relative mx-auto flex min-h-[calc(100svh-4rem)] w-full max-w-7xl items-end px-6 pt-72 pb-20 sm:items-center sm:py-24 md:px-8 md:py-32">
+      <div className="relative mx-auto flex min-h-[calc(100svh-4rem)] w-full max-w-7xl items-end px-6 pt-72 pb-20 sm:items-center sm:py-24 md:py-32 lg:px-10">
         <div className="relative z-2 max-w-3xl">
-          <h1 className="fade-in slide-in-from-bottom-3 animation-duration-500 motion-reduce:slide-in-from-bottom-0 motion-reduce:animation-duration-200 mb-0 animate-in fill-mode-both font-medium text-5xl tracking-tight ease-[cubic-bezier(0.23,1,0.32,1)] sm:text-6xl md:text-7xl xl:text-8xl">
+          <h1 className="fade-in slide-in-from-bottom-3 animation-duration-500 motion-reduce:slide-in-from-bottom-0 motion-reduce:animation-duration-200 mb-0 animate-in text-balance fill-mode-both font-medium text-5xl tracking-tight ease-[cubic-bezier(0.23,1,0.32,1)] sm:text-6xl md:text-7xl xl:text-8xl">
             {t.rich("title", {
               mark: (chunks) => <mark>{chunks}</mark>,
             })}

--- a/apps/www/components/marketing/about/logos.tsx
+++ b/apps/www/components/marketing/about/logos.tsx
@@ -44,7 +44,7 @@ export function Logos() {
 
   return (
     <section className="grid scroll-mt-28 gap-12 py-36" id="logos">
-      <div className="mx-auto grid w-full max-w-7xl gap-6 px-6">
+      <div className="mx-auto grid w-full max-w-7xl gap-6 px-6 lg:px-10">
         <div className="grid gap-6">
           <div className="flex items-center gap-2">
             <span className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm">

--- a/apps/www/components/marketing/about/pricing.tsx
+++ b/apps/www/components/marketing/about/pricing.tsx
@@ -62,10 +62,14 @@ function PricingPlanCards({ pricingDisplay }: PricingPlanCardsProps) {
 
   return (
     <div className="grid lg:grid-cols-2 lg:divide-x">
-      <div className="flex flex-col gap-6 px-6 py-12">
+      <div className="flex flex-col gap-6 px-6 py-12 lg:px-10">
         <div className="grid gap-2">
-          <h3 className="font-semibold text-3xl">{t("free-title")}</h3>
-          <p className="text-muted-foreground">{t("free-description")}</p>
+          <h3 className="text-balance font-semibold text-3xl">
+            {t("free-title")}
+          </h3>
+          <p className="text-pretty text-muted-foreground">
+            {t("free-description")}
+          </p>
           <div className="pt-2">
             <NumberFormat
               className="font-semibold text-4xl tracking-tight"
@@ -101,10 +105,14 @@ function PricingPlanCards({ pricingDisplay }: PricingPlanCardsProps) {
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 px-6 py-12">
+      <div className="flex flex-col gap-6 px-6 py-12 lg:px-10">
         <div className="grid gap-2">
-          <h3 className="font-semibold text-3xl">{t("pro-title")}</h3>
-          <p className="text-muted-foreground">{t("pro-description")}</p>
+          <h3 className="text-balance font-semibold text-3xl">
+            {t("pro-title")}
+          </h3>
+          <p className="text-pretty text-muted-foreground">
+            {t("pro-description")}
+          </p>
           <div className="flex items-baseline gap-1 pt-2">
             <NumberFormat
               className="font-semibold text-4xl tracking-tight"
@@ -166,7 +174,7 @@ export function Pricing() {
           <PricingDithering />
         </div>
 
-        <div className="scroll-mt-28 px-6 pb-12" id="pricing">
+        <div className="scroll-mt-28 px-6 pb-12 lg:px-10" id="pricing">
           <h2 className="max-w-3xl text-balance text-3xl tracking-tight sm:text-4xl">
             {t.rich("headline", {
               mark: (chunks) => <mark>{chunks}</mark>,

--- a/apps/www/components/marketing/about/schools.tsx
+++ b/apps/www/components/marketing/about/schools.tsx
@@ -10,7 +10,7 @@ export function Schools() {
     <section className="border-b">
       <div className="scroll-mt-28" id="schools">
         <div className="mx-auto w-full max-w-7xl border-x">
-          <div className="flex flex-col gap-6 px-6 py-24">
+          <div className="flex flex-col gap-6 px-6 py-24 lg:px-10">
             <div className="flex items-center gap-2">
               <span className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm">
                 <HugeIcons className="size-4" icon={School01Icon} />


### PR DESCRIPTION
## Summary

- use balanced wrapping for homepage titles and pretty wrapping for supporting descriptions
- standardize outer homepage gutters to 24px below desktop and 40px at the large breakpoint
- align both pricing plan panes with the same responsive horizontal rhythm
- preserve existing section composition, content, controls, animations, and theme tokens

## Why

Several homepage sections still used the older fixed `px-6` gutter while Features, Curricula, and Trust already used the responsive `px-6 lg:px-10` pattern. Features and Curricula also applied description wrapping to their titles. This caused visible alignment and line-wrapping drift across the landing-page story.

## Validation

- `pnpm --filter www typecheck`
- `pnpm --filter www test`: 1,160 tests passed with 100% coverage
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`: 100/100
- `pnpm --filter www build`: 1,303 pages generated
- production-mode browser QA in Indonesian and English
- computed gutter checks at desktop, below-large, 390px, and 320px test widths
- computed `text-wrap: balance` for titles and `text-wrap: pretty` for descriptions
- zero horizontal overflow and no browser console warnings or errors

No backend, Convex, schema, dependency, manifest, lockfile, design-system, or copy changes.