### PR TITLE
perf(convex): bound analytics drain batches

### DIFF
--- a/packages/backend/convex/contents/constants.ts
+++ b/packages/backend/convex/contents/constants.ts
@@ -3,8 +3,11 @@ import {
   SOURCE_REGISTRY_ROOT_VALUES,
 } from "@repo/contents/_types/graph/schema";
 
-/** Number of queued analytics rows processed in one mutation. */
-export const CONTENT_ANALYTICS_BATCH_SIZE = 250;
+/**
+ * Maximum queued analytics rows processed in one mutation.
+ * @see https://docs.convex.dev/production/state/limits#transactions
+ */
+export const CONTENT_ANALYTICS_BATCH_SIZE = 64;
 
 /** Number of popularity counters recomputed from daily signals in one mutation. */
 export const LEARNING_POPULARITY_REFRESH_BATCH_SIZE = 10;


### PR DESCRIPTION
## Summary

- reduce the content analytics drain ceiling from 250 rows to 64
- retain the existing partition lease and immediate continuation design
- link the single source-of-truth limit to the official Convex transaction limits

## Evidence

Production Convex insights recorded a successful 168-row drain reading about 14.5 MiB against the 16 MiB transaction ceiling. The same worker accumulated 802 internal index OCC retries over the 72-hour insight window. Under the same observed workload mix, a 64-row ceiling projects to about 5.5 MiB and materially shortens each transaction.

## Verification

- `pnpm --filter @repo/backend exec vitest run convex/contents/mutations/analytics.test.ts` (13 tests)
- `pnpm --filter @repo/backend test` (334 files, 1,402 tests)
- `pnpm --filter @repo/backend typecheck`
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main` (no changed www source files)

No frontend files changed. The repository's main-only Vercel deployment policy keeps this PR branch undeployed.