### PR TITLE
chore(tryouts): stage progress route index

### DIFF
--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -131,17 +131,20 @@ const tables = {
   })
     .index("by_userId_and_tryoutSetId", ["userId", "tryoutSetId"])
     .index("by_userId_and_setIdentity", ["userId", "setIdentity"])
-    .index("by_userId_and_route", {
-      fields: [
-        "userId",
-        "countryKey",
-        "examKey",
-        "trackKey",
-        "locale",
-        "setKey",
-      ],
-      staged: true,
-    })
+    .index(
+      "by_userId_and_countryKey_and_examKey_and_trackKey_and_locale_and_setKey",
+      {
+        fields: [
+          "userId",
+          "countryKey",
+          "examKey",
+          "trackKey",
+          "locale",
+          "setKey",
+        ],
+        staged: true,
+      }
+    )
     .index("by_userId_and_track_and_publishedScore_and_setKey", [
       "userId",
       "countryKey",

--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -131,6 +131,17 @@ const tables = {
   })
     .index("by_userId_and_tryoutSetId", ["userId", "tryoutSetId"])
     .index("by_userId_and_setIdentity", ["userId", "setIdentity"])
+    .index("by_userId_and_route", {
+      fields: [
+        "userId",
+        "countryKey",
+        "examKey",
+        "trackKey",
+        "locale",
+        "setKey",
+      ],
+      staged: true,
+    })
     .index("by_userId_and_track_and_publishedScore_and_setKey", [
       "userId",
       "countryKey",

--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -131,20 +131,17 @@ const tables = {
   })
     .index("by_userId_and_tryoutSetId", ["userId", "tryoutSetId"])
     .index("by_userId_and_setIdentity", ["userId", "setIdentity"])
-    .index(
-      "by_userId_and_countryKey_and_examKey_and_trackKey_and_locale_and_setKey",
-      {
-        fields: [
-          "userId",
-          "countryKey",
-          "examKey",
-          "trackKey",
-          "locale",
-          "setKey",
-        ],
-        staged: true,
-      }
-    )
+    .index("by_userId_countryKey_examKey_trackKey_locale_setKey", {
+      fields: [
+        "userId",
+        "countryKey",
+        "examKey",
+        "trackKey",
+        "locale",
+        "setKey",
+      ],
+      staged: true,
+    })
     .index("by_userId_and_track_and_publishedScore_and_setKey", [
       "userId",
       "countryKey",


### PR DESCRIPTION
## Summary

- add `tryoutSetProgress.by_userId_countryKey_examKey_trackKey_locale_setKey` as a staged Convex index
- preserve the exact index name and field order required by the signed Aksara cutover
- keep the index unavailable to queries until production backfill is proven and the cutover PR unstages it

## Why

Convex requires a two-deploy index rollout for a populated table. This prerequisite deploy creates and backfills the index before #242 starts querying it.

## Verification

- exact head: `07cfe9037d8013daf64c5899eb09aba0ec714467`
- exact tree: `7a89e47b685d9cafd312e8f43e2d733ecc68a653`

- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter @repo/backend test` (302 files, 1,341 tests on the unchanged staged index shape)
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (no changed React source)
- `git diff --check`

## Follow-up

After exact-head CI and review pass, merge and deploy this staged index to production. Confirm the backfill is complete before updating #242 to unstage and query it.

## Production dry run

- exact target: `nakafa:nakafa:production` at `dapper-antelope-269`
- Convex reported no index deletions
- the populated `tryoutSetProgress` table has 6 rows; the current exact head declares `by_userId_countryKey_examKey_trackKey_locale_setKey` as staged
- the pending Quran indexes from merged #240 target `quranRows` and `quranSearch`, both proven empty in production, so they have no backfill work
- exact head `07cfe9037d` passed `convex deploy --dry-run`; no production write occurred
- Convex accepted `by_userId_countryKey_examKey_trackKey_locale_setKey` as a staged index with the exact six ordered fields