### PR TITLE
perf(quran): cut over document and markdown consumers

### DIFF
--- a/apps/api/app/contents/quran/[surah]/route.test.ts
+++ b/apps/api/app/contents/quran/[surah]/route.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 const quranMocks = vi.hoisted(() => ({
-  readQuranApiPage: vi.fn(),
+  readQuranApiDocument: vi.fn(),
 }));
 const loggingMocks = vi.hoisted(() => ({
   logError: vi.fn(),
@@ -21,7 +21,7 @@ vi.mock("@repo/utilities/logging/effect", async () => {
 });
 
 vi.mock("@/lib/content/quran", () => ({
-  readQuranApiPage: quranMocks.readQuranApiPage,
+  readQuranApiDocument: quranMocks.readQuranApiDocument,
 }));
 
 afterEach(() => {
@@ -29,16 +29,22 @@ afterEach(() => {
 });
 
 describe("Quran content API route", () => {
-  it("returns the complete multilingual signed publication row", async () => {
-    quranMocks.readQuranApiPage.mockReturnValue(
+  it("returns one explicit locale-specific signed Quran document", async () => {
+    quranMocks.readQuranApiDocument.mockReturnValue(
       Effect.succeed({
-        surah: { name: { transliteration: "Al-Faatiha" }, number: 1 },
+        locale: "en",
+        surah: {
+          name: { transliteration: "Al-Faatiha" },
+          number: 1,
+          revelation: { order: 5, place: "Meccan" },
+        },
         verses: [
           {
+            arabic: "بِسْمِ اللّٰهِ",
             number: { inSurah: 1 },
             translation: {
-              en: { footnotes: "", text: "In the name of Allah." },
-              id: { footnotes: "", text: "Dengan nama Allah." },
+              footnotes: "Source note.",
+              text: "In Allah's name.",
             },
           },
         ],
@@ -53,18 +59,18 @@ describe("Quran content API route", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       name: { transliteration: "Al-Faatiha" },
+      locale: "en",
       number: 1,
+      revelation: { order: 5, place: "Meccan" },
       verses: [
         {
+          arabic: "بِسْمِ اللّٰهِ",
           number: { inSurah: 1 },
-          translation: {
-            en: { footnotes: "", text: "In the name of Allah." },
-            id: { footnotes: "", text: "Dengan nama Allah." },
-          },
+          translation: { footnotes: "Source note.", text: "In Allah's name." },
         },
       ],
     });
-    expect(quranMocks.readQuranApiPage).toHaveBeenCalledWith({
+    expect(quranMocks.readQuranApiDocument).toHaveBeenCalledWith({
       locale: "en",
       surahNumber: 1,
     });
@@ -78,12 +84,12 @@ describe("Quran content API route", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Failed to fetch surah." });
-    expect(quranMocks.readQuranApiPage).not.toHaveBeenCalled();
+    expect(quranMocks.readQuranApiDocument).not.toHaveBeenCalled();
   });
 
   it("logs signed publication failures with surah context", async () => {
     const readError = new Error("Publication unavailable");
-    quranMocks.readQuranApiPage.mockReturnValue(Effect.fail(readError));
+    quranMocks.readQuranApiDocument.mockReturnValue(Effect.fail(readError));
 
     const response = await GET(
       new Request("http://localhost/contents/quran/1"),
@@ -100,7 +106,7 @@ describe("Quran content API route", () => {
   });
 
   it("normalizes non-Error publication failures before logging", async () => {
-    quranMocks.readQuranApiPage.mockReturnValue(
+    quranMocks.readQuranApiDocument.mockReturnValue(
       Effect.fail("Publication unavailable")
     );
 

--- a/apps/api/app/contents/quran/[surah]/route.ts
+++ b/apps/api/app/contents/quran/[surah]/route.ts
@@ -3,7 +3,7 @@ import { defaultLocale } from "@repo/utilities/locales";
 import { logError } from "@repo/utilities/logging/effect";
 import { Effect } from "effect";
 import { NextResponse } from "next/server";
-import { readQuranApiPage } from "@/lib/content/quran";
+import { readQuranApiDocument } from "@/lib/content/quran";
 
 export const dynamic = "force-dynamic";
 export const revalidate = false;
@@ -26,9 +26,13 @@ export async function GET(
   }
 
   return Effect.runPromise(
-    readQuranApiPage({ locale: defaultLocale, surahNumber }).pipe(
-      Effect.map((page) =>
-        NextResponse.json({ ...page.surah, verses: page.verses })
+    readQuranApiDocument({ locale: defaultLocale, surahNumber }).pipe(
+      Effect.map((document) =>
+        NextResponse.json({
+          ...document.surah,
+          locale: document.locale,
+          verses: document.verses,
+        })
       ),
       Effect.catchAll((error) =>
         Effect.gen(function* () {

--- a/apps/api/lib/content/quran.test.ts
+++ b/apps/api/lib/content/quran.test.ts
@@ -1,13 +1,7 @@
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
-import {
-  encodeTestQuranRow,
-  makeQuranChunk,
-  makeQuranSearch,
-  makeQuranSurah,
-} from "@repo/backend/test/quran-rows";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readQuranApiPage } from "@/lib/content/quran";
+import { readQuranApiDocument } from "@/lib/content/quran";
 
 const runtimeClientMocks = vi.hoisted(() => ({
   fetchConvexRuntimeQuery: vi.fn(),
@@ -30,37 +24,40 @@ afterEach(() => {
 });
 
 describe("Quran API content", () => {
-  it("reads and validates one signed Quran page", async () => {
-    const surah = makeQuranSurah(1);
-    const chunk = makeQuranChunk({
-      firstQuranNumber: 1,
-      firstVerse: 1,
-      surahNumber: 1,
-      verseCount: 1,
-    });
-    const search = makeQuranSearch("en", 1);
-    const nextSurah = makeQuranSurah(2);
+  it("reads and validates one locale-specific signed Quran document", async () => {
     runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
       ...source,
-      chunkJson: [encodeTestQuranRow(source.snapshotId, chunk)],
-      nextSurahJson: encodeTestQuranRow(source.snapshotId, nextSurah),
-      prevSurahJson: null,
-      searchJson: encodeTestQuranRow(source.snapshotId, search),
-      surahJson: encodeTestQuranRow(source.snapshotId, surah),
+      locale: "en",
+      surah: {
+        kind: "quran-surah",
+        name: {
+          arabic: "الفاتحة",
+          translation: "The Opening",
+          transliteration: "Al-Fatihah",
+        },
+        number: 1,
+        numberOfVerses: 1,
+        revelation: { order: 5, place: "Meccan" },
+      },
+      verses: [
+        {
+          arabic: "بِسْمِ اللّٰهِ",
+          number: { inQuran: 1, inSurah: 1 },
+          translation: { footnotes: "Source note.", text: "In Allah's name." },
+        },
+      ],
     });
 
     await expect(
-      Effect.runPromise(readQuranApiPage({ locale: "en", surahNumber: 1 }))
-    ).resolves.toEqual({
-      activeManifestHash: source.activeManifestHash,
-      activeReleaseId: source.activeReleaseId,
-      nextSurah,
-      previousSurah: null,
-      search,
-      snapshotId: source.snapshotId,
-      sourceRevision: source.sourceRevision,
-      surah,
-      verses: chunk.verses,
+      Effect.runPromise(readQuranApiDocument({ locale: "en", surahNumber: 1 }))
+    ).resolves.toMatchObject({
+      locale: "en",
+      surah: { number: 1, revelation: { order: 5, place: "Meccan" } },
+      verses: [
+        {
+          translation: { footnotes: "Source note.", text: "In Allah's name." },
+        },
+      ],
     });
     expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
@@ -75,7 +72,7 @@ describe("Quran API content", () => {
     );
     await expect(
       Effect.runPromise(
-        Effect.either(readQuranApiPage({ locale: "en", surahNumber: 1 }))
+        Effect.either(readQuranApiDocument({ locale: "en", surahNumber: 1 }))
       )
     ).resolves.toMatchObject({
       _tag: "Left",
@@ -84,15 +81,13 @@ describe("Quran API content", () => {
 
     runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
       ...source,
-      chunkJson: [],
-      nextSurahJson: null,
-      prevSurahJson: null,
-      searchJson: null,
-      surahJson: null,
+      locale: "en",
+      surah: null,
+      verses: [],
     });
     await expect(
       Effect.runPromise(
-        Effect.either(readQuranApiPage({ locale: "en", surahNumber: 1 }))
+        Effect.either(readQuranApiDocument({ locale: "en", surahNumber: 1 }))
       )
     ).resolves.toMatchObject({
       _tag: "Left",

--- a/apps/api/lib/content/quran.ts
+++ b/apps/api/lib/content/quran.ts
@@ -1,34 +1,34 @@
-import { decodePublishedQuranPage } from "@repo/backend/client/quran/decode";
+import { decodePublishedQuranDocument } from "@repo/backend/client/quran/document";
 import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionArgs } from "convex/server";
 import { Effect, Schema } from "effect";
 import { env } from "@/env";
 
-type QuranPageArgs = FunctionArgs<typeof api.contentRelease.quran.page>;
+type QuranDocumentArgs = FunctionArgs<typeof api.contentRelease.quran.document>;
 
-/** The public API could not read or validate one signed Quran page. */
+/** The public API could not read or validate one signed Quran document. */
 export class QuranApiReadError extends Schema.TaggedError<QuranApiReadError>()(
   "QuranApiReadError",
   { cause: Schema.Unknown }
 ) {}
 
-/** Reads and validates one active signed Quran page for the public API. */
-export const readQuranApiPage = Effect.fn("api.quran.readPage")(function* (
-  args: QuranPageArgs
-) {
-  const result = yield* Effect.tryPromise({
-    try: () =>
-      fetchConvexRuntimeQuery(
-        env.NEXT_PUBLIC_CONVEX_URL,
-        api.contentRelease.quran.page,
-        args
-      ),
-    catch: (cause) => new QuranApiReadError({ cause }),
-  });
+/** Reads and validates one active signed Quran document for the public API. */
+export const readQuranApiDocument = Effect.fn("api.quran.readDocument")(
+  function* (args: QuranDocumentArgs) {
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        fetchConvexRuntimeQuery(
+          env.NEXT_PUBLIC_CONVEX_URL,
+          api.contentRelease.quran.document,
+          args
+        ),
+      catch: (cause) => new QuranApiReadError({ cause }),
+    });
 
-  return yield* decodePublishedQuranPage(result, {
-    locale: args.locale,
-    surahNumber: args.surahNumber,
-  }).pipe(Effect.mapError((cause) => new QuranApiReadError({ cause })));
-});
+    return yield* decodePublishedQuranDocument(result, {
+      locale: args.locale,
+      surahNumber: args.surahNumber,
+    }).pipe(Effect.mapError((cause) => new QuranApiReadError({ cause })));
+  }
+);

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -3,8 +3,6 @@
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import {
   encodeTestQuranRow,
-  makeQuranChunk,
-  makeQuranSearch,
   makeQuranSurah,
 } from "@repo/backend/test/quran-rows";
 import { Effect } from "effect";
@@ -14,7 +12,7 @@ import {
   getPublishedQuranView,
   readPublishedQuranCatalog,
   readPublishedQuranIdentity,
-  readPublishedQuranPage,
+  readPublishedQuranMarkdown,
 } from "@/lib/content/quran/publication";
 
 const fetchMock = vi.hoisted(() => vi.fn());
@@ -67,12 +65,28 @@ describe("published Quran content", () => {
     expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
   });
 
-  it("reads the complete signed page through the Effect boundary", async () => {
-    const result = pageResult();
+  it("reads the locale-specific signed markdown through the Effect boundary", async () => {
+    const result = markdownResult();
     fetchMock.mockResolvedValue(result);
 
     await expect(
-      Effect.runPromise(readPublishedQuranPage("id", 1))
+      Effect.runPromise(readPublishedQuranMarkdown("id", 1, 80))
+    ).resolves.toMatchObject({
+      surah: { number: 1 },
+      verses: [{ number: {} }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+      locale: "id",
+      surahNumber: 1,
+      verseLimit: 80,
+    });
+  });
+
+  it("reads the complete signed markdown when no verse limit is requested", async () => {
+    fetchMock.mockResolvedValue(markdownResult());
+
+    await expect(
+      Effect.runPromise(readPublishedQuranMarkdown("id", 1))
     ).resolves.toMatchObject({
       surah: { number: 1 },
       verses: [{ number: {} }],
@@ -159,20 +173,27 @@ function viewResult() {
   };
 }
 
-/** Builds one complete signed Quran page response. */
-function pageResult() {
-  const chunk = makeQuranChunk({
-    firstQuranNumber: 1,
-    firstVerse: 1,
-    surahNumber: 1,
-    verseCount: 1,
-  });
+/** Builds one locale-specific signed Quran markdown response. */
+function markdownResult() {
   return {
     ...source,
-    chunkJson: [encodeTestQuranRow(source.snapshotId, chunk)],
-    nextSurahJson: encodeTestQuranRow(source.snapshotId, makeQuranSurah(2)),
-    prevSurahJson: null,
-    searchJson: encodeTestQuranRow(source.snapshotId, makeQuranSearch("id", 1)),
-    surahJson: encodeTestQuranRow(source.snapshotId, makeQuranSurah(1)),
+    locale: "id",
+    surah: {
+      name: {
+        translation: "Technical meaning 1",
+        transliteration: "Technical Surah 1",
+      },
+      number: 1,
+      numberOfVerses: 1,
+      revelation: { place: "Meccan" },
+    },
+    toVerse: 1,
+    verses: [
+      {
+        arabic: "آية 1",
+        number: { inSurah: 1 },
+        translation: { footnotes: "", text: "Terjemahan teknis 1" },
+      },
+    ],
   };
 }

--- a/apps/www/lib/content/quran/publication.ts
+++ b/apps/www/lib/content/quran/publication.ts
@@ -2,9 +2,9 @@ import "server-only";
 
 import {
   decodePublishedQuranCatalog,
-  decodePublishedQuranPage,
   decodePublishedQuranSource,
 } from "@repo/backend/client/quran/decode";
+import { decodePublishedQuranMarkdown } from "@repo/backend/client/quran/markdown";
 import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
@@ -25,11 +25,22 @@ function fetchCatalogResult() {
   return fetchRuntimeQuery(api.contentRelease.quran.surahs, {});
 }
 
-/** Reads one raw signed Quran page through the public Convex query. */
-function fetchPageResult(locale: Locale, surahNumber: number) {
-  return fetchRuntimeQuery(api.contentRelease.quran.page, {
+/** Reads one raw signed Quran markdown projection through the public query. */
+function fetchMarkdownResult(
+  locale: Locale,
+  surahNumber: number,
+  verseLimit?: number
+) {
+  if (verseLimit === undefined) {
+    return fetchRuntimeQuery(api.contentRelease.quran.markdown, {
+      locale,
+      surahNumber,
+    });
+  }
+  return fetchRuntimeQuery(api.contentRelease.quran.markdown, {
     locale,
     surahNumber,
+    verseLimit,
   });
 }
 
@@ -63,14 +74,18 @@ export const readPublishedQuranCatalog = Effect.fn(
   return yield* decodePublishedQuranCatalog(result);
 });
 
-/** Reads and validates one complete active signed Quran page. */
-export const readPublishedQuranPage = Effect.fn(
-  "NakafaQuran.readPublishedPage"
-)(function* (locale: Locale, surahNumber: number) {
-  const result = yield* readRuntimeQuery("contentRelease.quran.page", () =>
-    fetchPageResult(locale, surahNumber)
+/** Reads and validates one active signed Quran markdown projection. */
+export const readPublishedQuranMarkdown = Effect.fn(
+  "NakafaQuran.readPublishedMarkdown"
+)(function* (locale: Locale, surahNumber: number, verseLimit?: number) {
+  const result = yield* readRuntimeQuery("contentRelease.quran.markdown", () =>
+    fetchMarkdownResult(locale, surahNumber, verseLimit)
   );
-  return yield* decodePublishedQuranPage(result, { locale, surahNumber });
+  return yield* decodePublishedQuranMarkdown(result, {
+    locale,
+    surahNumber,
+    verseLimit,
+  });
 });
 
 /** Caches the complete signed Quran metadata catalog by active release. */

--- a/apps/www/lib/llms/quran.test.ts
+++ b/apps/www/lib/llms/quran.test.ts
@@ -10,20 +10,20 @@ import {
 
 const publicationMocks = vi.hoisted(() => ({
   readPublishedQuranCatalog: vi.fn(),
-  readPublishedQuranPage: vi.fn(),
+  readPublishedQuranMarkdown: vi.fn(),
 }));
 
 vi.mock("@/lib/content/quran/publication", () => publicationMocks);
 
 beforeEach(() => {
   publicationMocks.readPublishedQuranCatalog.mockReset();
-  publicationMocks.readPublishedQuranPage.mockReset();
+  publicationMocks.readPublishedQuranMarkdown.mockReset();
   publicationMocks.readPublishedQuranCatalog.mockReturnValue(
     Effect.succeed({ surahs: [surahMetadata(1), surahMetadata(2)] })
   );
-  publicationMocks.readPublishedQuranPage.mockImplementation(
-    (_locale: "en" | "id", surahNumber: number) =>
-      Effect.succeed(surahPage(surahNumber))
+  publicationMocks.readPublishedQuranMarkdown.mockImplementation(
+    (_locale: "en" | "id", surahNumber: number, verseLimit?: number) =>
+      Effect.succeed(surahMarkdown(surahNumber, verseLimit))
   );
 });
 
@@ -140,38 +140,28 @@ function surahMetadata(number: number) {
   };
 }
 
-/** Builds one signed Quran page for markdown rendering checks. */
-function surahPage(number: number) {
+/** Builds one signed Quran projection for markdown rendering checks. */
+function surahMarkdown(number: number, verseLimit?: number) {
+  const numberOfVerses = number === 1 ? 1 : 82;
+  const toVerse = Math.min(verseLimit ?? numberOfVerses, numberOfVerses);
   return {
+    locale: "en",
     surah: surahMetadata(number),
-    verses: Array.from({ length: number === 1 ? 1 : 82 }, (_, index) =>
+    toVerse,
+    verses: Array.from({ length: toVerse }, (_, index) =>
       verseFixture(index + 1)
     ),
   };
 }
 
-/** Builds one exact signed Quran runtime verse. */
+/** Builds one exact locale-specific Quran markdown verse. */
 function verseFixture(number: number) {
   return {
-    meta: {
-      hizbQuarter: 1,
-      juz: 1,
-      manzil: 1,
-      page: 1,
-      ruku: 1,
-      sajda: null,
-    },
-    number: { inQuran: number, inSurah: number },
-    tafsir: {
-      id: { footnotes: null, text: `Tafsir ${number}.` },
-    },
-    text: { arabic: "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ" },
+    arabic: "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ",
+    number: { inSurah: number },
     translation: {
-      en: {
-        footnotes: number === 1 ? "Source note." : "",
-        text: `Translation ${number}.`,
-      },
-      id: { footnotes: "", text: `Terjemahan ${number}.` },
+      footnotes: number === 1 ? "Source note." : "",
+      text: `Translation ${number}.`,
     },
   };
 }

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import {
   readPublishedQuranCatalog,
-  readPublishedQuranPage,
+  readPublishedQuranMarkdown,
 } from "@/lib/content/quran/publication";
 import { BASE_URL } from "@/lib/llms/constants";
 import { buildPublishedContentLlmsEntries } from "@/lib/llms/entries";
@@ -109,8 +109,12 @@ function getSurahLlmsText({
   surahNumber: number;
 }) {
   return Effect.gen(function* () {
-    const page = yield* readPublishedQuranPage(locale, surahNumber);
-    const surah = page.surah;
+    const markdown = yield* readPublishedQuranMarkdown(
+      locale,
+      surahNumber,
+      QURAN_PAGE_MARKDOWN_VERSE_LIMIT
+    );
+    const surah = markdown.surah;
     const title = getQuranSurahName(surah.name);
     const translation = surah.name.translation;
     const scanned = buildHeader({
@@ -129,13 +133,13 @@ function getSurahLlmsText({
     scanned.push("### Verses");
     scanned.push("");
 
-    for (const verse of page.verses.slice(0, QURAN_PAGE_MARKDOWN_VERSE_LIMIT)) {
+    for (const verse of markdown.verses) {
       scanned.push(`#### Verse ${verse.number.inSurah}`);
       scanned.push("");
-      scanned.push(verse.text.arabic);
+      scanned.push(verse.arabic);
       scanned.push("");
-      scanned.push(`**Translation:** ${verse.translation[locale].text}`);
-      const footnotes = verse.translation[locale].footnotes;
+      scanned.push(`**Translation:** ${verse.translation.text}`);
+      const footnotes = verse.translation.footnotes;
       if (footnotes) {
         scanned.push("");
         scanned.push(`**Translation notes:** ${footnotes}`);
@@ -143,9 +147,9 @@ function getSurahLlmsText({
       scanned.push("");
     }
 
-    if (page.verses.length > QURAN_PAGE_MARKDOWN_VERSE_LIMIT) {
+    if (surah.numberOfVerses > markdown.toVerse) {
       scanned.push(
-        `_This page-level markdown is bounded to verses 1-${QURAN_PAGE_MARKDOWN_VERSE_LIMIT} of ${surah.numberOfVerses}. Use the Nakafa Quran reference tool for exact verse ranges._`
+        `_This page-level markdown is bounded to verses 1-${markdown.toVerse} of ${surah.numberOfVerses}. Use the Nakafa Quran reference tool for exact verse ranges._`
       );
       scanned.push("");
     }

--- a/packages/backend/client/nakafa/quran.test.ts
+++ b/packages/backend/client/nakafa/quran.test.ts
@@ -130,9 +130,10 @@ function readRuntimeFixture(
     return Promise.resolve(referenceResult(args));
   }
   if (
-    getFunctionName(query) === getFunctionName(api.contentRelease.quran.page)
+    getFunctionName(query) ===
+    getFunctionName(api.contentRelease.quran.markdown)
   ) {
-    return Promise.resolve(pageResult(args));
+    return Promise.resolve(markdownResult(args));
   }
 
   return Promise.reject(new Error("Unhandled Quran query fixture."));
@@ -151,16 +152,33 @@ function referenceResult(args: Record<string, unknown>) {
   };
 }
 
-/** Builds one complete signed page response around a bounded chunk. */
-function pageResult(args: Record<string, unknown>) {
+/** Builds one locale-specific signed markdown response. */
+function markdownResult(args: Record<string, unknown>) {
   const locale = args.locale === "id" ? "id" : "en";
+  const verse = chunkRow().verses[0];
+  if (!verse) {
+    throw new Error("Expected one technical Quran verse.");
+  }
   return {
     ...source,
-    chunkJson: [encodeTestQuranRow(source.snapshotId, chunkRow())],
-    nextSurahJson: encodeTestQuranRow(source.snapshotId, surahRow(2)),
-    prevSurahJson: null,
-    searchJson: encodeTestQuranRow(source.snapshotId, searchRow(locale)),
-    surahJson: encodeTestQuranRow(source.snapshotId, surahRow()),
+    locale,
+    surah: {
+      name: {
+        translation: "Pembukaan",
+        transliteration: "Al-Fatihah",
+      },
+      number: 1,
+      numberOfVerses: 1,
+      revelation: { place: "Meccan" },
+    },
+    toVerse: 1,
+    verses: [
+      {
+        arabic: verse.text.arabic,
+        number: { inSurah: verse.number.inSurah },
+        translation: verse.translation[locale],
+      },
+    ],
   };
 }
 

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -5,10 +5,8 @@ import {
   toNakafaQuranDataReadError,
 } from "@repo/backend/client/nakafa/decode";
 import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
-import {
-  decodePublishedQuranPage,
-  decodePublishedQuranReference,
-} from "@repo/backend/client/quran/decode";
+import { decodePublishedQuranReference } from "@repo/backend/client/quran/decode";
+import { decodePublishedQuranMarkdown } from "@repo/backend/client/quran/markdown";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
 import { api } from "@repo/backend/convex/_generated/api";
 import { createNakafaContentRefFromGraphProjection } from "@repo/contents/_lib/agent/refs";
@@ -84,18 +82,18 @@ export function readQuranMarkdown(
 
     const result = yield* fetchNakafaRuntimeQuery(
       convexUrl,
-      "contentRelease.quran.page",
-      api.contentRelease.quran.page,
+      "contentRelease.quran.markdown",
+      api.contentRelease.quran.markdown,
       {
         locale: ref.locale,
         surahNumber,
       }
     );
-    const page = yield* decodePublishedQuranPage(result, {
+    const publication = yield* decodePublishedQuranMarkdown(result, {
       locale: ref.locale,
       surahNumber,
     }).pipe(Effect.mapError(toNakafaQuranDataReadError));
-    const surah = page.surah;
+    const surah = publication.surah;
     const title = getSurahName(surah);
     const translation = surah.name.translation;
     const markdown = yield* decodeNakafaMarkdown({
@@ -109,12 +107,12 @@ export function readQuranMarkdown(
         "",
         "## Verses",
         "",
-        ...page.verses.flatMap((verse) => [
+        ...publication.verses.flatMap((verse) => [
           `### Verse ${verse.number.inSurah}`,
           "",
-          verse.text.arabic,
+          verse.arabic,
           "",
-          `Translation: ${verse.translation[ref.locale].text}`,
+          `Translation: ${verse.translation.text}`,
           "",
         ]),
       ].join("\n"),


### PR DESCRIPTION
## Summary

- switch API Quran reads to the signed document projection
- switch WWW markdown to the signed markdown projection with an 80-verse bound
- switch shared Nina and MCP Quran reads to the full signed markdown projection
- preserve exact snapshot cache tags and stale-snapshot recovery

## Verification

- API targeted suite: 2 files, 6 tests, 100% coverage
- www full suite: 178 files, 1105 tests, 100% coverage
- MCP: 7 files, 18 tests, 100% coverage
- AI: 61 files, 375 tests, 100% coverage
- backend, API, www, MCP, and AI typechecks
- lint, boundaries, security audit, React Doctor 100

## Rollout

PR #268 is merged, and the additive document, markdown, and legacy page functions are verified in Convex production. After this switch reaches all three production aliases, verify the web, API, Nina, and MCP consumers, then drain legacy page traffic for at least 300 seconds before PR #270 removes the old transport.