### PR TITLE
perf(tryouts): isolate missed expiry reconciliation

### DIFF
--- a/packages/backend/convex/tryouts/mutations/expiry.test.ts
+++ b/packages/backend/convex/tryouts/mutations/expiry.test.ts
@@ -1,0 +1,344 @@
+import { internal } from "@repo/backend/convex/_generated/api";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import {
+  insertTryoutAttempt,
+  insertTryoutSectionAttempt,
+  insertTryoutUser,
+  seedTryoutContentAccessState,
+} from "@repo/backend/test/tryout-runtime";
+import { makeTryoutSet } from "@repo/backend/test/tryouts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const NOW = Date.UTC(2026, 6, 7, 12, 0, 0);
+const EXPIRED_AT = NOW - 60_000;
+const ACTIVE_EXPIRES_AT = NOW + 3_600_000;
+const STALE_EXPIRES_AT = EXPIRED_AT - 60_000;
+const ATTEMPT_EXPIRY_NAME = "tryouts/mutations/expiry:attempt";
+const SECTION_EXPIRY_NAME = "tryouts/mutations/expiry:section";
+const ATTEMPT_RECONCILIATION_NAME =
+  "tryouts/mutations/expiry:reconcileAttempts";
+const SECTION_RECONCILIATION_NAME =
+  "tryouts/mutations/expiry:reconcileSections";
+
+describe("tryouts/mutations/expiry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it("queues isolated attempt and section expiry jobs idempotently", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const fixture = await t.mutation(async (ctx) => {
+      const expired = await seedTryoutContentAccessState(ctx, {
+        attemptStatus: "in-progress",
+        sectionStatus: "in-progress",
+        suffix: "expiry-sweep-attempt",
+      });
+      await ctx.db.patch(expired.attemptId, {
+        expiresAt: EXPIRED_AT,
+        scoreStatus: "official",
+        scoringStrategy: "raw",
+      });
+      await ctx.db.patch(expired.sectionAttemptId, {
+        expiresAt: EXPIRED_AT,
+      });
+
+      const expiredAttempt = await ctx.db.get(expired.attemptId);
+      if (!expiredAttempt) {
+        throw new Error("Expected the expired attempt fixture.");
+      }
+
+      const activeUserId = await insertTryoutUser(ctx, {
+        authId: "auth-expiry-sweep-section",
+        email: "expiry-sweep-section@example.com",
+        name: "Expiry Sweep Section",
+      });
+      const activeAttemptId = await insertTryoutAttempt(ctx, {
+        expiresAt: ACTIVE_EXPIRES_AT,
+        scoringStrategy: "raw",
+        sectionSnapshots: expiredAttempt.sectionSnapshots,
+        set: makeTryoutSet(),
+        snapshotId: expiredAttempt.tryoutSnapshotId,
+        snapshotReleaseId: expiredAttempt.snapshotReleaseId,
+        userId: activeUserId,
+      });
+      const expiredSectionId = await insertTryoutSectionAttempt(ctx, {
+        expiresAt: EXPIRED_AT,
+        tryoutAttemptId: activeAttemptId,
+      });
+
+      return {
+        activeAttemptId,
+        expiredAttemptId: expired.attemptId,
+        expiredAttemptSectionId: expired.sectionAttemptId,
+        expiredSectionId,
+      };
+    });
+
+    await t.mutation(internal.tryouts.mutations.expiry.sweep, {});
+    await t.mutation(internal.tryouts.mutations.expiry.sweep, {});
+
+    const beforeDrain = await t.query(async (ctx) => {
+      const scheduledJobs = await ctx.db.system
+        .query("_scheduled_functions")
+        .collect();
+
+      return {
+        activeAttempt: await ctx.db.get(fixture.activeAttemptId),
+        expiredAttempt: await ctx.db.get(fixture.expiredAttemptId),
+        expiredAttemptSection: await ctx.db.get(
+          fixture.expiredAttemptSectionId
+        ),
+        expiredSection: await ctx.db.get(fixture.expiredSectionId),
+        expiryJobs: scheduledJobs.filter(({ name }) =>
+          name.startsWith("tryouts/mutations/expiry:")
+        ),
+        scores: await ctx.db.query("tryoutScores").collect(),
+      };
+    });
+
+    const expectedAttemptReconciliation = {
+      args: [{ before: NOW }],
+      name: ATTEMPT_RECONCILIATION_NAME,
+      state: { kind: "pending" },
+    };
+
+    expect(
+      beforeDrain.expiryJobs.map(({ args, name, state }) => ({
+        args,
+        name,
+        state,
+      }))
+    ).toEqual([expectedAttemptReconciliation, expectedAttemptReconciliation]);
+    expect(beforeDrain).toMatchObject({
+      activeAttempt: { status: "in-progress" },
+      expiredAttempt: { status: "in-progress" },
+      expiredAttemptSection: { status: "in-progress" },
+      expiredSection: { status: "in-progress" },
+      scores: [],
+    });
+
+    vi.runOnlyPendingTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const afterAttemptPhase = await t.query(async (ctx) => {
+      const scheduledJobs = await ctx.db.system
+        .query("_scheduled_functions")
+        .collect();
+
+      return {
+        activeAttempt: await ctx.db.get(fixture.activeAttemptId),
+        attemptExpiryJobs: scheduledJobs.filter(
+          ({ name }) => name === ATTEMPT_EXPIRY_NAME
+        ),
+        attemptReconciliationJobs: scheduledJobs.filter(
+          ({ name }) => name === ATTEMPT_RECONCILIATION_NAME
+        ),
+        expiredAttempt: await ctx.db.get(fixture.expiredAttemptId),
+        scores: await ctx.db.query("tryoutScores").collect(),
+        sectionExpiryJobs: scheduledJobs.filter(
+          ({ name }) => name === SECTION_EXPIRY_NAME
+        ),
+        sectionReconciliationJobs: scheduledJobs.filter(
+          ({ name }) => name === SECTION_RECONCILIATION_NAME
+        ),
+      };
+    });
+
+    expect(afterAttemptPhase).toMatchObject({
+      activeAttempt: { status: "in-progress" },
+      expiredAttempt: { status: "in-progress" },
+      scores: [],
+      sectionExpiryJobs: [],
+    });
+    expect(afterAttemptPhase.attemptReconciliationJobs).toHaveLength(2);
+    expect(
+      afterAttemptPhase.attemptReconciliationJobs.every(
+        ({ state }) => state.kind === "success"
+      )
+    ).toBe(true);
+    expect(
+      afterAttemptPhase.attemptExpiryJobs.map(({ args, state }) => ({
+        args,
+        state,
+      }))
+    ).toEqual(
+      Array.from({ length: 2 }, () => ({
+        args: [
+          {
+            attemptId: fixture.expiredAttemptId,
+            expiresAt: EXPIRED_AT,
+          },
+        ],
+        state: { kind: "pending" },
+      }))
+    );
+    expect(
+      afterAttemptPhase.sectionReconciliationJobs.map(({ args, state }) => ({
+        args,
+        state,
+      }))
+    ).toEqual(
+      Array.from({ length: 2 }, () => ({
+        args: [
+          {
+            before: NOW,
+            scheduledAttemptIds: [fixture.expiredAttemptId],
+          },
+        ],
+        state: { kind: "pending" },
+      }))
+    );
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const afterDrain = await t.query(async (ctx) => {
+      const scheduledJobs = await ctx.db.system
+        .query("_scheduled_functions")
+        .collect();
+
+      return {
+        activeAttempt: await ctx.db.get(fixture.activeAttemptId),
+        activeAttemptScore: await ctx.db
+          .query("tryoutScores")
+          .withIndex("by_tryoutAttemptId", (query) =>
+            query.eq("tryoutAttemptId", fixture.activeAttemptId)
+          )
+          .unique(),
+        expiredAttempt: await ctx.db.get(fixture.expiredAttemptId),
+        expiredAttemptScore: await ctx.db
+          .query("tryoutScores")
+          .withIndex("by_tryoutAttemptId", (query) =>
+            query.eq("tryoutAttemptId", fixture.expiredAttemptId)
+          )
+          .unique(),
+        expiredAttemptSection: await ctx.db.get(
+          fixture.expiredAttemptSectionId
+        ),
+        expiredSection: await ctx.db.get(fixture.expiredSectionId),
+        expiryJobs: scheduledJobs.filter(({ name }) =>
+          name.startsWith("tryouts/mutations/expiry:")
+        ),
+        scores: await ctx.db.query("tryoutScores").collect(),
+      };
+    });
+
+    expect(afterDrain).toMatchObject({
+      activeAttempt: {
+        endReason: "submitted",
+        status: "completed",
+      },
+      activeAttemptScore: {
+        rawScore: 0,
+        scoringStrategy: "raw",
+      },
+      expiredAttempt: {
+        endReason: "time-expired",
+        status: "expired",
+      },
+      expiredAttemptScore: {
+        rawScore: 0,
+        scoringStrategy: "raw",
+      },
+      expiredAttemptSection: {
+        endReason: "time-expired",
+        status: "expired",
+      },
+      expiredSection: {
+        endReason: "time-expired",
+        status: "expired",
+      },
+    });
+    expect(afterDrain.scores).toHaveLength(2);
+    expect(
+      afterDrain.expiryJobs.every(({ state }) => state.kind === "success")
+    ).toBe(true);
+
+    const attemptReconciliationJobs = afterDrain.expiryJobs.filter(
+      ({ name }) => name === ATTEMPT_RECONCILIATION_NAME
+    );
+    const sectionReconciliationJobs = afterDrain.expiryJobs.filter(
+      ({ name }) => name === SECTION_RECONCILIATION_NAME
+    );
+    const attemptExpiryJobs = afterDrain.expiryJobs.filter(
+      ({ name }) => name === ATTEMPT_EXPIRY_NAME
+    );
+    const sectionExpiryJobs = afterDrain.expiryJobs.filter(
+      ({ name }) => name === SECTION_EXPIRY_NAME
+    );
+
+    expect(attemptReconciliationJobs).toHaveLength(2);
+    expect(sectionReconciliationJobs).toHaveLength(2);
+    expect(attemptExpiryJobs).toHaveLength(2);
+    expect(attemptExpiryJobs.map(({ args }) => args)).toEqual(
+      Array.from({ length: attemptExpiryJobs.length }, () => [
+        {
+          attemptId: fixture.expiredAttemptId,
+          expiresAt: EXPIRED_AT,
+        },
+      ])
+    );
+    expect(sectionExpiryJobs).toHaveLength(2);
+    expect(sectionExpiryJobs.map(({ args }) => args)).toEqual(
+      Array.from({ length: sectionExpiryJobs.length }, () => [
+        {
+          expiresAt: EXPIRED_AT,
+          sectionAttemptId: fixture.expiredSectionId,
+        },
+      ])
+    );
+  });
+
+  it("ignores stale attempt and section expiry jobs", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const fixture = await t.mutation(async (ctx) => {
+      const seeded = await seedTryoutContentAccessState(ctx, {
+        attemptStatus: "in-progress",
+        sectionStatus: "in-progress",
+        suffix: "expiry-stale-deadline",
+      });
+      await ctx.db.patch(seeded.attemptId, {
+        expiresAt: EXPIRED_AT,
+        scoreStatus: "official",
+        scoringStrategy: "raw",
+      });
+      await ctx.db.patch(seeded.sectionAttemptId, {
+        expiresAt: EXPIRED_AT,
+      });
+      return seeded;
+    });
+
+    await t.mutation(internal.tryouts.mutations.expiry.attempt, {
+      attemptId: fixture.attemptId,
+      expiresAt: STALE_EXPIRES_AT,
+    });
+    await t.mutation(internal.tryouts.mutations.expiry.section, {
+      expiresAt: STALE_EXPIRES_AT,
+      sectionAttemptId: fixture.sectionAttemptId,
+    });
+
+    const state = await t.query(async (ctx) => ({
+      attempt: await ctx.db.get(fixture.attemptId),
+      scheduledJobs: await ctx.db.system
+        .query("_scheduled_functions")
+        .collect(),
+      scores: await ctx.db.query("tryoutScores").collect(),
+      section: await ctx.db.get(fixture.sectionAttemptId),
+    }));
+
+    expect(state).toMatchObject({
+      attempt: {
+        expiresAt: EXPIRED_AT,
+        status: "in-progress",
+      },
+      scheduledJobs: [],
+      scores: [],
+      section: {
+        expiresAt: EXPIRED_AT,
+        status: "in-progress",
+      },
+    });
+  });
+});

--- a/packages/backend/convex/tryouts/mutations/expiry.ts
+++ b/packages/backend/convex/tryouts/mutations/expiry.ts
@@ -1,16 +1,43 @@
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/functions";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
 import {
   expireAttempt,
   finalizeSectionAttempt,
 } from "@repo/backend/convex/tryouts/runtime/finish";
+import { makeFunctionReference } from "convex/server";
 import { ConvexError, v } from "convex/values";
+import { Effect } from "effect";
 
 const EXPIRY_SWEEP_LIMIT = 50;
+const EXPIRY_SWEEP_ATTEMPT_BYTES = 6 * 1024 * 1024;
+const EXPIRY_SWEEP_SECTION_BYTES = 2 * 1024 * 1024;
 
 type TryoutAttempt = Doc<"tryoutAttempts">;
 type TryoutSectionAttempt = Doc<"tryoutSectionAttempts">;
+
+const attemptExpiryReference = makeFunctionReference<
+  "mutation",
+  { attemptId: Id<"tryoutAttempts">; expiresAt: number },
+  null
+>("tryouts/mutations/expiry:attempt");
+const sectionExpiryReference = makeFunctionReference<
+  "mutation",
+  { expiresAt: number; sectionAttemptId: Id<"tryoutSectionAttempts"> },
+  null
+>("tryouts/mutations/expiry:section");
+const attemptReconciliationReference = makeFunctionReference<
+  "mutation",
+  { before: number },
+  null
+>("tryouts/mutations/expiry:reconcileAttempts");
+const sectionReconciliationReference = makeFunctionReference<
+  "mutation",
+  { before: number; scheduledAttemptIds: Id<"tryoutAttempts">[] },
+  null
+>("tryouts/mutations/expiry:reconcileSections");
 
 /** Expires one overall try-out attempt at its scheduled deadline. */
 export const attempt = internalMutation({
@@ -83,51 +110,123 @@ export const sweep = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
-    const now = Date.now();
-    const attempts = await ctx.db
-      .query("tryoutAttempts")
-      .withIndex("by_status_and_expiresAt", (q) =>
-        q.eq("status", "in-progress").lt("expiresAt", now)
-      )
-      .take(EXPIRY_SWEEP_LIMIT);
-
-    for (const attemptRow of attempts) {
-      await runConvexProgram(expireAttempt(ctx, { attempt: attemptRow, now }));
-    }
-
-    const sections = await ctx.db
-      .query("tryoutSectionAttempts")
-      .withIndex("by_status_and_expiresAt", (q) =>
-        q.eq("status", "in-progress").lt("expiresAt", now)
-      )
-      .take(EXPIRY_SWEEP_LIMIT);
-
-    for (const sectionRow of sections) {
-      const attemptRow = await ctx.db.get(sectionRow.tryoutAttemptId);
-
-      if (attemptRow?.status !== "in-progress") {
-        continue;
-      }
-
-      if (now >= attemptRow.expiresAt) {
-        await runConvexProgram(
-          expireAttempt(ctx, { attempt: attemptRow, now })
-        );
-        continue;
-      }
-
-      await runConvexProgram(
-        finalizeSectionAttempt(ctx, {
-          attempt: attemptRow,
-          endReason: "time-expired",
-          now,
-          section: sectionRow,
-        })
-      );
-    }
-
+    await runConvexProgram(startExpiryReconciliation(ctx, Date.now()));
     return null;
   },
+});
+
+/** Starts one sequential, byte-bounded missed-expiry reconciliation. */
+const startExpiryReconciliation = Effect.fn(
+  "tryouts.expiry.startReconciliation"
+)(function* (ctx: MutationCtx, before: number) {
+  yield* tryRuntimePromise(() =>
+    ctx.scheduler.runAfter(0, attemptReconciliationReference, { before })
+  );
+});
+
+/** Queues missed attempt expiries before handing off section reconciliation. */
+export const reconcileAttempts = internalMutation({
+  args: { before: v.number() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await runConvexProgram(reconcileMissedAttemptExpiries(ctx, args.before));
+    return null;
+  },
+});
+
+const reconcileMissedAttemptExpiries = Effect.fn(
+  "tryouts.expiry.reconcileMissedAttemptExpiries"
+)(function* (ctx: MutationCtx, before: number) {
+  const attemptPage = yield* tryRuntimePromise(() =>
+    ctx.db
+      .query("tryoutAttempts")
+      .withIndex("by_status_and_expiresAt", (q) =>
+        q.eq("status", "in-progress").lt("expiresAt", before)
+      )
+      .paginate({
+        cursor: null,
+        maximumBytesRead: EXPIRY_SWEEP_ATTEMPT_BYTES,
+        maximumRowsRead: EXPIRY_SWEEP_LIMIT,
+        numItems: EXPIRY_SWEEP_LIMIT,
+      })
+  );
+
+  yield* Effect.forEach(
+    attemptPage.page,
+    (attemptRow) =>
+      tryRuntimePromise(() =>
+        ctx.scheduler.runAfter(0, attemptExpiryReference, {
+          attemptId: attemptRow._id,
+          expiresAt: attemptRow.expiresAt,
+        })
+      ),
+    { concurrency: "unbounded", discard: true }
+  );
+  const scheduledAttemptIds = attemptPage.page.map(
+    (attemptRow) => attemptRow._id
+  );
+  yield* tryRuntimePromise(() =>
+    ctx.scheduler.runAfter(0, sectionReconciliationReference, {
+      before,
+      scheduledAttemptIds,
+    })
+  );
+});
+
+/** Queues section expiries whose parent was not handled by the attempt phase. */
+export const reconcileSections = internalMutation({
+  args: {
+    before: v.number(),
+    scheduledAttemptIds: v.array(v.id("tryoutAttempts")),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await runConvexProgram(
+      reconcileMissedSectionExpiries(ctx, {
+        before: args.before,
+        scheduledAttemptIds: args.scheduledAttemptIds,
+      })
+    );
+    return null;
+  },
+});
+
+const reconcileMissedSectionExpiries = Effect.fn(
+  "tryouts.expiry.reconcileMissedSectionExpiries"
+)(function* (
+  ctx: MutationCtx,
+  args: {
+    before: number;
+    scheduledAttemptIds: Id<"tryoutAttempts">[];
+  }
+) {
+  const sectionPage = yield* tryRuntimePromise(() =>
+    ctx.db
+      .query("tryoutSectionAttempts")
+      .withIndex("by_status_and_expiresAt", (q) =>
+        q.eq("status", "in-progress").lt("expiresAt", args.before)
+      )
+      .paginate({
+        cursor: null,
+        maximumBytesRead: EXPIRY_SWEEP_SECTION_BYTES,
+        maximumRowsRead: EXPIRY_SWEEP_LIMIT,
+        numItems: EXPIRY_SWEEP_LIMIT,
+      })
+  );
+  const scheduledAttemptIds = new Set(args.scheduledAttemptIds);
+  yield* Effect.forEach(
+    sectionPage.page.filter(
+      (sectionRow) => !scheduledAttemptIds.has(sectionRow.tryoutAttemptId)
+    ),
+    (sectionRow) =>
+      tryRuntimePromise(() =>
+        ctx.scheduler.runAfter(0, sectionExpiryReference, {
+          expiresAt: sectionRow.expiresAt,
+          sectionAttemptId: sectionRow._id,
+        })
+      ),
+    { concurrency: "unbounded", discard: true }
+  );
 });
 
 /** Returns true when a scheduled expiry job still matches an active row. */


### PR DESCRIPTION
## What changed

- move missed attempt expiry into byte and row bounded scheduled workers
- chain section reconciliation after attempt selection to avoid redundant child jobs
- cover duplicate sweeps, stale deadlines, and one-score idempotency

## Why

The cron previously finalized many attempts in one transaction. Large or numerous attempts could exceed Convex transaction limits and block later expiries.

## Touched TypeScript LOC

- `packages/backend/convex/tryouts/mutations/expiry.ts`: 244 lines
- `packages/backend/convex/tryouts/mutations/expiry.test.ts`: 344 lines

Both files are hand-written and remain below the 500-line production-readiness blocker. No generated-file or over-500-line exception is required.

## Verification

- `pnpm --filter @repo/backend exec vitest run convex/tryouts/mutations/expiry.test.ts`
- `pnpm --filter @repo/backend test` (344 files, 1,437 tests)
- `pnpm --filter @repo/backend typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `git diff --check origin/main...HEAD`