### PR TITLE
fix(ci): preserve runtime command output

### DIFF
--- a/packages/backend/scripts/content-runtime/ci/command.test.ts
+++ b/packages/backend/scripts/content-runtime/ci/command.test.ts
@@ -120,6 +120,55 @@ describe("content runtime command diagnostics", () => {
     expect(result.stdout).not.toContain(sensitiveValue);
   });
 
+  it("captures output from fast child processes", async () => {
+    const stdoutValue = 'stdout $HOME ; "literal"';
+    const stderrValue = 'stderr $HOME ; "literal"';
+    const results = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const root = yield* fileSystem.makeTempDirectoryScoped({
+            directory: tmpdir(),
+            prefix: "content-runtime-fast-command-test-",
+          });
+
+          return yield* Effect.forEach(Array.from({ length: 20 }), (index) =>
+            Effect.gen(function* () {
+              const stderrPath = `${root}/stderr ${index}.log`;
+              const stdoutPath = `${root}/stdout ${index}.log`;
+
+              yield* runRuntimeCommand({
+                args: [
+                  "-c",
+                  'printf "%s" "$1"; printf "%s" "$2" >&2',
+                  "fast-child",
+                  stdoutValue,
+                  stderrValue,
+                ],
+                command: "sh",
+                operation: "Fast child probe",
+                stderrPath,
+                stdoutPath,
+              });
+
+              return {
+                stderr: yield* fileSystem.readFileString(stderrPath),
+                stdout: yield* fileSystem.readFileString(stdoutPath),
+              };
+            })
+          );
+        })
+      ).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect(results).toEqual(
+      Array.from({ length: 20 }, () => ({
+        stderr: stderrValue,
+        stdout: stdoutValue,
+      }))
+    );
+  });
+
   it("keeps entrypoint failures off stdout", async () => {
     const tsxCli = fileURLToPath(import.meta.resolve("tsx/cli"));
     const entrypoint = fileURLToPath(new URL("./main.ts", import.meta.url));

--- a/packages/backend/scripts/content-runtime/ci/command.ts
+++ b/packages/backend/scripts/content-runtime/ci/command.ts
@@ -1,10 +1,14 @@
 import { Command, FileSystem } from "@effect/platform";
-import { Effect, Stream } from "effect";
+import { Effect } from "effect";
 import stripAnsi from "strip-ansi";
 import { contentRuntimeCiError } from "./error";
 
 const MAX_COMMAND_ERROR_LENGTH = 500;
 const WHITESPACE = /\s+/u;
+const SHARED_OUTPUT_REDIRECT =
+  'output_path=$1; shift; exec "$@" >| "$output_path" 2>&1';
+const SPLIT_OUTPUT_REDIRECT =
+  'stdout_path=$1; stderr_path=$2; shift 2; exec "$@" >| "$stdout_path" 2>| "$stderr_path"';
 
 export const sanitizeRuntimeCommandError = (
   text: string,
@@ -37,19 +41,39 @@ interface RuntimeCommand {
   readonly stdoutPath: string;
 }
 
+/**
+ * Runs one runtime command with mode-600 output captured at process startup.
+ * Paths and arguments stay positional so the shell never reparses them.
+ * @see https://www.effect.website/docs/v3/platform/command
+ * @see https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_07
+ */
 export const runRuntimeCommand = Effect.fn("contentRuntime.runCommand")(
   function* (spec: RuntimeCommand) {
     const fileSystem = yield* FileSystem.FileSystem;
     const sharedOutput = spec.stdoutPath === spec.stderrPath;
 
-    if (sharedOutput) {
-      yield* fileSystem.writeFileString(spec.stdoutPath, "", {
-        mode: 0o600,
-      });
+    yield* fileSystem.writeFileString(spec.stdoutPath, "", { mode: 0o600 });
+    yield* fileSystem.chmod(spec.stdoutPath, 0o600);
+    if (!sharedOutput) {
+      yield* fileSystem.writeFileString(spec.stderrPath, "", { mode: 0o600 });
+      yield* fileSystem.chmod(spec.stderrPath, 0o600);
     }
 
-    const outputFlag = sharedOutput ? "a" : "w";
-    let command = Command.make(spec.command, ...spec.args);
+    const redirectScript = sharedOutput
+      ? SHARED_OUTPUT_REDIRECT
+      : SPLIT_OUTPUT_REDIRECT;
+    const outputPaths = sharedOutput
+      ? [spec.stdoutPath]
+      : [spec.stdoutPath, spec.stderrPath];
+    let command = Command.make(
+      "sh",
+      "-c",
+      redirectScript,
+      "content-runtime-command",
+      ...outputPaths,
+      spec.command,
+      ...spec.args
+    );
 
     command = Command.env(command, {
       AGENT_DOCS_CONTENT_CACHE_KEY: "",
@@ -60,32 +84,7 @@ export const runRuntimeCommand = Effect.fn("contentRuntime.runCommand")(
       command = Command.feed(command, spec.stdin);
     }
 
-    const [exitCode] = yield* Effect.scoped(
-      Effect.gen(function* () {
-        const process = yield* Command.start(command);
-
-        return yield* Effect.all(
-          [
-            process.exitCode,
-            Stream.run(
-              process.stdout,
-              fileSystem.sink(spec.stdoutPath, {
-                flag: outputFlag,
-                mode: 0o600,
-              })
-            ),
-            Stream.run(
-              process.stderr,
-              fileSystem.sink(spec.stderrPath, {
-                flag: outputFlag,
-                mode: 0o600,
-              })
-            ),
-          ] as const,
-          { concurrency: "unbounded" }
-        );
-      })
-    );
+    const exitCode = yield* Command.exitCode(command);
     if (exitCode !== 0) {
       if (spec.reportStderr) {
         const stderr = yield* fileSystem.readFileString(spec.stderrPath);


### PR DESCRIPTION
## What changed

- Capture content-runtime command output through fixed POSIX redirection before the target process starts, instead of subscribing to child-process pipes after startup.
- Precreate and truncate every capture file, enforce mode 0600, and use explicit POSIX clobber redirection so inherited noclobber cannot reject the secured files.
- Pass output paths, the executable, and every argument as quoted positional parameters. Nothing is evaluated or reconstructed as shell source.
- Preserve the existing Effect Command environment, inherited-secret scrub, optional deploy key, stdin feed, process lifecycle, exit status, redaction, and typed error behavior.
- Add one regression to the existing command.test.ts owner. It runs 20 fast children and proves exact stdout, stderr, path-with-spaces, and literal special-character handling.

## Why

[Agent-Friendly Docs run 31383614788](https://github.com/nakafaai/nakafa.com/actions/runs/31383614788) failed because tar exited successfully while an archive listing file was empty, which the integrity validator correctly rejected.

The failure is reproducible with the installed Effect 3.22.1 Node command implementation. A fast child can exit before the lazy stdout or stderr stream subscribes. The installed stream adapter then sees readable=false and ends the channel without draining buffered bytes. An independent Node 24.18 amd64 probe reproduced the loss 20 out of 20 times after delayed subscription.

This change removes that race at the command-capture boundary. It does not retry, sleep, relax archive validation, or change the signed archive contract.

## Verification

- pnpm effect:source:check
- pnpm --filter @repo/backend typecheck
- pnpm --filter @repo/backend exec vitest run scripts/content-runtime/ci/command.test.ts scripts/content-runtime/ci/archive.test.ts
  - macOS: 2 files, 7 tests
  - macOS with inherited noclobber: 2 files, 7 tests
  - Ubuntu 24.04.4 amd64, Node 24.18.0, GNU tar 1.35, GnuPG 2.4.4: 2 files, 7 tests
  - the same Ubuntu environment with inherited noclobber: 2 files, 7 tests
- pnpm --filter @repo/backend test
  - 348 files, 1,468 tests
- pnpm lint
  - test ownership passed
  - 3,015 files checked
- pnpm boundaries
  - 2,953 files checked
- git diff --check
- Independent exact-diff review found no major issues
- command.ts is 163 lines and command.test.ts is 211 lines
- Vercel preview remains disabled

## References

- [Effect Command](https://www.effect.website/docs/v3/platform/command)
- [POSIX shell redirection](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_07)