### PR TITLE
perf(quran): cut over projected reads

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -115,7 +115,7 @@ export default function Page(props: PageProps<"/[locale]/quran/[surah]">) {
   );
 }
 
-/** Resolves a localized surah route before rendering Quran SEO and page chrome. */
+/** Resolves a localized surah route before entering the cached Quran shell. */
 async function ResolvedSurahPage({
   params,
 }: {
@@ -129,49 +129,18 @@ async function ResolvedSurahPage({
     notFound();
   }
 
-  const [t, tCommon, surahData] = await Promise.all([
-    getTranslations({ locale, namespace: "Holy" }),
-    getTranslations({ locale, namespace: "Common" }),
-    getSurahMetadataData(surahNumber),
-  ]);
-
-  if (!surahData) {
-    notFound();
-  }
-
-  const translation = surahData.name.translation;
-  const title = getQuranSurahName(surahData.name);
-
   return (
-    <>
-      <BreadcrumbJsonLd
-        breadcrumbItems={createBreadcrumbItems(locale, [
-          { name: tCommon("home"), path: "" },
-          { name: t("quran"), path: "/quran" },
-          { name: title, path: `/quran/${surah}` },
-        ])}
-      />
-      <BookJsonLd
-        author={{ "@type": "Person", name: "Allah" }}
-        description={translation}
-        inLanguage={locale}
-        name={title}
-        position={surahNumber}
-        totalPages={surahData.numberOfVerses}
-        url={`https://nakafa.com/${locale}/quran/${surah}`}
-      />
-      <CachedSurahShell
-        footer={<RefContent key={`refs:${surah}`} />}
-        locale={locale}
-        surah={surah}
-        surahNumber={surahNumber}
-        toolbar={<DeferredAiSheetOpen key={`assistant:${surah}`} />}
-      />
-    </>
+    <CachedSurahShell
+      footer={<RefContent key={`refs:${surah}`} />}
+      locale={locale}
+      surah={surah}
+      surahNumber={surahNumber}
+      toolbar={<DeferredAiSheetOpen key={`assistant:${surah}`} />}
+    />
   );
 }
 
-/** Reads lightweight cached surah metadata for route metadata and JSON-LD. */
+/** Reads lightweight cached surah metadata for route metadata. */
 async function getSurahMetadataData(surahNumber: number) {
   "use cache";
 
@@ -195,8 +164,9 @@ async function CachedSurahShell({
 }) {
   "use cache";
 
-  const [t, result] = await Promise.all([
+  const [t, tCommon, result] = await Promise.all([
     getTranslations({ locale, namespace: "Holy" }),
+    getTranslations({ locale, namespace: "Common" }),
     getPublishedQuranView(locale, surahNumber),
   ]);
 
@@ -224,66 +194,84 @@ async function CachedSurahShell({
   const hasInterpretation = result.locale === "id";
 
   return (
-    <VirtualProvider>
-      <LayoutMaterialContent>
-        <HeaderContent
-          description={translation}
-          icon={AllahIcon}
-          link={{
-            href: "/quran",
-            label: t("quran"),
-          }}
-          title={title}
-        />
-        <LayoutContent>
-          <WindowVirtualized
-            ssrCount={Math.min(
-              result.verses.length,
-              QURAN_INITIAL_VERSE_SSR_COUNT
-            )}
-          >
-            {result.verses.map((verse, index) => {
-              const verseLabel = t("verse-count", {
-                count: verse.number.inSurah,
-              });
-
-              return (
-                <QuranVerse
-                  hasInterpretation={hasInterpretation}
-                  id={slugify(verseLabel)}
-                  interpretationLabel={interpretationLabel}
-                  isLast={index === result.verses.length - 1}
-                  key={verse.number.inQuran}
-                  verse={verse}
-                  verseLabel={verseLabel}
-                />
-              );
-            })}
-          </WindowVirtualized>
-        </LayoutContent>
-        <PaginationContent pagination={pagination} />
-        <FooterContent>{footer}</FooterContent>
-        {hasInterpretation && (
-          <QuranInterpretationControls
-            errorMessage={t("interpretation-error")}
-            label={interpretationLabel}
-            snapshotId={result.snapshotId}
-            surahNumber={surahData.number}
-          />
-        )}
-        {toolbar}
-      </LayoutMaterialContent>
-      <LayoutMaterialToc
-        chapters={{
-          label: t("verse"),
-          data: headings,
-        }}
-        header={{
-          title,
-          href: `/quran/${surah}`,
-          description: translation,
-        }}
+    <>
+      <BreadcrumbJsonLd
+        breadcrumbItems={createBreadcrumbItems(locale, [
+          { name: tCommon("home"), path: "" },
+          { name: t("quran"), path: "/quran" },
+          { name: title, path: `/quran/${surah}` },
+        ])}
       />
-    </VirtualProvider>
+      <BookJsonLd
+        author={{ "@type": "Person", name: "Allah" }}
+        description={translation}
+        inLanguage={locale}
+        name={title}
+        position={surahNumber}
+        totalPages={surahData.numberOfVerses}
+        url={`https://nakafa.com/${locale}/quran/${surah}`}
+      />
+      <VirtualProvider>
+        <LayoutMaterialContent>
+          <HeaderContent
+            description={translation}
+            icon={AllahIcon}
+            link={{
+              href: "/quran",
+              label: t("quran"),
+            }}
+            title={title}
+          />
+          <LayoutContent>
+            <WindowVirtualized
+              ssrCount={Math.min(
+                result.verses.length,
+                QURAN_INITIAL_VERSE_SSR_COUNT
+              )}
+            >
+              {result.verses.map((verse, index) => {
+                const verseLabel = t("verse-count", {
+                  count: verse.number.inSurah,
+                });
+
+                return (
+                  <QuranVerse
+                    hasInterpretation={hasInterpretation}
+                    id={slugify(verseLabel)}
+                    interpretationLabel={interpretationLabel}
+                    isLast={index === result.verses.length - 1}
+                    key={verse.number.inQuran}
+                    verse={verse}
+                    verseLabel={verseLabel}
+                  />
+                );
+              })}
+            </WindowVirtualized>
+          </LayoutContent>
+          <PaginationContent pagination={pagination} />
+          <FooterContent>{footer}</FooterContent>
+          {hasInterpretation && (
+            <QuranInterpretationControls
+              errorMessage={t("interpretation-error")}
+              label={interpretationLabel}
+              snapshotId={result.snapshotId}
+              surahNumber={surahData.number}
+            />
+          )}
+          {toolbar}
+        </LayoutMaterialContent>
+        <LayoutMaterialToc
+          chapters={{
+            label: t("verse"),
+            data: headings,
+          }}
+          header={{
+            title,
+            href: `/quran/${surah}`,
+            description: translation,
+          }}
+        />
+      </VirtualProvider>
+    </>
   );
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -1,5 +1,4 @@
 import { AllahIcon } from "@hugeicons/core-free-icons";
-import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/spec";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
 import { slugify } from "@repo/design-system/lib/routing/slug";
 import { BookJsonLd } from "@repo/seo/json-ld/book";
@@ -23,7 +22,7 @@ import { RefContent } from "@/components/shared/ref-content";
 import { WindowVirtualized } from "@/components/shared/window-virtualized";
 import {
   getPublishedQuranCatalog,
-  getPublishedQuranPage,
+  getPublishedQuranView,
 } from "@/lib/content/quran/publication";
 import { VirtualProvider } from "@/lib/context/use-virtual";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
@@ -35,30 +34,6 @@ import { generateSEOMetadata } from "@/lib/utils/seo/generator";
 import type { SEOContext } from "@/lib/utils/seo/types";
 
 const QURAN_INITIAL_VERSE_SSR_COUNT = 80;
-
-/** Returns complete localized tafsir controls only when every surah verse has data. */
-function getSurahInterpretations(
-  verses: readonly QuranRuntimeVerse[],
-  locale: Locale
-) {
-  if (locale !== "id") {
-    return;
-  }
-
-  const interpretations: string[] = [];
-
-  for (const verse of verses) {
-    const tafsir = verse.tafsir.id.text;
-
-    if (!tafsir.trim()) {
-      return;
-    }
-
-    interpretations.push(tafsir);
-  }
-
-  return interpretations;
-}
 
 /** Builds localized Quran surah metadata only after the runtime catalog confirms the surah exists. */
 export async function generateMetadata({
@@ -222,7 +197,7 @@ async function CachedSurahShell({
 
   const [t, result] = await Promise.all([
     getTranslations({ locale, namespace: "Holy" }),
-    getPublishedQuranPage(locale, surahNumber),
+    getPublishedQuranView(locale, surahNumber),
   ]);
 
   const surahData = result.surah;
@@ -246,7 +221,7 @@ async function CachedSurahShell({
   });
 
   const interpretationLabel = t("interpretation");
-  const interpretations = getSurahInterpretations(result.verses, locale);
+  const hasInterpretation = result.locale === "id";
 
   return (
     <VirtualProvider>
@@ -274,13 +249,11 @@ async function CachedSurahShell({
 
               return (
                 <QuranVerse
-                  hasInterpretation={interpretations !== undefined}
+                  hasInterpretation={hasInterpretation}
                   id={slugify(verseLabel)}
-                  index={index}
                   interpretationLabel={interpretationLabel}
                   isLast={index === result.verses.length - 1}
                   key={verse.number.inQuran}
-                  locale={locale}
                   verse={verse}
                   verseLabel={verseLabel}
                 />
@@ -290,10 +263,12 @@ async function CachedSurahShell({
         </LayoutContent>
         <PaginationContent pagination={pagination} />
         <FooterContent>{footer}</FooterContent>
-        {interpretations && (
+        {hasInterpretation && (
           <QuranInterpretationControls
-            interpretations={interpretations}
+            errorMessage={t("interpretation-error")}
             label={interpretationLabel}
+            snapshotId={result.snapshotId}
+            surahNumber={surahData.number}
           />
         )}
         {toolbar}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -3,6 +3,7 @@ import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
 import { slugify } from "@repo/design-system/lib/routing/slug";
 import { BookJsonLd } from "@repo/seo/json-ld/book";
 import { BreadcrumbJsonLd } from "@repo/seo/json-ld/breadcrumb";
+import { Effect } from "effect";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { Locale } from "next-intl";
@@ -24,6 +25,7 @@ import {
   getPublishedQuranCatalog,
   getPublishedQuranView,
 } from "@/lib/content/quran/publication";
+import { recoverStalePublishedQuranSnapshot } from "@/lib/content/quran/recovery";
 import { VirtualProvider } from "@/lib/context/use-virtual";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getSocialMetadata } from "@/lib/utils/metadata";
@@ -171,6 +173,14 @@ async function CachedSurahShell({
   ]);
 
   const surahData = result.surah;
+  const servedSnapshotId = result.snapshotId;
+  async function recoverSnapshot() {
+    "use server";
+
+    await Effect.runPromise(
+      recoverStalePublishedQuranSnapshot(servedSnapshotId)
+    );
+  }
   const translation = surahData.name.translation;
   const title = getQuranSurahName(surahData.name);
 
@@ -255,6 +265,7 @@ async function CachedSurahShell({
               errorMessage={t("interpretation-error")}
               label={interpretationLabel}
               loadingMessage={t("interpretation-loading")}
+              recoverSnapshot={recoverSnapshot}
               refreshingMessage={t("interpretation-refreshing")}
               snapshotId={result.snapshotId}
               surahNumber={surahData.number}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -254,6 +254,8 @@ async function CachedSurahShell({
             <QuranInterpretationControls
               errorMessage={t("interpretation-error")}
               label={interpretationLabel}
+              loadingMessage={t("interpretation-loading")}
+              refreshingMessage={t("interpretation-refreshing")}
               snapshotId={result.snapshotId}
               surahNumber={surahData.number}
             />

--- a/apps/www/components/shared/quran-interpretation-controls.tsx
+++ b/apps/www/components/shared/quran-interpretation-controls.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useDisclosure, useWindowEvent } from "@mantine/hooks";
-import { decodePublishedQuranInterpretation } from "@repo/backend/client/quran/interpretation";
+import {
+  decodePublishedQuranInterpretation,
+  isQuranSnapshotConflict,
+  toQuranInterpretationRequestError,
+} from "@repo/backend/client/quran/interpretation";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   Drawer,
@@ -12,13 +16,16 @@ import {
 } from "@repo/design-system/components/ui/drawer";
 import { useConvex } from "convex/react";
 import { Effect } from "effect";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLayoutEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { reportClientException } from "@/lib/analytics/client";
 
 interface Props {
   errorMessage: string;
   label: string;
+  loadingMessage: string;
+  refreshingMessage: string;
   snapshotId: string;
   surahNumber: number;
 }
@@ -55,19 +62,25 @@ function getVerseNumber(button: HTMLButtonElement) {
 export function QuranInterpretationControls({
   errorMessage,
   label,
+  loadingMessage,
+  refreshingMessage,
   snapshotId,
   surahNumber,
 }: Props) {
   const convex = useConvex();
+  const router = useRouter();
   const [isOpen, { close, open, set }] = useDisclosure(false);
   const [selectedInterpretation, setSelectedInterpretation] = useState("");
+  const [isPending, startTransition] = useTransition();
   const requestSequence = useRef(0);
+  const pendingRequestId = useRef<number | null>(null);
   const toastId = `quran-interpretation-${snapshotId}-${surahNumber}`;
 
   // Cached routes use React Activity, which runs layout cleanup while hidden.
   useLayoutEffect(
     () => () => {
       requestSequence.current += 1;
+      pendingRequestId.current = null;
       close();
       setSelectedInterpretation("");
       toast.dismiss(toastId);
@@ -86,16 +99,30 @@ export function QuranInterpretationControls({
       return;
     }
 
+    if (isPending || pendingRequestId.current !== null) {
+      return;
+    }
+
     requestSequence.current += 1;
     const requestId = requestSequence.current;
-    const program = Effect.tryPromise(() =>
-      convex.query(api.contentRelease.quran.interpretation, {
-        expectedSnapshotId: snapshotId,
-        locale: "id",
-        surahNumber,
-        verseNumber,
-      })
-    ).pipe(
+    pendingRequestId.current = requestId;
+    close();
+    setSelectedInterpretation("");
+    toast.loading(loadingMessage, {
+      id: toastId,
+      position: "bottom-center",
+    });
+
+    const program = Effect.tryPromise({
+      catch: toQuranInterpretationRequestError,
+      try: () =>
+        convex.query(api.contentRelease.quran.interpretation, {
+          expectedSnapshotId: snapshotId,
+          locale: "id",
+          surahNumber,
+          verseNumber,
+        }),
+    }).pipe(
       Effect.flatMap((result) =>
         decodePublishedQuranInterpretation(result, {
           locale: "id",
@@ -110,31 +137,52 @@ export function QuranInterpretationControls({
             return;
           }
 
+          toast.dismiss(toastId);
           setSelectedInterpretation(interpretation);
           open();
         })
       ),
-      Effect.catchAll((error) =>
-        Effect.sync(() => {
-          if (requestSequence.current === requestId) {
-            toast.error(errorMessage, {
+      Effect.catchAll((error) => {
+        if (requestSequence.current !== requestId) {
+          return Effect.void;
+        }
+
+        if (isQuranSnapshotConflict(error)) {
+          return Effect.sync(() => {
+            toast.info(refreshingMessage, {
               id: toastId,
               position: "bottom-center",
             });
-          }
+            router.refresh();
+          });
+        }
+
+        return Effect.sync(() => {
+          toast.error(errorMessage, {
+            id: toastId,
+            position: "bottom-center",
+          });
         }).pipe(
-          Effect.andThen(
+          Effect.zipRight(
             reportClientException(error, {
               source: "quran-interpretation",
               surahNumber,
               verseNumber,
             })
           )
-        )
-      )
+        );
+      }),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (pendingRequestId.current === requestId) {
+            pendingRequestId.current = null;
+          }
+        })
+      ),
+      Effect.asVoid
     );
 
-    Effect.runFork(program);
+    startTransition(() => Effect.runPromise(program));
   });
 
   return (

--- a/apps/www/components/shared/quran-interpretation-controls.tsx
+++ b/apps/www/components/shared/quran-interpretation-controls.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useDisclosure, useWindowEvent } from "@mantine/hooks";
+import { decodePublishedQuranInterpretation } from "@repo/backend/client/quran/interpretation";
+import { api } from "@repo/backend/convex/_generated/api";
 import {
   Drawer,
   DrawerHeader,
@@ -8,14 +10,20 @@ import {
   DrawerPopup,
   DrawerTitle,
 } from "@repo/design-system/components/ui/drawer";
-import { useState } from "react";
+import { useConvex } from "convex/react";
+import { Effect } from "effect";
+import { useLayoutEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { reportClientException } from "@/lib/analytics/client";
 
 interface Props {
-  interpretations: readonly string[];
+  errorMessage: string;
   label: string;
+  snapshotId: string;
+  surahNumber: number;
 }
 
-const INTERPRETATION_BUTTON_SELECTOR = "[data-quran-interpretation-index]";
+const INTERPRETATION_BUTTON_SELECTOR = "[data-quran-interpretation-verse]";
 
 /** Finds a delegated tafsir button from a browser click event. */
 function getInterpretationButton(event: MouseEvent) {
@@ -33,23 +41,39 @@ function getInterpretationButton(event: MouseEvent) {
   return button;
 }
 
-/** Reads the tafsir text selected by one delegated button. */
-function getInterpretationText(
-  button: HTMLButtonElement,
-  interpretations: readonly string[]
-) {
-  const index = Number(button.dataset.quranInterpretationIndex);
-  if (!Number.isInteger(index)) {
+/** Reads the exact verse identity selected by one delegated button. */
+function getVerseNumber(button: HTMLButtonElement) {
+  const verseNumber = Number(button.dataset.quranInterpretationVerse);
+  if (!Number.isSafeInteger(verseNumber) || verseNumber < 1) {
     return null;
   }
 
-  return interpretations[index] ?? null;
+  return verseNumber;
 }
 
 /** Handles all verse tafsir drawers through one hydrated client island. */
-export function QuranInterpretationControls({ interpretations, label }: Props) {
-  const [isOpen, { open, set }] = useDisclosure(false);
+export function QuranInterpretationControls({
+  errorMessage,
+  label,
+  snapshotId,
+  surahNumber,
+}: Props) {
+  const convex = useConvex();
+  const [isOpen, { close, open, set }] = useDisclosure(false);
   const [selectedInterpretation, setSelectedInterpretation] = useState("");
+  const requestSequence = useRef(0);
+  const toastId = `quran-interpretation-${snapshotId}-${surahNumber}`;
+
+  // Cached routes use React Activity, which runs layout cleanup while hidden.
+  useLayoutEffect(
+    () => () => {
+      requestSequence.current += 1;
+      close();
+      setSelectedInterpretation("");
+      toast.dismiss(toastId);
+    },
+    [close, toastId]
+  );
 
   useWindowEvent("click", (event) => {
     const button = getInterpretationButton(event);
@@ -57,13 +81,60 @@ export function QuranInterpretationControls({ interpretations, label }: Props) {
       return;
     }
 
-    const interpretation = getInterpretationText(button, interpretations);
-    if (!interpretation) {
+    const verseNumber = getVerseNumber(button);
+    if (verseNumber === null) {
       return;
     }
 
-    setSelectedInterpretation(interpretation);
-    open();
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
+    const program = Effect.tryPromise(() =>
+      convex.query(api.contentRelease.quran.interpretation, {
+        expectedSnapshotId: snapshotId,
+        locale: "id",
+        surahNumber,
+        verseNumber,
+      })
+    ).pipe(
+      Effect.flatMap((result) =>
+        decodePublishedQuranInterpretation(result, {
+          locale: "id",
+          snapshotId,
+          surahNumber,
+          verseNumber,
+        })
+      ),
+      Effect.tap(({ interpretation }) =>
+        Effect.sync(() => {
+          if (requestSequence.current !== requestId) {
+            return;
+          }
+
+          setSelectedInterpretation(interpretation);
+          open();
+        })
+      ),
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          if (requestSequence.current === requestId) {
+            toast.error(errorMessage, {
+              id: toastId,
+              position: "bottom-center",
+            });
+          }
+        }).pipe(
+          Effect.andThen(
+            reportClientException(error, {
+              source: "quran-interpretation",
+              surahNumber,
+              verseNumber,
+            })
+          )
+        )
+      )
+    );
+
+    Effect.runFork(program);
   });
 
   return (

--- a/apps/www/components/shared/quran-interpretation-controls.tsx
+++ b/apps/www/components/shared/quran-interpretation-controls.tsx
@@ -16,7 +16,6 @@ import {
 } from "@repo/design-system/components/ui/drawer";
 import { useConvex } from "convex/react";
 import { Effect } from "effect";
-import { useRouter } from "next/navigation";
 import { useLayoutEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { reportClientException } from "@/lib/analytics/client";
@@ -25,6 +24,7 @@ interface Props {
   errorMessage: string;
   label: string;
   loadingMessage: string;
+  recoverSnapshot: () => Promise<void>;
   refreshingMessage: string;
   snapshotId: string;
   surahNumber: number;
@@ -63,12 +63,12 @@ export function QuranInterpretationControls({
   errorMessage,
   label,
   loadingMessage,
+  recoverSnapshot,
   refreshingMessage,
   snapshotId,
   surahNumber,
 }: Props) {
   const convex = useConvex();
-  const router = useRouter();
   const [isOpen, { close, open, set }] = useDisclosure(false);
   const [selectedInterpretation, setSelectedInterpretation] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -148,13 +148,36 @@ export function QuranInterpretationControls({
         }
 
         if (isQuranSnapshotConflict(error)) {
-          return Effect.sync(() => {
+          return Effect.sync(() =>
             toast.info(refreshingMessage, {
               id: toastId,
               position: "bottom-center",
-            });
-            router.refresh();
-          });
+            })
+          ).pipe(
+            Effect.zipRight(
+              Effect.tryPromise({
+                catch: toQuranInterpretationRequestError,
+                try: recoverSnapshot,
+              }).pipe(
+                Effect.catchAll((recoveryError) =>
+                  Effect.sync(() => {
+                    toast.error(errorMessage, {
+                      id: toastId,
+                      position: "bottom-center",
+                    });
+                  }).pipe(
+                    Effect.zipRight(
+                      reportClientException(recoveryError, {
+                        source: "quran-interpretation-recovery",
+                        surahNumber,
+                        verseNumber,
+                      })
+                    )
+                  )
+                )
+              )
+            )
+          );
         }
 
         return Effect.sync(() => {

--- a/apps/www/components/shared/quran-verse.tsx
+++ b/apps/www/components/shared/quran-verse.tsx
@@ -1,19 +1,16 @@
 import { BookOpen02Icon } from "@hugeicons/core-free-icons";
-import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/spec";
+import type { QuranViewVerse } from "@repo/backend/client/quran/view";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import { buttonVariants } from "@repo/design-system/lib/button";
 import { cn } from "@repo/design-system/lib/utils";
-import type { Locale } from "next-intl";
 import { QuranText } from "@/components/shared/quran-text";
 
 interface Props {
   hasInterpretation: boolean;
   id: string;
-  index: number;
   interpretationLabel: string;
   isLast: boolean;
-  locale: Locale;
-  verse: QuranRuntimeVerse;
+  verse: QuranViewVerse;
   verseLabel: string;
 }
 
@@ -26,17 +23,17 @@ const verseButtonClassName = buttonVariants({
  * Renders one delegated tafsir button without mounting a drawer per verse.
  */
 function QuranInterpretationButton({
-  index,
   label,
+  verseNumber,
 }: {
-  index: number;
   label: string;
+  verseNumber: number;
 }) {
   return (
     <button
       aria-label={label}
       className={verseButtonClassName}
-      data-quran-interpretation-index={index}
+      data-quran-interpretation-verse={verseNumber}
       type="button"
     >
       <HugeIcons icon={BookOpen02Icon} />
@@ -51,15 +48,11 @@ function QuranInterpretationButton({
 export function QuranVerse({
   hasInterpretation,
   id,
-  index,
   interpretationLabel,
   isLast,
-  locale,
   verse,
   verseLabel,
 }: Props) {
-  const translation = verse.translation[locale].text;
-
   return (
     <div
       className={cn(
@@ -84,14 +77,14 @@ export function QuranVerse({
         <div className="flex items-center gap-2">
           {hasInterpretation && (
             <QuranInterpretationButton
-              index={index}
               label={interpretationLabel}
+              verseNumber={verse.number.inSurah}
             />
           )}
         </div>
       </div>
-      <QuranText>{verse.text.arabic}</QuranText>
-      <p className="text-pretty leading-relaxed">{translation}</p>
+      <QuranText>{verse.arabic}</QuranText>
+      <p className="text-pretty leading-relaxed">{verse.translation}</p>
     </div>
   );
 }

--- a/apps/www/lib/content/cache.test.ts
+++ b/apps/www/lib/content/cache.test.ts
@@ -47,6 +47,15 @@ describe("content runtime cache", () => {
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
 
+  it("applies global and exact immutable snapshot tags", async () => {
+    const cache = await import("@/lib/content/cache");
+
+    cache.applyPublishedSnapshotCache(artifactHash);
+
+    expect(cacheTagMock).toHaveBeenCalledWith("content-runtime", artifactTag);
+    expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
+  });
+
   it("applies global, family, and exact artifact tags", async () => {
     const cache = await import("@/lib/content/cache");
 

--- a/apps/www/lib/content/cache.ts
+++ b/apps/www/lib/content/cache.ts
@@ -27,6 +27,12 @@ export function applyContentRuntimeCache() {
   cacheLife(CONTENT_RUNTIME_CACHE_PROFILE);
 }
 
+/** Applies global and exact immutable snapshot tags to one published cache. */
+export function applyPublishedSnapshotCache(snapshotId: Sha256Hash) {
+  cacheTag(CONTENT_CACHE_GLOBAL_TAG, makeArtifactCacheTag(snapshotId));
+  cacheLife(CONTENT_RUNTIME_CACHE_PROFILE);
+}
+
 /** Applies global and family tags to one published catalog cache. */
 export function applyPublishedCatalogCache(family: ContentFamily) {
   cacheTag(CONTENT_CACHE_GLOBAL_TAG, makeContentFamilyCacheTag(family));

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -11,7 +11,7 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getPublishedQuranCatalog,
-  getPublishedQuranPage,
+  getPublishedQuranView,
   readPublishedQuranCatalog,
   readPublishedQuranPage,
 } from "@/lib/content/quran/publication";
@@ -57,7 +57,7 @@ describe("published Quran content", () => {
     expect(cacheMock).toHaveBeenCalledOnce();
   });
 
-  it("reads one signed page through Effect and cached Promise boundaries", async () => {
+  it("reads the complete signed page through the Effect boundary", async () => {
     const result = pageResult();
     fetchMock.mockResolvedValue(result);
 
@@ -67,9 +67,37 @@ describe("published Quran content", () => {
       surah: { number: 1 },
       verses: [{ number: {} }],
     });
-    await expect(getPublishedQuranPage("id", 1)).resolves.toMatchObject({
+    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+      locale: "id",
+      surahNumber: 1,
+    });
+  });
+
+  it("keeps a failed Quran query in the Effect error channel", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Quran unavailable"));
+
+    await expect(
+      Effect.runPromise(Effect.either(readPublishedQuranCatalog()))
+    ).resolves.toMatchObject({
+      _tag: "Left",
+      left: {
+        _tag: "TestRuntimeQueryError",
+        message: "Error: Quran unavailable",
+      },
+    });
+  });
+
+  it("caches the locale-specific Quran web projection", async () => {
+    fetchMock.mockResolvedValue(viewResult());
+
+    await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
+      locale: "id",
       surah: { number: 1 },
-      verses: [{ number: {} }],
+      verses: [
+        {
+          translation: "Terjemahan teknis 1",
+        },
+      ],
     });
     expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
       locale: "id",
@@ -86,6 +114,38 @@ function catalogResult() {
     rowJson: Array.from({ length: 114 }, (_, index) =>
       encodeTestQuranRow(source.snapshotId, makeQuranSurah(index + 1))
     ),
+  };
+}
+
+/** Builds one narrow locale-specific Quran web response. */
+function viewResult() {
+  return {
+    ...source,
+    locale: "id",
+    nextSurah: {
+      name: {
+        translation: "Technical meaning 2",
+        transliteration: "Technical Surah 2",
+      },
+      number: 2,
+      numberOfVerses: 1,
+    },
+    previousSurah: null,
+    surah: {
+      name: {
+        translation: "Technical meaning 1",
+        transliteration: "Technical Surah 1",
+      },
+      number: 1,
+      numberOfVerses: 1,
+    },
+    verses: [
+      {
+        arabic: "آية 1",
+        number: { inQuran: 1, inSurah: 1 },
+        translation: "Terjemahan teknis 1",
+      },
+    ],
   };
 }
 

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -13,6 +13,7 @@ import {
   getPublishedQuranCatalog,
   getPublishedQuranView,
   readPublishedQuranCatalog,
+  readPublishedQuranIdentity,
   readPublishedQuranPage,
 } from "@/lib/content/quran/publication";
 
@@ -20,7 +21,7 @@ const fetchMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/content/cache", () => ({
-  applyContentRuntimeCache: cacheMock,
+  applyPublishedSnapshotCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
   const { readTestRuntimeQuery } = await import("@/test/runtime-query");
@@ -44,6 +45,15 @@ beforeEach(() => {
 });
 
 describe("published Quran content", () => {
+  it("reads the active identity through the one-row attribution query", async () => {
+    fetchMock.mockResolvedValue({ ...source, rowJson: "attribution-row" });
+
+    await expect(
+      Effect.runPromise(readPublishedQuranIdentity())
+    ).resolves.toMatchObject({ snapshotId: source.snapshotId });
+    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {});
+  });
+
   it("reads the signed catalog through Effect and cached Promise boundaries", async () => {
     fetchMock.mockResolvedValue(catalogResult());
 
@@ -54,7 +64,7 @@ describe("published Quran content", () => {
       surahs: expect.any(Array),
     });
     expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {});
-    expect(cacheMock).toHaveBeenCalledOnce();
+    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
   });
 
   it("reads the complete signed page through the Effect boundary", async () => {
@@ -103,7 +113,7 @@ describe("published Quran content", () => {
       locale: "id",
       surahNumber: 1,
     });
-    expect(cacheMock).toHaveBeenCalledOnce();
+    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
   });
 });
 

--- a/apps/www/lib/content/quran/publication.ts
+++ b/apps/www/lib/content/quran/publication.ts
@@ -3,16 +3,22 @@ import "server-only";
 import {
   decodePublishedQuranCatalog,
   decodePublishedQuranPage,
+  decodePublishedQuranSource,
 } from "@repo/backend/client/quran/decode";
 import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
-import { applyContentRuntimeCache } from "@/lib/content/cache";
+import { applyPublishedSnapshotCache } from "@/lib/content/cache";
 import {
   fetchRuntimeQuery,
   readRuntimeQuery,
 } from "@/lib/content/runtime/query";
+
+/** Reads the raw active Quran attribution through the public Convex query. */
+function fetchAttributionResult() {
+  return fetchRuntimeQuery(api.contentRelease.quran.attribution, {});
+}
 
 /** Reads the raw signed Quran catalog through the public Convex query. */
 function fetchCatalogResult() {
@@ -34,6 +40,17 @@ function fetchViewResult(locale: Locale, surahNumber: number) {
     surahNumber,
   });
 }
+
+/** Reads and validates the active signed Quran identity without a catalog payload. */
+export const readPublishedQuranIdentity = Effect.fn(
+  "NakafaQuran.readPublishedIdentity"
+)(function* () {
+  const result = yield* readRuntimeQuery(
+    "contentRelease.quran.attribution",
+    fetchAttributionResult
+  );
+  return yield* decodePublishedQuranSource(result, "attribution");
+});
 
 /** Reads and validates the active signed Quran metadata catalog. */
 export const readPublishedQuranCatalog = Effect.fn(
@@ -62,7 +79,7 @@ export async function getPublishedQuranCatalog() {
 
   const result = await fetchCatalogResult();
   const catalog = await Effect.runPromise(decodePublishedQuranCatalog(result));
-  applyContentRuntimeCache();
+  applyPublishedSnapshotCache(catalog.snapshotId);
   return catalog;
 }
 
@@ -77,6 +94,6 @@ export async function getPublishedQuranView(
   const view = await Effect.runPromise(
     decodePublishedQuranView(result, { locale, surahNumber })
   );
-  applyContentRuntimeCache();
+  applyPublishedSnapshotCache(view.snapshotId);
   return view;
 }

--- a/apps/www/lib/content/quran/publication.ts
+++ b/apps/www/lib/content/quran/publication.ts
@@ -4,6 +4,7 @@ import {
   decodePublishedQuranCatalog,
   decodePublishedQuranPage,
 } from "@repo/backend/client/quran/decode";
+import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
@@ -21,6 +22,14 @@ function fetchCatalogResult() {
 /** Reads one raw signed Quran page through the public Convex query. */
 function fetchPageResult(locale: Locale, surahNumber: number) {
   return fetchRuntimeQuery(api.contentRelease.quran.page, {
+    locale,
+    surahNumber,
+  });
+}
+
+/** Reads one locale-specific Quran web projection through the public query. */
+function fetchViewResult(locale: Locale, surahNumber: number) {
+  return fetchRuntimeQuery(api.contentRelease.quran.view, {
     locale,
     surahNumber,
   });
@@ -57,17 +66,17 @@ export async function getPublishedQuranCatalog() {
   return catalog;
 }
 
-/** Caches one complete signed Quran page by locale and active release. */
-export async function getPublishedQuranPage(
+/** Caches one narrow signed Quran web projection by locale and active release. */
+export async function getPublishedQuranView(
   locale: Locale,
   surahNumber: number
 ) {
   "use cache";
 
-  const result = await fetchPageResult(locale, surahNumber);
-  const page = await Effect.runPromise(
-    decodePublishedQuranPage(result, { locale, surahNumber })
+  const result = await fetchViewResult(locale, surahNumber);
+  const view = await Effect.runPromise(
+    decodePublishedQuranView(result, { locale, surahNumber })
   );
   applyContentRuntimeCache();
-  return page;
+  return view;
 }

--- a/apps/www/lib/content/quran/recovery.test.ts
+++ b/apps/www/lib/content/quran/recovery.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+
+import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
+import { Effect, Either } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  QuranSnapshotRecoveryError,
+  recoverStalePublishedQuranSnapshot,
+} from "@/lib/content/quran/recovery";
+
+const activeSnapshotId = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
+const staleSnapshotId = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
+const readIdentityMock = vi.hoisted(() => vi.fn());
+const refreshMock = vi.hoisted(() => vi.fn());
+const updateTagMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/content/quran/publication", () => ({
+  readPublishedQuranIdentity: readIdentityMock,
+}));
+vi.mock("next/cache", () => ({
+  refresh: refreshMock,
+  updateTag: updateTagMock,
+}));
+
+beforeEach(() => {
+  readIdentityMock.mockReset().mockReturnValue(
+    Effect.succeed({
+      snapshotId: activeSnapshotId,
+    })
+  );
+  refreshMock.mockReset();
+  updateTagMock.mockReset();
+});
+
+describe("stale published Quran snapshot recovery", () => {
+  it("rejects an invalid captured snapshot before reading active state", async () => {
+    const result = await Effect.runPromise(
+      recoverStalePublishedQuranSnapshot("not-a-snapshot").pipe(Effect.either)
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toMatchObject({
+        _tag: "QuranSnapshotRecoveryError",
+        reason: "invalid-input",
+      });
+    }
+    expect(readIdentityMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(updateTagMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes without expiring the currently active snapshot", async () => {
+    await expect(
+      Effect.runPromise(recoverStalePublishedQuranSnapshot(activeSnapshotId))
+    ).resolves.toBe(false);
+    expect(refreshMock).toHaveBeenCalledOnce();
+    expect(updateTagMock).not.toHaveBeenCalled();
+  });
+
+  it("immediately expires only the captured stale snapshot tag", async () => {
+    await expect(
+      Effect.runPromise(recoverStalePublishedQuranSnapshot(staleSnapshotId))
+    ).resolves.toBe(true);
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(updateTagMock).toHaveBeenCalledWith(
+      `content-artifact:${staleSnapshotId}`
+    );
+  });
+
+  it("maps active identity failures into the recovery error channel", async () => {
+    const sourceFailure = new Error("identity unavailable");
+    readIdentityMock.mockReturnValueOnce(Effect.fail(sourceFailure));
+
+    const result = await Effect.runPromise(
+      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.either)
+    );
+
+    expect(result).toEqual(
+      Either.left(
+        new QuranSnapshotRecoveryError({
+          cause: sourceFailure,
+          reason: "active-identity",
+        })
+      )
+    );
+  });
+
+  it("keeps route refresh failures in the typed error channel", async () => {
+    refreshMock.mockImplementationOnce(() => {
+      throw new Error("refresh unavailable");
+    });
+
+    const result = await Effect.runPromise(
+      recoverStalePublishedQuranSnapshot(activeSnapshotId).pipe(Effect.either)
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toMatchObject({
+        _tag: "QuranSnapshotRecoveryError",
+        reason: "route-refresh",
+      });
+    }
+  });
+
+  it("keeps cache invalidation failures in the typed error channel", async () => {
+    updateTagMock.mockImplementationOnce(() => {
+      throw new Error("cache unavailable");
+    });
+
+    const result = await Effect.runPromise(
+      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.either)
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toMatchObject({
+        _tag: "QuranSnapshotRecoveryError",
+        reason: "cache-invalidation",
+      });
+    }
+  });
+});

--- a/apps/www/lib/content/quran/recovery.ts
+++ b/apps/www/lib/content/quran/recovery.ts
@@ -1,0 +1,67 @@
+import "server-only";
+
+import { makeArtifactCacheTag } from "@nakafa/aksara-contracts/cache/content";
+import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
+import { Effect, Schema } from "effect";
+import { refresh, updateTag } from "next/cache";
+import { readPublishedQuranIdentity } from "@/lib/content/quran/publication";
+
+/** One stale Quran snapshot could not be safely recovered. */
+export class QuranSnapshotRecoveryError extends Schema.TaggedError<QuranSnapshotRecoveryError>()(
+  "QuranSnapshotRecoveryError",
+  {
+    cause: Schema.Unknown,
+    reason: Schema.Literal(
+      "active-identity",
+      "cache-invalidation",
+      "invalid-input",
+      "route-refresh"
+    ),
+  }
+) {}
+
+/** Refreshes the current route without expiring any server cache entry. */
+const refreshQuranRoute = Effect.fn("www.quran.refreshStaleRoute")(
+  function* () {
+    yield* Effect.try({
+      catch: (cause) =>
+        new QuranSnapshotRecoveryError({ cause, reason: "route-refresh" }),
+      try: refresh,
+    });
+    return false;
+  }
+);
+
+/**
+ * Expires one server-captured stale Quran snapshot without touching other content.
+ */
+export const recoverStalePublishedQuranSnapshot = Effect.fn(
+  "www.quran.recoverStaleSnapshot"
+)(function* (input: unknown) {
+  const staleSnapshotId = yield* Schema.decodeUnknown(Sha256HashSchema)(
+    input
+  ).pipe(
+    Effect.mapError(
+      (cause) =>
+        new QuranSnapshotRecoveryError({ cause, reason: "invalid-input" })
+    )
+  );
+  const activeIdentity = yield* readPublishedQuranIdentity().pipe(
+    Effect.mapError(
+      (cause) =>
+        new QuranSnapshotRecoveryError({ cause, reason: "active-identity" })
+    )
+  );
+
+  if (activeIdentity.snapshotId === staleSnapshotId) {
+    return yield* refreshQuranRoute();
+  }
+
+  yield* Effect.try({
+    catch: (cause) =>
+      new QuranSnapshotRecoveryError({ cause, reason: "cache-invalidation" }),
+    try: () => updateTag(makeArtifactCacheTag(staleSnapshotId)),
+  });
+
+  return true;
+});

--- a/apps/www/lib/utils/pages/quran.ts
+++ b/apps/www/lib/utils/pages/quran.ts
@@ -1,7 +1,8 @@
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import type { QuranViewSurah } from "@repo/backend/client/quran/view";
 
 export type QuranSurah = QuranSurahRow;
-type QuranSurahMetadata = null | QuranSurahRow;
+type QuranSurahMetadata = null | QuranViewSurah;
 
 /** Navigation data for Quran previous and next links. */
 export interface QuranPagination {
@@ -42,6 +43,6 @@ function getQuranPaginationItem(surah: QuranSurahMetadata) {
 }
 
 /** Returns the source-authenticated transliterated name for one Quran surah. */
-export function getQuranSurahName(name: QuranSurah["name"]) {
+export function getQuranSurahName(name: QuranViewSurah["name"]) {
   return name.transliteration;
 }

--- a/packages/backend/client/quran/decode.ts
+++ b/packages/backend/client/quran/decode.ts
@@ -14,6 +14,10 @@ import {
   QuranSurahRowSchema,
 } from "@nakafa/aksara-contracts/quran/spec";
 import { ContentSnapshotRowSchema } from "@nakafa/aksara-contracts/release/snapshot/data";
+import {
+  hasExactQuranVerseRange,
+  hasExpectedQuranNeighbors,
+} from "@repo/backend/client/quran/integrity";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { Effect, Schema } from "effect";
@@ -28,8 +32,10 @@ type QuranReferenceResult = FunctionReturnType<
 
 const QuranPublicationOperationSchema = Schema.Literal(
   "catalog",
+  "interpretation",
   "page",
-  "reference"
+  "reference",
+  "view"
 );
 type QuranPublicationOperation = typeof QuranPublicationOperationSchema.Type;
 
@@ -82,31 +88,33 @@ function publicationError(
 }
 
 /** Requires a complete active source identity for every public Quran read. */
-const decodeSource = Effect.fn("NakafaQuran.decodeSource")(function* (
-  input: {
-    readonly activeManifestHash: null | string;
-    readonly activeReleaseId: null | string;
-    readonly managed: boolean;
-    readonly snapshotId: null | string;
-    readonly sourceRevision: null | string;
-  },
-  operation: QuranPublicationOperation
-) {
-  if (!input.managed) {
-    return yield* publicationError(
-      operation,
-      "Signed Quran publication is not active."
+export const decodePublishedQuranSource = Effect.fn("NakafaQuran.decodeSource")(
+  function* (
+    input: {
+      readonly activeManifestHash: null | string;
+      readonly activeReleaseId: null | string;
+      readonly managed: boolean;
+      readonly snapshotId: null | string;
+      readonly sourceRevision: null | string;
+    },
+    operation: QuranPublicationOperation
+  ) {
+    if (!input.managed) {
+      return yield* publicationError(
+        operation,
+        "Signed Quran publication is not active."
+      );
+    }
+
+    return yield* Schema.decodeUnknown(PublishedQuranSourceSchema)(input, {
+      onExcessProperty: "ignore",
+    }).pipe(
+      Effect.mapError(() =>
+        publicationError(operation, "Signed Quran source identity is invalid.")
+      )
     );
   }
-
-  return yield* Schema.decodeUnknown(PublishedQuranSourceSchema)(input, {
-    onExcessProperty: "ignore",
-  }).pipe(
-    Effect.mapError(() =>
-      publicationError(operation, "Signed Quran source identity is invalid.")
-    )
-  );
-});
+);
 
 /** Parses and strictly decodes one signed Quran JSON row. */
 const decodeRow = Effect.fn("NakafaQuran.decodeRow")(function* <A, I>(
@@ -205,41 +213,6 @@ function hasContiguousChunks(
   });
 }
 
-/** Checks that one decoded verse list exactly covers the requested local range. */
-function hasExactVerseRange(
-  verses: readonly QuranRuntimeVerse[],
-  fromVerse: number,
-  toVerse: number
-) {
-  if (
-    !(Number.isSafeInteger(fromVerse) && Number.isSafeInteger(toVerse)) ||
-    toVerse < fromVerse ||
-    verses.length !== toVerse - fromVerse + 1
-  ) {
-    return false;
-  }
-
-  return verses.every(
-    (verse, index) => verse.number.inSurah === fromVerse + index
-  );
-}
-
-/** Checks the exact previous and next metadata identities for one page. */
-function hasExpectedNeighbors(
-  previousSurah: null | QuranSurahRow,
-  nextSurah: null | QuranSurahRow,
-  surahNumber: number
-) {
-  const expectedPrevious = surahNumber === 1 ? null : surahNumber - 1;
-  const expectedNext =
-    surahNumber === QURAN_SURAH_COUNT ? null : surahNumber + 1;
-
-  return (
-    (previousSurah?.number ?? null) === expectedPrevious &&
-    (nextSurah?.number ?? null) === expectedNext
-  );
-}
-
 /** Checks the locale-specific search identity returned beside one surah. */
 function hasExpectedSearchIdentity(
   search: QuranSearchRow,
@@ -257,7 +230,7 @@ function hasExpectedSearchIdentity(
 export const decodePublishedQuranCatalog = Effect.fn(
   "NakafaQuran.decodeCatalog"
 )(function* (result: QuranCatalogResult) {
-  const source = yield* decodeSource(result, "catalog");
+  const source = yield* decodePublishedQuranSource(result, "catalog");
   const surahs = yield* Effect.forEach(result.rowJson, (row) =>
     decodeRow(row, source.snapshotId, QuranSurahRowSchema, "catalog")
   );
@@ -281,7 +254,7 @@ export const decodePublishedQuranPage = Effect.fn("NakafaQuran.decodePage")(
       readonly surahNumber: number;
     }
   ) {
-    const source = yield* decodeSource(result, "page");
+    const source = yield* decodePublishedQuranSource(result, "page");
     if (result.surahJson === null || result.searchJson === null) {
       return yield* publicationError("page", "Signed Quran page is missing.");
     }
@@ -311,8 +284,13 @@ export const decodePublishedQuranPage = Effect.fn("NakafaQuran.decodePage")(
     );
     if (
       surah.number !== expected.surahNumber ||
-      !hasExactVerseRange(verses, 1, surah.numberOfVerses) ||
-      !hasExpectedNeighbors(previousSurah, nextSurah, expected.surahNumber) ||
+      !hasExactQuranVerseRange(verses, 1, surah.numberOfVerses) ||
+      !hasExpectedQuranNeighbors(
+        previousSurah,
+        nextSurah,
+        expected.surahNumber,
+        QURAN_SURAH_COUNT
+      ) ||
       !hasExpectedSearchIdentity(search, expected.locale, expected.surahNumber)
     ) {
       return yield* publicationError(
@@ -342,7 +320,7 @@ export const decodePublishedQuranReference = Effect.fn(
     readonly surahNumber: number;
   }
 ) {
-  const source = yield* decodeSource(result, "reference");
+  const source = yield* decodePublishedQuranSource(result, "reference");
   if (result.surahJson === null || result.searchJson === null) {
     return yield* publicationError(
       "reference",
@@ -378,7 +356,7 @@ export const decodePublishedQuranReference = Effect.fn(
     surah.number !== expected.surahNumber ||
     result.fromVerse < 1 ||
     result.toVerse > surah.numberOfVerses ||
-    !hasExactVerseRange(verses, result.fromVerse, result.toVerse) ||
+    !hasExactQuranVerseRange(verses, result.fromVerse, result.toVerse) ||
     !hasExpectedSearchIdentity(search, expected.locale, expected.surahNumber)
   ) {
     return yield* publicationError(

--- a/packages/backend/client/quran/decode.ts
+++ b/packages/backend/client/quran/decode.ts
@@ -31,6 +31,7 @@ type QuranReferenceResult = FunctionReturnType<
 >;
 
 const QuranPublicationOperationSchema = Schema.Literal(
+  "attribution",
   "catalog",
   "interpretation",
   "page",

--- a/packages/backend/client/quran/integrity.test.ts
+++ b/packages/backend/client/quran/integrity.test.ts
@@ -1,0 +1,54 @@
+import {
+  hasExactQuranVerseRange,
+  hasExpectedQuranNeighbors,
+} from "@repo/backend/client/quran/integrity";
+import { describe, expect, it } from "vitest";
+
+/** Builds the minimal validator-independent verse identity used by integrity checks. */
+function verses(...numbers: number[]) {
+  return numbers.map((inSurah) => ({ number: { inSurah } }));
+}
+
+/** Builds the minimal surah identity used by neighboring-page checks. */
+function surah(number: number) {
+  return { number };
+}
+
+describe("hasExactQuranVerseRange", () => {
+  it("accepts one exact positive integer range", () => {
+    expect(hasExactQuranVerseRange(verses(2, 3, 4), 2, 4)).toBe(true);
+  });
+
+  it("rejects invalid or noninteger bounds", () => {
+    expect(hasExactQuranVerseRange(verses(0), 0, 0)).toBe(false);
+    expect(hasExactQuranVerseRange(verses(1), 1.5, 1.5)).toBe(false);
+    expect(hasExactQuranVerseRange(verses(1), 1, Number.NaN)).toBe(false);
+    expect(
+      hasExactQuranVerseRange(verses(1), 1, Number.POSITIVE_INFINITY)
+    ).toBe(false);
+    expect(hasExactQuranVerseRange([], 2, 1)).toBe(false);
+  });
+
+  it("rejects the wrong range length, order, or sequence", () => {
+    expect(hasExactQuranVerseRange(verses(1), 1, 2)).toBe(false);
+    expect(hasExactQuranVerseRange(verses(2, 1), 1, 2)).toBe(false);
+    expect(hasExactQuranVerseRange(verses(1, 3), 1, 2)).toBe(false);
+  });
+});
+
+describe("hasExpectedQuranNeighbors", () => {
+  it("accepts exact first, middle, last, and only-surah identities", () => {
+    expect(hasExpectedQuranNeighbors(null, surah(2), 1, 3)).toBe(true);
+    expect(hasExpectedQuranNeighbors(surah(1), surah(3), 2, 3)).toBe(true);
+    expect(hasExpectedQuranNeighbors(surah(2), null, 3, 3)).toBe(true);
+    expect(hasExpectedQuranNeighbors(null, null, 1, 1)).toBe(true);
+  });
+
+  it("rejects wrong neighbor identities and invalid page bounds", () => {
+    expect(hasExpectedQuranNeighbors(surah(1), surah(2), 2, 3)).toBe(false);
+    expect(hasExpectedQuranNeighbors(null, null, 2, 3)).toBe(false);
+    expect(hasExpectedQuranNeighbors(null, surah(2), 1.5, 3)).toBe(false);
+    expect(hasExpectedQuranNeighbors(null, surah(2), 1, 3.5)).toBe(false);
+    expect(hasExpectedQuranNeighbors(null, null, 1, 0)).toBe(false);
+  });
+});

--- a/packages/backend/client/quran/integrity.ts
+++ b/packages/backend/client/quran/integrity.ts
@@ -1,0 +1,53 @@
+interface NumberedSurah {
+  readonly number: number;
+}
+
+interface NumberedVerse {
+  readonly number: {
+    readonly inSurah: number;
+  };
+}
+
+/** Checks that one verse list exactly covers the requested local range. */
+export function hasExactQuranVerseRange(
+  verses: readonly NumberedVerse[],
+  fromVerse: number,
+  toVerse: number
+) {
+  if (
+    !(Number.isSafeInteger(fromVerse) && Number.isSafeInteger(toVerse)) ||
+    fromVerse < 1 ||
+    toVerse < fromVerse ||
+    verses.length !== toVerse - fromVerse + 1
+  ) {
+    return false;
+  }
+
+  return verses.every(
+    (verse, index) => verse.number.inSurah === fromVerse + index
+  );
+}
+
+/** Checks the exact previous and next surah identities around one page. */
+export function hasExpectedQuranNeighbors(
+  previousSurah: null | NumberedSurah,
+  nextSurah: null | NumberedSurah,
+  surahNumber: number,
+  surahCount: number
+) {
+  if (
+    !(Number.isSafeInteger(surahNumber) && Number.isSafeInteger(surahCount)) ||
+    surahNumber < 1 ||
+    surahNumber > surahCount
+  ) {
+    return false;
+  }
+
+  const expectedPrevious = surahNumber === 1 ? null : surahNumber - 1;
+  const expectedNext = surahNumber === surahCount ? null : surahNumber + 1;
+
+  return (
+    (previousSurah?.number ?? null) === expectedPrevious &&
+    (nextSurah?.number ?? null) === expectedNext
+  );
+}

--- a/packages/backend/client/quran/interpretation.test.ts
+++ b/packages/backend/client/quran/interpretation.test.ts
@@ -1,0 +1,94 @@
+import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
+import { QuranPublicationError } from "@repo/backend/client/quran/decode";
+import {
+  decodePublishedQuranInterpretation,
+  type PublishedQuranInterpretation,
+} from "@repo/backend/client/quran/interpretation";
+import type { api } from "@repo/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+const source = {
+  activeManifestHash: `sha256:${"a".repeat(64)}`,
+  activeReleaseId: "quran-release",
+  managed: true,
+  snapshotId: Sha256HashSchema.make(`sha256:${"b".repeat(64)}`),
+  sourceRevision: "c".repeat(40),
+};
+
+type QuranInterpretationResult = FunctionReturnType<
+  typeof api.contentRelease.quran.interpretation
+>;
+
+const activeInterpretation: QuranInterpretationResult = {
+  ...source,
+  interpretation: "Tafsir ayat tujuh.",
+  locale: "id",
+  surahNumber: 1,
+  verseNumber: 7,
+};
+
+describe("signed Quran interpretation decoder", () => {
+  it("preserves one exact active tafsir", async () => {
+    const interpretation = await Effect.runPromise(
+      decodePublishedQuranInterpretation(activeInterpretation, {
+        locale: "id",
+        snapshotId: source.snapshotId,
+        surahNumber: 1,
+        verseNumber: 7,
+      })
+    );
+
+    expect(interpretation).toMatchObject({
+      interpretation: "Tafsir ayat tujuh.",
+      locale: "id",
+      surahNumber: 1,
+      verseNumber: 7,
+    } satisfies Partial<PublishedQuranInterpretation>);
+  });
+
+  it("fails closed for inactive, stale, mismatched, and empty responses", async () => {
+    const inactive: QuranInterpretationResult = {
+      activeManifestHash: null,
+      activeReleaseId: null,
+      interpretation: null,
+      locale: "id",
+      managed: false,
+      snapshotId: null,
+      sourceRevision: null,
+      surahNumber: 1,
+      verseNumber: 7,
+    };
+    const mismatched: QuranInterpretationResult = {
+      ...activeInterpretation,
+      verseNumber: 6,
+    };
+    const stale: QuranInterpretationResult = {
+      ...activeInterpretation,
+      snapshotId: Sha256HashSchema.make(`sha256:${"d".repeat(64)}`),
+    };
+    const empty: QuranInterpretationResult = {
+      ...activeInterpretation,
+      interpretation: "   ",
+    };
+
+    for (const result of [inactive, stale, mismatched, empty]) {
+      const decoded = await Effect.runPromise(
+        Effect.either(
+          decodePublishedQuranInterpretation(result, {
+            locale: "id",
+            snapshotId: source.snapshotId,
+            surahNumber: 1,
+            verseNumber: 7,
+          })
+        )
+      );
+
+      expect(decoded._tag).toBe("Left");
+      if (decoded._tag === "Left") {
+        expect(decoded.left).toBeInstanceOf(QuranPublicationError);
+      }
+    }
+  });
+});

--- a/packages/backend/client/quran/interpretation.test.ts
+++ b/packages/backend/client/quran/interpretation.test.ts
@@ -2,10 +2,14 @@ import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { QuranPublicationError } from "@repo/backend/client/quran/decode";
 import {
   decodePublishedQuranInterpretation,
+  isQuranSnapshotConflict,
   type PublishedQuranInterpretation,
+  QuranInterpretationRequestError,
+  toQuranInterpretationRequestError,
 } from "@repo/backend/client/quran/interpretation";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
+import { ConvexError } from "convex/values";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
@@ -89,6 +93,32 @@ describe("signed Quran interpretation decoder", () => {
       if (decoded._tag === "Left") {
         expect(decoded.left).toBeInstanceOf(QuranPublicationError);
       }
+    }
+  });
+
+  it("recognizes only a typed snapshot conflict request failure", () => {
+    const conflict = toQuranInterpretationRequestError(
+      new ConvexError({
+        code: "CONTENT_RELEASE_CONFLICT",
+        message: "The active Quran snapshot changed.",
+      })
+    );
+
+    expect(conflict).toBeInstanceOf(QuranInterpretationRequestError);
+    expect(isQuranSnapshotConflict(conflict)).toBe(true);
+
+    for (const error of [
+      new Error("Network error"),
+      new ConvexError({ code: "CONTENT_RELEASE_CONFLICT" }),
+      toQuranInterpretationRequestError(new Error("Network error")),
+      toQuranInterpretationRequestError(new ConvexError("plain")),
+      toQuranInterpretationRequestError(new ConvexError(null)),
+      toQuranInterpretationRequestError(new ConvexError({})),
+      toQuranInterpretationRequestError(
+        new ConvexError({ code: "CONTENT_RELEASE_INVALID_REQUEST" })
+      ),
+    ]) {
+      expect(isQuranSnapshotConflict(error)).toBe(false);
     }
   });
 });

--- a/packages/backend/client/quran/interpretation.ts
+++ b/packages/backend/client/quran/interpretation.ts
@@ -1,0 +1,50 @@
+import {
+  decodePublishedQuranSource,
+  QuranPublicationError,
+} from "@repo/backend/client/quran/decode";
+import type { api } from "@repo/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+import { Effect } from "effect";
+
+type QuranInterpretationResult = FunctionReturnType<
+  typeof api.contentRelease.quran.interpretation
+>;
+
+/** Decodes one active exact-verse tafsir response. */
+export const decodePublishedQuranInterpretation = Effect.fn(
+  "NakafaQuran.decodeInterpretation"
+)(function* (
+  result: QuranInterpretationResult,
+  expected: {
+    readonly locale: QuranInterpretationResult["locale"];
+    readonly snapshotId: string;
+    readonly surahNumber: number;
+    readonly verseNumber: number;
+  }
+) {
+  const source = yield* decodePublishedQuranSource(result, "interpretation");
+  if (
+    result.locale !== expected.locale ||
+    source.snapshotId !== expected.snapshotId ||
+    result.surahNumber !== expected.surahNumber ||
+    result.verseNumber !== expected.verseNumber ||
+    !result.interpretation?.trim()
+  ) {
+    return yield* new QuranPublicationError({
+      operation: "interpretation",
+      reason: "Signed Quran interpretation identity is inconsistent.",
+    });
+  }
+
+  return {
+    ...source,
+    interpretation: result.interpretation,
+    locale: result.locale,
+    surahNumber: result.surahNumber,
+    verseNumber: result.verseNumber,
+  };
+});
+
+export type PublishedQuranInterpretation = Effect.Effect.Success<
+  ReturnType<typeof decodePublishedQuranInterpretation>
+>;

--- a/packages/backend/client/quran/interpretation.ts
+++ b/packages/backend/client/quran/interpretation.ts
@@ -4,11 +4,41 @@ import {
 } from "@repo/backend/client/quran/decode";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
-import { Effect } from "effect";
+import { ConvexError } from "convex/values";
+import { Data, Effect, Schema } from "effect";
 
 type QuranInterpretationResult = FunctionReturnType<
   typeof api.contentRelease.quran.interpretation
 >;
+
+const QuranSnapshotConflictDataSchema = Schema.Struct({
+  code: Schema.Literal("CONTENT_RELEASE_CONFLICT"),
+});
+
+/** Typed client failure for one exact tafsir request. */
+export class QuranInterpretationRequestError extends Data.TaggedError(
+  "QuranInterpretationRequestError"
+)<{
+  readonly cause: unknown;
+}> {}
+
+/** Maps an unknown Convex rejection into the Quran client error channel. */
+export function toQuranInterpretationRequestError(cause: unknown) {
+  return new QuranInterpretationRequestError({ cause });
+}
+
+/** Returns whether the active signed Quran snapshot superseded this request. */
+export function isQuranSnapshotConflict(error: unknown) {
+  if (!(error instanceof QuranInterpretationRequestError)) {
+    return false;
+  }
+
+  if (!(error.cause instanceof ConvexError)) {
+    return false;
+  }
+
+  return Schema.is(QuranSnapshotConflictDataSchema)(error.cause.data);
+}
 
 /** Decodes one active exact-verse tafsir response. */
 export const decodePublishedQuranInterpretation = Effect.fn(

--- a/packages/backend/client/quran/view.test.ts
+++ b/packages/backend/client/quran/view.test.ts
@@ -1,0 +1,131 @@
+import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
+import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
+import type { api } from "@repo/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+const source = {
+  activeManifestHash: `sha256:${"a".repeat(64)}`,
+  activeReleaseId: "quran-release",
+  managed: true,
+  snapshotId: Sha256HashSchema.make(`sha256:${"b".repeat(64)}`),
+  sourceRevision: "c".repeat(40),
+};
+
+const surah = {
+  name: {
+    translation: "Pembukaan",
+    transliteration: "Al-Fatihah",
+  },
+  number: 1,
+  numberOfVerses: 1,
+};
+
+type QuranViewResult = FunctionReturnType<typeof api.contentRelease.quran.view>;
+
+describe("signed Quran view decoder", () => {
+  it("preserves each validator-derived locale projection", async () => {
+    const english = await Effect.runPromise(
+      decodePublishedQuranView(englishViewResult(), {
+        locale: "en",
+        surahNumber: 1,
+      })
+    );
+    const indonesian = await Effect.runPromise(
+      decodePublishedQuranView(indonesianViewResult(), {
+        locale: "id",
+        surahNumber: 1,
+      })
+    );
+
+    expect(english.verses[0]).toEqual({
+      arabic: "بِسْمِ اللّٰهِ",
+      number: { inQuran: 1, inSurah: 1 },
+      translation: "In the name of Allah.",
+    });
+    expect(indonesian.verses[0]).toEqual({
+      arabic: "بِسْمِ اللّٰهِ",
+      number: { inQuran: 1, inSurah: 1 },
+      translation: "Dengan nama Allah.",
+    });
+    expect(JSON.stringify(indonesian)).not.toContain("Tafsir lengkap");
+  });
+
+  it("fails closed for inactive and inconsistent views", async () => {
+    const inactive = await Effect.runPromise(
+      Effect.either(
+        decodePublishedQuranView(
+          {
+            activeManifestHash: null,
+            activeReleaseId: null,
+            locale: "en",
+            managed: false,
+            nextSurah: null,
+            previousSurah: null,
+            snapshotId: null,
+            sourceRevision: null,
+            surah: null,
+            verses: [],
+          },
+          { locale: "en", surahNumber: 1 }
+        )
+      )
+    );
+    const inconsistent = await Effect.runPromise(
+      Effect.either(
+        decodePublishedQuranView(englishViewResult(), {
+          locale: "en",
+          surahNumber: 2,
+        })
+      )
+    );
+
+    expect(inactive._tag).toBe("Left");
+    expect(inconsistent._tag).toBe("Left");
+  });
+});
+
+/** Builds the source and metadata shared by locale-specific view fixtures. */
+function viewBase() {
+  return {
+    ...source,
+    nextSurah: {
+      ...surah,
+      name: { ...surah.name, transliteration: "Al-Baqarah" },
+      number: 2,
+    },
+    previousSurah: null,
+    surah,
+  };
+}
+
+/** Builds one complete English view response. */
+function englishViewResult(): QuranViewResult {
+  return {
+    ...viewBase(),
+    locale: "en",
+    verses: [
+      {
+        arabic: "بِسْمِ اللّٰهِ",
+        number: { inQuran: 1, inSurah: 1 },
+        translation: "In the name of Allah.",
+      },
+    ],
+  };
+}
+
+/** Builds one complete Indonesian view response. */
+function indonesianViewResult(): QuranViewResult {
+  return {
+    ...viewBase(),
+    locale: "id",
+    verses: [
+      {
+        arabic: "بِسْمِ اللّٰهِ",
+        number: { inQuran: 1, inSurah: 1 },
+        translation: "Dengan nama Allah.",
+      },
+    ],
+  };
+}

--- a/packages/backend/client/quran/view.ts
+++ b/packages/backend/client/quran/view.ts
@@ -1,0 +1,68 @@
+import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
+import {
+  decodePublishedQuranSource,
+  QuranPublicationError,
+} from "@repo/backend/client/quran/decode";
+import {
+  hasExactQuranVerseRange,
+  hasExpectedQuranNeighbors,
+} from "@repo/backend/client/quran/integrity";
+import type { api } from "@repo/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+import { Effect } from "effect";
+
+type QuranViewResult = FunctionReturnType<typeof api.contentRelease.quran.view>;
+
+/** One validator-derived verse rendered by the locale-specific Quran web view. */
+export type QuranViewVerse = QuranViewResult["verses"][number];
+
+/** Minimal validator-derived surah metadata rendered by the Quran web view. */
+export type QuranViewSurah = NonNullable<QuranViewResult["surah"]>;
+
+/** Decodes one active locale-specific Quran web projection. */
+export const decodePublishedQuranView = Effect.fn("NakafaQuran.decodeView")(
+  function* (
+    result: QuranViewResult,
+    expected: {
+      readonly locale: QuranViewResult["locale"];
+      readonly surahNumber: number;
+    }
+  ) {
+    const source = yield* decodePublishedQuranSource(result, "view");
+    if (result.surah === null) {
+      return yield* new QuranPublicationError({
+        operation: "view",
+        reason: "Signed Quran view is missing.",
+      });
+    }
+    if (
+      result.locale !== expected.locale ||
+      result.surah.number !== expected.surahNumber ||
+      !hasExactQuranVerseRange(result.verses, 1, result.surah.numberOfVerses) ||
+      !hasExpectedQuranNeighbors(
+        result.previousSurah,
+        result.nextSurah,
+        expected.surahNumber,
+        QURAN_SURAH_COUNT
+      )
+    ) {
+      return yield* new QuranPublicationError({
+        operation: "view",
+        reason: "Signed Quran view identity is inconsistent.",
+      });
+    }
+
+    return {
+      ...source,
+      locale: result.locale,
+      nextSurah: result.nextSurah,
+      previousSurah: result.previousSurah,
+      surah: result.surah,
+      verses: result.verses,
+    };
+  }
+);
+
+export type PublishedQuranView = Effect.Effect.Success<
+  ReturnType<typeof decodePublishedQuranView>
+>;

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -281,6 +281,8 @@
     "verse-count": "Verse {count}",
     "interpretation": "Interpretation",
     "interpretation-error": "This verse's interpretation could not be loaded. Try again.",
+    "interpretation-loading": "Loading this verse's interpretation...",
+    "interpretation-refreshing": "The Quran has been updated. Refreshing this page...",
     "surah-title": "Surah {number}: {name} ({translation}) - {quran}",
     "verses": "verses",
     "read-quran-description": "Read the Quran online with verse-by-verse translation and tafsir on Nakafa"

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -280,6 +280,7 @@
     "verse": "Verse",
     "verse-count": "Verse {count}",
     "interpretation": "Interpretation",
+    "interpretation-error": "This verse's interpretation could not be loaded. Try again.",
     "surah-title": "Surah {number}: {name} ({translation}) - {quran}",
     "verses": "verses",
     "read-quran-description": "Read the Quran online with verse-by-verse translation and tafsir on Nakafa"

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -281,6 +281,8 @@
     "verse-count": "Ayat {count}",
     "interpretation": "Tafsir",
     "interpretation-error": "Tafsir ayat ini belum dapat dimuat. Coba lagi.",
+    "interpretation-loading": "Memuat tafsir ayat ini...",
+    "interpretation-refreshing": "Al-Quran telah diperbarui. Memuat ulang halaman ini...",
     "surah-title": "Surat {number}: {name} ({translation}) - {quran}",
     "verses": "ayat",
     "read-quran-description": "Baca Al-Quran online dengan terjemahan dan tafsir per ayat di Nakafa"

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -280,6 +280,7 @@
     "verse": "Ayat",
     "verse-count": "Ayat {count}",
     "interpretation": "Tafsir",
+    "interpretation-error": "Tafsir ayat ini belum dapat dimuat. Coba lagi.",
     "surah-title": "Surat {number}: {name} ({translation}) - {quran}",
     "verses": "ayat",
     "read-quran-description": "Baca Al-Quran online dengan terjemahan dan tafsir per ayat di Nakafa"


### PR DESCRIPTION
## Summary

- Decode and render the narrow signed Quran view projection.
- Remove the 114-surah catalog gate from the page render path while retaining catalog use for metadata and static params.
- Replace one tafsir client island per verse with one delegated controller per surah.
- Fetch tafsir only after user intent and pin every request to the rendered signed snapshot.
- Refresh safely when the active snapshot supersedes an open page, with accessible pending and recovery feedback.

## Performance and correctness

- The server sends only the locale-specific fields rendered by the page.
- One global click listener replaces up to 286 hydrated verse controllers.
- Duplicate tafsir clicks are synchronously suppressed.
- Signed source identity, exact verse range, neighboring surah identity, locale, snapshot, surah, and verse are validated before rendering.
- The legacy Quran page transport remains available until this consumer is proven in production. Its removal is a separate follow-up PR.

## Verification

- Backend: 339 files, 1,423 tests.
- Web: 177 files, 1,096 tests with configured coverage at 100%.
- Backend and web typechecks.
- Format, lint, boundaries, React Doctor 100/100, and Effect source version check.
- Diff, prohibited-pattern, and touched-file size scans.
- Largest touched TypeScript module: 376 lines.
- Local production build compiled and typechecked. Page-data collection then stopped because the isolated worktree could not read the unrelated external `curricula` projection. This branch does not modify curricula. Exact-head CI is the full build authority.

## Rollout

- Additive Quran APIs are already live in Convex production from PR #262.
- This PR changes consumers only and does not alter Convex functions or schema.
- Vercel preview remains disabled.
- Merge only after exact-head CI is green, then verify Indonesian and English Quran routes, on-demand tafsir, request counts, Vercel runtime errors, and 5xx logs in production.