### PR TITLE
fix(ci): classify Agent Docs backend failures

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -198,7 +198,7 @@ jobs:
           chmod 600 "$convex_log"
           setsid pnpm --dir packages/backend exec convex dev \
             --typecheck enable \
-            --tail-logs disable > "$convex_log" 2>&1 &
+            --tail-logs always > "$convex_log" 2>&1 &
           echo "$!" > "$convex_pid"
 
           for _attempt in {1..120}; do
@@ -223,10 +223,61 @@ jobs:
         run: pnpm --silent --dir packages/backend runtime:ci import
 
       - name: Build production app
+        id: production_build
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: pnpm build
         env:
           NODE_ENV: production
+
+      - name: Classify local backend build failure
+        if: failure() && steps.production_build.outcome == 'failure'
+        env:
+          AGENT_DOCS_CONTENT_STATE_HASH: ""
+          AGENT_DOCS_ROUTE_GENERATION_HASH: ""
+          AGENT_DOCS_RUNTIME_SCHEMA_FINGERPRINT: ""
+          AGENT_DOCS_SITEMAP_GENERATION_HASH: ""
+          CONTENT_RUNTIME_TOKEN: ""
+          CONVEX_SITE_URL: ""
+          CONVEX_URL: ""
+          INTERNAL_CONTENT_API_KEY: ""
+          NEXT_PUBLIC_APP_URL: ""
+          NEXT_PUBLIC_CONVEX_SITE_URL: ""
+          NEXT_PUBLIC_CONVEX_URL: ""
+          NEXT_PUBLIC_MCP_URL: ""
+          NEXT_PUBLIC_POSTHOG_KEY: ""
+          NEXT_PUBLIC_POSTHOG_UI_HOST: ""
+          POSTHOG_PROXY_HOST: ""
+          SITE_URL: ""
+        run: |
+          convex_log="$RUNNER_TEMP/agent-docs-convex.log"
+          log_class=unavailable
+          event_class=unavailable
+          request_id_present=false
+
+          if [ -f "$convex_log" ] && [ ! -L "$convex_log" ] && \
+            [ "$(stat -c '%a' "$convex_log")" = "600" ]; then
+            log_class=private
+            event_class=handled-or-unobserved
+            if grep -Fq '[CONVEX Q(' "$convex_log"; then
+              if grep -Fq '[CONVEX H(' "$convex_log"; then
+                event_class=multiple
+              else
+                event_class=query
+              fi
+            elif grep -Fq '[CONVEX H(' "$convex_log"; then
+              event_class=http-action
+            fi
+            if grep -Fq '[Request ID:' "$convex_log"; then
+              request_id_present=true
+            fi
+          elif [ -e "$convex_log" ] || [ -L "$convex_log" ]; then
+            log_class=unsafe
+          fi
+
+          printf '%s\n' \
+            "local_backend_log_class=$log_class" \
+            "local_backend_event_class=$event_class" \
+            "local_backend_request_id_present=$request_id_present"
 
       - name: Start web app
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'


### PR DESCRIPTION
## What changed

- Tail failed anonymous local Convex functions into the workflow's existing private, mode-600 runner log.
- Classify a production-build failure with fixed safe values only: log safety, observed Convex event class, and whether a request ID was present.
- Run the classifier only when the exact production build step fails.
- Blank inherited content hashes, runtime credentials, local URLs, application URLs, and observability values for the diagnostic step.
- Keep the raw log local to the runner and erase it through the existing unconditional cleanup.

## Why

Nakafa main run [31379637222](https://github.com/nakafaai/nakafa.com/actions/runs/31379637222) passed tests, signed snapshot export, generation verification, anonymous Convex startup, and the full 32-table import, then received one sanitized `CONTENT_RUNTIME_INTERNAL` response during static generation. The same tree and signed publication contract generated all 1,303 pages in the exact PR run, an isolated Convex reproduction, and Vercel production, so the failure is not currently reproducible.

The failed workflow disabled Convex function logs and erased the private process log during cleanup. That made the query, HTTP action, and handled or unobserved cases indistinguishable. This change preserves coarse, sanitized evidence on the next failure without changing application behavior, signed data, retries, concurrency, or runtime fallbacks.

## Security boundary

- The classifier never prints raw log lines, function paths, request IDs, content, arguments, URLs, tokens, hashes, headers, bodies, or return values.
- It rejects a symlink, a non-regular file, or a log whose mode is not exactly 600.
- Convex success completion values are not tailed. Installed Convex 1.43.0 starts the log watcher with `success: false`.
- No raw log is cached or uploaded. Existing cleanup erases it even after failure.
- The implementation follows the official [Convex CLI `--tail-logs` contract](https://docs.convex.dev/cli/overview), [GitHub status-check expressions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions), and [GitHub secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use).

## Limitation

The emitted event class reports markers observed in the private log. It is coarse diagnostic evidence, not proof of causality. This PR does not claim the intermittent `CONTENT_RUNTIME_INTERNAL` event is fixed. The underlying cause remains unresolved until an exact workflow failure supplies new evidence.

## Verification

- Exact rebased head: `3a4193f54dcab84ce97fd1789cf5d41fd116d36b`
- Exact base: `4f31180280cb431ce08b6942aadc16af1ef748c6`
- `actionlint -verbose .github/workflows/agent-docs.yml`
- `pnpm lint`, including Effect source match, test ownership, and 3,015 checked files
- `git diff --check`
- Exact combined-head [Agent-Friendly Docs run 31388046680](https://github.com/nakafaai/nakafa.com/actions/runs/31388046680) passed: 12/12 test tasks, backend 348 files and 1,468 tests, www 178 files and 1,105 tests, all 32 signed tables imported with `contentState` last, 1,303/1,303 production pages, AFDocs 23/23, and unconditional cleanup.
- Exact-head [React Doctor run 31388047111](https://github.com/nakafaai/nakafa.com/actions/runs/31388047111) passed and correctly skipped the YAML-only diff.
- The healthy build skipped the failure classifier, emitted no classifier or raw Convex markers, and uploaded no artifacts.
- Hosted Codex review was unavailable due usage limits; independent exact one-file workflow, security, and installed-source review found no major issue.
- Vercel preview remains disabled