### PR TITLE
perf(tryouts): add exact attempt runtime reads

### DIFF
--- a/docs/adr/0003-tryout.md
+++ b/docs/adr/0003-tryout.md
@@ -75,6 +75,15 @@ validated placement inventory and score source, then reuses both for section
 and attempt results so maximum-size placements are not read twice in one
 transaction.
 
+Current attempt pages resolve the latest attempt through the one compact,
+indexed progress row, then fail closed unless its duplicated identity, attempt
+number, status, status rank, and latest attempt row agree. Historical review
+pages continue to render the exact signed snapshot frozen at attempt start.
+Restart actions and retained-route destinations resolve separately from the
+active signed catalog in the same Convex query transaction, so a catalog rename
+or entry revision cannot silently change the frozen review or send a new attempt
+to an obsolete route.
+
 ### Freemium Access
 
 Every account can start one complete try-out for free. The claim is global to the

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -520,6 +520,8 @@ import type * as triggers_tryouts_scores from "../triggers/tryouts/scores.js";
 import type * as tryouts_access_impl from "../tryouts/access/impl.js";
 import type * as tryouts_access_source from "../tryouts/access/source.js";
 import type * as tryouts_access_subscription from "../tryouts/access/subscription.js";
+import type * as tryouts_attemptPage_impl from "../tryouts/attemptPage/impl.js";
+import type * as tryouts_attemptPage_spec from "../tryouts/attemptPage/spec.js";
 import type * as tryouts_catalog_destination from "../tryouts/catalog/destination.js";
 import type * as tryouts_catalog_featured from "../tryouts/catalog/featured.js";
 import type * as tryouts_catalog_hierarchy from "../tryouts/catalog/hierarchy.js";
@@ -538,6 +540,7 @@ import type * as tryouts_progress_size from "../tryouts/progress/size.js";
 import type * as tryouts_progress_write from "../tryouts/progress/write.js";
 import type * as tryouts_queries_access from "../tryouts/queries/access.js";
 import type * as tryouts_queries_attempt from "../tryouts/queries/attempt.js";
+import type * as tryouts_queries_attemptPage from "../tryouts/queries/attemptPage.js";
 import type * as tryouts_queries_catalog from "../tryouts/queries/catalog.js";
 import type * as tryouts_queries_catalogModel from "../tryouts/queries/catalogModel.js";
 import type * as tryouts_queries_history from "../tryouts/queries/history.js";
@@ -552,6 +555,7 @@ import type * as tryouts_response_integrity from "../tryouts/response/integrity.
 import type * as tryouts_response_spec from "../tryouts/response/spec.js";
 import type * as tryouts_route from "../tryouts/route.js";
 import type * as tryouts_runtime_access from "../tryouts/runtime/access.js";
+import type * as tryouts_runtime_attempt_page from "../tryouts/runtime/attempt/page.js";
 import type * as tryouts_runtime_attempt_sections from "../tryouts/runtime/attempt/sections.js";
 import type * as tryouts_runtime_attempt_state from "../tryouts/runtime/attempt/state.js";
 import type * as tryouts_runtime_bundle from "../tryouts/runtime/bundle.js";
@@ -574,6 +578,7 @@ import type * as tryouts_runtime_section_state from "../tryouts/runtime/section/
 import type * as tryouts_runtime_sectionAttempt from "../tryouts/runtime/sectionAttempt.js";
 import type * as tryouts_runtime_selectors from "../tryouts/runtime/selectors.js";
 import type * as tryouts_runtime_set_state from "../tryouts/runtime/set/state.js";
+import type * as tryouts_runtime_spec from "../tryouts/runtime/spec.js";
 import type * as tryouts_score from "../tryouts/score.js";
 import type * as tryouts_score_result from "../tryouts/score/result.js";
 import type * as tryouts_sets_page from "../tryouts/sets/page.js";
@@ -1121,6 +1126,8 @@ declare const fullApi: ApiFromModules<{
   "tryouts/access/impl": typeof tryouts_access_impl;
   "tryouts/access/source": typeof tryouts_access_source;
   "tryouts/access/subscription": typeof tryouts_access_subscription;
+  "tryouts/attemptPage/impl": typeof tryouts_attemptPage_impl;
+  "tryouts/attemptPage/spec": typeof tryouts_attemptPage_spec;
   "tryouts/catalog/destination": typeof tryouts_catalog_destination;
   "tryouts/catalog/featured": typeof tryouts_catalog_featured;
   "tryouts/catalog/hierarchy": typeof tryouts_catalog_hierarchy;
@@ -1139,6 +1146,7 @@ declare const fullApi: ApiFromModules<{
   "tryouts/progress/write": typeof tryouts_progress_write;
   "tryouts/queries/access": typeof tryouts_queries_access;
   "tryouts/queries/attempt": typeof tryouts_queries_attempt;
+  "tryouts/queries/attemptPage": typeof tryouts_queries_attemptPage;
   "tryouts/queries/catalog": typeof tryouts_queries_catalog;
   "tryouts/queries/catalogModel": typeof tryouts_queries_catalogModel;
   "tryouts/queries/history": typeof tryouts_queries_history;
@@ -1153,6 +1161,7 @@ declare const fullApi: ApiFromModules<{
   "tryouts/response/spec": typeof tryouts_response_spec;
   "tryouts/route": typeof tryouts_route;
   "tryouts/runtime/access": typeof tryouts_runtime_access;
+  "tryouts/runtime/attempt/page": typeof tryouts_runtime_attempt_page;
   "tryouts/runtime/attempt/sections": typeof tryouts_runtime_attempt_sections;
   "tryouts/runtime/attempt/state": typeof tryouts_runtime_attempt_state;
   "tryouts/runtime/bundle": typeof tryouts_runtime_bundle;
@@ -1175,6 +1184,7 @@ declare const fullApi: ApiFromModules<{
   "tryouts/runtime/sectionAttempt": typeof tryouts_runtime_sectionAttempt;
   "tryouts/runtime/selectors": typeof tryouts_runtime_selectors;
   "tryouts/runtime/set/state": typeof tryouts_runtime_set_state;
+  "tryouts/runtime/spec": typeof tryouts_runtime_spec;
   "tryouts/score": typeof tryouts_score;
   "tryouts/score/result": typeof tryouts_score_result;
   "tryouts/sets/page": typeof tryouts_sets_page;

--- a/packages/backend/convex/tryouts/attemptPage/impl.ts
+++ b/packages/backend/convex/tryouts/attemptPage/impl.ts
@@ -1,0 +1,229 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import type { TryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/set";
+import { getOptionalAppUserForRead } from "@repo/backend/convex/lib/helpers/auth";
+import type {
+  TryoutSectionAttemptPageRequest,
+  TryoutSectionAttemptPageResult,
+  TryoutSetAttemptPageRequest,
+  TryoutSetAttemptPageResult,
+} from "@repo/backend/convex/tryouts/attemptPage/spec";
+import {
+  readActiveTryoutRestartTarget,
+  readTryoutDestinationPaths,
+} from "@repo/backend/convex/tryouts/catalog/destination";
+import {
+  readAttemptSectionPage,
+  readAttemptSetPage,
+} from "@repo/backend/convex/tryouts/runtime/attempt/page";
+import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
+import {
+  readAttemptSetIdentity,
+  readLatestProgressAttempt,
+  readOwnedAttemptById,
+} from "@repo/backend/convex/tryouts/runtime/lookup";
+import { loadSectionAttemptState } from "@repo/backend/convex/tryouts/runtime/section/state";
+import { loadSetAttemptState } from "@repo/backend/convex/tryouts/runtime/set/state";
+import { Effect } from "effect";
+
+type TryoutAttempt = Doc<"tryoutAttempts">;
+type RedirectPageResult = Extract<
+  NonNullable<TryoutSetAttemptPageResult>,
+  { readonly kind: "redirect" }
+>;
+type CurrentSetPageResult = Extract<
+  NonNullable<TryoutSetAttemptPageResult>,
+  { readonly kind: "current" }
+>;
+type RetainedSetPageResult = Extract<
+  NonNullable<TryoutSetAttemptPageResult>,
+  { readonly kind: "retained" }
+>;
+type RetainedSectionPageResult = Extract<
+  NonNullable<TryoutSectionAttemptPageResult>,
+  { readonly kind: "retained" }
+>;
+
+/** Resolves one current set overlay or exact frozen set page. */
+export const readSetAttemptPage = Effect.fn(
+  "tryouts.attemptPage.readSetAttemptPage"
+)(function* (ctx: QueryCtx, request: TryoutSetAttemptPageRequest) {
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
+  if (!auth) {
+    return null;
+  }
+
+  if (request.kind === "current") {
+    const attempt = yield* readLatestProgressAttempt(
+      ctx,
+      request,
+      auth.appUser._id
+    );
+    if (!attempt) {
+      return null;
+    }
+    if (attempt.status === "in-progress") {
+      const result: RedirectPageResult = {
+        attemptId: attempt._id,
+        kind: "redirect",
+        publicPath: attempt.setPublicPath,
+      };
+      return result;
+    }
+    return yield* loadCurrentSetPage(ctx, attempt);
+  }
+
+  const attempt = yield* readRetainedAttempt(
+    ctx,
+    request.attemptId,
+    auth.appUser._id
+  );
+  if (
+    !attempt ||
+    attempt.locale !== request.locale ||
+    attempt.setPublicPath !== request.publicPath
+  ) {
+    return null;
+  }
+
+  const identity = readAttemptSetIdentity(attempt);
+  const { loaded, page, restartTarget } = yield* Effect.all(
+    {
+      loaded: loadSetAttemptState(ctx, attempt),
+      page: readAttemptSetPage(
+        ctx,
+        { locale: request.locale, publicPath: request.publicPath },
+        attempt,
+        identity
+      ),
+      restartTarget: readActiveTryoutRestartTarget(ctx, identity),
+    },
+    { concurrency: "unbounded" }
+  );
+
+  const result: RetainedSetPageResult = {
+    attemptId: attempt._id,
+    content: loaded.content,
+    initialState: loaded.state,
+    kind: "retained",
+    page,
+    restartTarget,
+  };
+  return result;
+});
+
+/** Resolves one current section redirect or exact frozen section page. */
+export const readSectionAttemptPage = Effect.fn(
+  "tryouts.attemptPage.readSectionAttemptPage"
+)(function* (ctx: QueryCtx, request: TryoutSectionAttemptPageRequest) {
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
+  if (!auth) {
+    return null;
+  }
+
+  if (request.kind === "current") {
+    const attempt = yield* readLatestProgressAttempt(
+      ctx,
+      request,
+      auth.appUser._id
+    );
+    if (attempt?.status !== "in-progress") {
+      return null;
+    }
+    const snapshot = attempt.sectionSnapshots.find(
+      (section) => section.sectionKey === request.sectionKey
+    );
+    if (!snapshot?.publicPath) {
+      return null;
+    }
+    const result: RedirectPageResult = {
+      attemptId: attempt._id,
+      kind: "redirect",
+      publicPath: snapshot.publicPath,
+    };
+    return result;
+  }
+
+  const attempt = yield* readRetainedAttempt(
+    ctx,
+    request.attemptId,
+    auth.appUser._id
+  );
+  if (!attempt || attempt.locale !== request.locale) {
+    return null;
+  }
+  const snapshot = attempt.sectionSnapshots.find(
+    (section) => section.publicPath === request.publicPath
+  );
+  if (!snapshot) {
+    return null;
+  }
+
+  const identity = readAttemptSetIdentity(attempt);
+  const { destinations, loaded, page } = yield* Effect.all(
+    {
+      destinations: readTryoutDestinationPaths(ctx, {
+        ...identity,
+        sectionKey: snapshot.sectionKey,
+      }),
+      loaded: loadSectionAttemptState(ctx, attempt, snapshot.sectionKey),
+      page: readAttemptSectionPage(ctx, request, attempt),
+    },
+    { concurrency: "unbounded" }
+  );
+  if (!loaded) {
+    return null;
+  }
+
+  const result: RetainedSectionPageResult = {
+    activeSectionPublicPath: destinations.activeSectionPublicPath,
+    activeSetPublicPath: destinations.activeSetPublicPath,
+    attemptId: attempt._id,
+    content: loaded.content,
+    initialState: loaded.state,
+    kind: "retained",
+    page,
+  };
+  return result;
+});
+
+/** Loads the frozen display rows and mutable terminal state in parallel. */
+const loadCurrentSetPage = Effect.fn("tryouts.attemptPage.loadCurrentSetPage")(
+  function* (ctx: QueryCtx, attempt: TryoutAttempt) {
+    const identity: TryoutSetIdentity = readAttemptSetIdentity(attempt);
+    const { loaded, page, restartTarget } = yield* Effect.all(
+      {
+        loaded: loadSetAttemptState(ctx, attempt),
+        page: readAttemptSetPage(
+          ctx,
+          { locale: attempt.locale, publicPath: attempt.setPublicPath },
+          attempt,
+          identity
+        ),
+        restartTarget: readActiveTryoutRestartTarget(ctx, identity),
+      },
+      { concurrency: "unbounded" }
+    );
+
+    const result: CurrentSetPageResult = {
+      attemptId: attempt._id,
+      content: loaded.content,
+      initialState: loaded.state,
+      kind: "current",
+      page,
+      restartTarget,
+    };
+    return result;
+  }
+);
+
+/** Normalizes one untrusted ID before applying exact ownership checks. */
+const readRetainedAttempt = Effect.fn(
+  "tryouts.attemptPage.readRetainedAttempt"
+)(function* (ctx: QueryCtx, attemptId: string, userId: Doc<"users">["_id"]) {
+  const normalized = ctx.db.normalizeId("tryoutAttempts", attemptId);
+  if (!normalized) {
+    return null;
+  }
+  return yield* readOwnedAttemptById(ctx, normalized, userId);
+});

--- a/packages/backend/convex/tryouts/attemptPage/spec.ts
+++ b/packages/backend/convex/tryouts/attemptPage/spec.ts
@@ -1,0 +1,137 @@
+import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
+import {
+  publicTryoutExamValidator,
+  publicTryoutSectionValidator,
+  publicTryoutSetValidator,
+  publicTryoutTrackValidator,
+} from "@repo/backend/convex/tryouts/queries/catalogModel";
+import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
+import { tryoutSectionContentAccessValidator } from "@repo/backend/convex/tryouts/runtime/content";
+import { tryoutRuntimeStateValidator } from "@repo/backend/convex/tryouts/runtime/spec";
+import { type Infer, v } from "convex/values";
+
+const setIdentityFields = {
+  countryKey: tryoutRouteKeyValidator,
+  examKey: tryoutRouteKeyValidator,
+  locale: localeValidator,
+  setKey: tryoutRouteKeyValidator,
+  trackKey: tryoutRouteKeyValidator,
+};
+
+const currentSetRequestValidator = v.object({
+  kind: v.literal("current"),
+  ...setIdentityFields,
+});
+
+const retainedRequestFields = {
+  attemptId: v.string(),
+  kind: v.literal("retained"),
+  locale: localeValidator,
+  publicPath: v.string(),
+};
+
+const retainedSetRequestValidator = v.object(retainedRequestFields);
+
+export const tryoutSetAttemptPageRequestValidator = v.union(
+  currentSetRequestValidator,
+  retainedSetRequestValidator
+);
+
+export type TryoutSetAttemptPageRequest = Infer<
+  typeof tryoutSetAttemptPageRequestValidator
+>;
+
+const currentSectionRequestValidator = v.object({
+  kind: v.literal("current"),
+  sectionKey: tryoutRouteKeyValidator,
+  ...setIdentityFields,
+});
+
+const retainedSectionRequestValidator = v.object(retainedRequestFields);
+
+export const tryoutSectionAttemptPageRequestValidator = v.union(
+  currentSectionRequestValidator,
+  retainedSectionRequestValidator
+);
+
+export type TryoutSectionAttemptPageRequest = Infer<
+  typeof tryoutSectionAttemptPageRequestValidator
+>;
+
+const setPageValidator = v.object({
+  exam: publicTryoutExamValidator,
+  entrySection: v.union(publicTryoutSectionValidator, v.null()),
+  set: publicTryoutSetValidator,
+  sections: v.array(publicTryoutSectionValidator),
+  track: publicTryoutTrackValidator,
+});
+
+const sectionPageValidator = v.object({
+  exam: publicTryoutExamValidator,
+  section: publicTryoutSectionValidator,
+  set: publicTryoutSetValidator,
+  track: publicTryoutTrackValidator,
+});
+
+const redirectResultValidator = v.object({
+  attemptId: v.id("tryoutAttempts"),
+  kind: v.literal("redirect"),
+  publicPath: v.string(),
+});
+
+const restartTargetValidator = v.union(
+  v.object({
+    entrySection: publicTryoutSectionValidator,
+    setPublicPath: v.string(),
+  }),
+  v.null()
+);
+
+const setPageResultFields = {
+  attemptId: v.id("tryoutAttempts"),
+  content: tryoutSectionContentAccessValidator,
+  initialState: tryoutRuntimeStateValidator,
+  page: setPageValidator,
+  restartTarget: restartTargetValidator,
+};
+
+const currentSetResultValidator = v.object({
+  kind: v.literal("current"),
+  ...setPageResultFields,
+});
+
+const retainedSetResultValidator = v.object({
+  kind: v.literal("retained"),
+  ...setPageResultFields,
+});
+
+export const tryoutSetAttemptPageResultValidator = v.union(
+  v.null(),
+  redirectResultValidator,
+  currentSetResultValidator,
+  retainedSetResultValidator
+);
+
+export type TryoutSetAttemptPageResult = Infer<
+  typeof tryoutSetAttemptPageResultValidator
+>;
+
+const retainedSectionResultValidator = v.object({
+  activeSectionPublicPath: v.union(v.string(), v.null()),
+  activeSetPublicPath: v.union(v.string(), v.null()),
+  attemptId: v.id("tryoutAttempts"),
+  content: tryoutSectionContentAccessValidator,
+  initialState: tryoutRuntimeStateValidator,
+  kind: v.literal("retained"),
+  page: sectionPageValidator,
+});
+
+export const tryoutSectionAttemptPageResultValidator = v.union(
+  v.null(),
+  redirectResultValidator,
+  retainedSectionResultValidator
+);
+
+export type TryoutSectionAttemptPageResult = Infer<
+  typeof tryoutSectionAttemptPageResultValidator
+>;

--- a/packages/backend/convex/tryouts/catalog/destination.ts
+++ b/packages/backend/convex/tryouts/catalog/destination.ts
@@ -6,9 +6,14 @@ import { loadTryoutOwner } from "@repo/backend/convex/contentRelease/tryout/owne
 import type { TryoutSectionIdentity } from "@repo/backend/convex/contentRelease/tryout/section";
 import type { TryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/set";
 import {
+  readPublishedEntrySection,
+  toPublicPublishedSection,
+} from "@repo/backend/convex/tryouts/catalog/published";
+import {
   readTryoutCatalogRowByIdentity,
   readTryoutCatalogRowByPath,
 } from "@repo/backend/convex/tryouts/catalog/row";
+import { readTryoutSetSections } from "@repo/backend/convex/tryouts/catalog/selection";
 import { Effect } from "effect";
 
 interface TryoutDestinationIdentity extends TryoutSetIdentity {
@@ -92,3 +97,47 @@ export const readTryoutDestinationPaths = Effect.fn(
 function destinationIntegrity(message: string) {
   return releaseFail("CONTENT_RELEASE_INTEGRITY", message);
 }
+
+/** Resolves one current signed restart target from a frozen set identity. */
+export const readActiveTryoutRestartTarget = Effect.fn(
+  "tryouts.catalog.readActiveRestartTarget"
+)(function* (ctx: QueryCtx, identity: TryoutSetIdentity) {
+  const owner = yield* loadTryoutOwner(ctx);
+  const setIdentity = tryoutCatalogIdentity({ ...identity, kind: "set" });
+  const set = yield* readTryoutCatalogRowByIdentity(
+    ctx,
+    owner.snapshotId,
+    setIdentity
+  );
+  if (!set) {
+    return null;
+  }
+  if (set.kind !== "set") {
+    return yield* destinationIntegrity(
+      "Active try-out set changed its row kind."
+    );
+  }
+
+  const sectionRecords = yield* readTryoutSetSections(
+    ctx,
+    owner.snapshotId,
+    set
+  );
+  const sections = sectionRecords.map(({ row }) => row);
+  const visibleSections = sections.filter(
+    (section) => section.visibility === "visible"
+  );
+  const entrySection = yield* readPublishedEntrySection(
+    set,
+    sections,
+    visibleSections
+  );
+  if (!entrySection) {
+    return null;
+  }
+
+  return {
+    entrySection: toPublicPublishedSection(entrySection),
+    setPublicPath: set.publicPath,
+  };
+});

--- a/packages/backend/convex/tryouts/catalog/published.ts
+++ b/packages/backend/convex/tryouts/catalog/published.ts
@@ -74,7 +74,7 @@ export function toPublicPublishedSet(set: TryoutSet) {
 }
 
 /** Projects one signed section into the existing public catalog contract. */
-function toPublicSection(section: TryoutSection) {
+export function toPublicPublishedSection(section: TryoutSection) {
   return {
     description: section.description,
     publicPath: section.publicPath,
@@ -187,12 +187,16 @@ export const readPublishedSetPageFromIndex = Effect.fn(
   const visibleSections = sections.filter(
     (section) => section.visibility === "visible"
   );
-  const entrySection = yield* readEntrySection(set, sections, visibleSections);
+  const entrySection = yield* readPublishedEntrySection(
+    set,
+    sections,
+    visibleSections
+  );
   return {
     exam: toPublicExam(parents.exam),
-    entrySection: entrySection ? toPublicSection(entrySection) : null,
+    entrySection: entrySection ? toPublicPublishedSection(entrySection) : null,
     set: toPublicPublishedSet(set),
-    sections: visibleSections.map(toPublicSection),
+    sections: visibleSections.map(toPublicPublishedSection),
     track: toPublicTrack(parents.track),
   };
 });
@@ -226,32 +230,32 @@ export const readPublishedSectionPageFromIndex = Effect.fn(
   yield* readPublishedSetSections(index, set);
   return {
     exam: toPublicExam(parents.exam),
-    section: toPublicSection(section),
+    section: toPublicPublishedSection(section),
     set: toPublicPublishedSet(set),
     track: toPublicTrack(parents.track),
   };
 });
 
 /** Selects and validates the authored internal entry or first visible section. */
-const readEntrySection = Effect.fn("tryouts.catalog.readPublishedEntry")(
-  function* (
-    set: TryoutSet,
-    sections: readonly TryoutSection[],
-    visibleSections: readonly TryoutSection[]
-  ) {
-    if (!set.internalEntrySectionKey) {
-      return visibleSections.at(0) ?? null;
-    }
-
-    const entrySection = sections.find(
-      (section) => section.sectionKey === set.internalEntrySectionKey
-    );
-    if (entrySection?.visibility !== "internal-entry") {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Signed try-out set lost its internal entry section."
-      );
-    }
-    return entrySection;
+export const readPublishedEntrySection = Effect.fn(
+  "tryouts.catalog.readPublishedEntry"
+)(function* (
+  set: TryoutSet,
+  sections: readonly TryoutSection[],
+  visibleSections: readonly TryoutSection[]
+) {
+  if (!set.internalEntrySectionKey) {
+    return visibleSections.at(0) ?? null;
   }
-);
+
+  const entrySection = sections.find(
+    (section) => section.sectionKey === set.internalEntrySectionKey
+  );
+  if (entrySection?.visibility !== "internal-entry") {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Signed try-out set lost its internal entry section."
+    );
+  }
+  return entrySection;
+});

--- a/packages/backend/convex/tryouts/catalog/selection.ts
+++ b/packages/backend/convex/tryouts/catalog/selection.ts
@@ -3,6 +3,7 @@ import type {
   TryoutSection,
   TryoutSet,
 } from "@nakafa/aksara-contracts/tryout/spec";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { TRYOUT_CATALOG_LIMIT } from "@repo/backend/convex/contentRelease/tryout/limits";
@@ -13,6 +14,17 @@ import {
   readTryoutCatalogRowByPath,
 } from "@repo/backend/convex/tryouts/catalog/row";
 import { Effect } from "effect";
+
+/** One authenticated section row with its signed immutable digest. */
+export interface SelectedTryoutSection {
+  readonly row: TryoutSection;
+  readonly rowHash: Doc<"tryoutCatalog">["rowHash"];
+}
+
+/** Complete verified set-local catalog needed by public and attempt reads. */
+export interface TryoutSetSelection extends PublishedCatalogIndex {
+  readonly sectionRecords: readonly SelectedTryoutSection[];
+}
 
 /** Reads the verified parent and section rows needed for one set route. */
 export const readTryoutSetSelection = Effect.fn(
@@ -87,7 +99,7 @@ export const readTryoutSetSelection = Effect.fn(
         input.snapshotId,
         parentIdentities.exam
       ),
-      sections: readSetSections(ctx, input.snapshotId, set),
+      sectionRecords: readTryoutSetSections(ctx, input.snapshotId, set),
       track: readTryoutCatalogRowByIdentity(
         ctx,
         input.snapshotId,
@@ -106,22 +118,24 @@ export const readTryoutSetSelection = Effect.fn(
     return yield* selectionIntegrity("Signed try-out set lost its track.");
   }
 
-  const index: PublishedCatalogIndex = {
+  const index: TryoutSetSelection = {
     countries: [selectedRows.country],
     exams: [selectedRows.exam],
-    sections: selectedRows.sections,
+    sectionRecords: selectedRows.sectionRecords,
+    sections: selectedRows.sectionRecords.map(({ row }) => row),
     sets: [set],
     tracks: [selectedRows.track],
   };
   return index;
 });
 
-/** Reads and verifies the complete bounded section family for one signed set. */
-const readSetSections = Effect.fn("tryouts.catalog.readSetSections")(function* (
-  ctx: QueryCtx,
-  snapshotId: string,
-  set: TryoutSet
-) {
+/**
+ * Reads and verifies the complete bounded section family for one signed set.
+ * @see https://docs.convex.dev/database/reading-data/indexes/
+ */
+export const readTryoutSetSections = Effect.fn(
+  "tryouts.catalog.readSetSections"
+)(function* (ctx: QueryCtx, snapshotId: string, set: TryoutSet) {
   if (set.sectionCount > TRYOUT_CATALOG_LIMIT) {
     return yield* selectionIntegrity(
       `Try-out set exceeds ${TRYOUT_CATALOG_LIMIT} sections.`
@@ -144,17 +158,15 @@ const readSetSections = Effect.fn("tryouts.catalog.readSetSections")(function* (
       "Signed try-out set lost one or more sections."
     );
   }
-  const rows = yield* Effect.forEach(stored, (row) =>
-    verifyTryoutCatalog(row, snapshotId)
-  );
-  const sections: TryoutSection[] = [];
-  for (const row of rows) {
+  const sections: SelectedTryoutSection[] = [];
+  for (const storedSection of stored) {
+    const row = yield* verifyTryoutCatalog(storedSection, snapshotId);
     if (row.kind !== "section") {
       return yield* selectionIntegrity(
         "Signed try-out set contains another row kind."
       );
     }
-    sections.push(row);
+    sections.push({ row, rowHash: storedSection.rowHash });
   }
   return sections;
 });

--- a/packages/backend/convex/tryouts/progress/write.ts
+++ b/packages/backend/convex/tryouts/progress/write.ts
@@ -6,9 +6,9 @@ import {
   readConvexErrorData,
 } from "@repo/backend/convex/lib/effect";
 import { ensureTryoutProgressWithinReadBudget } from "@repo/backend/convex/tryouts/progress/size";
-import type {
-  TryoutStatus,
-  TryoutStatusRank,
+import {
+  getTryoutStatusRank,
+  type TryoutStatus,
 } from "@repo/backend/convex/tryouts/status";
 import { Effect, Schema } from "effect";
 
@@ -28,19 +28,6 @@ export class TryoutProgressError
 {
   declare readonly code: string;
   declare readonly message: string;
-}
-
-/** Returns the stable workflow rank used by the progress sorting index. */
-export function getTryoutStatusRank(status: TryoutStatus): TryoutStatusRank {
-  if (status === "in-progress") {
-    return 1;
-  }
-
-  if (status === "completed") {
-    return 2;
-  }
-
-  return 3;
 }
 
 /** Stores the latest compact attempt state used by set discovery queries. */

--- a/packages/backend/convex/tryouts/queries/attempt.test.ts
+++ b/packages/backend/convex/tryouts/queries/attempt.test.ts
@@ -57,9 +57,25 @@ describe("tryouts/queries/attempt", () => {
     );
 
     await expect(
+      t.query(api.tryouts.queries.attempt.isLockedByAttemptId, {
+        attemptId: started.attemptId,
+      })
+    ).resolves.toBe(false);
+    await expect(
+      authed.query(api.tryouts.queries.attempt.isLockedByAttemptId, {
+        attemptId: "not-an-id",
+      })
+    ).resolves.toBe(false);
+
+    await expect(
       authed.query(api.tryouts.queries.attempt.isLockedByPublicPath, {
         locale: "id",
         publicPath: setPublicPath,
+      })
+    ).resolves.toBe(true);
+    await expect(
+      authed.query(api.tryouts.queries.attempt.isLockedByAttemptId, {
+        attemptId: started.attemptId,
       })
     ).resolves.toBe(true);
 
@@ -75,6 +91,11 @@ describe("tryouts/queries/attempt", () => {
       authed.query(api.tryouts.queries.attempt.isLockedByPublicPath, {
         locale: "id",
         publicPath: setPublicPath,
+      })
+    ).resolves.toBe(false);
+    await expect(
+      authed.query(api.tryouts.queries.attempt.isLockedByAttemptId, {
+        attemptId: started.attemptId,
       })
     ).resolves.toBe(false);
   });

--- a/packages/backend/convex/tryouts/queries/attempt.ts
+++ b/packages/backend/convex/tryouts/queries/attempt.ts
@@ -2,7 +2,11 @@ import { query } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { getOptionalAppUserForRead } from "@repo/backend/convex/lib/helpers/auth";
 import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
-import { readLatestAttemptByPath } from "@repo/backend/convex/tryouts/runtime/lookup";
+import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
+import {
+  readLatestAttemptByPath,
+  readOwnedAttemptById,
+} from "@repo/backend/convex/tryouts/runtime/lookup";
 import { v } from "convex/values";
 import { Effect } from "effect";
 
@@ -16,7 +20,7 @@ export const isLockedByPublicPath = query({
   handler: (ctx, args) =>
     runConvexProgram(
       Effect.gen(function* () {
-        const auth = yield* Effect.promise(() =>
+        const auth = yield* tryRuntimePromise(() =>
           getOptionalAppUserForRead(ctx)
         );
         if (!auth) {
@@ -25,6 +29,33 @@ export const isLockedByPublicPath = query({
         const attempt = yield* readLatestAttemptByPath(
           ctx,
           args,
+          auth.appUser._id
+        );
+        return attempt?.status === "in-progress";
+      })
+    ),
+});
+
+/** Reports whether one exact owned attempt must lock the app shell. */
+export const isLockedByAttemptId = query({
+  args: { attemptId: v.string() },
+  returns: v.boolean(),
+  handler: (ctx, args) =>
+    runConvexProgram(
+      Effect.gen(function* () {
+        const attemptId = ctx.db.normalizeId("tryoutAttempts", args.attemptId);
+        if (!attemptId) {
+          return false;
+        }
+        const auth = yield* tryRuntimePromise(() =>
+          getOptionalAppUserForRead(ctx)
+        );
+        if (!auth) {
+          return false;
+        }
+        const attempt = yield* readOwnedAttemptById(
+          ctx,
+          attemptId,
           auth.appUser._id
         );
         return attempt?.status === "in-progress";

--- a/packages/backend/convex/tryouts/queries/attemptPage.test.ts
+++ b/packages/backend/convex/tryouts/queries/attemptPage.test.ts
@@ -1,0 +1,463 @@
+import { api } from "@repo/backend/convex/_generated/api";
+import {
+  createConvexTestWithBetterAuth,
+  seedAuthenticatedUser,
+} from "@repo/backend/convex/test.helpers";
+import {
+  activateRenamedTryoutStartSource,
+  activateReusedTryoutStartPath,
+  activateRevisedTryoutStartEntry,
+  TRYOUT_RENAMED_SET_PATH,
+  TRYOUT_REUSED_SECTION,
+  TRYOUT_REUSED_SET,
+  TRYOUT_REVISED_SECTION,
+  TRYOUT_START_COUNTRY,
+  TRYOUT_START_EXAM,
+  TRYOUT_START_NOW,
+  TRYOUT_START_SECTION,
+  TRYOUT_START_SET,
+  TRYOUT_START_TRACK,
+} from "@repo/backend/test/tryout-source";
+import { seedTryoutStartSet } from "@repo/backend/test/tryout-start";
+import { describe, expect, it, vi } from "vitest";
+
+const setIdentity = {
+  countryKey: TRYOUT_START_COUNTRY,
+  examKey: TRYOUT_START_EXAM,
+  locale: "id" as const,
+  setKey: TRYOUT_START_SET,
+  trackKey: TRYOUT_START_TRACK,
+};
+const setPublicPath = `try-out/${TRYOUT_START_COUNTRY}/${TRYOUT_START_EXAM}/${TRYOUT_START_TRACK}/${TRYOUT_START_SET}`;
+const sectionPublicPath = `${setPublicPath}/${TRYOUT_START_SECTION}`;
+
+describe("tryouts/queries/attemptPage", () => {
+  it("redirects an active set and resolves a current terminal restart", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "set-attempt-page",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: user.userId,
+        visibility: "internal-entry",
+      });
+      return user;
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setIdentity, entrySectionKey: TRYOUT_START_SECTION }
+    );
+
+    const currentRequest = { kind: "current" as const, ...setIdentity };
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSet, {
+        request: currentRequest,
+      })
+    ).resolves.toEqual({
+      attemptId: started.attemptId,
+      kind: "redirect",
+      publicPath: setPublicPath,
+    });
+
+    const retainedRequest = {
+      attemptId: started.attemptId,
+      kind: "retained" as const,
+      locale: "id" as const,
+      publicPath: setPublicPath,
+    };
+    const active = await authed.query(api.tryouts.queries.attemptPage.getSet, {
+      request: retainedRequest,
+    });
+    expect(active).toMatchObject({
+      attemptId: started.attemptId,
+      content: { answers: [], kind: "signed" },
+      initialState: {
+        attempt: { status: "in-progress" },
+        runtime: { questions: expect.any(Array) },
+      },
+      kind: "retained",
+      page: {
+        entrySection: { sectionKey: TRYOUT_START_SECTION },
+        set: { setKey: TRYOUT_START_SET },
+      },
+    });
+    expect(active).not.toHaveProperty("setIdentity");
+
+    await authed.mutation(api.tryouts.mutations.sections.complete, {
+      attemptId: started.attemptId,
+      sectionKey: TRYOUT_START_SECTION,
+    });
+    await t.mutation(activateRevisedTryoutStartEntry);
+    const terminal = await authed.query(
+      api.tryouts.queries.attemptPage.getSet,
+      { request: currentRequest }
+    );
+    expect(terminal).toMatchObject({
+      attemptId: started.attemptId,
+      content: {
+        answers: expect.any(Array),
+        kind: "signed",
+        questions: expect.any(Array),
+      },
+      initialState: {
+        attempt: {
+          score: { publishedScore: 0 },
+          status: "completed",
+        },
+        runtime: { section: { status: "completed" } },
+      },
+      kind: "current",
+      page: { set: { publicPath: setPublicPath } },
+      restartTarget: {
+        entrySection: { sectionKey: TRYOUT_REVISED_SECTION },
+        setPublicPath: TRYOUT_RENAMED_SET_PATH,
+      },
+    });
+    expect(terminal).not.toHaveProperty("setIdentity");
+    if (terminal?.kind !== "current") {
+      throw new Error("Expected one current terminal set page.");
+    }
+    if (terminal.content.kind !== "signed") {
+      throw new Error("Expected signed terminal set content.");
+    }
+    expect(terminal.content.answers).toHaveLength(1);
+  });
+
+  it("rejects progress that disagrees with its latest attempt", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const owner = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "progress-owner",
+      });
+      const other = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "progress-other",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: owner.userId,
+        visibility: "internal-entry",
+      });
+      return { ...owner, otherUserId: other.userId };
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setIdentity, entrySectionKey: TRYOUT_START_SECTION }
+    );
+    const request = { kind: "current" as const, ...setIdentity };
+    const expectMismatch = () =>
+      expect(
+        authed.query(api.tryouts.queries.attemptPage.getSet, { request })
+      ).rejects.toThrow("TRYOUT_PROGRESS_ATTEMPT_MISMATCH");
+
+    const progress = await t.mutation(async (ctx) => {
+      const progress = await ctx.db.query("tryoutSetProgress").unique();
+      if (!progress) {
+        throw new Error("Expected one try-out progress row.");
+      }
+      return { id: progress._id, setIdentity: progress.setIdentity };
+    });
+
+    await t.mutation((ctx) =>
+      ctx.db.patch(progress.id, { countryKey: "germany" })
+    );
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(progress.id, { countryKey: TRYOUT_START_COUNTRY })
+    );
+
+    await t.mutation((ctx) =>
+      ctx.db.patch(started.attemptId, { countryKey: "germany" })
+    );
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(started.attemptId, {
+        countryKey: TRYOUT_START_COUNTRY,
+        userId: identity.otherUserId,
+      })
+    );
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(started.attemptId, {
+        setIdentity: "set:drift",
+        userId: identity.userId,
+      })
+    );
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(started.attemptId, {
+        setIdentity: progress.setIdentity,
+      })
+    );
+
+    await t.mutation((ctx) => ctx.db.patch(progress.id, { attemptNumber: 2 }));
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(progress.id, { attemptNumber: 1, status: "completed" })
+    );
+    await expectMismatch();
+    await t.mutation((ctx) =>
+      ctx.db.patch(progress.id, { status: "in-progress", statusRank: 2 })
+    );
+    await expectMismatch();
+  });
+
+  it("keeps frozen review while resolving the current signed restart entry", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "set-restart-target",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: user.userId,
+        visibility: "internal-entry",
+      });
+      return user;
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setIdentity, entrySectionKey: TRYOUT_START_SECTION }
+    );
+    await authed.mutation(api.tryouts.mutations.sections.complete, {
+      attemptId: started.attemptId,
+      sectionKey: TRYOUT_START_SECTION,
+    });
+    const request = {
+      attemptId: started.attemptId,
+      kind: "retained" as const,
+      locale: "id" as const,
+      publicPath: setPublicPath,
+    };
+
+    await t.mutation(activateRevisedTryoutStartEntry);
+    const revised = await authed.query(api.tryouts.queries.attemptPage.getSet, {
+      request,
+    });
+    expect(revised).toMatchObject({
+      kind: "retained",
+      page: {
+        entrySection: { sectionKey: TRYOUT_START_SECTION },
+        set: { publicPath: setPublicPath },
+      },
+      restartTarget: {
+        entrySection: {
+          sectionKey: TRYOUT_REVISED_SECTION,
+          visibility: "internal-entry",
+        },
+        setPublicPath: TRYOUT_RENAMED_SET_PATH,
+      },
+    });
+    if (revised?.kind !== "retained") {
+      throw new Error("Expected one retained set page.");
+    }
+    expect(revised.page.entrySection?.publicPath).toBeUndefined();
+    expect(revised.restartTarget?.entrySection.publicPath).toBeUndefined();
+
+    await t.mutation(activateReusedTryoutStartPath);
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSet, { request })
+    ).resolves.toMatchObject({
+      kind: "retained",
+      page: {
+        entrySection: { sectionKey: TRYOUT_START_SECTION },
+        set: { publicPath: setPublicPath },
+      },
+      restartTarget: null,
+    });
+  });
+
+  it("keeps exact section ownership after rename and rejects reused paths", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "section-attempt-page",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: user.userId,
+        visibility: "visible",
+      });
+      return user;
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setIdentity, destinationSectionKey: TRYOUT_START_SECTION }
+    );
+    await authed.mutation(api.tryouts.mutations.sections.start, {
+      attemptId: started.attemptId,
+      sectionKey: TRYOUT_START_SECTION,
+    });
+
+    const currentRequest = {
+      kind: "current" as const,
+      sectionKey: TRYOUT_START_SECTION,
+      ...setIdentity,
+    };
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: currentRequest,
+      })
+    ).resolves.toEqual({
+      attemptId: started.attemptId,
+      kind: "redirect",
+      publicPath: sectionPublicPath,
+    });
+
+    const retainedRequest = {
+      attemptId: started.attemptId,
+      kind: "retained" as const,
+      locale: "id" as const,
+      publicPath: sectionPublicPath,
+    };
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).resolves.toMatchObject({
+      activeSectionPublicPath: sectionPublicPath,
+      activeSetPublicPath: setPublicPath,
+      content: { answers: [], kind: "signed" },
+      initialState: {
+        attempt: { attemptId: started.attemptId },
+        runtime: { questions: expect.any(Array) },
+      },
+      kind: "retained",
+      page: { section: { sectionKey: TRYOUT_START_SECTION } },
+    });
+
+    await t.mutation(activateRenamedTryoutStartSource);
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).resolves.toMatchObject({
+      activeSectionPublicPath: expect.stringContaining(TRYOUT_START_SECTION),
+      activeSetPublicPath: TRYOUT_RENAMED_SET_PATH,
+      kind: "retained",
+    });
+
+    await t.mutation(activateRevisedTryoutStartEntry);
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).resolves.toMatchObject({
+      activeSectionPublicPath: null,
+      activeSetPublicPath: TRYOUT_RENAMED_SET_PATH,
+      kind: "retained",
+    });
+
+    await t.mutation(activateReusedTryoutStartPath);
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: {
+          countryKey: TRYOUT_START_COUNTRY,
+          examKey: TRYOUT_START_EXAM,
+          kind: "current",
+          locale: "id",
+          sectionKey: TRYOUT_REUSED_SECTION,
+          setKey: TRYOUT_REUSED_SET,
+          trackKey: TRYOUT_START_TRACK,
+        },
+      })
+    ).resolves.toBeNull();
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).resolves.toMatchObject({
+      activeSectionPublicPath: null,
+      activeSetPublicPath: null,
+      kind: "retained",
+    });
+    await expect(
+      t.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSet, {
+        request: {
+          attemptId: "not-an-id",
+          kind: "retained",
+          locale: "id",
+          publicPath: setPublicPath,
+        },
+      })
+    ).resolves.toBeNull();
+
+    const originalSnapshot = await t.mutation(async (ctx) => {
+      const attempt = await ctx.db.get(started.attemptId);
+      if (!attempt) {
+        throw new Error("Expected one frozen attempt.");
+      }
+      const snapshot = attempt.sectionSnapshots.at(0);
+      if (!snapshot) {
+        throw new Error("Expected one frozen section snapshot.");
+      }
+      await ctx.db.patch(started.attemptId, {
+        sectionSnapshots: attempt.sectionSnapshots.map((candidate) => ({
+          ...candidate,
+          sourceRevision: `${candidate.sourceRevision}-drift`,
+        })),
+      });
+      return snapshot;
+    });
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSection, {
+        request: retainedRequest,
+      })
+    ).rejects.toThrow("TRYOUT_SECTION_SNAPSHOT_MISMATCH");
+
+    await t.mutation(async (ctx) => {
+      const attempt = await ctx.db.get(started.attemptId);
+      if (!attempt) {
+        throw new Error("Expected one frozen attempt.");
+      }
+      await ctx.db.patch(started.attemptId, {
+        sectionSnapshots: attempt.sectionSnapshots.map((snapshot) => ({
+          ...snapshot,
+          sectionRowHash: `${snapshot.sectionRowHash}-drift`,
+          sourceRevision: originalSnapshot.sourceRevision,
+        })),
+      });
+    });
+    await expect(
+      authed.query(api.tryouts.queries.attemptPage.getSet, {
+        request: {
+          attemptId: started.attemptId,
+          kind: "retained",
+          locale: "id",
+          publicPath: setPublicPath,
+        },
+      })
+    ).rejects.toThrow("TRYOUT_SECTION_SNAPSHOT_MISMATCH");
+  });
+});

--- a/packages/backend/convex/tryouts/queries/attemptPage.ts
+++ b/packages/backend/convex/tryouts/queries/attemptPage.ts
@@ -1,0 +1,28 @@
+import { query } from "@repo/backend/convex/_generated/server";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import {
+  readSectionAttemptPage,
+  readSetAttemptPage,
+} from "@repo/backend/convex/tryouts/attemptPage/impl";
+import {
+  tryoutSectionAttemptPageRequestValidator,
+  tryoutSectionAttemptPageResultValidator,
+  tryoutSetAttemptPageRequestValidator,
+  tryoutSetAttemptPageResultValidator,
+} from "@repo/backend/convex/tryouts/attemptPage/spec";
+
+/** Fetches one current set overlay or exact frozen set page. */
+export const getSet = query({
+  args: { request: tryoutSetAttemptPageRequestValidator },
+  returns: tryoutSetAttemptPageResultValidator,
+  handler: (ctx, args) =>
+    runConvexProgram(readSetAttemptPage(ctx, args.request)),
+});
+
+/** Fetches one current section redirect or exact frozen section page. */
+export const getSection = query({
+  args: { request: tryoutSectionAttemptPageRequestValidator },
+  returns: tryoutSectionAttemptPageResultValidator,
+  handler: (ctx, args) =>
+    runConvexProgram(readSectionAttemptPage(ctx, args.request)),
+});

--- a/packages/backend/convex/tryouts/queries/runtime.test.ts
+++ b/packages/backend/convex/tryouts/queries/runtime.test.ts
@@ -206,4 +206,132 @@ describe("tryouts/queries/runtime", () => {
       })
     ).rejects.toThrow("TRYOUT_SECTION_SNAPSHOT_MISMATCH");
   });
+
+  it("keeps exact live state compact and skips score reads while active", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "exact-active-state",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: user.userId,
+        visibility: "internal-entry",
+      });
+      return user;
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setRoute, entrySectionKey: TRYOUT_START_SECTION }
+    );
+
+    await t.mutation(async (ctx) => {
+      const attempt = await ctx.db.get(started.attemptId);
+      if (!attempt) {
+        throw new Error("Expected one active attempt.");
+      }
+      for (const offset of [0, 1]) {
+        await ctx.db.insert("tryoutScores", {
+          finalizedAt: TRYOUT_START_NOW + offset,
+          publishedScore: 0,
+          rawScore: 0,
+          scoreStatus: "official",
+          scoringStrategy: "raw",
+          setIdentity: attempt.setIdentity,
+          totalCorrect: 0,
+          totalQuestions: attempt.totalQuestions,
+          tryoutAttemptId: attempt._id,
+          tryoutSnapshotId: attempt.tryoutSnapshotId,
+          userId: attempt.userId,
+        });
+      }
+    });
+
+    const exact = await authed.query(
+      api.tryouts.queries.runtime.getSetAttemptState,
+      { attemptId: started.attemptId }
+    );
+    expect(exact).toMatchObject({
+      attempt: {
+        activeSectionKey: TRYOUT_START_SECTION,
+        attemptId: started.attemptId,
+        score: null,
+      },
+      runtime: {
+        questions: expect.any(Array),
+        section: { status: "in-progress" },
+      },
+    });
+    expect(exact?.attempt).not.toHaveProperty("lastActivityAt");
+    expect(exact?.attempt).not.toHaveProperty("sectionRoutes");
+    expect(exact?.attempt).not.toHaveProperty("totalQuestions");
+    expect(exact?.runtime?.questions.at(0)).not.toHaveProperty("title");
+
+    await expect(
+      authed.query(api.tryouts.queries.runtime.getSetState, {
+        attemptId: started.attemptId,
+        locale: "id",
+        publicPath: setPublicPath,
+      })
+    ).resolves.toMatchObject({ attempt: { score: null } });
+  });
+
+  it("binds exact section state to ownership instead of the active catalog", async () => {
+    vi.setSystemTime(new Date(TRYOUT_START_NOW));
+
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: TRYOUT_START_NOW,
+        suffix: "exact-section-state",
+      });
+      await seedTryoutStartSet(ctx, {
+        userId: user.userId,
+        visibility: "visible",
+      });
+      return user;
+    });
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const started = await authed.mutation(
+      api.tryouts.mutations.attempts.startAttempt,
+      { ...setRoute, destinationSectionKey: TRYOUT_START_SECTION }
+    );
+    await authed.mutation(api.tryouts.mutations.sections.start, {
+      attemptId: started.attemptId,
+      sectionKey: TRYOUT_START_SECTION,
+    });
+    const args = {
+      attemptId: started.attemptId,
+      sectionKey: TRYOUT_START_SECTION,
+    };
+
+    const initial = await authed.query(
+      api.tryouts.queries.runtime.getSectionAttemptState,
+      args
+    );
+    expect(initial).toMatchObject({
+      attempt: {
+        attemptId: started.attemptId,
+        section: { sectionKey: TRYOUT_START_SECTION },
+      },
+      runtime: { questions: expect.any(Array) },
+    });
+
+    await t.mutation(activateReusedTryoutStartPath);
+    await expect(
+      authed.query(api.tryouts.queries.runtime.getSectionAttemptState, args)
+    ).resolves.toEqual(initial);
+    await expect(
+      t.query(api.tryouts.queries.runtime.getSectionAttemptState, args)
+    ).resolves.toBeNull();
+  });
 });

--- a/packages/backend/convex/tryouts/queries/runtime.ts
+++ b/packages/backend/convex/tryouts/queries/runtime.ts
@@ -5,8 +5,15 @@ import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
 import { tryoutAttemptSectionRouteValidator } from "@repo/backend/convex/tryouts/runtime/attempt/sections";
 import { tryoutRuntimeChoiceValidator } from "@repo/backend/convex/tryouts/runtime/choice";
 import { tryoutCurrentSectionValidator } from "@repo/backend/convex/tryouts/runtime/content";
-import { readSectionState } from "@repo/backend/convex/tryouts/runtime/section/state";
-import { readSetState } from "@repo/backend/convex/tryouts/runtime/set/state";
+import {
+  readSectionAttemptState,
+  readSectionState,
+} from "@repo/backend/convex/tryouts/runtime/section/state";
+import {
+  readSetAttemptState,
+  readSetState,
+} from "@repo/backend/convex/tryouts/runtime/set/state";
+import { tryoutRuntimeStateValidator } from "@repo/backend/convex/tryouts/runtime/spec";
 import { tryoutScoreResultValidator } from "@repo/backend/convex/tryouts/score";
 import { tryoutStatusValidator } from "@repo/backend/convex/tryouts/status";
 import { v } from "convex/values";
@@ -93,4 +100,22 @@ export const getSectionState = query({
     })
   ),
   handler: (ctx, args) => runConvexProgram(readSectionState(ctx, args)),
+});
+
+/** Loads compact mutable set state through one exact owned attempt ID. */
+export const getSetAttemptState = query({
+  args: { attemptId: v.id("tryoutAttempts") },
+  returns: v.union(v.null(), tryoutRuntimeStateValidator),
+  handler: (ctx, args) =>
+    runConvexProgram(readSetAttemptState(ctx, args.attemptId)),
+});
+
+/** Loads compact mutable section state through one exact owned attempt ID. */
+export const getSectionAttemptState = query({
+  args: {
+    attemptId: v.id("tryoutAttempts"),
+    sectionKey: tryoutRouteKeyValidator,
+  },
+  returns: v.union(v.null(), tryoutRuntimeStateValidator),
+  handler: (ctx, args) => runConvexProgram(readSectionAttemptState(ctx, args)),
 });

--- a/packages/backend/convex/tryouts/runtime/attempt/page.ts
+++ b/packages/backend/convex/tryouts/runtime/attempt/page.ts
@@ -1,0 +1,255 @@
+import { tryoutCatalogIdentity } from "@nakafa/aksara-contracts/tryout/identity";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { loadVerifiedSnapshot } from "@repo/backend/convex/contentRelease/runtime/snapshot";
+import type { TryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/set";
+import {
+  readPublishedSectionPageFromIndex,
+  readPublishedSetPageFromIndex,
+} from "@repo/backend/convex/tryouts/catalog/published";
+import {
+  readTryoutSetSelection,
+  type TryoutSetSelection,
+} from "@repo/backend/convex/tryouts/catalog/selection";
+import { TryoutRuntimeError } from "@repo/backend/convex/tryouts/runtime/error";
+import {
+  matchesAttemptIdentity,
+  readAttemptSetIdentity,
+} from "@repo/backend/convex/tryouts/runtime/lookup";
+import { Effect } from "effect";
+
+type TryoutAttempt = Doc<"tryoutAttempts">;
+
+interface AttemptPath {
+  readonly locale: "en" | "id";
+  readonly publicPath: string;
+}
+
+/** Reads and verifies one set page from the attempt-owned source snapshot. */
+export const readAttemptSetPage = Effect.fn("tryouts.attempt.readSetPage")(
+  function* (
+    ctx: QueryCtx,
+    args: AttemptPath,
+    attempt: TryoutAttempt,
+    identity: TryoutSetIdentity
+  ) {
+    const selection = yield* readAttemptSetSelection(
+      ctx,
+      args,
+      attempt,
+      identity
+    );
+    const page = yield* readPublishedSetPageFromIndex(
+      selection,
+      args.publicPath
+    );
+    if (!(page && matchesSetPage(attempt, identity, page))) {
+      return yield* attemptPageIntegrity(
+        "Frozen try-out set page no longer matches its attempt snapshot."
+      );
+    }
+    return page;
+  }
+);
+
+/** Reads and verifies one section page from the attempt-owned source snapshot. */
+export const readAttemptSectionPage = Effect.fn(
+  "tryouts.attempt.readSectionPage"
+)(function* (ctx: QueryCtx, args: AttemptPath, attempt: TryoutAttempt) {
+  const identity = readAttemptSetIdentity(attempt);
+  const selection = yield* readAttemptSetSelection(
+    ctx,
+    args,
+    attempt,
+    identity
+  );
+  const page = yield* readPublishedSectionPageFromIndex(
+    selection,
+    args.publicPath
+  );
+  if (!(page && matchesSectionPage(attempt, identity, page))) {
+    return yield* attemptPageIntegrity(
+      "Frozen try-out section page no longer matches its attempt snapshot."
+    );
+  }
+  return page;
+});
+
+/** Reads and checks the complete immutable set-local catalog for one attempt. */
+const readAttemptSetSelection = Effect.fn("tryouts.attempt.readSetSelection")(
+  function* (
+    ctx: QueryCtx,
+    args: AttemptPath,
+    attempt: TryoutAttempt,
+    identity: TryoutSetIdentity
+  ) {
+    yield* loadVerifiedSnapshot(ctx, "tryout", attempt.tryoutSnapshotId);
+    const selection = yield* readTryoutSetSelection(ctx, {
+      ...args,
+      snapshotId: attempt.tryoutSnapshotId,
+    });
+    if (!(selection && matchesAttemptSelection(attempt, identity, selection))) {
+      return yield* attemptPageIntegrity(
+        "Frozen try-out catalog no longer matches its attempt snapshot."
+      );
+    }
+    return selection;
+  }
+);
+
+/** Checks every attempt-owned set and section field against signed source rows. */
+function matchesAttemptSelection(
+  attempt: TryoutAttempt,
+  identity: TryoutSetIdentity,
+  selection: TryoutSetSelection
+) {
+  const set = selection.sets.at(0);
+  if (
+    !set ||
+    selection.sets.length !== 1 ||
+    !matchesAttemptIdentity(identity, set) ||
+    tryoutCatalogIdentity(set) !== attempt.setIdentity ||
+    set.publicPath !== attempt.setPublicPath ||
+    set.questionCount !== attempt.totalQuestions ||
+    set.scoringStrategy !== attempt.scoringStrategy ||
+    set.sectionCount !== attempt.sectionSnapshots.length ||
+    selection.sectionRecords.length !== attempt.sectionSnapshots.length
+  ) {
+    return false;
+  }
+
+  return attempt.sectionSnapshots.every((snapshot) => {
+    const record = selection.sectionRecords.find(
+      ({ row }) => tryoutCatalogIdentity(row) === snapshot.sectionIdentity
+    );
+    if (!record) {
+      return false;
+    }
+    const { row } = record;
+    return (
+      record.rowHash === snapshot.sectionRowHash &&
+      row.order === snapshot.sectionOrder &&
+      row.publicPath === snapshot.publicPath &&
+      row.questionCount === snapshot.questionCount &&
+      row.questionSourcePath === snapshot.questionSourcePath &&
+      row.sectionKey === snapshot.sectionKey &&
+      row.sourceRevision === snapshot.sourceRevision &&
+      row.timeLimitSeconds === snapshot.timeLimitSeconds
+    );
+  });
+}
+
+/** Checks one frozen page against the attempt's immutable set snapshot. */
+function matchesSetPage(
+  attempt: TryoutAttempt,
+  identity: TryoutSetIdentity,
+  page: {
+    readonly entrySection: {
+      readonly publicPath?: string;
+      readonly questionCount: number;
+      readonly sectionKey: string;
+      readonly timeLimitSeconds: number;
+      readonly visibility: "internal-entry" | "visible";
+    } | null;
+    readonly sections: readonly {
+      readonly publicPath?: string;
+      readonly questionCount: number;
+      readonly sectionKey: string;
+      readonly timeLimitSeconds: number;
+    }[];
+    readonly set: {
+      readonly countryKey: string;
+      readonly examKey: string;
+      readonly publicPath: string;
+      readonly setKey: string;
+      readonly totalQuestionCount: number;
+      readonly trackKey: string;
+    };
+  }
+) {
+  const pageIdentity = {
+    countryKey: page.set.countryKey,
+    examKey: page.set.examKey,
+    locale: identity.locale,
+    setKey: page.set.setKey,
+    trackKey: page.set.trackKey,
+  };
+  if (
+    !matchesAttemptIdentity(identity, pageIdentity) ||
+    page.set.publicPath !== attempt.setPublicPath ||
+    page.set.totalQuestionCount !== attempt.totalQuestions
+  ) {
+    return false;
+  }
+
+  const sections =
+    page.entrySection?.visibility === "internal-entry"
+      ? [page.entrySection, ...page.sections]
+      : page.sections;
+  if (sections.length !== attempt.sectionSnapshots.length) {
+    return false;
+  }
+  return attempt.sectionSnapshots.every((snapshot) => {
+    const section = sections.find(
+      (candidate) => candidate.sectionKey === snapshot.sectionKey
+    );
+    if (!section) {
+      return false;
+    }
+    return (
+      section.publicPath === snapshot.publicPath &&
+      section.questionCount === snapshot.questionCount &&
+      section.timeLimitSeconds === snapshot.timeLimitSeconds
+    );
+  });
+}
+
+/** Checks one frozen section projection against its exact route. */
+function matchesSectionPage(
+  attempt: TryoutAttempt,
+  identity: TryoutSetIdentity,
+  page: {
+    readonly section: {
+      readonly publicPath?: string;
+      readonly questionCount: number;
+      readonly sectionKey: string;
+      readonly timeLimitSeconds: number;
+    };
+    readonly set: {
+      readonly countryKey: string;
+      readonly examKey: string;
+      readonly publicPath: string;
+      readonly setKey: string;
+      readonly trackKey: string;
+    };
+  }
+) {
+  const snapshot = attempt.sectionSnapshots.find(
+    (candidate) => candidate.publicPath === page.section.publicPath
+  );
+  if (!snapshot) {
+    return false;
+  }
+  const pageIdentity = {
+    countryKey: page.set.countryKey,
+    examKey: page.set.examKey,
+    locale: identity.locale,
+    setKey: page.set.setKey,
+    trackKey: page.set.trackKey,
+  };
+  return (
+    matchesAttemptIdentity(identity, pageIdentity) &&
+    page.set.publicPath === attempt.setPublicPath &&
+    page.section.sectionKey === snapshot.sectionKey &&
+    page.section.questionCount === snapshot.questionCount &&
+    page.section.timeLimitSeconds === snapshot.timeLimitSeconds
+  );
+}
+
+/** Rejects any drift inside an immutable attempt-owned page. */
+function attemptPageIntegrity(message: string) {
+  return new TryoutRuntimeError({
+    code: "TRYOUT_SECTION_SNAPSHOT_MISMATCH",
+    message,
+  });
+}

--- a/packages/backend/convex/tryouts/runtime/attempt/state.ts
+++ b/packages/backend/convex/tryouts/runtime/attempt/state.ts
@@ -12,24 +12,30 @@ import {
 } from "@repo/backend/convex/tryouts/score/result";
 import { Effect } from "effect";
 
-interface CurrentAttemptInput {
+interface AttemptStateInput {
   readonly attempt: Doc<"tryoutAttempts">;
   readonly sectionKey?: string;
   readonly sections?: readonly Doc<"tryoutSectionAttempts">[];
+}
+
+interface CurrentAttemptInput extends AttemptStateInput {
   readonly signedSections?: readonly TryoutSection[];
 }
 
-/** Projects one owned attempt into the shared reactive state contract. */
-export const loadCurrentAttempt = Effect.fn("tryouts.attempt.loadCurrent")(
-  function* (ctx: QueryCtx, input: CurrentAttemptInput) {
+/** Loads the mutable attempt graph without immutable catalog fields. */
+const loadAttemptProjection = Effect.fn("tryouts.attempt.loadProjection")(
+  function* (ctx: QueryCtx, input: AttemptStateInput) {
     const attempt = input.attempt;
-    const [sections, score, sectionRoutes] = yield* Effect.all(
+    const scoreEffect =
+      attempt.status === "in-progress"
+        ? Effect.succeed(null)
+        : loadAttemptScoreResult(ctx, attempt);
+    const [sections, score] = yield* Effect.all(
       [
         input.sections
           ? Effect.succeed(input.sections)
           : loadAttemptSections(ctx, attempt),
-        loadAttemptScoreResult(ctx, attempt),
-        loadAttemptSectionRoutes(ctx, attempt, input.signedSections),
+        scoreEffect,
       ],
       { concurrency: "unbounded" }
     );
@@ -38,36 +44,79 @@ export const loadCurrentAttempt = Effect.fn("tryouts.attempt.loadCurrent")(
           (candidate) => candidate.sectionKey === input.sectionKey
         ) ?? null)
       : null;
-    const resume = readAttemptResume(attempt, sections);
-    const sectionScore = section ? yield* getSectionScoreResult(section) : null;
+    const sectionState = section
+      ? {
+          answeredCount: section.answeredCount,
+          completedAt: section.completedAt,
+          endReason: section.endReason,
+          expiresAt: section.expiresAt,
+          score: yield* getSectionScoreResult(section),
+          sectionKey: section.sectionKey,
+          startedAt: section.startedAt,
+          status: section.status,
+          totalQuestions: section.totalQuestions,
+        }
+      : null;
 
     return {
-      activeSectionKey: resume.activeSectionKey,
-      attemptId: attempt._id,
-      attemptNumber: attempt.attemptNumber,
-      completedSectionKeys: attempt.completedSectionKeys,
-      expiresAt: attempt.expiresAt,
-      lastActivityAt: attempt.lastActivityAt,
-      resumeSectionKey: resume.resumeSectionKey,
-      resumeSectionPublicPath: resume.resumeSectionPublicPath,
+      attempt,
+      resume: readAttemptResume(attempt, sections),
       score,
-      section: section
-        ? {
-            answeredCount: section.answeredCount,
-            completedAt: section.completedAt,
-            endReason: section.endReason,
-            expiresAt: section.expiresAt,
-            score: sectionScore,
-            sectionKey: section.sectionKey,
-            startedAt: section.startedAt,
-            status: section.status,
-            totalQuestions: section.totalQuestions,
-          }
-        : null,
+      sectionState,
+    };
+  }
+);
+
+/** Projects one exact attempt into the compact reactive state contract. */
+export const loadAttemptState = Effect.fn("tryouts.attempt.loadState")(
+  function* (ctx: QueryCtx, input: AttemptStateInput) {
+    const projection = yield* loadAttemptProjection(ctx, input);
+    return {
+      activeSectionKey: projection.resume.activeSectionKey,
+      attemptId: projection.attempt._id,
+      attemptNumber: projection.attempt.attemptNumber,
+      completedSectionKeys: projection.attempt.completedSectionKeys,
+      expiresAt: projection.attempt.expiresAt,
+      resumeSectionKey: projection.resume.resumeSectionKey,
+      resumeSectionPublicPath: projection.resume.resumeSectionPublicPath,
+      score: projection.score,
+      section: projection.sectionState,
+      startedAt: projection.attempt.startedAt,
+      status: projection.attempt.status,
+    };
+  }
+);
+
+/** Projects the deployed state shape until the current web switches contracts. */
+export const loadCurrentAttempt = Effect.fn("tryouts.attempt.loadCurrent")(
+  function* (ctx: QueryCtx, input: CurrentAttemptInput) {
+    const { projection, sectionRoutes } = yield* Effect.all(
+      {
+        projection: loadAttemptProjection(ctx, input),
+        sectionRoutes: loadAttemptSectionRoutes(
+          ctx,
+          input.attempt,
+          input.signedSections
+        ),
+      },
+      { concurrency: "unbounded" }
+    );
+
+    return {
+      activeSectionKey: projection.resume.activeSectionKey,
+      attemptId: projection.attempt._id,
+      attemptNumber: projection.attempt.attemptNumber,
+      completedSectionKeys: projection.attempt.completedSectionKeys,
+      expiresAt: projection.attempt.expiresAt,
+      lastActivityAt: projection.attempt.lastActivityAt,
+      resumeSectionKey: projection.resume.resumeSectionKey,
+      resumeSectionPublicPath: projection.resume.resumeSectionPublicPath,
+      score: projection.score,
+      section: projection.sectionState,
       sectionRoutes,
-      startedAt: attempt.startedAt,
-      status: attempt.status,
-      totalQuestions: attempt.totalQuestions,
+      startedAt: projection.attempt.startedAt,
+      status: projection.attempt.status,
+      totalQuestions: projection.attempt.totalQuestions,
     };
   }
 );

--- a/packages/backend/convex/tryouts/runtime/content.ts
+++ b/packages/backend/convex/tryouts/runtime/content.ts
@@ -58,6 +58,10 @@ export type TryoutSectionContentAccess = Infer<
   typeof tryoutSectionContentAccessValidator
 >;
 
+export const noTryoutSectionContentAccess = {
+  kind: "none",
+} satisfies TryoutSectionContentAccess;
+
 /** Derives question and answer access from one coherent attempt lifecycle. */
 export function getTryoutSectionContentAccess(
   attemptStatus: TryoutStatus,

--- a/packages/backend/convex/tryouts/runtime/lookup.ts
+++ b/packages/backend/convex/tryouts/runtime/lookup.ts
@@ -4,6 +4,11 @@ import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { loadTryoutOwner } from "@repo/backend/convex/contentRelease/tryout/owner";
 import type { TryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/set";
 import { readTryoutCatalogRowByPath } from "@repo/backend/convex/tryouts/catalog/row";
+import {
+  TryoutRuntimeError,
+  tryRuntimePromise,
+} from "@repo/backend/convex/tryouts/runtime/error";
+import { getTryoutStatusRank } from "@repo/backend/convex/tryouts/status";
 import type { PaginationOptions } from "convex/server";
 import { Effect } from "effect";
 
@@ -24,7 +29,7 @@ interface PublicSetPath {
 /** Reads one bounded attempt set through its immutable signed identity. */
 export const readOwnedAttempts = Effect.fn("tryouts.runtime.readOwnedAttempts")(
   function* (ctx: QueryCtx, owner: AttemptOwnerIdentity, limit: number) {
-    return yield* Effect.promise(() =>
+    return yield* tryRuntimePromise(() =>
       ctx.db
         .query("tryoutAttempts")
         .withIndex("by_userId_and_setIdentity_and_startedAt", (index) =>
@@ -61,11 +66,53 @@ export const readLatestAttempt = Effect.fn("tryouts.runtime.readLatestAttempt")(
   }
 );
 
+/**
+ * Reads the latest attempt through the compact current-set progress row.
+ * @see https://docs.convex.dev/database/reading-data/indexes/
+ */
+export const readLatestProgressAttempt = Effect.fn(
+  "tryouts.runtime.readLatestProgressAttempt"
+)(function* (ctx: QueryCtx, identity: TryoutSetIdentity, userId: UserId) {
+  const setIdentity = tryoutCatalogIdentity({
+    countryKey: identity.countryKey,
+    examKey: identity.examKey,
+    kind: "set",
+    locale: identity.locale,
+    setKey: identity.setKey,
+    trackKey: identity.trackKey,
+  });
+  const progress = yield* tryRuntimePromise(() =>
+    ctx.db
+      .query("tryoutSetProgress")
+      .withIndex("by_userId_and_setIdentity", (index) =>
+        index.eq("userId", userId).eq("setIdentity", setIdentity)
+      )
+      .unique()
+  );
+  if (!progress) {
+    return null;
+  }
+
+  const attempt = yield* tryRuntimePromise(() =>
+    ctx.db.get(progress.latestAttemptId)
+  );
+  if (
+    !(attempt && matchesProgressAttempt(attempt, progress, identity, userId))
+  ) {
+    return yield* new TryoutRuntimeError({
+      code: "TRYOUT_PROGRESS_ATTEMPT_MISMATCH",
+      message: "Try-out progress no longer identifies its latest attempt.",
+    });
+  }
+
+  return attempt;
+});
+
 /** Reads one exact attempt only when it belongs to the current app user. */
 export const readOwnedAttemptById = Effect.fn(
   "tryouts.runtime.readOwnedAttemptById"
 )(function* (ctx: QueryCtx, attemptId: Id<"tryoutAttempts">, userId: UserId) {
-  const attempt = yield* Effect.promise(() => ctx.db.get(attemptId));
+  const attempt = yield* tryRuntimePromise(() => ctx.db.get(attemptId));
   if (attempt?.userId !== userId) {
     return null;
   }
@@ -99,6 +146,34 @@ export function matchesAttemptIdentity(
   );
 }
 
+/** Checks that compact progress and its latest attempt describe one state. */
+function matchesProgressAttempt(
+  attempt: TryoutAttempt,
+  progress: Doc<"tryoutSetProgress">,
+  identity: TryoutSetIdentity,
+  userId: UserId
+) {
+  if (!matchesAttemptIdentity(progress, identity)) {
+    return false;
+  }
+  if (!matchesAttemptIdentity(readAttemptSetIdentity(attempt), identity)) {
+    return false;
+  }
+  if (
+    attempt.userId !== userId ||
+    attempt.setIdentity !== progress.setIdentity
+  ) {
+    return false;
+  }
+  if (attempt.attemptNumber !== progress.attemptNumber) {
+    return false;
+  }
+  if (attempt.status !== progress.status) {
+    return false;
+  }
+  return progress.statusRank === getTryoutStatusRank(progress.status);
+}
+
 /** Reads the latest attempt for one current or frozen public set route. */
 export const readLatestAttemptByPath = Effect.fn(
   "tryouts.runtime.readLatestAttemptByPath"
@@ -116,7 +191,7 @@ export const readLatestAttemptByPath = Effect.fn(
     });
   }
 
-  return yield* Effect.promise(() =>
+  return yield* tryRuntimePromise(() =>
     ctx.db
       .query("tryoutAttempts")
       .withIndex(
@@ -146,7 +221,7 @@ export const readAttemptHistoryPage = Effect.fn(
   if (set?.kind !== "set") {
     return { continueCursor: "", isDone: true, page: [] };
   }
-  return yield* Effect.promise(() =>
+  return yield* tryRuntimePromise(() =>
     ctx.db
       .query("tryoutAttempts")
       .withIndex("by_userId_and_setIdentity_and_startedAt", (index) =>

--- a/packages/backend/convex/tryouts/runtime/section/questions.ts
+++ b/packages/backend/convex/tryouts/runtime/section/questions.ts
@@ -1,67 +1,18 @@
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
-import { getTryoutSectionContentAccess } from "@repo/backend/convex/tryouts/runtime/content";
+import { requireTryoutResponseSectionSnapshot } from "@repo/backend/convex/tryouts/response/integrity";
+import {
+  getTryoutSectionContentAccess,
+  noTryoutSectionContentAccess,
+} from "@repo/backend/convex/tryouts/runtime/content";
+import { loadSectionPlacements } from "@repo/backend/convex/tryouts/runtime/placement";
+import { loadSectionResponseIndex } from "@repo/backend/convex/tryouts/runtime/response";
+import { projectTryoutSignedContent } from "@repo/backend/convex/tryouts/runtime/selectors";
 import { getSectionScoreResult } from "@repo/backend/convex/tryouts/score/result";
-import { Effect, Schema } from "effect";
+import { Effect } from "effect";
 
-/** Stable integrity failure while reading one bounded section runtime. */
-class TryoutRuntimeReadError extends Schema.TaggedError<TryoutRuntimeReadError>()(
-  "TryoutRuntimeReadError",
-  {
-    code: Schema.Literal(
-      "TRYOUT_PLACEMENT_COUNT_EXCEEDED",
-      "TRYOUT_RESPONSE_COUNT_EXCEEDED"
-    ),
-    message: Schema.String,
-  }
-) {}
-
-/** Loads bounded runtime responses for one section attempt. */
-const loadRuntimeResponses = Effect.fn("tryouts.runtime.loadResponses")(
-  function* (ctx: QueryCtx, section: Doc<"tryoutSectionAttempts">) {
-    const responses = yield* Effect.promise(() =>
-      ctx.db
-        .query("tryoutResponses")
-        .withIndex("by_tryoutSectionAttemptId_and_answeredAt", (query) =>
-          query.eq("tryoutSectionAttemptId", section._id)
-        )
-        .take(section.totalQuestions + 1)
-    );
-
-    if (responses.length > section.totalQuestions) {
-      return yield* new TryoutRuntimeReadError({
-        code: "TRYOUT_RESPONSE_COUNT_EXCEEDED",
-        message: "Try-out response count exceeds the section question count.",
-      });
-    }
-
-    return new Map(
-      responses.map((response) => [response.placementId, response])
-    );
-  }
-);
-
-/** Loads placements through the immutable signed section key. */
-const loadRuntimePlacements = Effect.fn("tryouts.runtime.loadPlacements")(
-  function* (
-    ctx: QueryCtx,
-    attempt: Doc<"tryoutAttempts">,
-    section: Doc<"tryoutSectionAttempts">
-  ) {
-    return yield* Effect.promise(() =>
-      ctx.db
-        .query("tryoutAttemptPlacements")
-        .withIndex(
-          "by_tryoutAttemptId_and_sectionKey_and_questionOrder",
-          (index) =>
-            index
-              .eq("tryoutAttemptId", attempt._id)
-              .eq("sectionKey", section.sectionKey)
-        )
-        .take(section.totalQuestions + 1)
-    );
-  }
-);
+type TryoutPlacement = Doc<"tryoutAttemptPlacements">;
+type TryoutResponse = Doc<"tryoutResponses">;
 
 /** Projects the public state shared by attempt and runtime responses. */
 export const readCurrentSection = Effect.fn(
@@ -80,65 +31,125 @@ export const readCurrentSection = Effect.fn(
   };
 });
 
-/** Loads placements and responses for one already-owned section attempt. */
+/** Loads one bounded section graph shared by old and new runtime contracts. */
+const loadSectionRows = Effect.fn("tryouts.runtime.loadSectionRows")(function* (
+  ctx: QueryCtx,
+  attempt: Doc<"tryoutAttempts">,
+  section: Doc<"tryoutSectionAttempts">
+) {
+  const access = getTryoutSectionContentAccess(attempt.status, section.status);
+  if (!access.questions) {
+    return null;
+  }
+
+  const snapshot = yield* requireTryoutResponseSectionSnapshot(
+    attempt,
+    section
+  );
+  const placements = yield* loadSectionPlacements(ctx, attempt, snapshot);
+  const loaded = yield* loadSectionResponseIndex(
+    ctx,
+    attempt,
+    section,
+    placements
+  );
+  const currentSection = yield* readCurrentSection(section);
+  return { access, currentSection, ...loaded };
+});
+
+/** Loads the deployed runtime shape until the current web switches contracts. */
 export const loadSectionRuntime = Effect.fn("tryouts.runtime.loadSection")(
   function* (
     ctx: QueryCtx,
     attempt: Doc<"tryoutAttempts">,
     section: Doc<"tryoutSectionAttempts">
   ) {
-    const contentAccess = getTryoutSectionContentAccess(
-      attempt.status,
-      section.status
-    );
-    if (!contentAccess.questions) {
+    const loaded = yield* loadSectionRows(ctx, attempt, section);
+    if (!loaded) {
       return null;
     }
-
-    const placements = yield* loadRuntimePlacements(ctx, attempt, section);
-    if (placements.length !== section.totalQuestions) {
-      return yield* new TryoutRuntimeReadError({
-        code: "TRYOUT_PLACEMENT_COUNT_EXCEEDED",
-        message: "Try-out section has more placements than its snapshot count.",
-      });
-    }
-
-    const responses = yield* loadRuntimeResponses(ctx, section);
-    const currentSection = yield* readCurrentSection(section);
-    const questions = placements.map((placement) => {
-      const response = responses.get(placement._id) ?? null;
-      const choices = [...placement.choiceSnapshots].sort(
-        (left, right) => left.order - right.order
-      );
-
-      return {
-        choices: choices.map((choice) => ({
-          ...(contentAccess.answers ? { isCorrect: choice.isCorrect } : {}),
-          label: choice.label,
-          optionKey: choice.optionKey,
-          order: choice.order,
-        })),
-        contentHash: placement.contentHash,
-        placementId: placement._id,
-        questionOrder: placement.questionOrder,
-        response: response
-          ? {
-              answeredAt: response.answeredAt,
-              selectedOptionId: response.selectedOptionId,
-              updatedAt: response.updatedAt,
-            }
-          : null,
-        sourcePath: placement.sourcePath,
-        sourceRevision: placement.sourceRevision,
-        title: placement.title,
-      };
-    });
+    const questions = projectRuntimeQuestions(
+      loaded.placements,
+      loaded.responses,
+      loaded.access
+    );
 
     return {
       attemptId: attempt._id,
       expiresAt: section.expiresAt,
       questions,
-      section: currentSection,
+      section: loaded.currentSection,
     };
   }
 );
+
+/** Loads the compact runtime plus immutable content selectors once. */
+export const loadSectionState = Effect.fn("tryouts.runtime.loadSectionState")(
+  function* (
+    ctx: QueryCtx,
+    attempt: Doc<"tryoutAttempts">,
+    section: Doc<"tryoutSectionAttempts">
+  ) {
+    const loaded = yield* loadSectionRows(ctx, attempt, section);
+    if (!loaded) {
+      return { content: noTryoutSectionContentAccess, runtime: null };
+    }
+
+    const content = yield* projectTryoutSignedContent({
+      access: loaded.access,
+      attempt,
+      locale: attempt.locale,
+      placements: loaded.placements,
+      totalQuestions: section.totalQuestions,
+    });
+    return {
+      content,
+      runtime: {
+        attemptId: attempt._id,
+        expiresAt: section.expiresAt,
+        questions: projectRuntimeQuestions(
+          loaded.placements,
+          loaded.responses,
+          loaded.access
+        ).map(({ title: _title, ...question }) => question),
+        section: loaded.currentSection,
+      },
+    };
+  }
+);
+
+/** Projects mutable response state without repeating immutable page fields. */
+function projectRuntimeQuestions(
+  placements: readonly TryoutPlacement[],
+  responses: ReadonlyMap<TryoutPlacement["_id"], TryoutResponse>,
+  access: { readonly answers: boolean; readonly questions: boolean }
+) {
+  return placements.map((placement) => {
+    const response = responses.get(placement._id) ?? null;
+    const choices = [...placement.choiceSnapshots].sort(
+      (left, right) => left.order - right.order
+    );
+
+    return {
+      choices: choices.map((choice) => ({
+        ...(access.answers ? { isCorrect: choice.isCorrect } : {}),
+        label: choice.label,
+        optionKey: choice.optionKey,
+        order: choice.order,
+      })),
+      contentHash: placement.contentHash,
+      placementId: placement._id,
+      questionOrder: placement.questionOrder,
+      response: response
+        ? {
+            answeredAt: response.answeredAt,
+            selectedOptionId: response.selectedOptionId,
+            updatedAt: response.updatedAt,
+          }
+        : null,
+      sourcePath: placement.sourcePath,
+      sourceRevision: placement.sourceRevision,
+      title: placement.title,
+    };
+  });
+}

--- a/packages/backend/convex/tryouts/runtime/section/state.ts
+++ b/packages/backend/convex/tryouts/runtime/section/state.ts
@@ -1,16 +1,20 @@
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { getOptionalAppUserForRead } from "@repo/backend/convex/lib/helpers/auth";
 import {
   loadAttemptSections,
   readAttemptResume,
 } from "@repo/backend/convex/tryouts/runtime/attempt/sections";
+import { loadAttemptState } from "@repo/backend/convex/tryouts/runtime/attempt/state";
+import { noTryoutSectionContentAccess } from "@repo/backend/convex/tryouts/runtime/content";
+import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
 import {
   readLatestAttemptByPath,
   readOwnedAttemptById,
 } from "@repo/backend/convex/tryouts/runtime/lookup";
 import {
   loadSectionRuntime,
+  loadSectionState,
   readCurrentSection,
 } from "@repo/backend/convex/tryouts/runtime/section/questions";
 import { Effect } from "effect";
@@ -21,11 +25,79 @@ interface SectionStateArgs {
   readonly publicPath: string;
 }
 
+/** Loads one exact section without repeating immutable catalog reads. */
+export const loadSectionAttemptState = Effect.fn(
+  "tryouts.runtime.loadSectionAttemptState"
+)(function* (
+  ctx: QueryCtx,
+  attempt: Doc<"tryoutAttempts">,
+  sectionKey: string
+) {
+  const snapshot = attempt.sectionSnapshots.find(
+    (section) => section.sectionKey === sectionKey
+  );
+  if (!snapshot) {
+    return null;
+  }
+
+  const sections = yield* loadAttemptSections(ctx, attempt);
+  const section =
+    sections.find((candidate) => candidate.sectionKey === sectionKey) ?? null;
+  const { current, loaded } = yield* Effect.all(
+    {
+      current: loadAttemptState(ctx, { attempt, sectionKey, sections }),
+      loaded: section
+        ? loadSectionState(ctx, attempt, section)
+        : Effect.succeed({
+            content: noTryoutSectionContentAccess,
+            runtime: null,
+          }),
+    },
+    { concurrency: "unbounded" }
+  );
+
+  return {
+    content: loaded.content,
+    state: {
+      attempt: current,
+      runtime: loaded.runtime,
+    },
+  };
+});
+
+/** Reads one mutable section state through an exact owned attempt ID. */
+export const readSectionAttemptState = Effect.fn(
+  "tryouts.runtime.readSectionAttemptState"
+)(function* (
+  ctx: QueryCtx,
+  args: {
+    readonly attemptId: Id<"tryoutAttempts">;
+    readonly sectionKey: string;
+  }
+) {
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
+  if (!auth) {
+    return null;
+  }
+
+  const attempt = yield* readOwnedAttemptById(
+    ctx,
+    args.attemptId,
+    auth.appUser._id
+  );
+  if (!attempt) {
+    return null;
+  }
+
+  const loaded = yield* loadSectionAttemptState(ctx, attempt, args.sectionKey);
+  return loaded?.state ?? null;
+});
+
 /** Resolves one owned section through its exact localized public path. */
 const readCurrentUserSectionSelection = Effect.fn(
   "tryouts.runtime.readCurrentUserSectionSelection"
 )(function* (ctx: QueryCtx, args: SectionStateArgs) {
-  const auth = yield* Effect.promise(() => getOptionalAppUserForRead(ctx));
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
   if (!auth) {
     return null;
   }

--- a/packages/backend/convex/tryouts/runtime/selectors.ts
+++ b/packages/backend/convex/tryouts/runtime/selectors.ts
@@ -34,12 +34,14 @@ export const loadTryoutSignedContent = Effect.fn(
   readonly snapshotId: string;
   readonly totalQuestions: number;
 }) {
-  if (input.attempt.locale !== input.locale) {
+  if (
+    input.attempt.snapshotReleaseId !== input.snapshotReleaseId ||
+    input.attempt.tryoutSnapshotId !== input.snapshotId
+  ) {
     return yield* selectorIntegrity(
       "Signed try-out attempt lost its locale or snapshot identity."
     );
   }
-
   const placements = yield* trySelectorPromise(() =>
     input.ctx.db
       .query("tryoutAttemptPlacements")
@@ -52,7 +54,31 @@ export const loadTryoutSignedContent = Effect.fn(
       )
       .take(input.totalQuestions + 1)
   );
-  if (placements.length !== input.totalQuestions) {
+  return yield* projectTryoutSignedContent({
+    access: input.access,
+    attempt: input.attempt,
+    locale: input.locale,
+    placements,
+    totalQuestions: input.totalQuestions,
+  });
+});
+
+/** Projects protected selectors from already-loaded frozen placements. */
+export const projectTryoutSignedContent = Effect.fn(
+  "tryouts.selectors.projectSignedContent"
+)(function* (input: {
+  readonly access: { readonly answers: boolean; readonly questions: boolean };
+  readonly attempt: TryoutAttempt;
+  readonly locale: ContentLocale;
+  readonly placements: readonly TryoutPlacement[];
+  readonly totalQuestions: number;
+}) {
+  if (input.attempt.locale !== input.locale) {
+    return yield* selectorIntegrity(
+      "Signed try-out attempt lost its locale or snapshot identity."
+    );
+  }
+  if (input.placements.length !== input.totalQuestions) {
     return yield* selectorIntegrity(
       "Signed try-out section lost one or more frozen placements."
     );
@@ -60,22 +86,22 @@ export const loadTryoutSignedContent = Effect.fn(
 
   const content: Extract<TryoutSectionContentAccess, { kind: "signed" }> = {
     answers: input.access.answers
-      ? yield* Effect.forEach(placements, (placement) =>
+      ? yield* Effect.forEach(input.placements, (placement) =>
           makeAnswerSelector(
             placement,
             input.locale,
-            input.snapshotId,
-            input.snapshotReleaseId
+            input.attempt.tryoutSnapshotId,
+            input.attempt.snapshotReleaseId
           )
         )
       : [],
     kind: "signed",
-    questions: yield* Effect.forEach(placements, (placement) =>
+    questions: yield* Effect.forEach(input.placements, (placement) =>
       makeQuestionSelector(
         placement,
         input.locale,
-        input.snapshotId,
-        input.snapshotReleaseId
+        input.attempt.tryoutSnapshotId,
+        input.attempt.snapshotReleaseId
       )
     ),
   };

--- a/packages/backend/convex/tryouts/runtime/set/state.ts
+++ b/packages/backend/convex/tryouts/runtime/set/state.ts
@@ -1,13 +1,21 @@
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { getOptionalAppUserForRead } from "@repo/backend/convex/lib/helpers/auth";
 import { loadAttemptSections } from "@repo/backend/convex/tryouts/runtime/attempt/sections";
-import { loadCurrentAttempt } from "@repo/backend/convex/tryouts/runtime/attempt/state";
+import {
+  loadAttemptState,
+  loadCurrentAttempt,
+} from "@repo/backend/convex/tryouts/runtime/attempt/state";
+import { noTryoutSectionContentAccess } from "@repo/backend/convex/tryouts/runtime/content";
+import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
 import {
   readLatestAttemptByPath,
   readOwnedAttemptById,
 } from "@repo/backend/convex/tryouts/runtime/lookup";
-import { loadSectionRuntime } from "@repo/backend/convex/tryouts/runtime/section/questions";
+import {
+  loadSectionRuntime,
+  loadSectionState,
+} from "@repo/backend/convex/tryouts/runtime/section/questions";
 import { Effect } from "effect";
 
 interface SetStateArgs {
@@ -16,11 +24,64 @@ interface SetStateArgs {
   readonly publicPath: string;
 }
 
+/** Loads one exact attempt without repeating immutable catalog reads. */
+export const loadSetAttemptState = Effect.fn(
+  "tryouts.runtime.loadSetAttemptState"
+)(function* (ctx: QueryCtx, attempt: Doc<"tryoutAttempts">) {
+  const sections = yield* loadAttemptSections(ctx, attempt);
+  const entrySnapshot = attempt.sectionSnapshots.find(
+    (snapshot) => snapshot.publicPath === undefined
+  );
+  const entrySection = entrySnapshot
+    ? (sections.find(
+        (section) => section.sectionKey === entrySnapshot.sectionKey
+      ) ?? null)
+    : null;
+  const { current, entry } = yield* Effect.all(
+    {
+      current: loadAttemptState(ctx, { attempt, sections }),
+      entry: entrySection
+        ? loadSectionState(ctx, attempt, entrySection)
+        : Effect.succeed({
+            content: noTryoutSectionContentAccess,
+            runtime: null,
+          }),
+    },
+    { concurrency: "unbounded" }
+  );
+
+  return {
+    content: entry.content,
+    state: {
+      attempt: current,
+      runtime: entry.runtime,
+    },
+  };
+});
+
+/** Reads one mutable set state through an exact owned attempt ID. */
+export const readSetAttemptState = Effect.fn(
+  "tryouts.runtime.readSetAttemptState"
+)(function* (ctx: QueryCtx, attemptId: Id<"tryoutAttempts">) {
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
+  if (!auth) {
+    return null;
+  }
+
+  const attempt = yield* readOwnedAttemptById(ctx, attemptId, auth.appUser._id);
+  if (!attempt) {
+    return null;
+  }
+
+  const loaded = yield* loadSetAttemptState(ctx, attempt);
+  return loaded.state;
+});
+
 /** Selects an exact attempt or the latest attempt for one localized set. */
 const readCurrentUserSetAttempt = Effect.fn(
   "tryouts.runtime.readCurrentUserSetAttempt"
 )(function* (ctx: QueryCtx, args: SetStateArgs) {
-  const auth = yield* Effect.promise(() => getOptionalAppUserForRead(ctx));
+  const auth = yield* tryRuntimePromise(() => getOptionalAppUserForRead(ctx));
   if (!auth) {
     return null;
   }

--- a/packages/backend/convex/tryouts/runtime/spec.ts
+++ b/packages/backend/convex/tryouts/runtime/spec.ts
@@ -1,0 +1,48 @@
+import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
+import { tryoutRuntimeChoiceValidator } from "@repo/backend/convex/tryouts/runtime/choice";
+import { tryoutCurrentSectionValidator } from "@repo/backend/convex/tryouts/runtime/content";
+import { tryoutScoreResultValidator } from "@repo/backend/convex/tryouts/score";
+import { tryoutStatusValidator } from "@repo/backend/convex/tryouts/status";
+import { v } from "convex/values";
+
+export const tryoutAttemptStateValidator = v.object({
+  activeSectionKey: v.union(tryoutRouteKeyValidator, v.null()),
+  attemptId: v.id("tryoutAttempts"),
+  attemptNumber: v.number(),
+  completedSectionKeys: v.array(tryoutRouteKeyValidator),
+  expiresAt: v.number(),
+  resumeSectionPublicPath: v.union(v.string(), v.null()),
+  resumeSectionKey: v.union(tryoutRouteKeyValidator, v.null()),
+  score: v.union(tryoutScoreResultValidator, v.null()),
+  section: v.union(tryoutCurrentSectionValidator, v.null()),
+  startedAt: v.number(),
+  status: tryoutStatusValidator,
+});
+
+const runtimeResponseValidator = v.object({
+  answeredAt: v.number(),
+  selectedOptionId: v.optional(v.string()),
+  updatedAt: v.number(),
+});
+
+const runtimeQuestionValidator = v.object({
+  choices: v.array(tryoutRuntimeChoiceValidator),
+  contentHash: v.string(),
+  placementId: v.id("tryoutAttemptPlacements"),
+  questionOrder: v.number(),
+  response: v.union(runtimeResponseValidator, v.null()),
+  sourcePath: v.string(),
+  sourceRevision: v.string(),
+});
+
+export const tryoutSectionRuntimeValidator = v.object({
+  attemptId: v.id("tryoutAttempts"),
+  expiresAt: v.number(),
+  questions: v.array(runtimeQuestionValidator),
+  section: tryoutCurrentSectionValidator,
+});
+
+export const tryoutRuntimeStateValidator = v.object({
+  attempt: tryoutAttemptStateValidator,
+  runtime: v.union(v.null(), tryoutSectionRuntimeValidator),
+});

--- a/packages/backend/convex/tryouts/sets/published.test.ts
+++ b/packages/backend/convex/tryouts/sets/published.test.ts
@@ -5,7 +5,7 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { getTryoutStatusRank } from "@repo/backend/convex/tryouts/progress/write";
+import { getTryoutStatusRank } from "@repo/backend/convex/tryouts/status";
 import {
   activateTryoutStartSource,
   TRYOUT_START_COUNTRY,

--- a/packages/backend/convex/tryouts/status.ts
+++ b/packages/backend/convex/tryouts/status.ts
@@ -10,3 +10,16 @@ export type TryoutStatus = Infer<typeof tryoutStatusValidator>;
 
 export const tryoutStatusRankValidator = literals(1, 2, 3);
 export type TryoutStatusRank = Infer<typeof tryoutStatusRankValidator>;
+
+/** Returns the stable workflow rank used by progress indexes. */
+export function getTryoutStatusRank(status: TryoutStatus): TryoutStatusRank {
+  if (status === "in-progress") {
+    return 1;
+  }
+
+  if (status === "completed") {
+    return 2;
+  }
+
+  return 3;
+}

--- a/packages/backend/test/tryout-source.ts
+++ b/packages/backend/test/tryout-source.ts
@@ -23,6 +23,7 @@ export const TRYOUT_START_EXAM = "tka";
 export const TRYOUT_START_TRACK = "matematika";
 export const TRYOUT_START_SET = "set-1";
 export const TRYOUT_START_SECTION = "matematika";
+export const TRYOUT_REVISED_SECTION = "numerasi";
 export const TRYOUT_REUSED_SET = "set-2";
 export const TRYOUT_REUSED_SECTION = "aljabar";
 export const TRYOUT_RENAMED_SET_PATH = PublicPathSchema.make(
@@ -110,6 +111,40 @@ export async function activateRenamedTryoutStartSource(ctx: MutationCtx) {
   await activateTryoutSnapshot(ctx, {
     catalog,
     placements: tryoutStartLocales.map(makeTryoutStartPlacement),
+  });
+}
+
+/** Activates a new internal entry for the same logical set identity. */
+export async function activateRevisedTryoutStartEntry(ctx: MutationCtx) {
+  await clearActiveTryoutSnapshot(ctx);
+
+  const catalog = tryoutStartLocales.flatMap((locale) =>
+    Schema.decodeUnknownSync(Schema.Array(TryoutCatalogRowSchema))(
+      makeTryoutStartHierarchy(locale, "internal-entry").map((row) => {
+        if (row.kind === "set") {
+          return {
+            ...row,
+            internalEntrySectionKey: TRYOUT_REVISED_SECTION,
+            publicPath: TRYOUT_RENAMED_SET_PATH,
+            sourceRevision: "2027",
+          };
+        }
+        if (row.kind === "section") {
+          return {
+            ...row,
+            questionSourcePath: `packages/corpus/${revisedSourcePath}`,
+            sectionKey: TRYOUT_REVISED_SECTION,
+            sourceRevision: "2027",
+            title: "Numerasi",
+          };
+        }
+        return row;
+      })
+    )
+  );
+  await activateTryoutSnapshot(ctx, {
+    catalog,
+    placements: tryoutStartLocales.map(makeRevisedTryoutStartPlacement),
   });
 }
 
@@ -307,6 +342,21 @@ function makeGraph(
 }
 
 const reusedSourcePath = `question-bank/tryout/${TRYOUT_START_COUNTRY}/${TRYOUT_START_EXAM}/${TRYOUT_REUSED_SECTION}/${TRYOUT_REUSED_SET}`;
+const revisedSourcePath = `question-bank/tryout/${TRYOUT_START_COUNTRY}/${TRYOUT_START_EXAM}/${TRYOUT_REVISED_SECTION}/${TRYOUT_START_SET}`;
+
+/** Builds one replacement placement for the revised internal entry. */
+function makeRevisedTryoutStartPlacement(locale: ContentLocale) {
+  const questionRoot = `${revisedSourcePath}/question-1`;
+  return Schema.decodeUnknownSync(TryoutPlacementSchema)({
+    ...makeTryoutStartPlacement(locale),
+    answerContentKey: `${questionRoot}/answer`,
+    questionContentKey: `${questionRoot}/question`,
+    questionSourcePath: `packages/corpus/${questionRoot}`,
+    sectionKey: TRYOUT_REVISED_SECTION,
+    sourceRevision: "2027",
+    title: "Revised question",
+  });
+}
 
 /** Builds one replacement placement whose public path belongs to another set. */
 function makeReusedTryoutStartPlacement(locale: ContentLocale) {


### PR DESCRIPTION
## What changed

- add one exact attempt-page query for current and retained set and section pages
- add compact exact state reads that preserve the signed attempt snapshot instead of rebuilding runtime state in the client
- validate the latest progress row against the owned attempt identity, route identity, attempt number, status, and derived status rank
- load section placements and responses once, then reuse them across integrity validation and runtime projections
- return active signed restart targets for terminal set results while keeping their review page frozen
- return active set and section destinations for retained sections without changing their frozen review content
- document the frozen-display and current-destination split in the try-out architecture ADR

## Why

The current UI composes an attempt from several reactive reads whose ownership and timing can diverge. This backend contract gives the web cutover one authoritative projection per runtime responsibility while preserving retained-attempt history and resolving current destinations independently.

Current and retained review data remain bound to the signed snapshot stored on the attempt. Restart and navigation targets come from the current active signed catalog, fail closed when a logical identity is no longer active, and never rewrite the frozen review page.

## Scope

This is an additive backend follow-up to merged #265. The current web remains functional. Legacy runtime queries and the compatibility response mutation remain only for the separate #267 web cutover and will be removed after that exact production journey is accepted.

Exact diff: 26 files, +2,015/-218. The largest changed production TypeScript module is 261 lines, the largest test is 463 lines, and no hand-written changed module exceeds 500 lines.

## Local verification

- isolated anonymous Convex Agent Mode codegen and deployment typecheck
- focused runtime owner tests: 5 files, 13 tests
- backend suite: 356 files, 1,530 tests
- web suite: 179 files, 1,100 tests
- API suite: 8 files, 48 tests
- MCP suite: 7 files, 18 tests
- CAS suite: 233 tests
- root test graph: 12/12 tasks
- backend, web, API, and MCP typechecks
- Effect source version check at 3.22.1
- format, lint, test ownership, workspace boundaries across 2,977 files, dependency audit, and diff checks
- repository React Doctor changed-scope gate exited 0 and correctly skipped because no web source changed
- two independent exact-diff reviews found no remaining code issue

## Acceptance

React Doctor [run 31412679062](https://github.com/nakafaai/nakafa.com/actions/runs/31412679062) and Agent-Friendly Docs [run 31412681021](https://github.com/nakafaai/nakafa.com/actions/runs/31412681021) passed at exact commit `fe612259dbb03985549e3a7a02522712b3ccf9db`. Hosted Codex found no major issues at that commit. Agent Docs passed 12/12 test tasks, all signed-runtime and generation checks, the anonymous Convex import, the 5/5 production build with 1,303/1,303 web pages, 23/23 AFDocs checks, and cleanup. Vercel recorded zero deployments across www, API, MCP, and CAS in the exact-head acceptance window, confirming preview deployments remain disabled.