### PR TITLE
fix(content): classify and retry runtime transport failures

### DIFF
--- a/apps/api/lib/content/quran.test.ts
+++ b/apps/api/lib/content/quran.test.ts
@@ -4,11 +4,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { readQuranApiDocument } from "@/lib/content/quran";
 
 const runtimeClientMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
 vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeClientMocks.fetchConvexRuntimeQuery,
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeClientMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
 const source = {
@@ -20,12 +24,12 @@ const source = {
 };
 
 afterEach(() => {
-  runtimeClientMocks.fetchConvexRuntimeQuery.mockReset();
+  runtimeClientMocks.runtimeQuery.mockReset();
 });
 
 describe("Quran API content", () => {
   it("reads and validates one locale-specific signed Quran document", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
+    runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
       ...source,
       locale: "en",
       surah: {
@@ -59,7 +63,7 @@ describe("Quran API content", () => {
         },
       ],
     });
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       { locale: "en", surahNumber: 1 }
@@ -67,9 +71,7 @@ describe("Quran API content", () => {
   });
 
   it("maps transport and publication failures into its domain error", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockRejectedValueOnce(
-      new Error("offline")
-    );
+    runtimeClientMocks.runtimeQuery.mockRejectedValueOnce(new Error("offline"));
     await expect(
       Effect.runPromise(
         Effect.either(readQuranApiDocument({ locale: "en", surahNumber: 1 }))
@@ -79,7 +81,7 @@ describe("Quran API content", () => {
       left: { _tag: "QuranApiReadError" },
     });
 
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
+    runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
       ...source,
       locale: "en",
       surah: null,

--- a/apps/api/lib/content/quran.ts
+++ b/apps/api/lib/content/quran.ts
@@ -1,5 +1,5 @@
 import { decodePublishedQuranDocument } from "@repo/backend/client/quran/document";
-import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
+import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionArgs } from "convex/server";
 import { Effect, Schema } from "effect";
@@ -16,15 +16,11 @@ export class QuranApiReadError extends Schema.TaggedError<QuranApiReadError>()(
 /** Reads and validates one active signed Quran document for the public API. */
 export const readQuranApiDocument = Effect.fn("api.quran.readDocument")(
   function* (args: QuranDocumentArgs) {
-    const result = yield* Effect.tryPromise({
-      try: () =>
-        fetchConvexRuntimeQuery(
-          env.NEXT_PUBLIC_CONVEX_URL,
-          api.contentRelease.quran.document,
-          args
-        ),
-      catch: (cause) => new QuranApiReadError({ cause }),
-    });
+    const result = yield* readConvexRuntimeQuery(
+      env.NEXT_PUBLIC_CONVEX_URL,
+      api.contentRelease.quran.document,
+      args
+    ).pipe(Effect.mapError((cause) => new QuranApiReadError({ cause })));
 
     return yield* decodePublishedQuranDocument(result, {
       locale: args.locale,

--- a/apps/api/lib/content/runtime.test.ts
+++ b/apps/api/lib/content/runtime.test.ts
@@ -1,3 +1,4 @@
+import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { locales } from "@repo/utilities/locales";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,21 +13,26 @@ import {
 } from "@/lib/content/runtime";
 
 const runtimeClientMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 const publishedMaterialMocks = vi.hoisted(() => ({
   readPublishedMaterialApiItem: vi.fn(),
   readPublishedMaterialGraphRoute: vi.fn(),
 }));
 
-vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeClientMocks.fetchConvexRuntimeQuery,
+vi.mock("@repo/backend/client/runtime", async (importOriginal) => ({
+  ...(await importOriginal()),
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeClientMocks.runtimeQuery(url, query, args),
+    }),
 }));
 vi.mock("@/lib/content/material", () => publishedMaterialMocks);
 
 describe("API content runtime", () => {
   afterEach(() => {
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockReset();
+    runtimeClientMocks.runtimeQuery.mockReset();
     publishedMaterialMocks.readPublishedMaterialApiItem.mockReset();
     publishedMaterialMocks.readPublishedMaterialGraphRoute.mockReset();
   });
@@ -72,7 +78,7 @@ describe("API content runtime", () => {
     };
     const routeRow = { content_id: "asset:en:article:politics:article:a" };
 
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce(articlePage)
       .mockResolvedValueOnce(subjectPage)
       .mockResolvedValueOnce(null)
@@ -95,7 +101,7 @@ describe("API content runtime", () => {
         })
       )
     ).resolves.toEqual(articlePage);
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       {
@@ -120,7 +126,7 @@ describe("API content runtime", () => {
       isDone: true,
       page: [],
     });
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       {
@@ -138,7 +144,7 @@ describe("API content runtime", () => {
         })
       )
     ).resolves.toEqual(routeRow);
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenLastCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenLastCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       {}
@@ -146,7 +152,7 @@ describe("API content runtime", () => {
   });
 
   it("rejects a source graph fallback after ownership changes", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         activeReleaseId: "release-before",
         managed: false,
@@ -174,7 +180,7 @@ describe("API content runtime", () => {
   it("reconciles source and signed material page entries", async () => {
     const sourceItem = { slug: "material/lesson/test/source" };
     const publishedItem = { slug: "material/lesson/test/published" };
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
+    runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
       activeReleaseId: "release-test",
       continueCursor: "",
       isDone: true,
@@ -187,7 +193,7 @@ describe("API content runtime", () => {
         },
       ],
     });
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce({
+    runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
       releaseId: "release-test",
     });
     publishedMaterialMocks.readPublishedMaterialApiItem.mockReturnValue(
@@ -218,7 +224,7 @@ describe("API content runtime", () => {
   });
 
   it("rejects a source material page after ownership changes", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         activeReleaseId: "release-before",
         continueCursor: "",
@@ -242,7 +248,7 @@ describe("API content runtime", () => {
   });
 
   it("rejects incomplete or failed signed material page reads", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         activeReleaseId: null,
         continueCursor: "",
@@ -301,7 +307,7 @@ describe("API content runtime", () => {
       content_id: "asset:en:material:test:exact",
       route: "subjects/test/exact",
     };
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         activeReleaseId: "release-test",
         managed: true,
@@ -340,11 +346,11 @@ describe("API content runtime", () => {
         })
       )
     ).resolves.toBeNull();
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledTimes(2);
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledTimes(2);
   });
 
   it("rejects incomplete or failed exact graph reads", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         activeReleaseId: null,
         managed: true,
@@ -388,8 +394,12 @@ describe("API content runtime", () => {
   });
 
   it("wraps runtime query failures with content runtime context", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery.mockRejectedValueOnce(
-      new Error("offline")
+    runtimeClientMocks.runtimeQuery.mockRejectedValueOnce(
+      new ConvexRuntimeQueryError({
+        networkCodes: [],
+        query: "contents/queries/runtime:listArticleApiContentPage",
+        reason: "transport",
+      })
     );
 
     const effect = getArticleApiContentPage({
@@ -400,12 +410,12 @@ describe("API content runtime", () => {
     });
 
     await expect(Effect.runPromise(effect)).rejects.toThrow(
-      "Unable to read API content runtime query: listArticleApiContentPage."
+      "Unable to read API content runtime query: contents/queries/runtime:listArticleApiContentPage."
     );
   });
 
   it("maps route catalog rows into API static params", async () => {
-    runtimeClientMocks.fetchConvexRuntimeQuery
+    runtimeClientMocks.runtimeQuery
       .mockResolvedValueOnce({
         continueCursor: "",
         isDone: true,
@@ -440,8 +450,8 @@ describe("API content runtime", () => {
         slug: ["politics", "political-accountability"],
       },
     ]);
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledTimes(2);
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledTimes(2);
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       {
@@ -452,7 +462,7 @@ describe("API content runtime", () => {
         section: "articles",
       }
     );
-    expect(runtimeClientMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://test.convex.cloud",
       expect.anything(),
       {

--- a/apps/api/lib/content/runtime.ts
+++ b/apps/api/lib/content/runtime.ts
@@ -1,4 +1,4 @@
-import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
+import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { NakafaAgentContentIdSchema } from "@repo/contents/_lib/agent/schema/ref";
 import type { Locale } from "@repo/utilities/locales";
@@ -63,8 +63,7 @@ function mapPublishedMaterialError(cause: unknown) {
 /** Rejects a source fallback when ownership changed between runtime reads. */
 const verifyApiReleasePin = Effect.fn("api.content.verifyReleasePin")(
   function* (expectedActiveReleaseId: string | null) {
-    const active = yield* fetchApiRuntimeQuery(
-      "activeContentRelease",
+    const active = yield* readApiRuntimeQuery(
       api.contentRelease.runtime.active.read,
       {}
     );
@@ -134,8 +133,7 @@ export function parseApiContentId(contentId: string) {
 
 /** Reads one page of article content rows from Convex. */
 export function getArticleApiContentPage(args: ArticleApiPageArgs) {
-  return fetchApiRuntimeQuery(
-    "listArticleApiContentPage",
+  return readApiRuntimeQuery(
     api.contents.queries.runtime.listArticleApiContentPage,
     args
   );
@@ -143,11 +141,7 @@ export function getArticleApiContentPage(args: ArticleApiPageArgs) {
 
 /** Reads one page of material content rows from Convex. */
 export function getMaterialApiContentPage(args: MaterialApiPageArgs) {
-  return fetchApiRuntimeQuery(
-    "materialApiPage",
-    api.contentRelease.material.apiPage,
-    args
-  ).pipe(
+  return readApiRuntimeQuery(api.contentRelease.material.apiPage, args).pipe(
     Effect.flatMap((result) =>
       Effect.gen(function* () {
         const page = yield* Effect.forEach(
@@ -191,16 +185,14 @@ export function getApiContentRouteByContentId(
   const materialInput: MaterialApiRouteArgs = {
     input: { contentId: args.contentId, kind: "content" },
   };
-  return fetchApiRuntimeQuery(
-    "materialApiRoute",
+  return readApiRuntimeQuery(
     api.contentRelease.material.apiRoute,
     materialInput
   ).pipe(
     Effect.flatMap((material) => {
       if (!material.managed) {
         return Effect.gen(function* () {
-          const route = yield* fetchApiRuntimeQuery(
-            "getContentRouteByContentId",
+          const route = yield* readApiRuntimeQuery(
             api.contents.queries.runtime.getContentRouteByContentId,
             args
           );
@@ -271,8 +263,7 @@ function getContentRoutePage({
   prefix: string;
   section: RuntimeContentSection;
 }): Effect.Effect<RuntimeContentRoutePage, ApiContentRuntimeReadError> {
-  return fetchApiRuntimeQuery(
-    "listContentRoutesByPrefix",
+  return readApiRuntimeQuery(
     api.contents.queries.runtime.listContentRoutesByPrefix,
     {
       cursor: INITIAL_CURSOR,
@@ -284,18 +275,21 @@ function getContentRoutePage({
   );
 }
 
-/** Fetches one public Convex runtime query through the official client. */
-function fetchApiRuntimeQuery<Query extends FunctionReference<"query">>(
-  name: string,
-  query: Query,
-  args: FunctionArgs<Query>
-) {
-  return Effect.tryPromise({
-    try: () => fetchConvexRuntimeQuery(env.NEXT_PUBLIC_CONVEX_URL, query, args),
-    catch: (cause) =>
-      new ApiContentRuntimeReadError({
-        cause,
-        message: `Unable to read API content runtime query: ${name}.`,
-      }),
-  });
-}
+/** Reads one public Convex runtime query through the official client. */
+const readApiRuntimeQuery = Effect.fn("api.content.runtimeQuery")(function* <
+  Query extends FunctionReference<"query">,
+>(query: Query, args: FunctionArgs<Query>) {
+  return yield* readConvexRuntimeQuery(
+    env.NEXT_PUBLIC_CONVEX_URL,
+    query,
+    args
+  ).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ApiContentRuntimeReadError({
+          cause,
+          message: `Unable to read API content runtime query: ${cause.query}.`,
+        })
+    )
+  );
+});

--- a/apps/www/lib/content/article/catalog.test.ts
+++ b/apps/www/lib/content/article/catalog.test.ts
@@ -23,7 +23,7 @@ import {
 } from "@/test/content-article";
 
 const cacheMock = vi.hoisted(() => vi.fn());
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const revision = "a".repeat(40);
 type ArticleRow = FunctionReturnType<
   typeof api.contentRelease.article.page
@@ -109,22 +109,21 @@ vi.mock("@/lib/content/cache", () => ({
   applyPublishedCatalogCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published article catalog", () => {
   beforeEach(() => {
     cacheMock.mockReset();
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("decodes newest articles and preserves release-bound pagination", async () => {
     const older = makeTestArticleProjection("older-politics", "2023-01-01");
-    fetchMock.mockResolvedValueOnce(
+    runtimeQueryMock.mockResolvedValueOnce(
       articlePage({
         isDone: false,
         page: [articleRow(testArticleProjection), articleRow(older)],
@@ -153,7 +152,7 @@ describe("published article catalog", () => {
       nextCursor: "next",
       sourceRevision: null,
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       category: "politics",
       expectedManifestHash: null,
       expectedReleaseId: null,
@@ -164,7 +163,7 @@ describe("published article catalog", () => {
   });
 
   it("decodes source-owned category titles without UI fallbacks", async () => {
-    fetchMock.mockResolvedValueOnce(categoryPage());
+    runtimeQueryMock.mockResolvedValueOnce(categoryPage());
 
     const page = await getPublishedCategories({
       cursor: null,
@@ -197,7 +196,7 @@ describe("published article catalog", () => {
         title: testArticleProjection.metadata.title,
       },
     });
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce(articlePage({ page: [articleRow(projection)] }))
       .mockResolvedValueOnce(categoryPage({ isDone: false }));
 
@@ -227,7 +226,7 @@ describe("published article catalog", () => {
   });
 
   it("preserves a stale cursor response for the route redirect boundary", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce(articlePage({ page: [], stale: true }))
       .mockResolvedValueOnce(categoryPage({ stale: true }));
 
@@ -261,7 +260,7 @@ describe("published article catalog", () => {
     ["foreign key", { ...articleRow(), contentKey: "articles/other" }],
     ["foreign route", { ...articleRow(), publicPath: "articles/other" }],
   ])("rejects %s article rows", async (_name, row) => {
-    fetchMock.mockResolvedValueOnce(articlePage({ page: [row] }));
+    runtimeQueryMock.mockResolvedValueOnce(articlePage({ page: [row] }));
 
     await expect(
       Effect.runPromise(
@@ -281,7 +280,7 @@ describe("published article catalog", () => {
     ["empty title", categoryPage({ title: "" })],
     ["invalid source revision", { ...categoryPage(), sourceRevision: "main" }],
   ])("rejects %s rows", async (_name, response) => {
-    fetchMock.mockResolvedValueOnce(response);
+    runtimeQueryMock.mockResolvedValueOnce(response);
 
     await expect(
       Effect.runPromise(
@@ -296,7 +295,7 @@ describe("published article catalog", () => {
   });
 
   it("rejects continuation pages without a complete release identity", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         ...articlePage({ isDone: false }),
         activeManifestHash: null,
@@ -330,7 +329,7 @@ describe("published article catalog", () => {
   });
 
   it("rejects unmanaged article and category catalogs", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         ...articlePage({ page: [] }),
         activeManifestHash: null,
@@ -369,7 +368,7 @@ describe("published article catalog", () => {
 
   it("preserves runtime query failures in the Effect error channel", async () => {
     const failure = new Error("catalog unavailable");
-    fetchMock.mockRejectedValueOnce(failure);
+    runtimeQueryMock.mockRejectedValueOnce(failure);
 
     await expect(
       Effect.runPromise(

--- a/apps/www/lib/content/article/catalog.ts
+++ b/apps/www/lib/content/article/catalog.ts
@@ -15,10 +15,7 @@ import type { Locale } from "next-intl";
 import { applyPublishedCatalogCache } from "@/lib/content/cache";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Stable source root for immutable Aksara article links. */
 export const ARTICLE_SOURCE_ROOT = "packages/corpus/articles";
@@ -160,9 +157,7 @@ export const readPublishedArticlePage = Effect.fn(
       numItems: PROJECTION_PAGE_LIMIT,
     },
   } satisfies ArticlePageArgs;
-  const result = yield* readRuntimeQuery("contentRelease.article.page", () =>
-    fetchRuntimeQuery(api.contentRelease.article.page, args)
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.article.page, args);
   const {
     activeManifestHash,
     activeReleaseId,
@@ -212,8 +207,8 @@ export const readPublishedCategories = Effect.fn(
     },
   } satisfies CategoryPageArgs;
   const result = yield* readRuntimeQuery(
-    "contentRelease.article.categories",
-    () => fetchRuntimeQuery(api.contentRelease.article.categories, args)
+    api.contentRelease.article.categories,
+    args
   );
   const {
     activeManifestHash,

--- a/apps/www/lib/content/article/category.test.ts
+++ b/apps/www/lib/content/article/category.test.ts
@@ -4,35 +4,34 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { hasPublishedArticleCategory } from "@/lib/content/article/category";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published article category", () => {
   beforeEach(() => {
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("reads one exact localized category", async () => {
-    fetchMock.mockResolvedValueOnce({ exists: true, managed: true });
+    runtimeQueryMock.mockResolvedValueOnce({ exists: true, managed: true });
 
     await expect(
       Effect.runPromise(hasPublishedArticleCategory("politics", "en"))
     ).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       category: "politics",
       locale: "en",
     });
   });
 
   it("rejects an unmanaged article catalog", async () => {
-    fetchMock.mockResolvedValueOnce({ exists: false, managed: false });
+    runtimeQueryMock.mockResolvedValueOnce({ exists: false, managed: false });
 
     await expect(
       Effect.runPromise(
@@ -46,7 +45,7 @@ describe("published article category", () => {
   });
 
   it("preserves runtime query failures in the Effect error channel", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("category unavailable"));
+    runtimeQueryMock.mockRejectedValueOnce(new Error("category unavailable"));
 
     await expect(
       Effect.runPromise(hasPublishedArticleCategory("politics", "id"))

--- a/apps/www/lib/content/article/category.ts
+++ b/apps/www/lib/content/article/category.ts
@@ -4,23 +4,16 @@ import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Checks whether one category exists in the signed article catalog. */
 export const hasPublishedArticleCategory = Effect.fn(
   "www.articles.hasCategory"
 )(function* (category: string, locale: Locale) {
-  const result = yield* readRuntimeQuery(
-    "contentRelease.article.category",
-    () =>
-      fetchRuntimeQuery(api.contentRelease.article.category, {
-        category,
-        locale,
-      })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.article.category, {
+    category,
+    locale,
+  });
   if (!result.managed) {
     return yield* new PublishedProjectionError({
       locale,

--- a/apps/www/lib/content/article/discovery.ts
+++ b/apps/www/lib/content/article/discovery.ts
@@ -13,10 +13,7 @@ import { Effect, Schema } from "effect";
 import type { Locale } from "next-intl";
 import type { PublishedArticleSummary } from "@/lib/content/article/catalog";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type DiscoveryItem = FunctionReturnType<
   typeof api.contentRelease.article.latest
@@ -60,11 +57,10 @@ const decodeDiscoveryItem = Effect.fn("www.articles.decodeDiscovery")(
 /** Reads one complete published article partition for agent discovery. */
 export const readPublishedArticleBucket = Effect.fn("www.articles.readBucket")(
   function* (locale: Locale, bucket: string) {
-    const result = yield* readRuntimeQuery(
-      "contentRelease.article.bucket",
-      () =>
-        fetchRuntimeQuery(api.contentRelease.article.bucket, { bucket, locale })
-    );
+    const result = yield* readRuntimeQuery(api.contentRelease.article.bucket, {
+      bucket,
+      locale,
+    });
     if (!result.managed) {
       return yield* new PublishedProjectionError({
         locale,
@@ -84,11 +80,10 @@ export const readPublishedArticleBucket = Effect.fn("www.articles.readBucket")(
 /** Reads a bounded newest-first article set for feed discovery. */
 export const readPublishedLatestArticles = Effect.fn("www.articles.readLatest")(
   function* (locale: Locale, limit: number) {
-    const result = yield* readRuntimeQuery(
-      "contentRelease.article.latest",
-      () =>
-        fetchRuntimeQuery(api.contentRelease.article.latest, { limit, locale })
-    );
+    const result = yield* readRuntimeQuery(api.contentRelease.article.latest, {
+      limit,
+      locale,
+    });
     if (!result.managed) {
       return yield* new PublishedProjectionError({
         locale,
@@ -106,13 +101,11 @@ export const readPublishedLatestArticles = Effect.fn("www.articles.readLatest")(
 export const readPublishedCategoryArticles = Effect.fn(
   "www.articles.readCategory"
 )(function* (locale: Locale, category: string, limit: number) {
-  const result = yield* readRuntimeQuery("contentRelease.article.listing", () =>
-    fetchRuntimeQuery(api.contentRelease.article.listing, {
-      category,
-      limit,
-      locale,
-    })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.article.listing, {
+    category,
+    limit,
+    locale,
+  });
   if (!result.managed) {
     return yield* new PublishedProjectionError({
       locale,

--- a/apps/www/lib/content/article/sitemap.test.ts
+++ b/apps/www/lib/content/article/sitemap.test.ts
@@ -7,23 +7,22 @@ import {
   readPublishedArticleSitemap,
 } from "@/lib/content/article/sitemap";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published article sitemap", () => {
   beforeEach(() => {
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("reads bucket discovery and one exact route partition", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         articleCount: 1,
         buckets: ["abc"],
@@ -49,17 +48,17 @@ describe("published article sitemap", () => {
     ).resolves.toMatchObject({
       routes: [{ publicPath: "articles/politics/article" }],
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
       locale: "en",
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
       bucket: "abc",
       locale: "en",
     });
   });
 
   it("rejects an unmanaged article sitemap inventory", async () => {
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       articleCount: 0,
       buckets: [],
       managed: false,
@@ -71,7 +70,7 @@ describe("published article sitemap", () => {
   });
 
   it("preserves runtime query failures in the Effect error channel", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
+    runtimeQueryMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
 
     await expect(
       Effect.runPromise(readPublishedArticleBuckets("id"))

--- a/apps/www/lib/content/article/sitemap.ts
+++ b/apps/www/lib/content/article/sitemap.ts
@@ -4,19 +4,15 @@ import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Reads non-empty article sitemap partitions for one localized catalog. */
 export const readPublishedArticleBuckets = Effect.fn(
   "www.articles.readSitemapBuckets"
 )(function* (locale: Locale) {
   const result = yield* readRuntimeQuery(
-    "contentRelease.article.sitemapBuckets",
-    () =>
-      fetchRuntimeQuery(api.contentRelease.article.sitemapBuckets, { locale })
+    api.contentRelease.article.sitemapBuckets,
+    { locale }
   );
   if (!result.managed) {
     return yield* new PublishedProjectionError({
@@ -34,10 +30,8 @@ export const readPublishedArticleBuckets = Effect.fn(
 export const readPublishedArticleSitemap = Effect.fn(
   "www.articles.readSitemapPage"
 )(function* (locale: Locale, bucket: string) {
-  return yield* readRuntimeQuery("contentRelease.article.sitemapPage", () =>
-    fetchRuntimeQuery(api.contentRelease.article.sitemapPage, {
-      bucket,
-      locale,
-    })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.article.sitemapPage, {
+    bucket,
+    locale,
+  });
 });

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/content/material/catalog";
 import { previewIdProjection, previewProjection } from "@/test/content-preview";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
 const manifestHash = `sha256:${"a".repeat(64)}`;
 const releaseId = "release-material";
@@ -24,10 +24,9 @@ vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
@@ -58,13 +57,13 @@ function materialPage({
 }
 
 beforeEach(() => {
-  fetchMock.mockReset();
+  runtimeQueryMock.mockReset();
   cacheMock.mockReset();
 });
 
 describe("published material catalog", () => {
   it("decodes one bounded release page", async () => {
-    fetchMock.mockResolvedValueOnce(materialPage({ done: false }));
+    runtimeQueryMock.mockResolvedValueOnce(materialPage({ done: false }));
 
     await expect(
       Effect.runPromise(
@@ -85,7 +84,7 @@ describe("published material catalog", () => {
       sourceRevision,
       stale: false,
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       expectedManifestHash: null,
       expectedReleaseId: null,
       locale: "en",
@@ -94,7 +93,7 @@ describe("published material catalog", () => {
   });
 
   it("reads all pages through one stable release cursor", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce(materialPage({ done: false }))
       .mockResolvedValueOnce(materialPage());
 
@@ -102,7 +101,7 @@ describe("published material catalog", () => {
       routes: [previewProjection, previewProjection],
       sourceRevision,
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
       expectedManifestHash: manifestHash,
       expectedReleaseId: releaseId,
       locale: "en",
@@ -112,7 +111,7 @@ describe("published material catalog", () => {
   });
 
   it("rejects unmanaged and stale ownership states", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce(materialPage({ managed: false, routes: [] }))
       .mockResolvedValueOnce(materialPage({ routes: [], stale: true }));
 
@@ -134,7 +133,7 @@ describe("published material catalog", () => {
       },
     ],
   ])("rejects %s", async (_label, result) => {
-    fetchMock.mockResolvedValueOnce(result);
+    runtimeQueryMock.mockResolvedValueOnce(result);
 
     await expect(
       Effect.runPromise(

--- a/apps/www/lib/content/material/catalog.ts
+++ b/apps/www/lib/content/material/catalog.ts
@@ -11,10 +11,7 @@ import { applyContentRuntimeCache } from "@/lib/content/cache";
 import { decodeMaterialJson } from "@/lib/content/material/decode";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type MaterialPageArgs = FunctionArgs<typeof api.contentRelease.material.page>;
 
@@ -63,8 +60,9 @@ export const readPublishedMaterialPage = Effect.fn(
       numItems: PROJECTION_PAGE_LIMIT,
     },
   } satisfies MaterialPageArgs;
-  const result = yield* readRuntimeQuery("contentRelease.material.page", () =>
-    fetchRuntimeQuery(api.contentRelease.material.page, args)
+  const result = yield* readRuntimeQuery(
+    api.contentRelease.material.page,
+    args
   );
   const routes = yield* Effect.forEach(result.result.page, (source) =>
     decodeMaterialJson(source, {

--- a/apps/www/lib/content/material/context.test.ts
+++ b/apps/www/lib/content/material/context.test.ts
@@ -19,7 +19,7 @@ import {
   testProgramSubject,
 } from "@/test/content-program";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
 const group = testProgramGroups[0];
 if (!group) {
@@ -47,21 +47,20 @@ vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 beforeEach(() => {
-  fetchMock.mockReset();
+  runtimeQueryMock.mockReset();
   cacheMock.mockReset();
 });
 
 describe("published material context", () => {
   it("builds a return link from verified curriculum rows", async () => {
-    fetchMock.mockResolvedValueOnce(publishedContext);
+    runtimeQueryMock.mockResolvedValueOnce(publishedContext);
 
     await expect(
       getPublishedMaterialContext("en", previewProjection, context)
@@ -87,7 +86,7 @@ describe("published material context", () => {
   });
 
   it("rejects unmanaged context and preserves an invalid optional hint", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         groupJson: null,
         managed: false,
@@ -119,7 +118,7 @@ describe("published material context", () => {
 
   it("pins a context read to the expected active release", async () => {
     const activeReleaseId = ReleaseIdSchema.make("release-material");
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       groupJson: null,
       managed: true,
       mappingJson: null,
@@ -137,7 +136,7 @@ describe("published material context", () => {
         )
       )
     ).resolves.toBeNull();
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(runtimeQueryMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         contentKey: previewProjection.contentKey,
@@ -155,7 +154,7 @@ describe("published material context", () => {
       ...group,
       materialCardTitle: undefined,
     };
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         ...publishedContext,
         parentJson: testCurriculumRowJson(courseParent),
@@ -188,7 +187,7 @@ describe("published material context", () => {
         `${renamedParent}/renamed-function-concept`
       ),
     };
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       ...publishedContext,
       resolvedCanonicalPath: renamedParent,
     });
@@ -233,7 +232,7 @@ describe("published material context", () => {
       },
     ],
   ])("rejects %s", async (_label, result) => {
-    fetchMock.mockResolvedValueOnce(result);
+    runtimeQueryMock.mockResolvedValueOnce(result);
 
     await expect(
       Effect.runPromise(
@@ -245,7 +244,7 @@ describe("published material context", () => {
   });
 
   it("rejects a mapping for a different material route", async () => {
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       ...publishedContext,
       mappingJson: testCurriculumRowJson({
         ...mapping,

--- a/apps/www/lib/content/material/context.ts
+++ b/apps/www/lib/content/material/context.ts
@@ -11,10 +11,7 @@ import { applyContentRuntimeCache } from "@/lib/content/cache";
 import { decodeCurriculumJson } from "@/lib/content/program/decode";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import type { ContentReleasePin } from "@/lib/content/published/release";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type PublishedMaterialIdentity = Pick<
   MaterialLessonProjection,
@@ -40,20 +37,18 @@ export const readPublishedMaterialContext = Effect.fn(
   context: MaterialContextIdentity,
   expectedActiveReleaseId?: ContentReleasePin
 ) {
-  const result = yield* readRuntimeQuery("contentRelease.program.context", () =>
-    fetchRuntimeQuery(api.contentRelease.program.context, {
-      ...(expectedActiveReleaseId === undefined
-        ? {}
-        : { expectedActiveReleaseId }),
-      contentKey: material.contentKey,
-      locale,
-      materialKey: material.materialKey,
-      nodeKey: context.nodeKey,
-      parentPath: material.parentPath,
-      programKey: context.programKey,
-      publicPath: material.publicPath,
-    })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.program.context, {
+    ...(expectedActiveReleaseId === undefined
+      ? {}
+      : { expectedActiveReleaseId }),
+    contentKey: material.contentKey,
+    locale,
+    materialKey: material.materialKey,
+    nodeKey: context.nodeKey,
+    parentPath: material.parentPath,
+    programKey: context.programKey,
+    publicPath: material.publicPath,
+  });
   if (!result.managed) {
     return yield* new PublishedProjectionError({
       locale,

--- a/apps/www/lib/content/material/discovery.test.ts
+++ b/apps/www/lib/content/material/discovery.test.ts
@@ -8,7 +8,7 @@ import {
   readPublishedMaterialBucket,
 } from "@/lib/content/material/discovery";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const publicPath =
   "subjects/mathematics/function-composition-inverse-function/function-concept";
 const sourcePath =
@@ -16,10 +16,9 @@ const sourcePath =
 const activeReleaseId = ReleaseIdSchema.make("release-material");
 
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
@@ -35,11 +34,11 @@ const summary = {
 
 describe("published material discovery", () => {
   beforeEach(() => {
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("rejects unmanaged buckets and reads complete signed buckets", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         activeReleaseId,
         managed: false,
@@ -90,7 +89,7 @@ describe("published material discovery", () => {
   });
 
   it("decodes newest signed materials", async () => {
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       activeReleaseId,
       managed: true,
       materials: [summary],
@@ -105,7 +104,7 @@ describe("published material discovery", () => {
   });
 
   it("rejects malformed summaries, unmanaged results, and runtime failures", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         activeReleaseId,
         managed: true,
@@ -136,7 +135,7 @@ describe("published material discovery", () => {
   });
 
   it("rejects a material bucket from a different active release", async () => {
-    fetchMock.mockResolvedValueOnce({
+    runtimeQueryMock.mockResolvedValueOnce({
       activeReleaseId: ReleaseIdSchema.make("release-next"),
       managed: true,
       materials: [summary],

--- a/apps/www/lib/content/material/discovery.ts
+++ b/apps/www/lib/content/material/discovery.ts
@@ -14,10 +14,7 @@ import {
   type ContentReleasePin,
   decodeContentReleasePin,
 } from "@/lib/content/published/release";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type MaterialSummary = FunctionReturnType<
   typeof api.contentRelease.material.latest
@@ -68,9 +65,10 @@ export const readPublishedMaterialBucket = Effect.fn(
   bucket: string,
   expectedActiveReleaseId?: ContentReleasePin
 ) {
-  const result = yield* readRuntimeQuery("contentRelease.material.bucket", () =>
-    fetchRuntimeQuery(api.contentRelease.material.bucket, { bucket, locale })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.material.bucket, {
+    bucket,
+    locale,
+  });
   const activeReleaseId = yield* decodeContentReleasePin(
     result.activeReleaseId,
     expectedActiveReleaseId,
@@ -95,9 +93,10 @@ export const readPublishedMaterialBucket = Effect.fn(
 export const readPublishedLatestMaterials = Effect.fn(
   "www.materials.readLatest"
 )(function* (locale: Locale, limit: number) {
-  const result = yield* readRuntimeQuery("contentRelease.material.latest", () =>
-    fetchRuntimeQuery(api.contentRelease.material.latest, { limit, locale })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.material.latest, {
+    limit,
+    locale,
+  });
   const activeReleaseId = yield* decodeContentReleasePin(
     result.activeReleaseId,
     undefined,

--- a/apps/www/lib/content/material/route.test.ts
+++ b/apps/www/lib/content/material/route.test.ts
@@ -15,7 +15,7 @@ import {
   previewSourcePath,
 } from "@/test/content-preview";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
 const activeManifestHash = `sha256:${"a".repeat(64)}`;
 const activeReleaseId = ReleaseIdSchema.make("release-material");
@@ -25,10 +25,9 @@ vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
@@ -88,13 +87,13 @@ function foundModel(overrides?: {
 }
 
 beforeEach(() => {
-  fetchMock.mockReset();
+  runtimeQueryMock.mockReset();
   cacheMock.mockReset();
 });
 
 describe("published material route", () => {
   it("decodes one complete signed route, locale set, and sibling group", async () => {
-    fetchMock.mockResolvedValueOnce(foundModel());
+    runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
     await expect(
       getPublishedMaterialRoute("en", previewProjection.publicPath)
@@ -110,7 +109,7 @@ describe("published material route", () => {
   });
 
   it("pins a route read to the expected active release", async () => {
-    fetchMock.mockResolvedValueOnce(foundModel());
+    runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
     await expect(
       getPublishedMaterialRoute(
@@ -119,14 +118,14 @@ describe("published material route", () => {
         activeReleaseId
       )
     ).resolves.toMatchObject({ activeReleaseId });
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(runtimeQueryMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
     );
   });
 
   it("preserves a signed missing-route tombstone", async () => {
-    fetchMock.mockResolvedValueOnce(
+    runtimeQueryMock.mockResolvedValueOnce(
       foundModel({
         alternateJson: [],
         projectionJson: null,
@@ -203,7 +202,7 @@ describe("published material route", () => {
     ["alternate JSON", foundModel({ alternateJson: ["{}"] })],
     ["sibling JSON", foundModel({ siblingJson: ["{}"] })],
   ])("rejects an invalid %s", async (_label, result) => {
-    fetchMock.mockResolvedValueOnce(result);
+    runtimeQueryMock.mockResolvedValueOnce(result);
 
     await expect(
       Effect.runPromise(

--- a/apps/www/lib/content/material/route.ts
+++ b/apps/www/lib/content/material/route.ts
@@ -27,10 +27,7 @@ import {
   type ContentReleasePin,
   decodeContentReleasePin,
 } from "@/lib/content/published/release";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 interface PublishedMaterialIdentity {
   readonly activeManifestHash: typeof Sha256HashSchema.Type;
@@ -92,15 +89,13 @@ export const readPublishedMaterialRoute = Effect.fn(
   publicPath: string,
   expectedActiveReleaseId?: ContentReleasePin
 ) {
-  const result = yield* readRuntimeQuery("contentRelease.material.route", () =>
-    fetchRuntimeQuery(api.contentRelease.material.route, {
-      ...(expectedActiveReleaseId === undefined
-        ? {}
-        : { expectedActiveReleaseId }),
-      locale,
-      publicPath,
-    })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.material.route, {
+    ...(expectedActiveReleaseId === undefined
+      ? {}
+      : { expectedActiveReleaseId }),
+    locale,
+    publicPath,
+  });
   if (!(result.managed && result.familyManaged)) {
     return yield* makeMaterialProjectionError({ locale, publicPath });
   }

--- a/apps/www/lib/content/material/sitemap.test.ts
+++ b/apps/www/lib/content/material/sitemap.test.ts
@@ -8,24 +8,23 @@ import {
   readPublishedMaterialSitemap,
 } from "@/lib/content/material/sitemap";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const activeReleaseId = ReleaseIdSchema.make("release-material");
 
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 beforeEach(() => {
-  fetchMock.mockReset();
+  runtimeQueryMock.mockReset();
 });
 
 describe("published material sitemap", () => {
   it("decodes the release identity and reads one sitemap page", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         activeReleaseId,
         buckets: ["abc"],
@@ -57,7 +56,7 @@ describe("published material sitemap", () => {
   });
 
   it("rejects invalid and unmanaged material inventories", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({
         activeReleaseId: "",
         buckets: [],

--- a/apps/www/lib/content/material/sitemap.ts
+++ b/apps/www/lib/content/material/sitemap.ts
@@ -8,19 +8,15 @@ import {
   type ContentReleasePin,
   decodeContentReleasePin,
 } from "@/lib/content/published/release";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Reads non-empty material sitemap partitions for one localized catalog. */
 export const readPublishedMaterialBuckets = Effect.fn(
   "www.materials.readSitemapBuckets"
 )(function* (locale: Locale, expectedActiveReleaseId?: ContentReleasePin) {
   const result = yield* readRuntimeQuery(
-    "contentRelease.material.sitemapBuckets",
-    () =>
-      fetchRuntimeQuery(api.contentRelease.material.sitemapBuckets, { locale })
+    api.contentRelease.material.sitemapBuckets,
+    { locale }
   );
   const activeReleaseId = yield* decodeContentReleasePin(
     result.activeReleaseId,
@@ -44,10 +40,8 @@ export const readPublishedMaterialBuckets = Effect.fn(
 export const readPublishedMaterialSitemap = Effect.fn(
   "www.materials.readSitemapPage"
 )(function* (locale: Locale, bucket: string) {
-  return yield* readRuntimeQuery("contentRelease.material.sitemapPage", () =>
-    fetchRuntimeQuery(api.contentRelease.material.sitemapPage, {
-      bucket,
-      locale,
-    })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.material.sitemapPage, {
+    bucket,
+    locale,
+  });
 });

--- a/apps/www/lib/content/program/catalog.test.ts
+++ b/apps/www/lib/content/program/catalog.test.ts
@@ -18,7 +18,7 @@ import {
 } from "@/test/content-program";
 
 const cacheMock = vi.hoisted(() => vi.fn());
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const revision = "a".repeat(40);
 
 /** Builds one successful bounded program catalog response. */
@@ -68,21 +68,20 @@ vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published program catalog", () => {
   beforeEach(() => {
     cacheMock.mockReset();
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("decodes real program roots and applies the runtime cache", async () => {
-    fetchMock.mockResolvedValueOnce(catalogResponse());
+    runtimeQueryMock.mockResolvedValueOnce(catalogResponse());
 
     const catalog = await getPublishedProgramCatalog("en");
 
@@ -99,7 +98,7 @@ describe("published program catalog", () => {
   });
 
   it("rejects an unmanaged catalog", async () => {
-    fetchMock.mockResolvedValueOnce(
+    runtimeQueryMock.mockResolvedValueOnce(
       catalogResponse({
         managed: false,
         programJson: [],
@@ -128,7 +127,7 @@ describe("published program catalog", () => {
     ],
     ["invalid source revision", catalogResponse({ sourceRevision: "main" })],
   ])("rejects a catalog with %s", async (_name, response) => {
-    fetchMock.mockResolvedValueOnce(response);
+    runtimeQueryMock.mockResolvedValueOnce(response);
 
     await expect(
       Effect.runPromise(readPublishedProgramCatalog("en").pipe(Effect.flip))
@@ -136,7 +135,7 @@ describe("published program catalog", () => {
   });
 
   it("reads every route page under one immutable release identity", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce(pageResponse({ isDone: false }))
       .mockResolvedValueOnce(
         pageResponse({
@@ -153,7 +152,7 @@ describe("published program catalog", () => {
       ],
       sourceRevision: revision,
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
       expectedManifestHash: `sha256:${"b".repeat(64)}`,
       expectedReleaseId: "program-release",
       locale: "en",
@@ -163,7 +162,7 @@ describe("published program catalog", () => {
   });
 
   it("preserves both terminal page cursor states", async () => {
-    fetchMock.mockResolvedValueOnce(pageResponse({ isDone: false }));
+    runtimeQueryMock.mockResolvedValueOnce(pageResponse({ isDone: false }));
 
     await expect(
       Effect.runPromise(
@@ -181,7 +180,9 @@ describe("published program catalog", () => {
   });
 
   it("rejects routes before Aksara owns the program family", async () => {
-    fetchMock.mockResolvedValueOnce(pageResponse({ managed: false, page: [] }));
+    runtimeQueryMock.mockResolvedValueOnce(
+      pageResponse({ managed: false, page: [] })
+    );
 
     await expect(
       Effect.runPromise(readPublishedProgramRoutes("id").pipe(Effect.flip))
@@ -195,7 +196,7 @@ describe("published program catalog", () => {
       { ...pageResponse({ isDone: false }), activeReleaseId: null },
     ],
   ])("rejects a %s", async (_name, response) => {
-    fetchMock.mockResolvedValueOnce(response);
+    runtimeQueryMock.mockResolvedValueOnce(response);
 
     await expect(
       Effect.runPromise(readPublishedProgramRoutes("en").pipe(Effect.flip))
@@ -203,7 +204,7 @@ describe("published program catalog", () => {
   });
 
   it("preserves runtime query failures in the Effect error channel", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("program unavailable"));
+    runtimeQueryMock.mockRejectedValueOnce(new Error("program unavailable"));
 
     await expect(
       Effect.runPromise(readPublishedProgramCatalog("en"))

--- a/apps/www/lib/content/program/catalog.ts
+++ b/apps/www/lib/content/program/catalog.ts
@@ -15,10 +15,7 @@ import {
 } from "@/lib/content/program/decode";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type ProgramPageArgs = FunctionArgs<typeof api.contentRelease.program.page>;
 
@@ -55,9 +52,9 @@ export interface PublishedProgramPage {
 export const readPublishedProgramCatalog = Effect.fn(
   "NakafaProgram.readPublishedCatalog"
 )(function* (locale: Locale) {
-  const result = yield* readRuntimeQuery("contentRelease.program.catalog", () =>
-    fetchRuntimeQuery(api.contentRelease.program.catalog, { locale })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.program.catalog, {
+    locale,
+  });
   const sourceRevision = yield* decodeSourceRevision(result.sourceRevision, {
     locale,
     publicPath: "curricula",
@@ -107,9 +104,7 @@ export const readPublishedProgramPage = Effect.fn(
       numItems: PROJECTION_PAGE_LIMIT,
     },
   } satisfies ProgramPageArgs;
-  const result = yield* readRuntimeQuery("contentRelease.program.page", () =>
-    fetchRuntimeQuery(api.contentRelease.program.page, args)
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.program.page, args);
   const routes = yield* Effect.forEach(result.result.page, (source) =>
     decodeCurriculumJson(source, input.locale, "curricula")
   );

--- a/apps/www/lib/content/program/path.ts
+++ b/apps/www/lib/content/program/path.ts
@@ -4,18 +4,16 @@ import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import { decodeCurriculumJson } from "@/lib/content/program/decode";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Resolves one exact curriculum path without loading its full page model. */
 export const readPublishedProgramPath = Effect.fn(
   "NakafaProgram.readPublishedPath"
 )(function* (locale: Locale, publicPath: string) {
-  const result = yield* readRuntimeQuery("contentRelease.program.path", () =>
-    fetchRuntimeQuery(api.contentRelease.program.path, { locale, publicPath })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.program.path, {
+    locale,
+    publicPath,
+  });
   if (!(result.managed && result.routeJson)) {
     return {
       managed: result.managed,

--- a/apps/www/lib/content/program/route.test.ts
+++ b/apps/www/lib/content/program/route.test.ts
@@ -19,7 +19,7 @@ import {
 } from "@/test/content-program";
 
 const cacheMock = vi.hoisted(() => vi.fn());
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const revision = "a".repeat(40);
 
 /** Builds one complete route-model response from real Merdeka rows. */
@@ -66,21 +66,20 @@ vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published program route", () => {
   beforeEach(() => {
     cacheMock.mockReset();
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("decodes one complete real curriculum route model", async () => {
-    fetchMock.mockResolvedValueOnce(routeResponse());
+    runtimeQueryMock.mockResolvedValueOnce(routeResponse());
 
     const model = await getPublishedProgramRoute(
       "en",
@@ -102,7 +101,7 @@ describe("published program route", () => {
   });
 
   it("rejects an unmanaged family", async () => {
-    fetchMock.mockResolvedValueOnce(
+    runtimeQueryMock.mockResolvedValueOnce(
       routeResponse({
         managed: false,
         materialJson: [],
@@ -121,7 +120,7 @@ describe("published program route", () => {
   });
 
   it("distinguishes a managed missing route", async () => {
-    fetchMock.mockResolvedValueOnce(
+    runtimeQueryMock.mockResolvedValueOnce(
       routeResponse({
         materialJson: [],
         programJson: null,
@@ -173,7 +172,7 @@ describe("published program route", () => {
       }),
     ],
   ])("rejects a %s", async (_name, response) => {
-    fetchMock.mockResolvedValueOnce(response);
+    runtimeQueryMock.mockResolvedValueOnce(response);
 
     await expect(
       Effect.runPromise(

--- a/apps/www/lib/content/program/route.ts
+++ b/apps/www/lib/content/program/route.ts
@@ -18,10 +18,7 @@ import {
 } from "@/lib/content/program/decode";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Complete immutable data needed by one curriculum route page. */
 export interface PublishedProgramRoute {
@@ -52,12 +49,10 @@ const decodeRoutes = Effect.fn("NakafaProgram.decodeRoutes")(function* (
 export const readPublishedProgramRoute = Effect.fn(
   "NakafaProgram.readPublishedRoute"
 )(function* (locale: Locale, publicPath: string) {
-  const result = yield* readRuntimeQuery("contentRelease.program.route", () =>
-    fetchRuntimeQuery(api.contentRelease.program.route, {
-      locale,
-      publicPath,
-    })
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.program.route, {
+    locale,
+    publicPath,
+  });
   const sourceRevision = yield* decodeSourceRevision(result.sourceRevision, {
     locale,
     publicPath,

--- a/apps/www/lib/content/program/sitemap.ts
+++ b/apps/www/lib/content/program/sitemap.ts
@@ -3,28 +3,23 @@ import "server-only";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Reads non-empty curriculum sitemap partitions for one locale. */
 export const readPublishedProgramBuckets = Effect.fn(
   "www.programs.readSitemapBuckets"
 )(function* (locale: Locale) {
-  return yield* readRuntimeQuery("contentRelease.program.sitemapBuckets", () =>
-    fetchRuntimeQuery(api.contentRelease.program.sitemapBuckets, { locale })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.program.sitemapBuckets, {
+    locale,
+  });
 });
 
 /** Reads one complete verified curriculum sitemap partition. */
 export const readPublishedProgramSitemap = Effect.fn(
   "www.programs.readSitemapPage"
 )(function* (locale: Locale, bucket: string) {
-  return yield* readRuntimeQuery("contentRelease.program.sitemapPage", () =>
-    fetchRuntimeQuery(api.contentRelease.program.sitemapPage, {
-      bucket,
-      locale,
-    })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.program.sitemapPage, {
+    bucket,
+    locale,
+  });
 });

--- a/apps/www/lib/content/published/active.test.ts
+++ b/apps/www/lib/content/published/active.test.ts
@@ -6,30 +6,20 @@ import {
 } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchActiveContentIdentity,
-  getActiveContentIdentity,
-  readActiveContentIdentity,
-} from "@/lib/content/published/active";
-import { readTestRuntimeQuery } from "@/test/runtime-query";
+import { readActiveContentIdentity } from "@/lib/content/published/active";
+import { createTestRuntimeQuery } from "@/test/runtime-query";
 
-const applyContentRuntimeCacheMock = vi.hoisted(() => vi.fn());
 const fetchQueryMock = vi.hoisted(() => vi.fn());
 const readQueryMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/lib/content/cache", () => ({
-  applyContentRuntimeCache: applyContentRuntimeCacheMock,
-}));
 vi.mock("@/lib/content/runtime/query", () => ({
-  fetchRuntimeQuery: fetchQueryMock,
   readRuntimeQuery: readQueryMock,
 }));
 
 beforeEach(() => {
-  applyContentRuntimeCacheMock.mockReset();
   fetchQueryMock.mockReset();
   readQueryMock.mockReset();
-  readQueryMock.mockImplementation(readTestRuntimeQuery);
+  readQueryMock.mockImplementation(createTestRuntimeQuery(fetchQueryMock));
 });
 
 describe("published active identity", () => {
@@ -44,10 +34,7 @@ describe("published active identity", () => {
     await expect(
       Effect.runPromise(readActiveContentIdentity())
     ).resolves.toEqual(identity);
-    expect(readQueryMock).toHaveBeenCalledWith(
-      "contentRelease.runtime.active.read",
-      expect.any(Function)
-    );
+    expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {});
   });
 
   it("preserves the absence of an active release", async () => {
@@ -56,31 +43,5 @@ describe("published active identity", () => {
     await expect(
       Effect.runPromise(readActiveContentIdentity())
     ).resolves.toBeNull();
-  });
-
-  it("decodes the framework-safe active identity", async () => {
-    const identity = {
-      manifestHash: Sha256HashSchema.make(`sha256:${"b".repeat(64)}`),
-      releaseId: ReleaseIdSchema.make("release-static"),
-      sequence: 4,
-    };
-    fetchQueryMock.mockResolvedValue(identity);
-
-    await expect(fetchActiveContentIdentity()).resolves.toEqual(identity);
-  });
-
-  it("rejects malformed framework-safe active identity", async () => {
-    fetchQueryMock.mockResolvedValue({ releaseId: "invalid release" });
-
-    await expect(fetchActiveContentIdentity()).rejects.toMatchObject({
-      _tag: "ParseError",
-    });
-  });
-
-  it("applies global invalidation to the cached framework boundary", async () => {
-    fetchQueryMock.mockResolvedValue(null);
-
-    await expect(getActiveContentIdentity()).resolves.toBeNull();
-    expect(applyContentRuntimeCacheMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/www/lib/content/published/active.ts
+++ b/apps/www/lib/content/published/active.ts
@@ -5,12 +5,8 @@ import {
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
 import { api } from "@repo/backend/convex/_generated/api";
-import { Effect, Either, Schema } from "effect";
-import { applyContentRuntimeCache } from "@/lib/content/cache";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { Effect, Schema } from "effect";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 const ActiveContentIdentitySchema = Schema.NullOr(
   Schema.Struct({
@@ -32,41 +28,9 @@ export const readActiveContentIdentity = Effect.fn(
   "NakafaContent.readActiveContentIdentity"
 )(function* () {
   const identity = yield* readRuntimeQuery(
-    "contentRelease.runtime.active.read",
-    () => fetchRuntimeQuery(api.contentRelease.runtime.active.read, {})
+    api.contentRelease.runtime.active.read,
+    {}
   );
 
   return yield* Schema.decodeUnknown(ActiveContentIdentitySchema)(identity);
 });
-
-/**
- * Reads the active identity without starting an Effect fiber during prerender.
- *
- * Static RSCs use the official Convex Promise boundary and Effect's synchronous
- * Either decoder. Starting an Effect runtime here would read the current time,
- * which Cache Components reject during static prerender.
- *
- * @see https://nextjs.org/docs/messages/next-prerender-current-time
- */
-export function fetchActiveContentIdentity() {
-  return fetchRuntimeQuery(api.contentRelease.runtime.active.read, {}).then(
-    (identity) => {
-      const decoded = Schema.decodeUnknownEither(ActiveContentIdentitySchema)(
-        identity
-      );
-      if (Either.isLeft(decoded)) {
-        return Promise.reject(decoded.left);
-      }
-      return decoded.right;
-    }
-  );
-}
-
-/** Caches the globally active publication identity under content invalidation. */
-export async function getActiveContentIdentity() {
-  "use cache";
-
-  applyContentRuntimeCache();
-
-  return await fetchActiveContentIdentity();
-}

--- a/apps/www/lib/content/published/release.test.ts
+++ b/apps/www/lib/content/published/release.test.ts
@@ -7,10 +7,8 @@ import type { PublishedProjectionIdentity } from "@/lib/content/published/errors
 import {
   decodeContentReleasePin,
   verifyContentReleasePin,
-  verifyStaticContentReleasePin,
 } from "@/lib/content/published/release";
 
-const fetchActiveContentIdentityMock = vi.hoisted(() => vi.fn());
 const readActiveContentIdentityMock = vi.hoisted(() => vi.fn());
 const activeReleaseId = ReleaseIdSchema.make("release-active");
 const nextReleaseId = ReleaseIdSchema.make("release-next");
@@ -21,12 +19,10 @@ const identity = {
 } satisfies PublishedProjectionIdentity;
 
 vi.mock("@/lib/content/published/active", () => ({
-  fetchActiveContentIdentity: fetchActiveContentIdentityMock,
   readActiveContentIdentity: readActiveContentIdentityMock,
 }));
 
 beforeEach(() => {
-  fetchActiveContentIdentityMock.mockReset();
   readActiveContentIdentityMock.mockReset();
 });
 
@@ -88,42 +84,5 @@ describe("content release pin", () => {
     await expect(
       Effect.runPromise(verifyContentReleasePin(null, identity))
     ).resolves.toBeNull();
-  });
-
-  it("rechecks a static route without an Effect runtime", async () => {
-    fetchActiveContentIdentityMock.mockResolvedValueOnce({
-      manifestHash: `sha256:${"a".repeat(64)}`,
-      releaseId: activeReleaseId,
-      sequence: 3,
-    });
-
-    await expect(
-      verifyStaticContentReleasePin(activeReleaseId, identity)
-    ).resolves.toBe(activeReleaseId);
-    expect(fetchActiveContentIdentityMock).toHaveBeenCalledOnce();
-  });
-
-  it("preserves an absent static active release", async () => {
-    fetchActiveContentIdentityMock.mockResolvedValueOnce(null);
-
-    await expect(
-      verifyStaticContentReleasePin(null, identity)
-    ).resolves.toBeNull();
-  });
-
-  it("preserves a static route release mismatch", async () => {
-    fetchActiveContentIdentityMock.mockResolvedValueOnce({
-      manifestHash: `sha256:${"b".repeat(64)}`,
-      releaseId: nextReleaseId,
-      sequence: 4,
-    });
-
-    await expect(
-      verifyStaticContentReleasePin(activeReleaseId, identity)
-    ).rejects.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: nextReleaseId,
-      expectedReleaseId: activeReleaseId,
-    });
   });
 });

--- a/apps/www/lib/content/published/release.ts
+++ b/apps/www/lib/content/published/release.ts
@@ -2,7 +2,6 @@ import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Either, Schema } from "effect";
 import {
   type ActiveContentReleaseId,
-  fetchActiveContentIdentity,
   readActiveContentIdentity,
 } from "@/lib/content/published/active";
 import {
@@ -70,28 +69,3 @@ export const verifyContentReleasePin = Effect.fn(
     identity
   );
 });
-
-/**
- * Rechecks one static signed read without starting an Effect fiber.
- *
- * The direct Promise is the framework boundary for static RSC prerender. Domain
- * validation still uses the same pure decoder as the Effect-native operation.
- *
- * @see https://nextjs.org/docs/messages/next-prerender-current-time
- */
-export function verifyStaticContentReleasePin(
-  expected: ContentReleasePin,
-  identity: PublishedProjectionIdentity
-) {
-  return fetchActiveContentIdentity().then((active) => {
-    const decoded = decodeReleasePin(
-      active?.releaseId ?? null,
-      expected,
-      identity
-    );
-    if (Either.isLeft(decoded)) {
-      return Promise.reject(decoded.left);
-    }
-    return decoded.right;
-  });
-}

--- a/apps/www/lib/content/published/route.test.ts
+++ b/apps/www/lib/content/published/route.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readActiveContentRoute } from "@/lib/content/published/route";
 import { testArticleProjection } from "@/test/content-article";
 import { previewProjection } from "@/test/content-preview";
-import { readTestRuntimeQuery } from "@/test/runtime-query";
+import { createTestRuntimeQuery } from "@/test/runtime-query";
 
 const fetchQueryMock = vi.hoisted(() => vi.fn());
 const readQueryMock = vi.hoisted(() => vi.fn());
@@ -19,14 +19,13 @@ const input = {
 };
 
 vi.mock("@/lib/content/runtime/query", () => ({
-  fetchRuntimeQuery: fetchQueryMock,
   readRuntimeQuery: readQueryMock,
 }));
 
 beforeEach(() => {
   fetchQueryMock.mockReset();
   readQueryMock.mockReset();
-  readQueryMock.mockImplementation(readTestRuntimeQuery);
+  readQueryMock.mockImplementation(createTestRuntimeQuery(fetchQueryMock));
 });
 
 describe("published content route", () => {
@@ -120,10 +119,11 @@ describe("published content route", () => {
       locale: input.locale,
       publicPath: input.publicPath,
     });
-    expect(readQueryMock).toHaveBeenCalledWith(
-      "contentRelease.ownership.resolve",
-      expect.any(Function)
-    );
+    expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {
+      family: input.family,
+      locale: input.locale,
+      publicPath: input.publicPath,
+    });
   });
 
   it("surfaces malformed stored projections as typed integrity failures", async () => {

--- a/apps/www/lib/content/published/route.ts
+++ b/apps/www/lib/content/published/route.ts
@@ -14,10 +14,7 @@ import {
   PublishedProjectionError,
   PublishedReleaseMismatchError,
 } from "@/lib/content/published/errors";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type ContentRouteArgs = FunctionArgs<
   typeof api.contentRelease.ownership.resolve
@@ -46,11 +43,6 @@ type ActiveContentRoute =
       readonly kind: "found";
       readonly projection: typeof RoutedContentProjectionSchema.Type;
     };
-
-/** Reads one exact active public-route projection from Convex. */
-function fetchActiveContentRoute(args: ContentRouteArgs) {
-  return fetchRuntimeQuery(api.contentRelease.ownership.resolve, args);
-}
 
 /** Verifies one found projection against its requested family and route. */
 const decodeActiveProjection = Effect.fn(
@@ -98,8 +90,8 @@ export const readActiveContentRoute = Effect.fn(
     publicPath: input.publicPath,
   };
   const result = yield* readRuntimeQuery(
-    "contentRelease.ownership.resolve",
-    () => fetchActiveContentRoute(args)
+    api.contentRelease.ownership.resolve,
+    args
   );
   if (result.kind === "unmanaged") {
     const activeReleaseId = yield* Schema.decodeUnknown(

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -15,17 +15,16 @@ import {
   readPublishedQuranMarkdown,
 } from "@/lib/content/quran/publication";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/content/cache", () => ({
   applyPublishedSnapshotCache: cacheMock,
 }));
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
@@ -39,21 +38,24 @@ const source = {
 
 beforeEach(() => {
   cacheMock.mockReset();
-  fetchMock.mockReset();
+  runtimeQueryMock.mockReset();
 });
 
 describe("published Quran content", () => {
   it("reads the active identity through the one-row attribution query", async () => {
-    fetchMock.mockResolvedValue({ ...source, rowJson: "attribution-row" });
+    runtimeQueryMock.mockResolvedValue({
+      ...source,
+      rowJson: "attribution-row",
+    });
 
     await expect(
       Effect.runPromise(readPublishedQuranIdentity())
     ).resolves.toMatchObject({ snapshotId: source.snapshotId });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {});
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
   });
 
-  it("reads the signed catalog through Effect and cached Promise boundaries", async () => {
-    fetchMock.mockResolvedValue(catalogResult());
+  it("reads and caches the signed catalog through the Effect boundary", async () => {
+    runtimeQueryMock.mockResolvedValue(catalogResult());
 
     await expect(
       Effect.runPromise(readPublishedQuranCatalog())
@@ -61,13 +63,13 @@ describe("published Quran content", () => {
     await expect(getPublishedQuranCatalog()).resolves.toMatchObject({
       surahs: expect.any(Array),
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {});
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
     expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
   });
 
   it("reads the locale-specific signed markdown through the Effect boundary", async () => {
     const result = markdownResult();
-    fetchMock.mockResolvedValue(result);
+    runtimeQueryMock.mockResolvedValue(result);
 
     await expect(
       Effect.runPromise(readPublishedQuranMarkdown("id", 1, 80))
@@ -75,7 +77,7 @@ describe("published Quran content", () => {
       surah: { number: 1 },
       verses: [{ number: {} }],
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       locale: "id",
       surahNumber: 1,
       verseLimit: 80,
@@ -83,7 +85,7 @@ describe("published Quran content", () => {
   });
 
   it("reads the complete signed markdown when no verse limit is requested", async () => {
-    fetchMock.mockResolvedValue(markdownResult());
+    runtimeQueryMock.mockResolvedValue(markdownResult());
 
     await expect(
       Effect.runPromise(readPublishedQuranMarkdown("id", 1))
@@ -91,14 +93,14 @@ describe("published Quran content", () => {
       surah: { number: 1 },
       verses: [{ number: {} }],
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       locale: "id",
       surahNumber: 1,
     });
   });
 
   it("keeps a failed Quran query in the Effect error channel", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("Quran unavailable"));
+    runtimeQueryMock.mockRejectedValueOnce(new Error("Quran unavailable"));
 
     await expect(
       Effect.runPromise(Effect.either(readPublishedQuranCatalog()))
@@ -112,7 +114,7 @@ describe("published Quran content", () => {
   });
 
   it("caches the locale-specific Quran web projection", async () => {
-    fetchMock.mockResolvedValue(viewResult());
+    runtimeQueryMock.mockResolvedValue(viewResult());
 
     await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
       locale: "id",
@@ -123,7 +125,7 @@ describe("published Quran content", () => {
         },
       ],
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
       locale: "id",
       surahNumber: 1,
     });

--- a/apps/www/lib/content/quran/publication.ts
+++ b/apps/www/lib/content/quran/publication.ts
@@ -10,55 +10,15 @@ import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import { applyPublishedSnapshotCache } from "@/lib/content/cache";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
-
-/** Reads the raw active Quran attribution through the public Convex query. */
-function fetchAttributionResult() {
-  return fetchRuntimeQuery(api.contentRelease.quran.attribution, {});
-}
-
-/** Reads the raw signed Quran catalog through the public Convex query. */
-function fetchCatalogResult() {
-  return fetchRuntimeQuery(api.contentRelease.quran.surahs, {});
-}
-
-/** Reads one raw signed Quran markdown projection through the public query. */
-function fetchMarkdownResult(
-  locale: Locale,
-  surahNumber: number,
-  verseLimit?: number
-) {
-  if (verseLimit === undefined) {
-    return fetchRuntimeQuery(api.contentRelease.quran.markdown, {
-      locale,
-      surahNumber,
-    });
-  }
-  return fetchRuntimeQuery(api.contentRelease.quran.markdown, {
-    locale,
-    surahNumber,
-    verseLimit,
-  });
-}
-
-/** Reads one locale-specific Quran web projection through the public query. */
-function fetchViewResult(locale: Locale, surahNumber: number) {
-  return fetchRuntimeQuery(api.contentRelease.quran.view, {
-    locale,
-    surahNumber,
-  });
-}
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Reads and validates the active signed Quran identity without a catalog payload. */
 export const readPublishedQuranIdentity = Effect.fn(
   "NakafaQuran.readPublishedIdentity"
 )(function* () {
   const result = yield* readRuntimeQuery(
-    "contentRelease.quran.attribution",
-    fetchAttributionResult
+    api.contentRelease.quran.attribution,
+    {}
   );
   return yield* decodePublishedQuranSource(result, "attribution");
 });
@@ -67,10 +27,7 @@ export const readPublishedQuranIdentity = Effect.fn(
 export const readPublishedQuranCatalog = Effect.fn(
   "NakafaQuran.readPublishedCatalog"
 )(function* () {
-  const result = yield* readRuntimeQuery(
-    "contentRelease.quran.surahs",
-    fetchCatalogResult
-  );
+  const result = yield* readRuntimeQuery(api.contentRelease.quran.surahs, {});
   return yield* decodePublishedQuranCatalog(result);
 });
 
@@ -78,8 +35,11 @@ export const readPublishedQuranCatalog = Effect.fn(
 export const readPublishedQuranMarkdown = Effect.fn(
   "NakafaQuran.readPublishedMarkdown"
 )(function* (locale: Locale, surahNumber: number, verseLimit?: number) {
-  const result = yield* readRuntimeQuery("contentRelease.quran.markdown", () =>
-    fetchMarkdownResult(locale, surahNumber, verseLimit)
+  const result = yield* readRuntimeQuery(
+    api.contentRelease.quran.markdown,
+    verseLimit === undefined
+      ? { locale, surahNumber }
+      : { locale, surahNumber, verseLimit }
   );
   return yield* decodePublishedQuranMarkdown(result, {
     locale,
@@ -88,12 +48,22 @@ export const readPublishedQuranMarkdown = Effect.fn(
   });
 });
 
+/** Reads and validates one locale-specific signed Quran web projection. */
+const readPublishedQuranView = Effect.fn("NakafaQuran.readPublishedView")(
+  function* (locale: Locale, surahNumber: number) {
+    const result = yield* readRuntimeQuery(api.contentRelease.quran.view, {
+      locale,
+      surahNumber,
+    });
+    return yield* decodePublishedQuranView(result, { locale, surahNumber });
+  }
+);
+
 /** Caches the complete signed Quran metadata catalog by active release. */
 export async function getPublishedQuranCatalog() {
   "use cache";
 
-  const result = await fetchCatalogResult();
-  const catalog = await Effect.runPromise(decodePublishedQuranCatalog(result));
+  const catalog = await Effect.runPromise(readPublishedQuranCatalog());
   applyPublishedSnapshotCache(catalog.snapshotId);
   return catalog;
 }
@@ -105,9 +75,8 @@ export async function getPublishedQuranView(
 ) {
   "use cache";
 
-  const result = await fetchViewResult(locale, surahNumber);
   const view = await Effect.runPromise(
-    decodePublishedQuranView(result, { locale, surahNumber })
+    readPublishedQuranView(locale, surahNumber)
   );
   applyPublishedSnapshotCache(view.snapshotId);
   return view;

--- a/apps/www/lib/content/runtime/query.test.ts
+++ b/apps/www/lib/content/runtime/query.test.ts
@@ -1,20 +1,19 @@
 // @vitest-environment node
 
+import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import { describe, expect, it, vi } from "vitest";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
-const { fetchMock, runtimeUrl } = vi.hoisted(() => ({
-  fetchMock: vi.fn(),
+const { readMock, runtimeUrl } = vi.hoisted(() => ({
+  readMock: vi.fn(),
   runtimeUrl: "https://runtime.example",
 }));
 
-vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: fetchMock,
+vi.mock("@repo/backend/client/runtime", async (importOriginal) => ({
+  ...(await importOriginal()),
+  readConvexRuntimeQuery: readMock,
 }));
 
 vi.mock("@/env", () => ({
@@ -22,38 +21,39 @@ vi.mock("@/env", () => ({
 }));
 
 describe("content runtime query", () => {
-  it("reads one official Convex runtime query", async () => {
-    const response = { activeReleaseId: null, sourceClaims: [] };
-    fetchMock.mockResolvedValueOnce(response);
-
+  it("maps the Effect runtime query into the typed data-read channel", async () => {
+    readMock.mockReturnValueOnce(Effect.succeed(42));
     await expect(
-      fetchRuntimeQuery(api.contentRelease.material.claims, {
-        sourceCandidates: [],
-      })
-    ).resolves.toBe(response);
-    expect(fetchMock).toHaveBeenCalledWith(
+      Effect.runPromise(
+        readRuntimeQuery(api.contentRelease.material.claims, {
+          sourceCandidates: [],
+        })
+      )
+    ).resolves.toBe(42);
+
+    const runtimeError = new ConvexRuntimeQueryError({
+      networkCodes: ["EPIPE"],
+      query: "contentRelease.material.route",
+      reason: "transport",
+    });
+    readMock.mockReturnValueOnce(Effect.fail(runtimeError));
+    await expect(
+      Effect.runPromise(
+        Effect.flip(
+          readRuntimeQuery(api.contentRelease.material.claims, {
+            sourceCandidates: [],
+          })
+        )
+      )
+    ).resolves.toMatchObject({
+      cause: runtimeError.message,
+      message:
+        "Unable to read Nakafa runtime content query: contentRelease.material.route.",
+    });
+    expect(readMock).toHaveBeenCalledWith(
       runtimeUrl,
       api.contentRelease.material.claims,
       { sourceCandidates: [] }
     );
-  });
-
-  it("maps runtime failures into the typed data-read error", async () => {
-    await expect(
-      Effect.runPromise(readRuntimeQuery("success", () => Promise.resolve(42)))
-    ).resolves.toBe(42);
-    await expect(
-      Effect.runPromise(
-        Effect.flip(
-          readRuntimeQuery("failure", () =>
-            Promise.reject(new Error("network unavailable"))
-          )
-        )
-      )
-    ).resolves.toMatchObject({
-      _tag: "NakafaAgentDataReadError",
-      cause: "network unavailable",
-      message: "Unable to read Nakafa runtime content query: failure.",
-    });
   });
 });

--- a/apps/www/lib/content/runtime/query.ts
+++ b/apps/www/lib/content/runtime/query.ts
@@ -1,41 +1,27 @@
-import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
-import {
-  getUnknownErrorMessage,
-  NakafaAgentDataReadError,
-} from "@repo/contents/_lib/agent/errors";
-import type {
-  FunctionArgs,
-  FunctionReference,
-  FunctionReturnType,
-} from "convex/server";
+import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
+import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
+import type { FunctionArgs, FunctionReference } from "convex/server";
 import { Effect } from "effect";
 import { env } from "@/env";
 
-/**
- * Fetches one public content-runtime query through the official Convex client.
- *
- * `convex/nextjs` does not expose logger configuration. Its default
- * `ConvexHttpClient` logger allocates a random listener id, which Next Cache
- * Components reject during static prerender. A short-lived official client with
- * `logger: false` and a public custom fetch keeps this boundary framework-safe
- * without copying protocol.
- */
-export function fetchRuntimeQuery<Query extends FunctionReference<"query">>(
-  query: Query,
-  args: FunctionArgs<Query>
-): Promise<FunctionReturnType<Query>> {
-  return fetchConvexRuntimeQuery(env.NEXT_PUBLIC_CONVEX_URL, query, args);
-}
-
-/** Wraps a Convex runtime query in the agent data-read error model. */
-export function readRuntimeQuery<T>(name: string, read: () => Promise<T>) {
-  return Effect.tryPromise({
-    try: read,
-    /** Converts Convex/runtime read failures into the agent data-read error. */
-    catch: (error) =>
-      new NakafaAgentDataReadError({
-        cause: getUnknownErrorMessage(error),
-        message: `Unable to read Nakafa runtime content query: ${name}.`,
-      }),
-  });
-}
+/** Reads one query through the Effect-native agent data-read error channel. */
+export const readRuntimeQuery = Effect.fn("www.contentRuntime.query")(
+  function* <Query extends FunctionReference<"query">>(
+    query: Query,
+    args: FunctionArgs<Query>
+  ) {
+    return yield* readConvexRuntimeQuery(
+      env.NEXT_PUBLIC_CONVEX_URL,
+      query,
+      args
+    ).pipe(
+      Effect.mapError(
+        (error) =>
+          new NakafaAgentDataReadError({
+            cause: error.message,
+            message: `Unable to read Nakafa runtime content query: ${error.query}.`,
+          })
+      )
+    );
+  }
+);

--- a/apps/www/lib/content/runtime/routes.ts
+++ b/apps/www/lib/content/runtime/routes.ts
@@ -1,10 +1,7 @@
 import { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionArgs } from "convex/server";
 import { Effect } from "effect";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type ContentRouteArgs = FunctionArgs<
   typeof api.contents.queries.runtime.getContentRoute
@@ -14,16 +11,12 @@ type TryoutRouteArgs = FunctionArgs<
 >;
 
 /** Reads one exact route-catalog row from the Convex content runtime model. */
-export function fetchRuntimeContentRoute(args: ContentRouteArgs) {
-  return fetchRuntimeQuery(api.contents.queries.runtime.getContentRoute, args);
-}
-
-/** Reads one exact route-catalog row from the Convex content runtime model. */
 export const getRuntimeContentRoute = Effect.fn(
   "www.contentRuntime.contentRoute"
 )(function* (args: ContentRouteArgs) {
-  return yield* readRuntimeQuery("getContentRoute", () =>
-    fetchRuntimeContentRoute(args)
+  return yield* readRuntimeQuery(
+    api.contents.queries.runtime.getContentRoute,
+    args
   );
 });
 
@@ -31,7 +24,5 @@ export const getRuntimeContentRoute = Effect.fn(
 export const getRuntimeTryoutRoute = Effect.fn(
   "www.contentRuntime.tryoutRoute"
 )(function* (args: TryoutRouteArgs) {
-  return yield* readRuntimeQuery("getTryoutRoute", () =>
-    fetchRuntimeQuery(api.tryouts.queries.catalog.getRoute, args)
-  );
+  return yield* readRuntimeQuery(api.tryouts.queries.catalog.getRoute, args);
 });

--- a/apps/www/lib/content/tryout/path.ts
+++ b/apps/www/lib/content/tryout/path.ts
@@ -3,10 +3,7 @@ import "server-only";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionArgs } from "convex/server";
 import { Effect } from "effect";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 type TryoutLocalizedPathArgs = FunctionArgs<
   typeof api.tryouts.queries.catalog.getLocalizedPath
@@ -16,7 +13,8 @@ type TryoutLocalizedPathArgs = FunctionArgs<
 export const readPublishedTryoutLocalizedPath = Effect.fn(
   "www.tryouts.readLocalizedPath"
 )(function* (args: TryoutLocalizedPathArgs) {
-  return yield* readRuntimeQuery("tryouts.catalog.getLocalizedPath", () =>
-    fetchRuntimeQuery(api.tryouts.queries.catalog.getLocalizedPath, args)
+  return yield* readRuntimeQuery(
+    api.tryouts.queries.catalog.getLocalizedPath,
+    args
   );
 });

--- a/apps/www/lib/content/tryout/sitemap.test.ts
+++ b/apps/www/lib/content/tryout/sitemap.test.ts
@@ -7,23 +7,22 @@ import {
   readPublishedTryoutSitemapCount,
 } from "@/lib/content/tryout/sitemap";
 
-const fetchMock = vi.hoisted(() => vi.fn());
+const runtimeQueryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/content/runtime/query", async () => {
-  const { readTestRuntimeQuery } = await import("@/test/runtime-query");
+  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
   return {
-    fetchRuntimeQuery: fetchMock,
-    readRuntimeQuery: readTestRuntimeQuery,
+    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
   };
 });
 
 describe("published try-out sitemap", () => {
   beforeEach(() => {
-    fetchMock.mockReset();
+    runtimeQueryMock.mockReset();
   });
 
   it("reads route inventory and one exact bounded page", async () => {
-    fetchMock
+    runtimeQueryMock
       .mockResolvedValueOnce({ pageCount: 1, routeCount: 2 })
       .mockResolvedValueOnce({ paths: ["try-out/alpha", "try-out/zeta"] });
 
@@ -33,17 +32,17 @@ describe("published try-out sitemap", () => {
     await expect(
       Effect.runPromise(readPublishedTryoutSitemap("en", 0))
     ).resolves.toEqual({ paths: ["try-out/alpha", "try-out/zeta"] });
-    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
       locale: "en",
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
       locale: "en",
       page: 0,
     });
   });
 
   it("preserves runtime query failures in the Effect error channel", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
+    runtimeQueryMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
 
     await expect(
       Effect.runPromise(readPublishedTryoutSitemapCount("id"))

--- a/apps/www/lib/content/tryout/sitemap.ts
+++ b/apps/www/lib/content/tryout/sitemap.ts
@@ -3,25 +3,23 @@ import "server-only";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
-import {
-  fetchRuntimeQuery,
-  readRuntimeQuery,
-} from "@/lib/content/runtime/query";
+import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 /** Reads the active signed try-out sitemap inventory for one locale. */
 export const readPublishedTryoutSitemapCount = Effect.fn(
   "www.tryouts.readSitemapCount"
 )(function* (locale: Locale) {
-  return yield* readRuntimeQuery("contentRelease.tryout.sitemapCount", () =>
-    fetchRuntimeQuery(api.contentRelease.tryout.sitemapCount, { locale })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.tryout.sitemapCount, {
+    locale,
+  });
 });
 
 /** Reads one exact bounded signed try-out sitemap page. */
 export const readPublishedTryoutSitemap = Effect.fn(
   "www.tryouts.readSitemapPage"
 )(function* (locale: Locale, page: number) {
-  return yield* readRuntimeQuery("contentRelease.tryout.sitemapPage", () =>
-    fetchRuntimeQuery(api.contentRelease.tryout.sitemapPage, { locale, page })
-  );
+  return yield* readRuntimeQuery(api.contentRelease.tryout.sitemapPage, {
+    locale,
+    page,
+  });
 });

--- a/apps/www/test/runtime-query.ts
+++ b/apps/www/test/runtime-query.ts
@@ -5,16 +5,19 @@ class TestRuntimeQueryError extends Data.TaggedError("TestRuntimeQueryError")<{
   readonly message: string;
 }> {}
 
-/** Preserves a mocked runtime query rejection message in the Effect error channel. */
-export function readTestRuntimeQuery(
-  _name: string,
-  read: () => Promise<unknown>
-) {
-  return Effect.tryPromise({
-    try: read,
-    catch: (cause) =>
-      new TestRuntimeQueryError({
-        message: String(cause),
-      }),
-  });
+type TestRuntimeQueryClient = (
+  query: unknown,
+  args: unknown
+) => Promise<unknown>;
+
+/** Adapts one mocked client to the Effect-native runtime query interface. */
+export function createTestRuntimeQuery(read: TestRuntimeQueryClient) {
+  return (query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      try: () => read(query, args),
+      catch: (cause) =>
+        new TestRuntimeQueryError({
+          message: String(cause),
+        }),
+    });
 }

--- a/packages/backend/client/content/errors.ts
+++ b/packages/backend/client/content/errors.ts
@@ -1,6 +1,7 @@
 import { ProtectedContentRuntimeRequestSchema } from "@nakafa/aksara-contracts/runtime/protected/spec";
 import { ContentRuntimeFailureCodeSchema } from "@nakafa/aksara-contracts/runtime/result";
 import { PublicContentRuntimeRequestSchema } from "@nakafa/aksara-contracts/runtime/spec";
+import { NetworkRetryCodeSchema } from "@repo/backend/client/network";
 import { Schema } from "effect";
 
 const ContentRuntimeRequestSchema = Schema.Union(
@@ -12,6 +13,7 @@ const ContentRuntimeRequestSchema = Schema.Union(
 export class ContentTransportError extends Schema.TaggedError<ContentTransportError>()(
   "ContentTransportError",
   {
+    networkCodes: Schema.optional(Schema.Array(NetworkRetryCodeSchema)),
     reason: Schema.Literal(
       "body",
       "content-length",

--- a/packages/backend/client/content/errors.ts
+++ b/packages/backend/client/content/errors.ts
@@ -17,10 +17,12 @@ export class ContentTransportError extends Schema.TaggedError<ContentTransportEr
       "content-length",
       "content-type",
       "fetch",
-      "json",
+      "json-syntax",
       "request",
       "request-size",
+      "response-contract",
       "response-size",
+      "response-unmarked",
       "response-url",
       "status",
       "url"

--- a/packages/backend/client/content/protected.test.ts
+++ b/packages/backend/client/content/protected.test.ts
@@ -12,8 +12,15 @@ import {
 } from "@nakafa/aksara-contracts/release/snapshot/spec";
 import type { ProtectedContentRuntimeRequest } from "@nakafa/aksara-contracts/runtime/protected/spec";
 import { verifyProtectedContentRuntimeExchange } from "@nakafa/aksara-contracts/runtime/protected/verify";
-import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
+import {
+  ContentRuntimeMissingError,
+  ContentTransportError,
+} from "@repo/backend/client/content/errors";
 import { readProtectedContent } from "@repo/backend/client/content/protected";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+} from "@repo/backend/content/endpoint";
 import {
   TEST_PROOF_RENDERER,
   testEmptyManifest,
@@ -88,9 +95,16 @@ vi.mock("@nakafa/aksara-contracts/runtime/protected/verify", () => ({
 }));
 
 /** Creates one response with the immutable network URL populated. */
-function createResponse(body: unknown, status: number) {
+function createResponse(body: unknown, status: number, marked = true) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (marked) {
+    headers.set(
+      CONTENT_RUNTIME_RESPONSE_HEADER,
+      CONTENT_RUNTIME_RESPONSE_MARKER
+    );
+  }
   const response = new Response(JSON.stringify(body), {
-    headers: { "content-type": "application/json" },
+    headers,
     status,
   });
   Object.defineProperty(response, "url", { value: endpoint });
@@ -110,7 +124,7 @@ afterEach(() => {
 
 describe("protected content runtime client", () => {
   it("posts and verifies one retained-snapshot batch", async () => {
-    fetchMock.mockResolvedValue(createResponse(found, 200));
+    fetchMock.mockResolvedValue(createResponse(found, 200, false));
 
     await expect(
       Effect.runPromise(
@@ -137,5 +151,31 @@ describe("protected content runtime client", () => {
         )
       )
     ).resolves.toEqual(new ContentRuntimeMissingError({ request }));
+  });
+
+  it("classifies valid JSON outside the protected response contract", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createResponse({ unexpected: true }, 200, false))
+      .mockResolvedValueOnce(createResponse({ unexpected: true }, 200));
+
+    await expect(
+      Effect.runPromise(
+        readProtectedContent(target, request, TEST_PROOF_RENDERER).pipe(
+          Effect.flip
+        )
+      )
+    ).resolves.toEqual(
+      new ContentTransportError({ reason: "response-unmarked" })
+    );
+    await expect(
+      Effect.runPromise(
+        readProtectedContent(target, request, TEST_PROOF_RENDERER).pipe(
+          Effect.flip
+        )
+      )
+    ).resolves.toEqual(
+      new ContentTransportError({ reason: "response-contract" })
+    );
+    expect(verifyProtectedContentRuntimeExchange).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/client/content/protected.ts
+++ b/packages/backend/client/content/protected.ts
@@ -18,6 +18,7 @@ import {
 } from "@repo/backend/client/content/errors";
 import {
   type ContentHttpTarget,
+  createContentContractError,
   createContentEndpoint,
   encodeContentRequest,
   postContentRequest,
@@ -38,7 +39,7 @@ const readProtectedRuntimeResponse = Effect.fn(
     MAX_PROTECTED_RUNTIME_RESPONSE_BYTES
   );
   const decoded = yield* decodeProtectedContentRuntimeResponse(input).pipe(
-    Effect.mapError(() => new ContentTransportError({ reason: "json" }))
+    Effect.mapError(() => createContentContractError(response))
   );
   yield* validateContentRuntimeStatus(decoded, response.status);
   return decoded;

--- a/packages/backend/client/content/public.test.ts
+++ b/packages/backend/client/content/public.test.ts
@@ -6,11 +6,16 @@ import {
   ContentRuntimeFailureError,
   ContentRuntimeMissingError,
   ContentRuntimeVerificationError,
+  ContentTransportError,
 } from "@repo/backend/client/content/errors";
 import {
   readPublicContent,
   readPublicContentEvidence,
 } from "@repo/backend/client/content/public";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+} from "@repo/backend/content/endpoint";
 import { testArtifactJson } from "@repo/backend/test/content-artifact";
 import { testProjectionJson } from "@repo/backend/test/content-material";
 import {
@@ -41,9 +46,16 @@ vi.mock("@nakafa/aksara-contracts/runtime/verify", () => ({
 }));
 
 /** Creates one response with the immutable network URL populated. */
-function createResponse(body: unknown, status: number) {
+function createResponse(body: unknown, status: number, marked = true) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (marked) {
+    headers.set(
+      CONTENT_RUNTIME_RESPONSE_HEADER,
+      CONTENT_RUNTIME_RESPONSE_MARKER
+    );
+  }
   const response = new Response(JSON.stringify(body), {
-    headers: { "content-type": "application/json" },
+    headers,
     status,
   });
   Object.defineProperty(response, "url", { value: endpoint });
@@ -80,7 +92,7 @@ afterEach(() => {
 describe("public content runtime client", () => {
   it("posts, verifies, and returns one active public artifact", async () => {
     const found = foundResponse();
-    fetchMock.mockResolvedValue(createResponse(found, 200));
+    fetchMock.mockResolvedValue(createResponse(found, 200, false));
 
     await expect(
       Effect.runPromise(
@@ -125,6 +137,28 @@ describe("public content runtime client", () => {
         status: 500,
       })
     );
+  });
+
+  it("classifies valid JSON outside the public response contract", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createResponse({ unexpected: true }, 200, false))
+      .mockResolvedValueOnce(createResponse({ unexpected: true }, 200));
+
+    await expect(
+      Effect.runPromise(
+        readPublicContentEvidence(target, input).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ContentTransportError({ reason: "response-unmarked" })
+    );
+    await expect(
+      Effect.runPromise(
+        readPublicContentEvidence(target, input).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ContentTransportError({ reason: "response-contract" })
+    );
+    expect(verifyContentRuntimeExchange).not.toHaveBeenCalled();
   });
 
   it("preserves signature failures in the typed verification boundary", async () => {

--- a/packages/backend/client/content/public.ts
+++ b/packages/backend/client/content/public.ts
@@ -18,6 +18,7 @@ import {
 } from "@repo/backend/client/content/errors";
 import {
   type ContentHttpTarget,
+  createContentContractError,
   createContentEndpoint,
   encodeContentRequest,
   postContentRequest,
@@ -65,7 +66,7 @@ const readPublicRuntimeResponse = Effect.fn(
     MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
   );
   const decoded = yield* decodePublicContentRuntimeResponse(input).pipe(
-    Effect.mapError(() => new ContentTransportError({ reason: "json" }))
+    Effect.mapError(() => createContentContractError(response))
   );
   yield* validateContentRuntimeStatus(decoded, response.status);
   return decoded;

--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -2,13 +2,18 @@
 
 import { ContentTransportError } from "@repo/backend/client/content/errors";
 import {
+  createContentContractError,
   createContentEndpoint,
   encodeContentRequest,
   postContentRequest,
   readContentResponse,
   validateContentRuntimeStatus,
 } from "@repo/backend/client/content/transport";
-import { PUBLIC_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+  PUBLIC_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -27,6 +32,7 @@ function createResponse(
   status: number,
   headers: HeadersInit = {
     "content-type": "application/json; charset=utf-8",
+    [CONTENT_RUNTIME_RESPONSE_HEADER]: CONTENT_RUNTIME_RESPONSE_MARKER,
   },
   url = endpoint
 ) {
@@ -129,6 +135,14 @@ describe("content runtime transport", () => {
         )
       )
     ).resolves.toEqual({ kind: "missing" });
+    expect(createContentContractError(createResponse("{}", 200))).toEqual(
+      new ContentTransportError({ reason: "response-contract" })
+    );
+    expect(
+      createContentContractError(
+        createResponse("{}", 200, { "content-type": "application/json" })
+      )
+    ).toEqual(new ContentTransportError({ reason: "response-unmarked" }));
 
     const invalid: readonly [Response, string][] = [
       [
@@ -136,17 +150,25 @@ describe("content runtime transport", () => {
         "response-url",
       ],
       [
-        createResponse("{}", 200, { "content-type": "text/plain" }),
+        createResponse("{}", 200, {
+          "content-type": "text/plain",
+          [CONTENT_RUNTIME_RESPONSE_HEADER]: CONTENT_RUNTIME_RESPONSE_MARKER,
+        }),
         "content-type",
       ],
       [
         createResponse("{}", 200, {
           "content-length": "invalid",
           "content-type": "application/json",
+          [CONTENT_RUNTIME_RESPONSE_HEADER]: CONTENT_RUNTIME_RESPONSE_MARKER,
         }),
         "content-length",
       ],
-      [createResponse("{", 200), "json"],
+      [
+        createResponse("{", 200, { "content-type": "application/json" }),
+        "response-unmarked",
+      ],
+      [createResponse("{", 200), "json-syntax"],
       [createResponse("x".repeat(20), 200), "response-size"],
     ];
     for (const [response, reason] of invalid) {

--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -14,7 +14,7 @@ import {
   CONTENT_RUNTIME_RESPONSE_MARKER,
   PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
-import { Effect } from "effect";
+import { Duration, Effect, Fiber, TestClock, TestContext } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const endpoint = "https://example.convex.site/internal/content/runtime";
@@ -23,6 +23,17 @@ const target = {
   token: "runtime-test-token",
 };
 const fetchMock = vi.hoisted(() => vi.fn<typeof fetch>());
+
+const runWithTestClock = <Value, Error>(program: Effect.Effect<Value, Error>) =>
+  Effect.runPromise(program.pipe(Effect.provide(TestContext.TestContext)));
+
+/** Creates the nested rejection shape produced by Node fetch. */
+function createFetchFailure(code?: string) {
+  const cause = code
+    ? Object.assign(new Error("private network detail"), { code })
+    : new Error("private network detail");
+  return new TypeError("fetch failed", { cause });
+}
 
 vi.mock("server-only", () => ({}));
 
@@ -123,6 +134,58 @@ describe("content runtime transport", () => {
         signal: expect.any(AbortSignal),
       })
     );
+  });
+
+  it("retries rejected read-only runtime fetches", async () => {
+    const response = createResponse("{}", 200);
+    fetchMock
+      .mockRejectedValueOnce(createFetchFailure("ECONNRESET"))
+      .mockRejectedValueOnce(createFetchFailure("UND_ERR_SOCKET"))
+      .mockResolvedValueOnce(response);
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.fork(
+        postContentRequest({ endpoint, source: "{}", target })
+      );
+      yield* TestClock.adjust(Duration.seconds(2));
+
+      return yield* Fiber.join(fiber);
+    });
+
+    await expect(runWithTestClock(program)).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves sanitized codes after bounded retries", async () => {
+    fetchMock.mockRejectedValue(createFetchFailure("EPIPE"));
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.fork(
+        postContentRequest({ endpoint, source: "{}", target }).pipe(Effect.flip)
+      );
+      yield* TestClock.adjust(Duration.seconds(2));
+
+      return yield* Fiber.join(fiber);
+    });
+
+    await expect(runWithTestClock(program)).resolves.toEqual(
+      new ContentTransportError({
+        networkCodes: ["EPIPE"],
+        reason: "fetch",
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry unknown or timeout fetch failures", async () => {
+    fetchMock.mockRejectedValue(createFetchFailure("UND_ERR_CONNECT_TIMEOUT"));
+
+    await expect(
+      Effect.runPromise(
+        postContentRequest({ endpoint, source: "{}", target }).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ContentTransportError({ networkCodes: [], reason: "fetch" })
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("reads exact bounded JSON and rejects untrusted responses", async () => {

--- a/packages/backend/client/content/transport.ts
+++ b/packages/backend/client/content/transport.ts
@@ -4,14 +4,23 @@ import type { ProtectedContentRuntimeResponse } from "@nakafa/aksara-contracts/r
 import type { PublicContentRuntimeResponse } from "@nakafa/aksara-contracts/runtime/spec";
 import { ContentTransportError } from "@repo/backend/client/content/errors";
 import {
+  createNetworkRequestError,
+  isRetryableNetworkError,
+  NETWORK_RETRY_DELAYS_MILLISECONDS,
+} from "@repo/backend/client/network";
+import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
 } from "@repo/backend/content/endpoint";
 import { parseContentLength, readBoundedBody } from "@repo/utilities/body";
 import { isJsonContentType } from "@repo/utilities/mime";
-import { Effect } from "effect";
+import { Effect, Schedule } from "effect";
 
 const CONTENT_TIMEOUT_MILLISECONDS = 10_000;
+const CONTENT_RETRY_SCHEDULE = Schedule.fromDelays(
+  NETWORK_RETRY_DELAYS_MILLISECONDS[0],
+  NETWORK_RETRY_DELAYS_MILLISECONDS[1]
+);
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "[::1]", "localhost"]);
 
 type ContentRuntimeResponse =
@@ -125,15 +134,24 @@ export const encodeContentRequest = Effect.fn(
   return source;
 });
 
-/** Posts one no-store request with the server-owned runtime capability. */
+/**
+ * Posts one no-store request with the server-owned runtime capability.
+ *
+ * The runtime action is read-only, so only allowlisted network failures receive
+ * two bounded retries. Every HTTP response continues without retry into the
+ * exact status, response, and signature checks.
+ *
+ * @see https://docs.convex.dev/functions/http-actions
+ * @see https://effect.website/docs/error-management/retrying/
+ */
 export const postContentRequest = Effect.fn("NakafaContent.postContentRequest")(
   function* (input: {
     readonly endpoint: string;
     readonly source: string;
     readonly target: ContentHttpTarget;
   }) {
-    return yield* Effect.tryPromise({
-      catch: () => new ContentTransportError({ reason: "fetch" }),
+    const response = yield* Effect.tryPromise({
+      catch: createNetworkRequestError,
       try: () =>
         fetch(input.endpoint, {
           body: input.source,
@@ -147,7 +165,21 @@ export const postContentRequest = Effect.fn("NakafaContent.postContentRequest")(
           redirect: "error",
           signal: AbortSignal.timeout(CONTENT_TIMEOUT_MILLISECONDS),
         }),
-    });
+    }).pipe(
+      Effect.retry({
+        schedule: CONTENT_RETRY_SCHEDULE,
+        while: isRetryableNetworkError,
+      }),
+      Effect.mapError(
+        (error) =>
+          new ContentTransportError({
+            networkCodes: error.networkCodes,
+            reason: "fetch",
+          })
+      )
+    );
+
+    return response;
   }
 );
 

--- a/packages/backend/client/content/transport.ts
+++ b/packages/backend/client/content/transport.ts
@@ -3,6 +3,10 @@ import "server-only";
 import type { ProtectedContentRuntimeResponse } from "@nakafa/aksara-contracts/runtime/protected/spec";
 import type { PublicContentRuntimeResponse } from "@nakafa/aksara-contracts/runtime/spec";
 import { ContentTransportError } from "@repo/backend/client/content/errors";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+} from "@repo/backend/content/endpoint";
 import { parseContentLength, readBoundedBody } from "@repo/utilities/body";
 import { isJsonContentType } from "@repo/utilities/mime";
 import { Effect } from "effect";
@@ -25,6 +29,30 @@ type ContentRuntimeStatus =
 export interface ContentHttpTarget {
   readonly siteUrl: string;
   readonly token: string;
+}
+
+/** Returns whether the response carries the current diagnostic marker. */
+function hasContentRuntimeMarker(response: Response) {
+  return (
+    response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER) ===
+    CONTENT_RUNTIME_RESPONSE_MARKER
+  );
+}
+
+/** Classifies an out-of-contract JSON body without exposing its contents. */
+export function createContentContractError(response: Response) {
+  if (hasContentRuntimeMarker(response)) {
+    return new ContentTransportError({ reason: "response-contract" });
+  }
+  return new ContentTransportError({ reason: "response-unmarked" });
+}
+
+/** Classifies malformed JSON without exposing its response body. */
+function createContentSyntaxError(response: Response) {
+  if (hasContentRuntimeMarker(response)) {
+    return new ContentTransportError({ reason: "json-syntax" });
+  }
+  return new ContentTransportError({ reason: "response-unmarked" });
 }
 
 /** Enforces the runtime endpoints' shared response and HTTP status pairs. */
@@ -154,7 +182,7 @@ export const readContentResponse = Effect.fn(
     try: () => new TextDecoder("utf-8", { fatal: true }).decode(bytes),
   });
   return yield* Effect.try({
-    catch: () => new ContentTransportError({ reason: "json" }),
+    catch: () => createContentSyntaxError(response),
     try: (): unknown => JSON.parse(source),
   });
 });

--- a/packages/backend/client/nakafa/markdown.test.ts
+++ b/packages/backend/client/nakafa/markdown.test.ts
@@ -7,7 +7,7 @@ import { Effect, Option } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchNakafaRuntimeQuery: vi.fn(),
+  readNakafaRuntimeQuery: vi.fn(),
   readPublishedMaterialMarkdown: vi.fn(),
   resolveNakafaContentRef: vi.fn(),
   verifyNakafaReleasePin: vi.fn(),
@@ -20,7 +20,7 @@ vi.mock("@repo/backend/client/nakafa/ref", () => ({
   resolveNakafaContentRef: runtimeMocks.resolveNakafaContentRef,
 }));
 vi.mock("@repo/backend/client/nakafa/query", () => ({
-  fetchNakafaRuntimeQuery: runtimeMocks.fetchNakafaRuntimeQuery,
+  readNakafaRuntimeQuery: runtimeMocks.readNakafaRuntimeQuery,
 }));
 vi.mock("@repo/backend/client/nakafa/release", () => ({
   verifyNakafaReleasePin: runtimeMocks.verifyNakafaReleasePin,
@@ -29,7 +29,7 @@ vi.mock("@repo/backend/client/nakafa/release", () => ({
 const materialRef = makeMaterialContentRef(makeMaterialProjection("en", 1));
 
 beforeEach(() => {
-  runtimeMocks.fetchNakafaRuntimeQuery.mockReset();
+  runtimeMocks.readNakafaRuntimeQuery.mockReset();
   runtimeMocks.readPublishedMaterialMarkdown.mockReset();
   runtimeMocks.resolveNakafaContentRef.mockReset();
   runtimeMocks.verifyNakafaReleasePin
@@ -76,7 +76,7 @@ describe("readNakafaMarkdown", () => {
         markdown: Option.none(),
       })
     );
-    runtimeMocks.fetchNakafaRuntimeQuery.mockReturnValue(
+    runtimeMocks.readNakafaRuntimeQuery.mockReturnValue(
       Effect.succeed({
         body: "## Source lesson",
         metadata: { title: "Source material" },

--- a/packages/backend/client/nakafa/markdown.ts
+++ b/packages/backend/client/nakafa/markdown.ts
@@ -1,7 +1,7 @@
 import type { ContentRuntimeTarget } from "@repo/backend/client/content/public";
 import { decodeNakafaMarkdown } from "@repo/backend/client/nakafa/decode";
 import { readPublishedMaterialMarkdown } from "@repo/backend/client/nakafa/material";
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { readQuranMarkdown } from "@repo/backend/client/nakafa/quran";
 import { resolveNakafaContentRef } from "@repo/backend/client/nakafa/ref";
 import { verifyNakafaReleasePin } from "@repo/backend/client/nakafa/release";
@@ -74,9 +74,8 @@ export function getMdxRuntimePage(
   ref: NakafaAgentContentRef
 ) {
   if (ref.section === "articles") {
-    return fetchNakafaRuntimeQuery(
+    return readNakafaRuntimeQuery(
       convexUrl,
-      "getArticlePage",
       api.contents.queries.runtime.getArticlePage,
       {
         locale: ref.locale,
@@ -86,9 +85,8 @@ export function getMdxRuntimePage(
   }
 
   if (ref.section === "material") {
-    return fetchNakafaRuntimeQuery(
+    return readNakafaRuntimeQuery(
       convexUrl,
-      "getCurriculumPage",
       api.contents.queries.runtime.getCurriculumPage,
       {
         locale: ref.locale,

--- a/packages/backend/client/nakafa/material.test.ts
+++ b/packages/backend/client/nakafa/material.test.ts
@@ -2,7 +2,7 @@
 
 import { readPublicContentEvidence } from "@repo/backend/client/content/public";
 import { readPublishedMaterialMarkdown } from "@repo/backend/client/nakafa/material";
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { makeMaterialProjection } from "@repo/backend/test/content-material";
 import { Effect, Option } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,7 +18,7 @@ const target = {
 
 vi.mock("server-only", () => ({}));
 vi.mock("@repo/backend/client/nakafa/query", () => ({
-  fetchNakafaRuntimeQuery: queryMock,
+  readNakafaRuntimeQuery: queryMock,
 }));
 vi.mock("@repo/backend/client/content/public", () => ({
   readPublicContentEvidence: readMock,
@@ -84,7 +84,7 @@ describe("Nakafa material reader", () => {
       managed: true,
       markdown: Option.none(),
     });
-    expect(fetchNakafaRuntimeQuery).toHaveBeenCalledTimes(2);
+    expect(readNakafaRuntimeQuery).toHaveBeenCalledTimes(2);
     expect(readPublicContentEvidence).not.toHaveBeenCalled();
   });
 
@@ -121,9 +121,8 @@ describe("Nakafa material reader", () => {
       )
     );
 
-    expect(fetchNakafaRuntimeQuery).toHaveBeenCalledWith(
+    expect(readNakafaRuntimeQuery).toHaveBeenCalledWith(
       "https://example.convex.cloud",
-      "lookupMaterial",
       expect.anything(),
       {
         input: {

--- a/packages/backend/client/nakafa/material.ts
+++ b/packages/backend/client/nakafa/material.ts
@@ -5,7 +5,7 @@ import {
   readPublicContentEvidence,
 } from "@repo/backend/client/content/public";
 import { decodeNakafaMarkdown } from "@repo/backend/client/nakafa/decode";
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { getMaterialLookupInput } from "@repo/backend/client/nakafa/ref";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
@@ -43,9 +43,8 @@ export const readPublishedMaterialMarkdown = Effect.fn(
     };
   }
 
-  const lookup = yield* fetchNakafaRuntimeQuery(
+  const lookup = yield* readNakafaRuntimeQuery(
     convexUrl,
-    "lookupMaterial",
     api.contentRelease.material.lookup,
     { input: lookupInput.value }
   );

--- a/packages/backend/client/nakafa/query.test.ts
+++ b/packages/backend/client/nakafa/query.test.ts
@@ -1,4 +1,5 @@
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import type { FunctionArgs } from "convex/server";
@@ -6,16 +7,21 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
-vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+vi.mock("@repo/backend/client/runtime", async (importOriginal) => ({
+  ...(await importOriginal()),
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
-describe("fetchNakafaRuntimeQuery", () => {
+describe("readNakafaRuntimeQuery", () => {
   beforeEach(() => {
-    runtimeMocks.fetchConvexRuntimeQuery.mockReset();
+    runtimeMocks.runtimeQuery.mockReset();
   });
 
   it("returns generated query results from the shared Convex runtime client", async () => {
@@ -25,19 +31,18 @@ describe("fetchNakafaRuntimeQuery", () => {
       locale: "en",
       route: "articles/example",
     };
-    runtimeMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce(null);
+    runtimeMocks.runtimeQuery.mockResolvedValueOnce(null);
 
     const result = await Effect.runPromise(
-      fetchNakafaRuntimeQuery(
+      readNakafaRuntimeQuery(
         "https://example.convex.cloud",
-        "getContentRoute",
         api.contents.queries.runtime.getContentRoute,
         args
       )
     );
 
     expect(result).toBeNull();
-    expect(runtimeMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeMocks.runtimeQuery).toHaveBeenCalledWith(
       "https://example.convex.cloud",
       api.contents.queries.runtime.getContentRoute,
       args
@@ -51,15 +56,17 @@ describe("fetchNakafaRuntimeQuery", () => {
       locale: "en",
       route: "articles/example",
     };
-    runtimeMocks.fetchConvexRuntimeQuery.mockRejectedValueOnce(
-      new Error("network down")
-    );
+    const runtimeError = new ConvexRuntimeQueryError({
+      networkCodes: [],
+      query: "contents/queries/runtime:getContentRoute",
+      reason: "client",
+    });
+    runtimeMocks.runtimeQuery.mockRejectedValueOnce(runtimeError);
 
     const result = await Effect.runPromise(
       Effect.either(
-        fetchNakafaRuntimeQuery(
+        readNakafaRuntimeQuery(
           "https://example.convex.cloud",
-          "getContentRoute",
           api.contents.queries.runtime.getContentRoute,
           args
         )
@@ -71,7 +78,40 @@ describe("fetchNakafaRuntimeQuery", () => {
     if (result._tag === "Left") {
       expect(result.left).toBeInstanceOf(NakafaAgentDataReadError);
       expect(result.left.message).toContain("getContentRoute");
-      expect(result.left.cause).toContain("network down");
+      expect(result.left.cause).toBe(runtimeError.message);
     }
+  });
+
+  it("preserves classified runtime diagnostics", async () => {
+    const args: FunctionArgs<
+      typeof api.contents.queries.runtime.getContentRoute
+    > = {
+      locale: "en",
+      route: "articles/example",
+    };
+    const runtimeError = new ConvexRuntimeQueryError({
+      networkCodes: ["EPIPE"],
+      query: "contents/queries/runtime:getContentRoute",
+      reason: "transport",
+    });
+    runtimeMocks.runtimeQuery.mockRejectedValueOnce(runtimeError);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        readNakafaRuntimeQuery(
+          "https://example.convex.cloud",
+          api.contents.queries.runtime.getContentRoute,
+          args
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      left: {
+        cause: runtimeError.message,
+        message:
+          "Unable to read Nakafa runtime content query: contents/queries/runtime:getContentRoute.",
+      },
+    });
   });
 });

--- a/packages/backend/client/nakafa/query.ts
+++ b/packages/backend/client/nakafa/query.ts
@@ -1,13 +1,6 @@
-import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
-import {
-  getUnknownErrorMessage,
-  NakafaAgentDataReadError,
-} from "@repo/contents/_lib/agent/errors";
-import type {
-  FunctionArgs,
-  FunctionReference,
-  FunctionReturnType,
-} from "convex/server";
+import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
+import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
+import type { FunctionArgs, FunctionReference } from "convex/server";
 import { Effect } from "effect";
 
 type ContentRuntimeQuery = FunctionReference<"query">;
@@ -18,21 +11,21 @@ export const NAKAFA_RUNTIME_PAGE_SIZE = 100;
 /** Initial cursor used by Convex paginated runtime readers. */
 export const NAKAFA_INITIAL_CURSOR: string | null = null;
 
-/** Fetches one generated Convex runtime query with agent read errors. */
-export function fetchNakafaRuntimeQuery<Query extends ContentRuntimeQuery>(
+/** Reads one generated Convex query through the agent error channel. */
+export const readNakafaRuntimeQuery = Effect.fn(
+  "NakafaContent.readRuntimeQuery"
+)(function* <Query extends ContentRuntimeQuery>(
   convexUrl: string,
-  name: string,
   query: Query,
   args: FunctionArgs<Query>
-): Effect.Effect<FunctionReturnType<Query>, NakafaAgentDataReadError> {
-  return Effect.tryPromise({
-    /** Runs the official Convex client query with the shared no-store client. */
-    try: () => fetchConvexRuntimeQuery(convexUrl, query, args),
-    /** Maps client failures into the shared Nakafa data-read error model. */
-    catch: (error) =>
-      new NakafaAgentDataReadError({
-        cause: getUnknownErrorMessage(error),
-        message: `Unable to read Nakafa runtime content query: ${name}.`,
-      }),
-  });
-}
+) {
+  return yield* readConvexRuntimeQuery(convexUrl, query, args).pipe(
+    Effect.mapError(
+      (error) =>
+        new NakafaAgentDataReadError({
+          cause: error.message,
+          message: `Unable to read Nakafa runtime content query: ${error.query}.`,
+        })
+    )
+  );
+});

--- a/packages/backend/client/nakafa/quran.test.ts
+++ b/packages/backend/client/nakafa/quran.test.ts
@@ -18,11 +18,15 @@ import { Effect, Option, Schema } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
 vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
 const convexUrl = "https://example.convex.cloud";
@@ -35,8 +39,8 @@ const source = {
 };
 
 beforeEach(() => {
-  runtimeMocks.fetchConvexRuntimeQuery.mockReset();
-  runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(readRuntimeFixture);
+  runtimeMocks.runtimeQuery.mockReset();
+  runtimeMocks.runtimeQuery.mockImplementation(readRuntimeFixture);
 });
 
 describe("Quran Nakafa reader", () => {

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -4,7 +4,7 @@ import {
   parseQuranReferenceOptions,
   toNakafaQuranDataReadError,
 } from "@repo/backend/client/nakafa/decode";
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { decodePublishedQuranReference } from "@repo/backend/client/quran/decode";
 import { decodePublishedQuranMarkdown } from "@repo/backend/client/quran/markdown";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
@@ -18,9 +18,8 @@ import { Effect, Option } from "effect";
 export function readNakafaQuranReference(convexUrl: string, input: unknown) {
   return Effect.gen(function* () {
     const parsed = yield* parseQuranReferenceOptions(input);
-    const result = yield* fetchNakafaRuntimeQuery(
+    const result = yield* readNakafaRuntimeQuery(
       convexUrl,
-      "contentRelease.quran.reference",
       api.contentRelease.quran.reference,
       {
         fromVerse: parsed.from_verse,
@@ -80,9 +79,8 @@ export function readQuranMarkdown(
       return Option.none<NakafaAgentMarkdown>();
     }
 
-    const result = yield* fetchNakafaRuntimeQuery(
+    const result = yield* readNakafaRuntimeQuery(
       convexUrl,
-      "contentRelease.quran.markdown",
       api.contentRelease.quran.markdown,
       {
         locale: ref.locale,

--- a/packages/backend/client/nakafa/ref.test.ts
+++ b/packages/backend/client/nakafa/ref.test.ts
@@ -12,11 +12,15 @@ import { Effect, Option, Schema } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
 vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
 const ContentIdArgsSchema = Schema.Struct({
@@ -34,8 +38,8 @@ const detachedArticleRef = createDetachedArticleRef();
 const materialProjection = makeMaterialProjection("en", 1);
 
 beforeEach(() => {
-  runtimeMocks.fetchConvexRuntimeQuery.mockReset();
-  runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(readRuntimeFixture);
+  runtimeMocks.runtimeQuery.mockReset();
+  runtimeMocks.runtimeQuery.mockImplementation(readRuntimeFixture);
 });
 
 describe("resolveNakafaContentRef", () => {
@@ -76,7 +80,7 @@ describe("resolveNakafaContentRef", () => {
 
     expect(Option.getOrUndefined(graphRef)).toStrictEqual(articleRef);
     expect(Option.getOrUndefined(resourceRef)).toStrictEqual(articleRef);
-    expect(runtimeMocks.fetchConvexRuntimeQuery).toHaveBeenCalledTimes(2);
+    expect(runtimeMocks.runtimeQuery).toHaveBeenCalledTimes(2);
   });
 
   it("preserves graph fields returned by the route catalog", async () => {
@@ -96,7 +100,7 @@ describe("resolveNakafaContentRef", () => {
     );
 
     expect(Option.getOrUndefined(ref)).toStrictEqual(detachedArticleRef);
-    expect(runtimeMocks.fetchConvexRuntimeQuery).toHaveBeenCalledWith(
+    expect(runtimeMocks.runtimeQuery).toHaveBeenCalledWith(
       convexUrl,
       api.contents.queries.runtime.getContentRoute,
       {
@@ -116,7 +120,7 @@ describe("resolveNakafaContentRef", () => {
 
     expect(Option.isNone(localizedRoute)).toBe(true);
     expect(Option.isNone(localeFreeRoute)).toBe(true);
-    expect(runtimeMocks.fetchConvexRuntimeQuery).not.toHaveBeenCalled();
+    expect(runtimeMocks.runtimeQuery).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/client/nakafa/ref.ts
+++ b/packages/backend/client/nakafa/ref.ts
@@ -1,4 +1,4 @@
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createNakafaContentRefFromGraphProjection,
@@ -65,9 +65,8 @@ export function resolveNakafaContentRef(convexUrl: string, input: string) {
 /** Resolves one graph asset ID through the backend route catalog. */
 function resolveNakafaContentId(convexUrl: string, contentId: string) {
   return Effect.gen(function* () {
-    const route = yield* fetchNakafaRuntimeQuery(
+    const route = yield* readNakafaRuntimeQuery(
       convexUrl,
-      "getContentRouteByContentId",
       api.contents.queries.runtime.getContentRouteByContentId,
       { contentId }
     );
@@ -89,9 +88,8 @@ function resolveNakafaContentUrlProjection(convexUrl: string, input: string) {
       return Option.none<NakafaAgentContentRef>();
     }
 
-    const route = yield* fetchNakafaRuntimeQuery(
+    const route = yield* readNakafaRuntimeQuery(
       convexUrl,
-      "getContentRoute",
       api.contents.queries.runtime.getContentRoute,
       {
         locale: parsed.value.locale,

--- a/packages/backend/client/nakafa/release.test.ts
+++ b/packages/backend/client/nakafa/release.test.ts
@@ -1,4 +1,4 @@
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { verifyNakafaReleasePin } from "@repo/backend/client/nakafa/release";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const queryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@repo/backend/client/nakafa/query", () => ({
-  fetchNakafaRuntimeQuery: queryMock,
+  readNakafaRuntimeQuery: queryMock,
 }));
 
 describe("Nakafa release pin", () => {
@@ -27,9 +27,8 @@ describe("Nakafa release pin", () => {
         )
       )
     ).resolves.toBe("release-material");
-    expect(fetchNakafaRuntimeQuery).toHaveBeenCalledWith(
+    expect(readNakafaRuntimeQuery).toHaveBeenCalledWith(
       "https://example.convex.cloud",
-      "readActiveContentIdentity",
       expect.anything(),
       {}
     );

--- a/packages/backend/client/nakafa/release.ts
+++ b/packages/backend/client/nakafa/release.ts
@@ -1,4 +1,4 @@
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { api } from "@repo/backend/convex/_generated/api";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { Effect } from "effect";
@@ -7,9 +7,8 @@ import { Effect } from "effect";
 export const verifyNakafaReleasePin = Effect.fn(
   "NakafaContent.verifyReleasePin"
 )(function* (convexUrl: string, expectedActiveReleaseId: string | null) {
-  const active = yield* fetchNakafaRuntimeQuery(
+  const active = yield* readNakafaRuntimeQuery(
     convexUrl,
-    "readActiveContentIdentity",
     api.contentRelease.runtime.active.read,
     {}
   );

--- a/packages/backend/client/nakafa/taxonomy.test.ts
+++ b/packages/backend/client/nakafa/taxonomy.test.ts
@@ -10,18 +10,22 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
 vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
 const quranSnapshotId = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
 
 beforeEach(() => {
-  runtimeMocks.fetchConvexRuntimeQuery.mockReset();
-  runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(readRuntimeFixture);
+  runtimeMocks.runtimeQuery.mockReset();
+  runtimeMocks.runtimeQuery.mockImplementation(readRuntimeFixture);
 });
 
 describe("readNakafaTaxonomy", () => {
@@ -69,15 +73,13 @@ describe("readNakafaTaxonomy", () => {
         family === "article"
           ? api.contentRelease.article.sitemapBuckets
           : api.contentRelease.material.sitemapBuckets;
-      runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(
-        (convexUrl, query, args) => {
-          if (getFunctionName(query) === getFunctionName(target)) {
-            return Promise.resolve({ managed: false });
-          }
-
-          return readRuntimeFixture(convexUrl, query, args);
+      runtimeMocks.runtimeQuery.mockImplementation((convexUrl, query, args) => {
+        if (getFunctionName(query) === getFunctionName(target)) {
+          return Promise.resolve({ managed: false });
         }
-      );
+
+        return readRuntimeFixture(convexUrl, query, args);
+      });
 
       await expect(
         Effect.runPromise(
@@ -157,7 +159,7 @@ function readRuntimeFixture(
 
 /** Returns generated Convex query names called by the taxonomy reader. */
 function calledRuntimeQueries() {
-  return runtimeMocks.fetchConvexRuntimeQuery.mock.calls.map(([, query]) =>
+  return runtimeMocks.runtimeQuery.mock.calls.map(([, query]) =>
     getFunctionName(query)
   );
 }

--- a/packages/backend/client/nakafa/taxonomy.ts
+++ b/packages/backend/client/nakafa/taxonomy.ts
@@ -2,7 +2,7 @@ import {
   decodeNakafaTaxonomy,
   toNakafaQuranDataReadError,
 } from "@repo/backend/client/nakafa/decode";
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { decodePublishedQuranCatalog } from "@repo/backend/client/quran/decode";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
@@ -31,12 +31,7 @@ export function readNakafaTaxonomy(
   return Effect.gen(function* () {
     const [signedInventory, quranResult] = yield* Effect.all([
       readSignedInventory(convexUrl, locale),
-      fetchNakafaRuntimeQuery(
-        convexUrl,
-        "contentRelease.quran.surahs",
-        api.contentRelease.quran.surahs,
-        {}
-      ),
+      readNakafaRuntimeQuery(convexUrl, api.contentRelease.quran.surahs, {}),
     ]);
     const quran = yield* decodePublishedQuranCatalog(quranResult).pipe(
       Effect.mapError(toNakafaQuranDataReadError)
@@ -112,24 +107,19 @@ const readLocaleSignedInventory = Effect.fn(
   "nakafa.taxonomy.readLocaleSignedInventory"
 )(function* (convexUrl: string, locale: Locale) {
   const [articles, materials, tryout] = yield* Effect.all([
-    fetchNakafaRuntimeQuery(
+    readNakafaRuntimeQuery(
       convexUrl,
-      "readArticleSitemapBuckets",
       api.contentRelease.article.sitemapBuckets,
       { locale }
     ),
-    fetchNakafaRuntimeQuery(
+    readNakafaRuntimeQuery(
       convexUrl,
-      "readMaterialSitemapBuckets",
       api.contentRelease.material.sitemapBuckets,
       { locale }
     ),
-    fetchNakafaRuntimeQuery(
-      convexUrl,
-      "readTryoutTaxonomy",
-      api.contentRelease.tryout.taxonomy,
-      { locale }
-    ),
+    readNakafaRuntimeQuery(convexUrl, api.contentRelease.tryout.taxonomy, {
+      locale,
+    }),
   ]);
   if (!articles.managed) {
     return yield* missingSignedInventory("article", locale);

--- a/packages/backend/client/nakafa/verify.test.ts
+++ b/packages/backend/client/nakafa/verify.test.ts
@@ -1,4 +1,5 @@
 import { verifyNakafaContent } from "@repo/backend/client/nakafa/verify";
+import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   makeMaterialContentRef,
@@ -11,11 +12,16 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  fetchConvexRuntimeQuery: vi.fn(),
+  runtimeQuery: vi.fn(),
 }));
 
-vi.mock("@repo/backend/client/runtime", () => ({
-  fetchConvexRuntimeQuery: runtimeMocks.fetchConvexRuntimeQuery,
+vi.mock("@repo/backend/client/runtime", async (importOriginal) => ({
+  ...(await importOriginal()),
+  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) => cause,
+      try: () => runtimeMocks.runtimeQuery(url, query, args),
+    }),
 }));
 
 const convexUrl = "https://example.convex.cloud";
@@ -24,7 +30,7 @@ const materialRef = makeMaterialContentRef(makeMaterialProjection("en", 1));
 
 describe("verifyNakafaContent", () => {
   beforeEach(() => {
-    runtimeMocks.fetchConvexRuntimeQuery.mockReset();
+    runtimeMocks.runtimeQuery.mockReset();
   });
 
   it("returns false without a query for unsupported references", async () => {
@@ -33,11 +39,11 @@ describe("verifyNakafaContent", () => {
     );
 
     expect(result).toBe(false);
-    expect(runtimeMocks.fetchConvexRuntimeQuery).not.toHaveBeenCalled();
+    expect(runtimeMocks.runtimeQuery).not.toHaveBeenCalled();
   });
 
   it("returns false when a canonical route is not present", async () => {
-    runtimeMocks.fetchConvexRuntimeQuery.mockResolvedValueOnce(null);
+    runtimeMocks.runtimeQuery.mockResolvedValueOnce(null);
 
     const result = await Effect.runPromise(
       verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1")
@@ -47,7 +53,7 @@ describe("verifyNakafaContent", () => {
   });
 
   it("returns false when the resolved content route is no longer active", async () => {
-    runtimeMocks.fetchConvexRuntimeQuery
+    runtimeMocks.runtimeQuery
       .mockResolvedValueOnce({ ...quranRef, title: "Al-Fatihah" })
       .mockResolvedValueOnce(null);
 
@@ -59,7 +65,7 @@ describe("verifyNakafaContent", () => {
   });
 
   it("returns true when the canonical content route is active", async () => {
-    runtimeMocks.fetchConvexRuntimeQuery.mockImplementation(
+    runtimeMocks.runtimeQuery.mockImplementation(
       (_url: string, query: FunctionReference<"query">) => {
         const name = getFunctionName(query);
 
@@ -88,7 +94,7 @@ describe("verifyNakafaContent", () => {
   it.each([materialRef.content_id, materialRef.url])(
     "verifies exact material ownership for %s",
     async (input) => {
-      runtimeMocks.fetchConvexRuntimeQuery
+      runtimeMocks.runtimeQuery
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({
           activeReleaseId: "release-material",
@@ -104,7 +110,7 @@ describe("verifyNakafaContent", () => {
       );
 
       expect(result).toBe(true);
-      expect(runtimeMocks.fetchConvexRuntimeQuery).toHaveBeenLastCalledWith(
+      expect(runtimeMocks.runtimeQuery).toHaveBeenLastCalledWith(
         convexUrl,
         api.contentRelease.material.lookup,
         expect.anything()
@@ -113,7 +119,7 @@ describe("verifyNakafaContent", () => {
   );
 
   it("rejects source material verification after a release activates", async () => {
-    runtimeMocks.fetchConvexRuntimeQuery
+    runtimeMocks.runtimeQuery
       .mockResolvedValueOnce(materialRef)
       .mockResolvedValueOnce({
         activeReleaseId: null,
@@ -134,9 +140,12 @@ describe("verifyNakafaContent", () => {
   });
 
   it("preserves typed runtime read failures instead of returning false", async () => {
-    runtimeMocks.fetchConvexRuntimeQuery.mockRejectedValueOnce(
-      new Error("runtime unavailable")
-    );
+    const runtimeError = new ConvexRuntimeQueryError({
+      networkCodes: ["EPIPE"],
+      query: "contentRelease.quran.markdown",
+      reason: "transport",
+    });
+    runtimeMocks.runtimeQuery.mockRejectedValueOnce(runtimeError);
 
     const error = await Effect.runPromise(
       verifyNakafaContent(convexUrl, "https://nakafa.com/en/quran/1").pipe(
@@ -147,7 +156,7 @@ describe("verifyNakafaContent", () => {
     expect(error).toBeInstanceOf(NakafaAgentDataReadError);
     expect(error).toMatchObject({
       _tag: "NakafaAgentDataReadError",
-      cause: "runtime unavailable",
+      cause: runtimeError.message,
     });
   });
 });

--- a/packages/backend/client/nakafa/verify.ts
+++ b/packages/backend/client/nakafa/verify.ts
@@ -1,4 +1,4 @@
-import { fetchNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import {
   getMaterialLookupInput,
   resolveNakafaContentRef,
@@ -19,9 +19,8 @@ export function verifyNakafaContent(convexUrl: string, input: string) {
     const materialInput = getMaterialLookupInput(input);
     let expectedActiveReleaseId: string | null | undefined;
     if (Option.isSome(materialInput)) {
-      const material = yield* fetchNakafaRuntimeQuery(
+      const material = yield* readNakafaRuntimeQuery(
         convexUrl,
-        "lookupMaterial",
         api.contentRelease.material.lookup,
         { input: materialInput.value }
       );
@@ -48,9 +47,8 @@ export function verifyNakafaContent(convexUrl: string, input: string) {
 
 /** Verifies one source-owned identity remains present in the active catalog. */
 function verifySourceContent(convexUrl: string, contentId: string) {
-  return fetchNakafaRuntimeQuery(
+  return readNakafaRuntimeQuery(
     convexUrl,
-    "getContentRouteByContentId",
     api.contents.queries.runtime.getContentRouteByContentId,
     { contentId }
   ).pipe(Effect.map((route) => route !== null));

--- a/packages/backend/client/network.test.ts
+++ b/packages/backend/client/network.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+
+import {
+  createNetworkRequestError,
+  isRetryableNetworkError,
+  NetworkRequestError,
+} from "@repo/backend/client/network";
+import { describe, expect, it } from "vitest";
+
+describe("network request classification", () => {
+  it("classifies nested Undici and Node retry codes", () => {
+    const cause = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("private socket detail"), {
+        code: "ECONNRESET",
+      }),
+    });
+
+    const error = createNetworkRequestError(cause);
+
+    expect(error).toEqual(
+      new NetworkRequestError({
+        networkCodes: ["ECONNRESET"],
+      })
+    );
+    expect(isRetryableNetworkError(error)).toBe(true);
+    expect(JSON.stringify(error)).not.toContain("private socket detail");
+  });
+
+  it("deduplicates retry codes across aggregate failures", () => {
+    const error = createNetworkRequestError(
+      new AggregateError(
+        [
+          { code: "UND_ERR_SOCKET" },
+          { code: "EPIPE" },
+          { code: "UND_ERR_SOCKET" },
+        ],
+        "aggregate network failure"
+      )
+    );
+
+    expect(error).toMatchObject({
+      networkCodes: ["EPIPE", "UND_ERR_SOCKET"],
+    });
+  });
+
+  it("rejects partially classified failures", () => {
+    const failures = [
+      new AggregateError(
+        [{ code: "ECONNREFUSED" }, { code: "UND_ERR_CONNECT_TIMEOUT" }],
+        "mixed network failure"
+      ),
+      new AggregateError(
+        [{ code: "EPIPE" }, new Error("code-less network failure")],
+        "partially classified network failure"
+      ),
+      { cause: "unclassified network failure", code: "EPIPE" },
+    ];
+
+    for (const failure of failures) {
+      const error = createNetworkRequestError(failure);
+      expect(error).toMatchObject({ networkCodes: [] });
+      expect(isRetryableNetworkError(error)).toBe(false);
+    }
+  });
+
+  it.each([
+    new Error("unclassified fetch failure"),
+    "fetch failed",
+    { code: "lowercase-code" },
+    { code: 23 },
+  ])("keeps code-less and malformed failures terminal", (cause) => {
+    expect(createNetworkRequestError(cause)).toMatchObject({
+      networkCodes: [],
+    });
+  });
+
+  it("handles cyclic causes without exposing them", () => {
+    const cause: { cause?: unknown; code: string; privateValue: string } = {
+      code: "EPIPE",
+      privateValue: "private-cycle-value",
+    };
+    cause.cause = cause;
+
+    const error = createNetworkRequestError(cause);
+
+    expect(error).toMatchObject({
+      networkCodes: ["EPIPE"],
+    });
+    expect(JSON.stringify(error)).not.toContain(cause.privateValue);
+  });
+
+  it("keeps accessor failures and oversized graphs terminal", () => {
+    const accessorFailure = Object.defineProperty({}, "code", {
+      get: () => {
+        throw new Error("private accessor detail");
+      },
+    });
+    const oversizedFailure = new AggregateError(
+      Array.from({ length: 33 }, () => ({ code: "ECONNRESET" })),
+      "oversized network graph"
+    );
+
+    for (const cause of [accessorFailure, oversizedFailure]) {
+      const error = createNetworkRequestError(cause);
+      expect(error).toMatchObject({ networkCodes: [] });
+      expect(JSON.stringify(error)).not.toContain("private");
+    }
+  });
+});

--- a/packages/backend/client/network.ts
+++ b/packages/backend/client/network.ts
@@ -1,0 +1,141 @@
+import { Either, Schema } from "effect";
+
+export const NETWORK_RETRY_DELAYS_MILLISECONDS = [500, 1000] as const;
+
+export const NetworkRetryCodeSchema = Schema.Literal(
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "EHOSTDOWN",
+  "EHOSTUNREACH",
+  "EPIPE",
+  "UND_ERR_SOCKET"
+);
+
+type NetworkRetryCode = Schema.Schema.Type<typeof NetworkRetryCodeSchema>;
+
+const NETWORK_CODE_PATTERN = /^[A-Z][A-Z0-9_]{1,47}$/;
+const NETWORK_CAUSE_LIMIT = 32;
+const networkRetryCodes: ReadonlySet<string> = new Set(
+  NetworkRetryCodeSchema.literals
+);
+
+/** One rejected fetch has only sanitized retry classification. */
+export class NetworkRequestError extends Schema.TaggedError<NetworkRequestError>()(
+  "NetworkRequestError",
+  {
+    networkCodes: Schema.Array(NetworkRetryCodeSchema),
+  }
+) {}
+
+interface NetworkCodeInspection {
+  readonly foundCode: boolean;
+  readonly foundTerminalFailure: boolean;
+  readonly retryCodes: ReadonlySet<NetworkRetryCode>;
+}
+
+function isNetworkRetryCode(code: string): code is NetworkRetryCode {
+  return networkRetryCodes.has(code);
+}
+
+/**
+ * Classifies nested Node and Undici failures without retaining private data.
+ *
+ * Retryable codes match the defaults pinned in Undici 7.29.0. Unknown codes,
+ * timeouts, aborts, TLS failures, and independent unclassified leaves remain
+ * terminal.
+ *
+ * @see https://github.com/nodejs/undici/blob/v7.29.0/lib/handler/retry-handler.js
+ * @see https://nodejs.org/api/errors.html
+ */
+export function createNetworkRequestError(cause: unknown) {
+  const inspection = Either.try(() => inspectNetworkCodes(cause));
+  if (Either.isLeft(inspection)) {
+    return new NetworkRequestError({ networkCodes: [] });
+  }
+
+  const retryable =
+    inspection.right.foundCode && !inspection.right.foundTerminalFailure;
+  const networkCodes = retryable
+    ? NetworkRetryCodeSchema.literals.filter((code) =>
+        inspection.right.retryCodes.has(code)
+      )
+    : [];
+
+  return new NetworkRequestError({ networkCodes });
+}
+
+function inspectNetworkCodes(cause: unknown): NetworkCodeInspection {
+  const pending = [cause];
+  const visited = new Set<object>();
+  const retryCodes = new Set<NetworkRetryCode>();
+  let foundCode = false;
+  let foundTerminalFailure = false;
+
+  while (pending.length > 0 && visited.size < NETWORK_CAUSE_LIMIT) {
+    const current = pending.pop();
+    if (typeof current !== "object" || current === null) {
+      continue;
+    }
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const hasCodeProperty = "code" in current;
+    const code = hasCodeProperty ? current.code : undefined;
+    const hasNetworkCode =
+      typeof code === "string" && NETWORK_CODE_PATTERN.test(code);
+    if (hasNetworkCode) {
+      foundCode = true;
+      if (isNetworkRetryCode(code)) {
+        retryCodes.add(code);
+      } else {
+        foundTerminalFailure = true;
+      }
+    } else if (hasCodeProperty) {
+      foundTerminalFailure = true;
+    }
+
+    let hasObjectChild = false;
+    if ("cause" in current) {
+      const nestedCause = current.cause;
+      if (typeof nestedCause === "object" && nestedCause !== null) {
+        hasObjectChild = true;
+        pending.push(nestedCause);
+      } else {
+        foundTerminalFailure = true;
+      }
+    }
+    if (current instanceof AggregateError) {
+      for (const error of current.errors) {
+        if (typeof error !== "object" || error === null) {
+          foundTerminalFailure = true;
+          continue;
+        }
+        hasObjectChild = true;
+        if (pending.length + visited.size >= NETWORK_CAUSE_LIMIT) {
+          foundTerminalFailure = true;
+          break;
+        }
+        pending.push(error);
+      }
+    }
+    if (!(hasNetworkCode || hasObjectChild)) {
+      foundTerminalFailure = true;
+    }
+  }
+
+  return {
+    foundCode,
+    foundTerminalFailure: foundTerminalFailure || pending.length > 0,
+    retryCodes,
+  };
+}
+
+/** Returns whether a rejected fetch is safe for a bounded retry. */
+export function isRetryableNetworkError(error: NetworkRequestError) {
+  return error.networkCodes.length > 0;
+}

--- a/packages/backend/client/runtime.test.ts
+++ b/packages/backend/client/runtime.test.ts
@@ -1,9 +1,19 @@
-import { fetchConvexRuntimeQuery } from "@repo/backend/client/runtime";
+// @vitest-environment node
+
+import {
+  ConvexRuntimeQueryError,
+  readConvexRuntimeQuery,
+} from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionArgs } from "convex/server";
+import { ConvexError } from "convex/values";
+import { Duration, Effect, Fiber, TestClock, TestContext } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const clientState = vi.hoisted(() => {
+  const constructorFailure: { error: Error | undefined } = {
+    error: undefined,
+  };
   const instances: Array<{
     options: {
       fetch?: typeof fetch;
@@ -13,15 +23,12 @@ const clientState = vi.hoisted(() => {
   }> = [];
   const query = vi.fn();
 
-  return {
-    instances,
-    query,
-  };
+  return { constructorFailure, instances, query };
 });
 
 vi.mock("convex/browser", () => ({
   ConvexHttpClient: class {
-    query = clientState.query;
+    private readonly fetchHook: typeof fetch | undefined;
 
     /** Records official Convex client construction for runtime query tests. */
     constructor(
@@ -31,56 +38,200 @@ vi.mock("convex/browser", () => ({
         logger?: boolean;
       }
     ) {
+      if (clientState.constructorFailure.error) {
+        throw clientState.constructorFailure.error;
+      }
+      this.fetchHook = options.fetch;
       clientState.instances.push({ options, url });
+    }
+
+    /** Delegates query behavior to the test-owned client seam. */
+    query(query: unknown, args: unknown) {
+      return clientState.query(this.fetchHook, query, args);
     }
   },
 }));
 
-describe("fetchConvexRuntimeQuery", () => {
-  afterEach(() => {
-    clientState.instances.length = 0;
-    clientState.query.mockReset();
-    vi.unstubAllGlobals();
+const query = api.contents.queries.runtime.getContentRoute;
+const args: FunctionArgs<typeof query> = {
+  locale: "en",
+  route: "articles/example",
+};
+const queryName = "contents/queries/runtime:getContentRoute";
+const runtimeUrl = "https://example.convex.cloud";
+
+const runWithTestClock = <Value, Error>(program: Effect.Effect<Value, Error>) =>
+  Effect.runPromise(program.pipe(Effect.provide(TestContext.TestContext)));
+
+/** Makes the mocked official client execute its configured fetch hook. */
+function queryThroughFetch(result: unknown = null) {
+  clientState.query.mockImplementation(
+    async (fetchHook: typeof fetch | undefined) => {
+      if (!fetchHook) {
+        return Promise.reject(new Error("Expected Convex runtime fetch hook."));
+      }
+
+      await fetchHook("https://runtime.example/api/query", {
+        cache: "force-cache",
+      });
+      return result;
+    }
+  );
+}
+
+/** Creates the nested rejection shape produced by Node fetch. */
+function createFetchFailure(code?: string) {
+  const cause = code
+    ? Object.assign(new Error("private network detail"), { code })
+    : new Error("private network detail");
+  return new TypeError("fetch failed", { cause });
+}
+
+afterEach(() => {
+  clientState.constructorFailure.error = undefined;
+  clientState.instances.length = 0;
+  clientState.query.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("Convex runtime query", () => {
+  it("retries Effect callers through the typed network channel", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(createFetchFailure("ECONNRESET"))
+      .mockRejectedValueOnce(createFetchFailure("UND_ERR_SOCKET"))
+      .mockResolvedValueOnce(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    queryThroughFetch(42);
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.fork(
+        readConvexRuntimeQuery(runtimeUrl, query, args)
+      );
+      yield* TestClock.adjust(Duration.millis(1500));
+
+      return yield* Fiber.join(fiber);
+    });
+
+    await expect(runWithTestClock(program)).resolves.toBe(42);
+    expect(clientState.query).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://runtime.example/api/query",
+      {
+        cache: "no-store",
+      }
+    );
+    expect(clientState.instances).toEqual([
+      {
+        options: {
+          fetch: expect.any(Function),
+          logger: false,
+        },
+        url: runtimeUrl,
+      },
+    ]);
   });
 
-  it("uses the official Convex client with no-store fetch settings", async () => {
-    const args: FunctionArgs<
-      typeof api.contents.queries.runtime.getContentRoute
-    > = {
-      locale: "en",
-      route: "articles/example",
-    };
-    clientState.query.mockResolvedValueOnce(null);
+  it("does not retry Convex function failures", async () => {
+    clientState.query.mockRejectedValueOnce(new ConvexError("public failure"));
 
-    const result = await fetchConvexRuntimeQuery(
-      "https://example.convex.cloud",
-      api.contents.queries.runtime.getContentRoute,
-      args
+    await expect(
+      Effect.runPromise(
+        readConvexRuntimeQuery(runtimeUrl, query, args).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ConvexRuntimeQueryError({
+        networkCodes: [],
+        query: queryName,
+        reason: "query",
+      })
     );
+    expect(clientState.query).toHaveBeenCalledOnce();
+  });
 
-    expect(result).toBeNull();
-    expect(clientState.instances[0]?.url).toBe("https://example.convex.cloud");
-    expect(clientState.instances[0]?.options.logger).toBe(false);
-    expect(clientState.query).toHaveBeenCalledWith(
-      api.contents.queries.runtime.getContentRoute,
-      args
-    );
-
-    /** Captures fetch calls made through the shared no-store fetch hook. */
-    const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
+  it("preserves sanitized codes after retry exhaustion", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(createFetchFailure("EPIPE"));
     vi.stubGlobal("fetch", fetchMock);
-    const fetchHook = clientState.instances[0]?.options.fetch;
+    queryThroughFetch();
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.fork(
+        readConvexRuntimeQuery(runtimeUrl, query, args).pipe(Effect.flip)
+      );
+      yield* TestClock.adjust(Duration.millis(1500));
 
-    if (!fetchHook) {
-      throw new Error("Expected Convex runtime fetch hook.");
-    }
-
-    await fetchHook("https://convex.test", {
-      cache: "force-cache",
+      return yield* Fiber.join(fiber);
     });
+    const result = runWithTestClock(program);
 
-    expect(fetchMock).toHaveBeenCalledWith("https://convex.test", {
-      cache: "no-store",
-    });
+    await expect(result).resolves.toEqual(
+      new ConvexRuntimeQueryError({
+        networkCodes: ["EPIPE"],
+        query: queryName,
+        reason: "transport",
+      })
+    );
+    expect(clientState.query).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(await result)).not.toContain(
+      "private network detail"
+    );
+  });
+
+  it("does not retry unclassified or timeout fetch failures", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(createFetchFailure("UND_ERR_CONNECT_TIMEOUT"));
+    vi.stubGlobal("fetch", fetchMock);
+    queryThroughFetch();
+
+    await expect(
+      Effect.runPromise(
+        readConvexRuntimeQuery(runtimeUrl, query, args).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ConvexRuntimeQueryError({
+        networkCodes: [],
+        query: queryName,
+        reason: "transport",
+      })
+    );
+    expect(clientState.query).toHaveBeenCalledOnce();
+  });
+
+  it("sanitizes non-Convex query failures", async () => {
+    clientState.query.mockRejectedValueOnce(new Error("private client detail"));
+
+    const result = Effect.runPromise(
+      readConvexRuntimeQuery(runtimeUrl, query, args).pipe(Effect.flip)
+    );
+
+    await expect(result).resolves.toEqual(
+      new ConvexRuntimeQueryError({
+        networkCodes: [],
+        query: queryName,
+        reason: "query",
+      })
+    );
+    expect(JSON.stringify(await result)).not.toContain("private client detail");
+  });
+
+  it("converts synchronous client construction failures to typed errors", async () => {
+    clientState.constructorFailure.error = new Error(
+      "private constructor detail"
+    );
+
+    await expect(
+      Effect.runPromise(
+        readConvexRuntimeQuery(runtimeUrl, query, args).pipe(Effect.flip)
+      )
+    ).resolves.toEqual(
+      new ConvexRuntimeQueryError({
+        networkCodes: [],
+        query: queryName,
+        reason: "client",
+      })
+    );
+    expect(clientState.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/client/runtime.ts
+++ b/packages/backend/client/runtime.ts
@@ -1,29 +1,116 @@
+import {
+  createNetworkRequestError,
+  NETWORK_RETRY_DELAYS_MILLISECONDS,
+  NetworkRequestError,
+  NetworkRetryCodeSchema,
+} from "@repo/backend/client/network";
 import { ConvexHttpClient } from "convex/browser";
-import type {
-  FunctionArgs,
-  FunctionReference,
-  FunctionReturnType,
+import {
+  type FunctionArgs,
+  type FunctionReference,
+  getFunctionName,
 } from "convex/server";
+import { Effect, Schedule, Schema } from "effect";
 
-/** Fetches one public Convex query with framework-safe client settings. */
-export function fetchConvexRuntimeQuery<
-  Query extends FunctionReference<"query">,
->(
-  convexUrl: string,
-  query: Query,
-  args: FunctionArgs<Query>
-): Promise<FunctionReturnType<Query>> {
-  const client = new ConvexHttpClient(convexUrl, {
-    fetch: fetchNoStore,
-    logger: false,
-  });
+const CONVEX_QUERY_RETRY_SCHEDULE = Schedule.fromDelays(
+  NETWORK_RETRY_DELAYS_MILLISECONDS[0],
+  NETWORK_RETRY_DELAYS_MILLISECONDS[1]
+);
 
-  return client.query(query, args);
+/** One public Convex query failed at a sanitized client boundary. */
+export class ConvexRuntimeQueryError extends Schema.TaggedError<ConvexRuntimeQueryError>()(
+  "ConvexRuntimeQueryError",
+  {
+    networkCodes: Schema.Array(NetworkRetryCodeSchema),
+    query: Schema.String,
+    reason: Schema.Literal("client", "query", "transport"),
+  }
+) {
+  get message() {
+    return createQueryMessage(this.query, this.reason, this.networkCodes);
+  }
 }
 
-/** Forces runtime read-model queries to bypass framework fetch caching. */
+function createQueryMessage(
+  query: string,
+  reason: ConvexRuntimeQueryError["reason"],
+  networkCodes: ConvexRuntimeQueryError["networkCodes"]
+) {
+  const codeSuffix =
+    networkCodes.length > 0 ? ` Codes: ${networkCodes.join(", ")}.` : "";
+  return `Convex runtime query ${query} failed at the ${reason} boundary.${codeSuffix}`;
+}
+
+function createRuntimeQueryError(
+  query: string,
+  reason: ConvexRuntimeQueryError["reason"],
+  networkCodes: ConvexRuntimeQueryError["networkCodes"] = []
+) {
+  return new ConvexRuntimeQueryError({
+    networkCodes,
+    query,
+    reason,
+  });
+}
+
+function mapQueryFailure(query: string, cause: unknown) {
+  if (cause instanceof NetworkRequestError) {
+    return createRuntimeQueryError(query, "transport", cause.networkCodes);
+  }
+
+  return createRuntimeQueryError(query, "query");
+}
+
+function isRetryableQueryError(error: ConvexRuntimeQueryError) {
+  return error.reason === "transport" && error.networkCodes.length > 0;
+}
+
+/**
+ * Reads one public Convex query through the Effect error channel.
+ *
+ * Only allowlisted pre-response network failures receive the shared bounded
+ * retry schedule. Convex function, HTTP, protocol, timeout, and unknown
+ * failures remain terminal.
+ *
+ * @see https://docs.convex.dev/functions/error-handling/
+ * @see https://effect.website/docs/error-management/retrying/
+ */
+export const readConvexRuntimeQuery = Effect.fn("ConvexRuntime.query")(
+  function* <Query extends FunctionReference<"query">>(
+    convexUrl: string,
+    query: Query,
+    args: FunctionArgs<Query>
+  ) {
+    const queryName = yield* Effect.try({
+      catch: () => createRuntimeQueryError("unknown", "client"),
+      try: () => getFunctionName(query),
+    });
+    const client = yield* Effect.try({
+      catch: () => createRuntimeQueryError(queryName, "client"),
+      try: () =>
+        new ConvexHttpClient(convexUrl, {
+          fetch: fetchNoStore,
+          logger: false,
+        }),
+    });
+
+    return yield* Effect.tryPromise({
+      catch: (cause) => mapQueryFailure(queryName, cause),
+      try: () => client.query(query, args),
+    }).pipe(
+      Effect.retry({
+        schedule: CONVEX_QUERY_RETRY_SCHEDULE,
+        while: isRetryableQueryError,
+      })
+    );
+  }
+);
+
+/** Adapts the official client fetch hook to a sanitized network error. */
 const fetchNoStore: typeof fetch = (input, init) =>
   fetch(input, {
     ...init,
     cache: "no-store",
-  });
+  }).then(undefined, (cause) =>
+    Promise.reject(createNetworkRequestError(cause))
+  );

--- a/packages/backend/content/endpoint.ts
+++ b/packages/backend/content/endpoint.ts
@@ -3,3 +3,14 @@ export const PUBLIC_CONTENT_RUNTIME_PATH = "/internal/content/runtime";
 
 /** Private Convex endpoint for retained protected content reads. */
 export const PROTECTED_CONTENT_RUNTIME_PATH = `${PUBLIC_CONTENT_RUNTIME_PATH}/protected`;
+
+/**
+ * Marks responses built by the private runtime route after contract encoding.
+ * This diagnostic signal does not replace signed response verification.
+ *
+ * @see https://docs.convex.dev/functions/http-actions
+ */
+export const CONTENT_RUNTIME_RESPONSE_HEADER = "x-nakafa-runtime-response";
+
+/** Current private runtime response marker. */
+export const CONTENT_RUNTIME_RESPONSE_MARKER = "1";

--- a/packages/backend/convex/contentRelease/http/runtime/protected.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/protected.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 
 import { MAX_PROTECTED_RUNTIME_REQUEST_BYTES } from "@nakafa/aksara-contracts/runtime/protected/limits";
-import { PROTECTED_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+  PROTECTED_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -53,6 +57,9 @@ describe("protected content runtime HTTP route", () => {
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ kind: "missing" });
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
+      CONTENT_RUNTIME_RESPONSE_MARKER
+    );
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
   });
 

--- a/packages/backend/convex/contentRelease/http/runtime/public.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/public.test.ts
@@ -7,7 +7,11 @@ import {
 } from "@nakafa/aksara-contracts/runtime/spec";
 import { verifyContentRuntimeExchange } from "@nakafa/aksara-contracts/runtime/verify";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
-import { PUBLIC_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+  PUBLIC_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
 import { contentKeyResolver } from "@repo/backend/content/trust";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
@@ -47,6 +51,9 @@ function post(t: RuntimeFetcher, body: BodyInit | null, headers?: HeadersInit) {
 function expectPrivate(response: Response) {
   expect(response.headers.get("cache-control")).toBe("private, no-store");
   expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
+    CONTENT_RUNTIME_RESPONSE_MARKER
+  );
   expect(response.headers.get("x-content-type-options")).toBe("nosniff");
 }
 
@@ -266,6 +273,8 @@ describe("public content runtime HTTP route", () => {
 
     expect(corruptResponse.status).toBe(500);
     expect(oversizedResponse.status).toBe(500);
+    expectPrivate(corruptResponse);
+    expectPrivate(oversizedResponse);
     await expect(oversizedResponse.json()).resolves.toEqual({
       code: "CONTENT_RUNTIME_RESPONSE_TOO_LARGE",
       kind: "failure",

--- a/packages/backend/convex/contentRelease/http/runtime/response.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/response.ts
@@ -1,9 +1,14 @@
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+} from "@repo/backend/content/endpoint";
 import type { RuntimeHttpResult } from "@repo/backend/convex/contentRelease/runtime/result";
 
 /** Builds one private JSON response shared by both runtime endpoints. */
 export function privateRuntimeResponse(result: RuntimeHttpResult) {
   return new Response(result.body, {
     headers: {
+      [CONTENT_RUNTIME_RESPONSE_HEADER]: CONTENT_RUNTIME_RESPONSE_MARKER,
       "cache-control": "private, no-store",
       "content-type": "application/json; charset=utf-8",
       "x-content-type-options": "nosniff",


### PR DESCRIPTION
## What changed

- Add a fixed, nonsecret response marker to private signed-content responses so malformed JSON and out-of-contract responses are classified as `json-syntax`, `response-contract`, or `response-unmarked` without exposing response data.
- Route public Convex reads and signed-content POST reads through Effect-native, schema-tagged transport errors and one shared network classifier and bounded delay sequence.
- Retry only allowlisted pre-response network failures twice, after 500 ms and 1,000 ms. Mixed, unknown, timeout, abort, TLS, protocol, HTTP, query, contract, release, and signature failures remain terminal.
- Remove the dead raw Promise runtime APIs and manual query labels. Generated Convex references now own query names, and named `Effect.fn` programs own the API, Nakafa, and web boundaries.
- Run the Quran catalog and view Effects inside their existing `use cache` boundaries. No `io()`, `connection()`, dynamic rendering, compatibility path, or fallback was added.

## Why

Exact-main Vercel deployment `dpl_8Jkx6VkkQ5i8eiVL3eWZqu9ysR8A` compiled and typechecked, then failed during static generation at 325 of 1,303 pages. Direct Convex reads and the signed-content HTTP read both reported a pre-response `fetch failed` event in the same second. The exact nested Node network code was not retained, so this PR does not claim a more specific root cause or a content-row defect.

The byte-identical Agent-Friendly Docs path completed all 1,303 pages against its isolated signed runtime, and live production stayed healthy on the prior deployment. This correction therefore handles only classified transient transport failures and keeps every received response on the existing status, schema, release, and signature verification path.

The response marker is separate diagnostic evidence for invalid responses that were actually received. It is not authentication, does not affect valid marked or unmarked responses, and is never a retry trigger.

## Effect and Node boundary

Nakafa does not import or depend directly on Undici. Node's built-in `fetch` exposes Node and Undici transport codes, so the classifier uses the conservative default set documented in the pinned Undici 7.29.0 source. Effect 3.22.1 still owns the architecture: Schema errors, named programs, typed failure channels, retry schedules, and TestClock verification.

Both retried operations are read-only. Convex uses a query reference, and the signed HTTP action dispatches only through `ctx.runQuery`.

References:

- [Effect retry](https://effect.website/docs/error-management/retrying/)
- [Node 24 built-in fetch](https://nodejs.org/download/release/latest-v24.x/docs/api/globals.html#fetch)
- [Convex error handling](https://docs.convex.dev/functions/error-handling/)
- [Convex HTTP actions](https://docs.convex.dev/functions/http-actions)
- [Undici 7.29 retry codes](https://github.com/nodejs/undici/blob/v7.29.0/lib/handler/retry-handler.js)
- [Next.js use cache](https://nextjs.org/docs/app/api-reference/directives/use-cache)

## Verification

- Rebased on exact main `632c9e679e00eee24154734e9c9ac3dc19a0dca4`
- `pnpm test`: 12 of 12 tasks; backend 349 files and 1,488 tests; www 179 and 1,100; API 8 and 48
- Backend, API, and www typechecks
- `pnpm lint`: 3,020 files
- `pnpm boundaries`: 2,989 files
- `pnpm security:audit`: no known vulnerabilities
- [Exact-head Agent-Friendly Docs](https://github.com/nakafaai/nakafa.com/actions/runs/31402908408): 32 signed tables imported with `contentState` last, 1,303 of 1,303 pages, AFDocs 23 of 23, and cleanup passed
- [Exact-head React Doctor](https://github.com/nakafaai/nakafa.com/actions/runs/31402911931): 100/100, 0 errors, 0 warnings
- Full React Doctor: 0 errors; 115 warnings remain for separately audited work
- `git diff --check`
- Two independent exact-tree reviews found no blocker
- Largest changed production TypeScript module: 295 lines; largest changed test: 477 lines
- Vercel created no deployment for this head or branch across www, API, MCP, or CAS, so preview remains disabled