### PR TITLE
perf(curriculum): remove catalog waterfalls

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
@@ -1,7 +1,7 @@
 import { BreadcrumbJsonLd } from "@repo/seo/json-ld/breadcrumb";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { Suspense } from "react";
+import { type ReactNode, Suspense } from "react";
 import { readMaterialCardChapters } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data";
 import { readCurriculumRouteIcon } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/icons";
 import {
@@ -96,17 +96,38 @@ async function CurriculumRouteContent({
 }: Pick<CurriculumPageProps, "params">) {
   const model = await resolveRuntimeCurriculumRoute(params);
   const { locale, route } = model;
-  const [catalog, tCommon] = await Promise.all([
-    readRuntimeCurriculumCatalog(locale),
-    getTranslations({ locale, namespace: "Common" }),
-  ]);
-  const breadcrumbs = readRuntimeCurriculumBreadcrumbs(tCommon("home"), model);
-  const selectorLabel =
-    route.level === "track"
-      ? (await getTranslations({ locale, namespace: "LearningPrograms" }))(
-          "kind.school-curriculum"
-        )
-      : "";
+  const commonTranslations = getTranslations({ locale, namespace: "Common" });
+  let header: ReactNode;
+  let homeLabel: string;
+
+  if (route.level === "track") {
+    const [catalog, tCommon, tLearningPrograms] = await Promise.all([
+      readRuntimeCurriculumCatalog(locale),
+      commonTranslations,
+      getTranslations({ locale, namespace: "LearningPrograms" }),
+    ]);
+    homeLabel = tCommon("home");
+    header = (
+      <CurriculumRootHeader
+        currentRoute={route}
+        homeLabel={homeLabel}
+        options={readRuntimeCurriculumOptions(catalog, locale)}
+        selectorLabel={tLearningPrograms("kind.school-curriculum")}
+        subjectLabel={tCommon("subject")}
+      />
+    );
+  } else {
+    homeLabel = (await commonTranslations)("home");
+    header = (
+      <HeaderContent
+        icon={readCurriculumRouteIcon(route)}
+        link={readRuntimeCurriculumHeader(model)}
+        title={route.title}
+      />
+    );
+  }
+
+  const breadcrumbs = readRuntimeCurriculumBreadcrumbs(homeLabel, model);
   const sourceUrl = readCurriculumSourceUrl(model);
 
   return (
@@ -115,21 +136,7 @@ async function CurriculumRouteContent({
         breadcrumbItems={createBreadcrumbItems(locale, breadcrumbs)}
       />
       <LayoutMaterialContent>
-        {route.level === "track" ? (
-          <CurriculumRootHeader
-            currentRoute={route}
-            homeLabel={tCommon("home")}
-            options={readRuntimeCurriculumOptions(catalog, locale)}
-            selectorLabel={selectorLabel}
-            subjectLabel={tCommon("subject")}
-          />
-        ) : (
-          <HeaderContent
-            icon={readCurriculumRouteIcon(route)}
-            link={readRuntimeCurriculumHeader(model)}
-            title={route.title}
-          />
-        )}
+        {header}
         <LayoutContent>
           <CurriculumRouteBody {...model} />
         </LayoutContent>

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/page.tsx
@@ -60,15 +60,15 @@ export async function generateMetadata({
 /** Renders the public curriculum chooser with direct curriculum cards. */
 export default async function Page() {
   const locale = getLocaleOrThrow(await rootLocale());
-  const [tCommon, tLearningPrograms] = await Promise.all([
+  const [tCommon, tLearningPrograms, catalog] = await Promise.all([
     getTranslations({ locale, namespace: "Common" }),
     getTranslations({ locale, namespace: "LearningPrograms" }),
+    readRuntimeCurriculumCatalog(locale),
   ]);
   const title = tLearningPrograms("curriculum-index-title");
   const description = tLearningPrograms(
     "curriculum-index-metadata-description"
   );
-  const catalog = await readRuntimeCurriculumCatalog(locale);
   const sourceUrl = readCurriculumCatalogSource(catalog);
   const path = getLocalizedCurriculumIndexPath(locale);
 


### PR DESCRIPTION
## Outcome

- Start independent curriculum translations and catalog reads concurrently on catalog pages.
- Read the full curriculum catalog only for track-level routes that render the curriculum selector.
- Skip the catalog query entirely for nested grade, subject, and topic routes.
- Preserve the established curriculum header, cards, breadcrumbs, metadata, and signed Aksara ownership.

## Verification

- Exact rebased head `07b8012b2d1eb27044bbb0ed6b3d7749a5b10bbe` passed the focused curriculum runtime suite: 6 tests in 1 file.
- The full www gate passed 1,094 tests in 177 files with 100% statement, branch, function, and line coverage.
- Exact rebased head passed www typecheck, root lint, boundaries across 2,932 files in 19 packages, and React Doctor at 100/100 for the two-file PR diff.
- Agent-Friendly Docs run `31327566927` succeeded on the exact head. It ran the full repository tests, created and deployed an isolated Convex backend, bootstrapped signed content, completed the production build, and passed AFDocs acceptance.
- The local build independently completed compilation and TypeScript. Static generation correctly rejected the placeholder content token, so no production secret was fetched or used.

## Rollout

- This is a web-only scheduling change and does not alter a Convex contract.
- Vercel preview deployment remains disabled.
- Merge only while both exact-head Agent-Friendly Docs and React Doctor remain green.
