### PR TITLE
Stage try-out route index and isolate Agent Mode CI

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: agent-docs
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   agent-docs:

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -106,6 +106,34 @@ jobs:
           } >> "$GITHUB_ENV"
           rm "$HOME/.convex/config.json"
 
+      - name: Configure isolated backend
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        run: |
+          # Agent docs exercises content reads only. External integrations stay inert.
+          pnpm --dir packages/backend exec convex env set --force <<EOF
+          AI_GATEWAY_API_KEY=agent-docs-disabled
+          AKSARA_PUBLICATION_TOKEN=$CONTENT_RUNTIME_TOKEN
+          AUTH_GOOGLE_ID=agent-docs-disabled
+          AUTH_GOOGLE_SECRET=agent-docs-disabled
+          BETTER_AUTH_SECRET=agent-docs-inert-secret-00000000
+          CONTENT_RUNTIME_TOKEN=$CONTENT_RUNTIME_TOKEN
+          ELEVENLABS_API_KEY=agent-docs-disabled
+          FIRECRAWL_API_KEY=agent-docs-disabled
+          INTERNAL_CONTENT_API_KEY=$INTERNAL_CONTENT_API_KEY
+          JWKS=[]
+          NEXT_PUBLIC_POLAR_SERVER=sandbox
+          OPENWEATHER_API_KEY=agent-docs-disabled
+          POLAR_ACCESS_TOKEN=agent-docs-disabled
+          POLAR_WEBHOOK_SECRET=agent-docs-disabled
+          POSTHOG_ACCOUNT_DELETION_API_KEY=agent-docs-disabled
+          POSTHOG_HOST=https://example.invalid
+          POSTHOG_PROJECT_ID=0
+          POSTHOG_PROJECT_TOKEN=agent-docs-disabled
+          RESEND_API_KEY=agent-docs-disabled
+          RESEND_WEBHOOK_SECRET=agent-docs-disabled
+          SITE_URL=$SITE_URL
+          EOF
+
       - name: Deploy isolated backend
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: pnpm --dir packages/backend exec convex dev --once --typecheck enable --tail-logs disable

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
+      AGENT_DOCS_RUN_IDENTITY: agent-docs-${{ github.run_id }}-${{ github.run_attempt }}
       CONTENT_RUNTIME_TOKEN: ci-agent-docs
       INTERNAL_CONTENT_API_KEY: ci-agent-docs
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -71,20 +72,20 @@ jobs:
       - name: Create isolated backend
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: |
-          deployment_reference="dev/agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          deployment_reference="nakafa:nakafa:dev/$AGENT_DOCS_RUN_IDENTITY"
           pnpm --dir packages/backend exec convex deployment create \
-            "nakafa:nakafa:${deployment_reference}" \
+            "$deployment_reference" \
             --type dev \
             --select \
             --expiration "in 1 day"
+          echo "AGENT_DOCS_DEPLOY_KEY_CLEANUP_ARMED=true" >> "$GITHUB_ENV"
 
       - name: Export isolated backend credentials
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: |
-          deploy_key_name="agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          deploy_key_file="$RUNNER_TEMP/agent-docs-convex.env"
+          deploy_key_file="$RUNNER_TEMP/$AGENT_DOCS_RUN_IDENTITY.env"
           pnpm --dir packages/backend exec convex deployment token create \
-            "$deploy_key_name" \
+            "$AGENT_DOCS_RUN_IDENTITY" \
             --save-env "$deploy_key_file"
 
           deploy_key="$(sed -n 's/^CONVEX_DEPLOY_KEY=//p' "$deploy_key_file")"
@@ -100,7 +101,6 @@ jobs:
             echo "CONVEX_DEPLOY_KEY=$deploy_key"
             echo "CONVEX_SITE_URL=$convex_site_url"
             echo "CONVEX_URL=$convex_url"
-            echo "AGENT_DOCS_DEPLOY_KEY_CREATED=true"
             echo "NEXT_PUBLIC_CONVEX_SITE_URL=$convex_site_url"
             echo "NEXT_PUBLIC_CONVEX_URL=$convex_url"
           } >> "$GITHUB_ENV"
@@ -186,17 +186,39 @@ jobs:
           fi
 
       - name: Revoke isolated backend credential
-        if: always() && env.TRUSTED_CONTENT_ENVIRONMENT == 'true' && env.AGENT_DOCS_DEPLOY_KEY_CREATED == 'true'
+        if: always() && env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         env:
           CONVEX_ACCESS_TOKEN: ${{ secrets.AGENT_DOCS_CONVEX_ACCESS_TOKEN }}
           CONVEX_DEPLOY_KEY: <ignore_deploy_key>
         run: |
+          config_path="$HOME/.convex/config.json"
+          trap 'rm -f "$config_path"' EXIT
+
           install -d -m 700 "$HOME/.convex"
           jq -n --arg accessToken "$CONVEX_ACCESS_TOKEN" \
-            '{accessToken: $accessToken}' > "$HOME/.convex/config.json"
-          chmod 600 "$HOME/.convex/config.json"
+            '{accessToken: $accessToken}' > "$config_path"
+          chmod 600 "$config_path"
 
-          deploy_key_name="agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          pnpm --dir packages/backend exec convex deployment token delete \
-            "$deploy_key_name"
-          rm "$HOME/.convex/config.json"
+          if [ "${AGENT_DOCS_DEPLOY_KEY_CLEANUP_ARMED:-false}" != "true" ]; then
+            exit 0
+          fi
+
+          deployment_reference="nakafa:nakafa:dev/$AGENT_DOCS_RUN_IDENTITY"
+          if delete_output="$(
+            pnpm --dir packages/backend exec convex deployment token delete \
+              "$AGENT_DOCS_RUN_IDENTITY" \
+              --deployment "$deployment_reference" 2>&1
+          )"; then
+            printf '%s\n' "$delete_output"
+            exit 0
+          fi
+
+          case "$delete_output" in
+            *"DeployKeyNotFound: Deploy key not found"*)
+              printf 'No deploy key was created for %s.\n' "$AGENT_DOCS_RUN_IDENTITY"
+              ;;
+            *)
+              printf '%s\n' "$delete_output" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -87,19 +87,22 @@ jobs:
             "$deploy_key_name" \
             --save-env "$deploy_key_file"
 
-          set -a
-          source packages/backend/.env.local
-          source "$deploy_key_file"
-          set +a
+          deploy_key="$(sed -n 's/^CONVEX_DEPLOY_KEY=//p' "$deploy_key_file")"
+          convex_url="$(sed -n 's/^VITE_CONVEX_URL=//p' packages/backend/.env.local)"
+          convex_site_url="$(sed -n 's/^VITE_CONVEX_SITE_URL=//p' packages/backend/.env.local)"
 
-          echo "::add-mask::$CONVEX_DEPLOY_KEY"
+          test -n "$deploy_key"
+          test -n "$convex_url"
+          test -n "$convex_site_url"
+
+          echo "::add-mask::$deploy_key"
           {
-            echo "CONVEX_DEPLOY_KEY=$CONVEX_DEPLOY_KEY"
-            echo "CONVEX_SITE_URL=$CONVEX_SITE_URL"
-            echo "CONVEX_URL=$CONVEX_URL"
+            echo "CONVEX_DEPLOY_KEY=$deploy_key"
+            echo "CONVEX_SITE_URL=$convex_site_url"
+            echo "CONVEX_URL=$convex_url"
             echo "AGENT_DOCS_DEPLOY_KEY_CREATED=true"
-            echo "NEXT_PUBLIC_CONVEX_SITE_URL=$CONVEX_SITE_URL"
-            echo "NEXT_PUBLIC_CONVEX_URL=$CONVEX_URL"
+            echo "NEXT_PUBLIC_CONVEX_SITE_URL=$convex_site_url"
+            echo "NEXT_PUBLIC_CONVEX_URL=$convex_url"
           } >> "$GITHUB_ENV"
           rm "$HOME/.convex/config.json"
 

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -78,10 +78,6 @@ jobs:
             --select \
             --expiration "in 1 day"
 
-      - name: Deploy isolated backend
-        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
-        run: pnpm --dir packages/backend exec convex dev --once --typecheck enable --tail-logs disable
-
       - name: Export isolated backend credentials
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: |
@@ -106,6 +102,10 @@ jobs:
             echo "NEXT_PUBLIC_CONVEX_URL=$CONVEX_URL"
           } >> "$GITHUB_ENV"
           rm "$HOME/.convex/config.json"
+
+      - name: Deploy isolated backend
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        run: pnpm --dir packages/backend exec convex dev --once --typecheck enable --tail-logs disable
 
       - name: Sync real content
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -19,18 +19,14 @@ jobs:
     timeout-minutes: 40
     env:
       CONTENT_RUNTIME_TOKEN: ci-agent-docs
-      CONVEX_SITE_URL: ${{ vars.AGENT_DOCS_CONVEX_SITE_URL }}
-      CONVEX_URL: ${{ vars.AGENT_DOCS_CONVEX_URL }}
       INTERNAL_CONTENT_API_KEY: ci-agent-docs
       NEXT_PUBLIC_APP_URL: http://localhost:3000
-      NEXT_PUBLIC_CONVEX_SITE_URL: ${{ vars.AGENT_DOCS_CONVEX_SITE_URL }}
-      NEXT_PUBLIC_CONVEX_URL: ${{ vars.AGENT_DOCS_CONVEX_URL }}
       NEXT_PUBLIC_MCP_URL: https://mcp.nakafa.com
       NEXT_PUBLIC_POSTHOG_KEY: phc_agent_docs_ci
       NEXT_PUBLIC_POSTHOG_UI_HOST: https://eu.posthog.com
       POSTHOG_PROXY_HOST: https://t.nakafa.com
       SITE_URL: http://localhost:3000
-      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -62,16 +58,57 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Deploy isolated backend
+      - name: Authenticate Convex CLI
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
+          CONVEX_ACCESS_TOKEN: ${{ secrets.AGENT_DOCS_CONVEX_ACCESS_TOKEN }}
+        run: |
+          install -d -m 700 "$HOME/.convex"
+          jq -n --arg accessToken "$CONVEX_ACCESS_TOKEN" \
+            '{accessToken: $accessToken}' > "$HOME/.convex/config.json"
+          chmod 600 "$HOME/.convex/config.json"
+
+      - name: Create isolated backend
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        run: |
+          deployment_reference="dev/agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          pnpm --dir packages/backend exec convex deployment create \
+            "nakafa:nakafa:${deployment_reference}" \
+            --type dev \
+            --select \
+            --expiration "in 1 day"
+
+      - name: Deploy isolated backend
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: pnpm --dir packages/backend exec convex dev --once --typecheck enable --tail-logs disable
+
+      - name: Export isolated backend credentials
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        run: |
+          deploy_key_name="agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          deploy_key_file="$RUNNER_TEMP/agent-docs-convex.env"
+          pnpm --dir packages/backend exec convex deployment token create \
+            "$deploy_key_name" \
+            --save-env "$deploy_key_file"
+
+          set -a
+          source packages/backend/.env.local
+          source "$deploy_key_file"
+          set +a
+
+          echo "::add-mask::$CONVEX_DEPLOY_KEY"
+          {
+            echo "CONVEX_DEPLOY_KEY=$CONVEX_DEPLOY_KEY"
+            echo "CONVEX_SITE_URL=$CONVEX_SITE_URL"
+            echo "CONVEX_URL=$CONVEX_URL"
+            echo "AGENT_DOCS_DEPLOY_KEY_CREATED=true"
+            echo "NEXT_PUBLIC_CONVEX_SITE_URL=$CONVEX_SITE_URL"
+            echo "NEXT_PUBLIC_CONVEX_URL=$CONVEX_URL"
+          } >> "$GITHUB_ENV"
+          rm "$HOME/.convex/config.json"
 
       - name: Sync real content
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
-        env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
         run: pnpm --filter @repo/backend sync
 
       - name: Build production app
@@ -116,3 +153,19 @@ jobs:
           if [ -f /tmp/nakafa-www.pid ]; then
             kill "$(cat /tmp/nakafa-www.pid)" || true
           fi
+
+      - name: Revoke isolated backend credential
+        if: always() && env.TRUSTED_CONTENT_ENVIRONMENT == 'true' && env.AGENT_DOCS_DEPLOY_KEY_CREATED == 'true'
+        env:
+          CONVEX_ACCESS_TOKEN: ${{ secrets.AGENT_DOCS_CONVEX_ACCESS_TOKEN }}
+          CONVEX_DEPLOY_KEY: <ignore_deploy_key>
+        run: |
+          install -d -m 700 "$HOME/.convex"
+          jq -n --arg accessToken "$CONVEX_ACCESS_TOKEN" \
+            '{accessToken: $accessToken}' > "$HOME/.convex/config.json"
+          chmod 600 "$HOME/.convex/config.json"
+
+          deploy_key_name="agent-docs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          pnpm --dir packages/backend exec convex deployment token delete \
+            "$deploy_key_name"
+          rm "$HOME/.convex/config.json"

--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -40,6 +40,8 @@ const tables = {
     /** Optional only during the stable Aksara identity backfill. */
     tryoutSnapshotId: v.optional(v.string()),
     setIdentity: v.optional(v.string()),
+    /** Frozen localized route prepared for the signed-runtime cutover. */
+    setPublicPath: v.optional(v.string()),
     countryKey: v.optional(tryoutRouteKeyValidator),
     examKey: v.optional(tryoutRouteKeyValidator),
     trackKey: v.optional(tryoutRouteKeyValidator),
@@ -89,6 +91,10 @@ const tables = {
       "setIdentity",
       "startedAt",
     ])
+    .index("by_userId_and_locale_and_setPublicPath_and_startedAt", {
+      fields: ["userId", "locale", "setPublicPath", "startedAt"],
+      staged: true,
+    })
     .index("by_accessCampaignId_and_startedAt", [
       "accessCampaignId",
       "startedAt",


### PR DESCRIPTION
## Summary

- add the optional frozen public path field before signed runtime cutover
- stage the retained-route lookup index so production backfills without blocking deployment
- keep the staged index unused until its production build reaches 100 percent
- isolate every trusted Agent-Friendly Docs run on its own expiring Convex Agent Mode dev deployment
- configure only inert external integrations required for module analysis in that isolated backend
- keep per-ref GitHub concurrency so stale runs cancel only on the same ref
- arm scoped-key cleanup before token creation and distinguish a missing key from a real revocation failure

## Convex isolation

Trusted `main` runs and Nabil-authored same-repository pull requests now:

1. derive one run identity for the deployment and scoped key
2. authenticate with the dedicated Convex CI personal access token
3. create and select one expiring Agent Mode dev deployment
4. arm cleanup before the token-creation boundary
5. create a deployment-scoped key and remove the personal token
6. parse the exact CLI dotenv output without shell-sourcing its pipe-delimited secret
7. configure content credentials plus inert external integration values in the isolated backend
8. deploy the exact checked-out backend with the scoped key
9. use that scoped key and its deployment URLs for content sync, production build, and app checks
10. explicitly target the run deployment during always-run cleanup
11. revoke an existing key, accept only the exact missing-key response when no key was created, and fail on every other cleanup error

The former shared URLs and shared deployment key are no longer used by this workflow. Production integration secrets are not copied into arbitrary pull request code. The account credential exists only during isolated deployment provisioning and scoped-key cleanup. Concurrent refs share no backend deployment, key, or URLs.

## Verification

Exact head: `39cb3bcad73675562871394c748a688b609f03a1`

- `pnpm --filter @repo/backend typecheck`
- `pnpm exec ultracite check packages/backend/convex/tryouts/runtime/schema.ts`
- `pnpm format`
- `pnpm lint`
- Ruby YAML parse of `.github/workflows/agent-docs.yml`
- `git diff --check`
- local one-hour Agent Mode deployment accepted all isolated env values and completed the full Convex push
- canonical local Convex selection restored and hash-verified against a clean worktree
- live cleanup proof deleted a real scoped key from the exact isolated deployment
- live cleanup proof accepted the installed CLI exact `DeployKeyNotFound` response and no broader failure
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`
- hosted React Doctor passed at the exact head
- hosted Agent-Friendly Docs passed at the exact head in 17m15s
- Codex reviewed the exact head and found no further issue

This is the required first deployment of the Convex staged-index rollout. PR #242 will update from main, remove `staged: true`, and enable the exact route lookup only after this index is ready in production.
