### PR TITLE
fix(content): retry unmarked runtime failures

### DIFF
--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -14,13 +14,23 @@ import {
   CONTENT_RUNTIME_RESPONSE_MARKER,
   PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
-import { Duration, Effect, Fiber, TestClock, TestContext } from "effect";
+import {
+  Duration,
+  Effect,
+  Fiber,
+  Logger,
+  TestClock,
+  TestContext,
+} from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const endpoint = "https://example.convex.site/internal/content/runtime";
 const target = {
   siteUrl: "https://example.convex.site",
   token: "runtime-test-token",
+};
+const unmarkedJsonHeaders = {
+  "content-type": "application/json; charset=utf-8",
 };
 const fetchMock = vi.hoisted(() => vi.fn<typeof fetch>());
 
@@ -51,6 +61,25 @@ function createResponse(
   Object.defineProperty(response, "url", { value: url });
   return response;
 }
+
+/** Observes cancellation of one concrete response body. */
+function observeResponseCancel(response: Response) {
+  const body = response.body;
+  if (body === null) {
+    return expect.fail("Expected the test response to have a body.");
+  }
+  return vi.spyOn(body, "cancel");
+}
+
+/** Runs a retrying request under Effect's deterministic clock. */
+const runRetryRequest = <Value, Error>(program: Effect.Effect<Value, Error>) =>
+  runWithTestClock(
+    Effect.gen(function* () {
+      const fiber = yield* Effect.fork(program);
+      yield* TestClock.adjust(Duration.seconds(2));
+      return yield* Fiber.join(fiber);
+    })
+  );
 
 beforeEach(() => {
   fetchMock.mockReset();
@@ -136,37 +165,155 @@ describe("content runtime transport", () => {
     );
   });
 
-  it("retries rejected read-only runtime fetches", async () => {
+  it("shares one retry budget across network and platform failures", async () => {
+    const platformFailure = createResponse(
+      '{"code":"Server Error"}',
+      500,
+      unmarkedJsonHeaders
+    );
+    const cancelPlatformFailure = observeResponseCancel(platformFailure);
     const response = createResponse("{}", 200);
     fetchMock
       .mockRejectedValueOnce(createFetchFailure("ECONNRESET"))
-      .mockRejectedValueOnce(createFetchFailure("UND_ERR_SOCKET"))
+      .mockResolvedValueOnce(platformFailure)
       .mockResolvedValueOnce(response);
-    const program = Effect.gen(function* () {
-      const fiber = yield* Effect.fork(
-        postContentRequest({ endpoint, source: "{}", target })
-      );
-      yield* TestClock.adjust(Duration.seconds(2));
 
-      return yield* Fiber.join(fiber);
-    });
-
-    await expect(runWithTestClock(program)).resolves.toBe(response);
+    await expect(
+      runRetryRequest(postContentRequest({ endpoint, source: "{}", target }))
+    ).resolves.toBe(response);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(cancelPlatformFailure).toHaveBeenCalledOnce();
+  });
+
+  it("cancels only discarded unmarked platform responses", async () => {
+    const first = createResponse("first", 500, unmarkedJsonHeaders);
+    const second = createResponse("second", 500, unmarkedJsonHeaders);
+    const success = createResponse("success", 200);
+    const cancelFirst = observeResponseCancel(first);
+    const cancelSecond = observeResponseCancel(second);
+    const cancelSuccess = observeResponseCancel(success);
+    fetchMock
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValueOnce(success);
+
+    await expect(
+      runRetryRequest(postContentRequest({ endpoint, source: "{}", target }))
+    ).resolves.toBe(success);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(cancelFirst).toHaveBeenCalledOnce();
+    expect(cancelSecond).toHaveBeenCalledOnce();
+    expect(cancelSuccess).not.toHaveBeenCalled();
+  });
+
+  it("returns the final unmarked response untouched after exhaustion", async () => {
+    const first = createResponse("first", 500, unmarkedJsonHeaders);
+    const second = createResponse("second", 500, unmarkedJsonHeaders);
+    const final = createResponse(
+      '{"code":"[Request ID: private] Server Error"}',
+      500,
+      unmarkedJsonHeaders
+    );
+    const cancelFirst = observeResponseCancel(first);
+    const cancelSecond = observeResponseCancel(second);
+    const cancelFinal = observeResponseCancel(final);
+    fetchMock
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValueOnce(final);
+
+    const response = await runRetryRequest(
+      postContentRequest({ endpoint, source: "{}", target })
+    );
+
+    expect(response).toBe(final);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(cancelFirst).toHaveBeenCalledOnce();
+    expect(cancelSecond).toHaveBeenCalledOnce();
+    expect(cancelFinal).not.toHaveBeenCalled();
+    await expect(
+      Effect.runPromise(readContentResponse(response, endpoint, 1024))
+    ).resolves.toEqual({ code: "[Request ID: private] Server Error" });
+    expect(createContentContractError(response)).toEqual(
+      new ContentTransportError({ reason: "response-unmarked" })
+    );
+  });
+
+  it("keeps other received responses on one attempt", async () => {
+    const responses = [
+      createResponse("{}", 200, unmarkedJsonHeaders),
+      createResponse("{}", 401, unmarkedJsonHeaders),
+      createResponse("{}", 404, unmarkedJsonHeaders),
+      createResponse("{}", 502, unmarkedJsonHeaders),
+      createResponse("{}", 503, unmarkedJsonHeaders),
+      createResponse("{}", 500),
+      createResponse("{}", 500, {
+        "content-type": "application/json",
+        [CONTENT_RUNTIME_RESPONSE_HEADER]: "wrong-marker",
+      }),
+      createResponse("{}", 500, { "content-type": "text/plain" }),
+      createResponse(
+        "{}",
+        500,
+        unmarkedJsonHeaders,
+        "https://other.test/internal/content/runtime"
+      ),
+    ];
+
+    for (const response of responses) {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue(response);
+
+      await expect(
+        Effect.runPromise(
+          postContentRequest({ endpoint, source: "{}", target })
+        )
+      ).resolves.toBe(response);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("continues when a discarded response body cannot be canceled", async () => {
+    const messages: unknown[] = [];
+    const logger = Logger.make(({ message }) => messages.push(message));
+    const platformFailure = createResponse("failure", 500, unmarkedJsonHeaders);
+    const cancelPlatformFailure = observeResponseCancel(platformFailure);
+    cancelPlatformFailure.mockRejectedValueOnce(new Error("private detail"));
+    const success = createResponse("success", 200);
+    fetchMock
+      .mockResolvedValueOnce(platformFailure)
+      .mockResolvedValueOnce(success);
+    const request = postContentRequest({ endpoint, source: "{}", target }).pipe(
+      Effect.provide(Logger.replace(Logger.defaultLogger, logger))
+    );
+
+    await expect(runRetryRequest(request)).resolves.toBe(success);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(messages).toEqual([
+      ["Unable to cancel a discarded content runtime response body."],
+    ]);
+  });
+
+  it("retries an unmarked platform response without a body", async () => {
+    const success = createResponse("success", 200);
+    fetchMock
+      .mockResolvedValueOnce(createResponse(null, 500, unmarkedJsonHeaders))
+      .mockResolvedValueOnce(success);
+
+    await expect(
+      runRetryRequest(postContentRequest({ endpoint, source: "{}", target }))
+    ).resolves.toBe(success);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("preserves sanitized codes after bounded retries", async () => {
     fetchMock.mockRejectedValue(createFetchFailure("EPIPE"));
-    const program = Effect.gen(function* () {
-      const fiber = yield* Effect.fork(
+
+    await expect(
+      runRetryRequest(
         postContentRequest({ endpoint, source: "{}", target }).pipe(Effect.flip)
-      );
-      yield* TestClock.adjust(Duration.seconds(2));
-
-      return yield* Fiber.join(fiber);
-    });
-
-    await expect(runWithTestClock(program)).resolves.toEqual(
+      )
+    ).resolves.toEqual(
       new ContentTransportError({
         networkCodes: ["EPIPE"],
         reason: "fetch",

--- a/packages/backend/client/content/transport.ts
+++ b/packages/backend/client/content/transport.ts
@@ -7,6 +7,7 @@ import {
   createNetworkRequestError,
   isRetryableNetworkError,
   NETWORK_RETRY_DELAYS_MILLISECONDS,
+  type NetworkRequestError,
 } from "@repo/backend/client/network";
 import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
@@ -14,13 +15,9 @@ import {
 } from "@repo/backend/content/endpoint";
 import { parseContentLength, readBoundedBody } from "@repo/utilities/body";
 import { isJsonContentType } from "@repo/utilities/mime";
-import { Effect, Schedule } from "effect";
+import { Data, Effect, Schedule, ScheduleDecision } from "effect";
 
 const CONTENT_TIMEOUT_MILLISECONDS = 10_000;
-const CONTENT_RETRY_SCHEDULE = Schedule.fromDelays(
-  NETWORK_RETRY_DELAYS_MILLISECONDS[0],
-  NETWORK_RETRY_DELAYS_MILLISECONDS[1]
-);
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "[::1]", "localhost"]);
 
 type ContentRuntimeResponse =
@@ -39,6 +36,76 @@ export interface ContentHttpTarget {
   readonly siteUrl: string;
   readonly token: string;
 }
+
+/** One exact unmarked response may share the safe read retry budget. */
+class RetryableContentResponse extends Data.TaggedError(
+  "RetryableContentResponse"
+)<{
+  readonly response: Response;
+}> {}
+
+type ContentRequestFailure = NetworkRequestError | RetryableContentResponse;
+
+/** Returns whether one failure is safe to retry as the same read request. */
+function isRetryableContentFailure(error: ContentRequestFailure) {
+  if (error._tag === "RetryableContentResponse") {
+    return true;
+  }
+  return isRetryableNetworkError(error);
+}
+
+/** Returns whether an exact unmarked JSON 500 is eligible for read retry. */
+function isRetryableContentResponse(response: Response, endpoint: string) {
+  return (
+    response.url === endpoint &&
+    response.status === 500 &&
+    isJsonContentType(response.headers.get("content-type")) &&
+    response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER) === null
+  );
+}
+
+/**
+ * Releases only a response that the retry schedule will discard.
+ *
+ * @see https://github.com/nodejs/undici/blob/v7.29.0/README.md#garbage-collection
+ */
+const cancelRetryResponse = Effect.fn("NakafaContent.cancelRetryResponse")(
+  function* (
+    failure: ContentRequestFailure,
+    decision: ScheduleDecision.ScheduleDecision
+  ) {
+    if (!ScheduleDecision.isContinue(decision)) {
+      return;
+    }
+    if (failure._tag !== "RetryableContentResponse") {
+      return;
+    }
+    const body = failure.response.body;
+    if (body === null) {
+      return;
+    }
+
+    yield* Effect.tryPromise({
+      catch: () => undefined,
+      try: () => body.cancel(),
+    }).pipe(
+      Effect.catchAll(() =>
+        Effect.logWarning(
+          "Unable to cancel a discarded content runtime response body."
+        )
+      )
+    );
+  }
+);
+
+const CONTENT_RETRY_SCHEDULE = Schedule.fromDelays(
+  NETWORK_RETRY_DELAYS_MILLISECONDS[0],
+  NETWORK_RETRY_DELAYS_MILLISECONDS[1]
+).pipe(
+  Schedule.whileInput<ContentRequestFailure>(isRetryableContentFailure),
+  Schedule.passthrough,
+  Schedule.onDecision(cancelRetryResponse)
+);
 
 /** Returns whether the response carries the current diagnostic marker. */
 function hasContentRuntimeMarker(response: Response) {
@@ -137,11 +204,14 @@ export const encodeContentRequest = Effect.fn(
 /**
  * Posts one no-store request with the server-owned runtime capability.
  *
- * The runtime action is read-only, so only allowlisted network failures receive
- * two bounded retries. Every HTTP response continues without retry into the
- * exact status, response, and signature checks.
+ * The runtime action is read-only. Allowlisted network failures and the exact
+ * unmarked JSON 500 that the pinned Convex backend creates when Nakafa does not
+ * complete the action share two bounded retries. Every other HTTP response
+ * continues without retry into the exact status, response, and signature
+ * checks.
  *
  * @see https://docs.convex.dev/functions/http-actions
+ * @see https://github.com/get-convex/convex-backend/blob/38abb46277140838cc5cdad59c6e85ad0432fc9a/crates/application/src/redaction.rs#L143-L160
  * @see https://effect.website/docs/error-management/retrying/
  */
 export const postContentRequest = Effect.fn("NakafaContent.postContentRequest")(
@@ -150,7 +220,7 @@ export const postContentRequest = Effect.fn("NakafaContent.postContentRequest")(
     readonly source: string;
     readonly target: ContentHttpTarget;
   }) {
-    const response = yield* Effect.tryPromise({
+    const request = Effect.tryPromise({
       catch: createNetworkRequestError,
       try: () =>
         fetch(input.endpoint, {
@@ -166,9 +236,19 @@ export const postContentRequest = Effect.fn("NakafaContent.postContentRequest")(
           signal: AbortSignal.timeout(CONTENT_TIMEOUT_MILLISECONDS),
         }),
     }).pipe(
-      Effect.retry({
-        schedule: CONTENT_RETRY_SCHEDULE,
-        while: isRetryableNetworkError,
+      Effect.flatMap((response) => {
+        if (!isRetryableContentResponse(response, input.endpoint)) {
+          return Effect.succeed(response);
+        }
+        return Effect.fail(new RetryableContentResponse({ response }));
+      })
+    );
+    const response = yield* request.pipe(
+      Effect.retryOrElse(CONTENT_RETRY_SCHEDULE, (failure) => {
+        if (failure._tag === "RetryableContentResponse") {
+          return Effect.succeed(failure.response);
+        }
+        return Effect.fail(failure);
       }),
       Effect.mapError(
         (error) =>


### PR DESCRIPTION
## What changed

- Use one Effect retry schedule for allowlisted pre-response network failures and exact unmarked JSON 500 responses from the signed content endpoint.
- Keep one three-attempt budget across mixed failures, with 500 ms and 1,000 ms delays.
- Cancel only discarded retry-response bodies before sleeping, and return the exhausted response untouched to the existing fail-closed decoder.
- Extend the colocated transport tests for eligibility, mixed failures, cancellation, exhaustion, privacy, and terminal response handling.

## Why

Exact main Agent-Friendly Docs run [31414610044](https://github.com/nakafaai/nakafa.com/actions/runs/31414610044) failed during WWW prerender at 977 of 1,303 pages with `ContentTransportError { reason: response-unmarked }`. The accepted PR tree and exact Vercel production tree both completed all 1,303 pages, which rules out a deterministic content or tree defect.

The existing retry policy handled rejected `fetch` calls only. Convex can replace a thrown HTTP action with its own resolved `application/json` 500 response before Nakafa's marked response builder runs. That response has no Nakafa marker, so the current decoder correctly rejects it but previously had no bounded retry opportunity. The exact underlying backend exception is unavailable because the workflow sanitizes and erases the private backend log.

Pinned source evidence:

- [Convex backend redaction response](https://github.com/get-convex/convex-backend/blob/38abb46277140838cc5cdad59c6e85ad0432fc9a/crates/application/src/redaction.rs#L143-L160)
- [Convex HTTP action response conversion](https://github.com/get-convex/convex-backend/blob/38abb46277140838cc5cdad59c6e85ad0432fc9a/crates/udf/src/http_action.rs#L103-L124)
- [Convex HTTP action retry ownership](https://docs.convex.dev/functions/http-actions#limits)
- [Effect retry documentation](https://effect.website/docs/error-management/retrying/)
- [Undici response-body lifecycle guidance](https://github.com/nodejs/undici/blob/v7.29.0/README.md#garbage-collection)

## Safety

A resolved response is retryable only when its URL exactly matches the endpoint, its status is exactly 500, its media type is valid JSON, and the Nakafa response marker is absent.

The retry path never reads or trusts the response body. Marked responses, wrong marker values, other statuses, wrong URLs, non-JSON responses, schema failures, status-contract failures, and signature failures remain terminal. After exhaustion, the final response follows the existing bounded decoder and cryptographic verification path unchanged.

Both runtime POST handlers are read-only query actions. Effect owns the typed failure channel, schedule, and retry lifecycle. The implementation adds no direct Undici dependency.

## Verification

- `pnpm effect:source:check`, installed and vendored Effect 3.22.1 match
- focused transport, public, and protected tests, 20 of 20
- full backend suite, 356 files and 1,535 tests
- root test graph, 12 of 12 tasks
- WWW suite, 179 files and 1,100 tests at full coverage
- API suite, 8 files and 48 tests at full coverage
- MCP suite, 7 files and 18 tests at full coverage
- backend typecheck
- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`, 2,977 files with no issues
- `pnpm security:audit`, no known vulnerabilities
- changed-scope React Doctor, 0 errors and 0 warnings
- production `pnpm build` with `NODE_ENV=production`, 5 of 5 tasks and WWW 1,303 of 1,303 pages
- independent exact-diff review, no blocker
- production source is 300 lines; its colocated owner test is 412 lines
