### PR TITLE
fix(www): restore curriculum navigation

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
@@ -90,24 +90,35 @@ export default function Page({ params }: CurriculumPageProps) {
   );
 }
 
-/** Resolves and renders the URL-specific curriculum node inside its boundary. */
+/** Resolves the URL-specific route before choosing its named composition. */
 async function CurriculumRouteContent({
   params,
 }: Pick<CurriculumPageProps, "params">) {
   const model = await resolveRuntimeCurriculumRoute(params);
-  const { locale, route } = model;
-  const commonTranslations = getTranslations({ locale, namespace: "Common" });
-  let header: ReactNode;
-  let homeLabel: string;
 
-  if (route.level === "track") {
-    const [catalog, tCommon, tLearningPrograms] = await Promise.all([
-      readRuntimeCurriculumCatalog(locale),
-      commonTranslations,
-      getTranslations({ locale, namespace: "LearningPrograms" }),
-    ]);
-    homeLabel = tCommon("home");
-    header = (
+  if (model.route.level === "track") {
+    return <CurriculumTrackRoute model={model} />;
+  }
+
+  return <CurriculumNestedRoute model={model} />;
+}
+
+/** Renders the curriculum chooser with its catalog-owned selector. */
+async function CurriculumTrackRoute({
+  model,
+}: {
+  model: CurriculumRouteModel;
+}) {
+  const { locale, route } = model;
+  const [catalog, tCommon, tLearningPrograms] = await Promise.all([
+    readRuntimeCurriculumCatalog(locale),
+    getTranslations({ locale, namespace: "Common" }),
+    getTranslations({ locale, namespace: "LearningPrograms" }),
+  ]);
+  const homeLabel = tCommon("home");
+
+  return (
+    <CurriculumRouteFrame homeLabel={homeLabel} model={model}>
       <CurriculumRootHeader
         currentRoute={route}
         homeLabel={homeLabel}
@@ -115,17 +126,41 @@ async function CurriculumRouteContent({
         selectorLabel={tLearningPrograms("kind.school-curriculum")}
         subjectLabel={tCommon("subject")}
       />
-    );
-  } else {
-    homeLabel = (await commonTranslations)("home");
-    header = (
+    </CurriculumRouteFrame>
+  );
+}
+
+/** Renders one nested curriculum node with its established route header. */
+async function CurriculumNestedRoute({
+  model,
+}: {
+  model: CurriculumRouteModel;
+}) {
+  const { locale, route } = model;
+  const tCommon = await getTranslations({ locale, namespace: "Common" });
+
+  return (
+    <CurriculumRouteFrame homeLabel={tCommon("home")} model={model}>
       <HeaderContent
         icon={readCurriculumRouteIcon(route)}
         link={readRuntimeCurriculumHeader(model)}
         title={route.title}
       />
-    );
-  }
+    </CurriculumRouteFrame>
+  );
+}
+
+/** Composes the shared curriculum body around one explicit route header. */
+function CurriculumRouteFrame({
+  children,
+  homeLabel,
+  model,
+}: {
+  children: ReactNode;
+  homeLabel: string;
+  model: CurriculumRouteModel;
+}) {
+  const { locale, route } = model;
 
   const breadcrumbs = readRuntimeCurriculumBreadcrumbs(homeLabel, model);
   const sourceUrl = readCurriculumSourceUrl(model);
@@ -136,7 +171,7 @@ async function CurriculumRouteContent({
         breadcrumbItems={createBreadcrumbItems(locale, breadcrumbs)}
       />
       <LayoutMaterialContent>
-        {header}
+        {children}
         <LayoutContent>
           <CurriculumRouteBody {...model} />
         </LayoutContent>

--- a/patches/next.patch
+++ b/patches/next.patch
@@ -1,0 +1,54 @@
+diff --git a/dist/client/components/segment-cache/cache.js b/dist/client/components/segment-cache/cache.js
+--- a/dist/client/components/segment-cache/cache.js
++++ b/dist/client/components/segment-cache/cache.js
+@@ -1805 +1805 @@ payloadFetchStrategy) {
+-        const payloadVaryPath = fetchStrategy === _types.FetchStrategy.StaticShell ? node.tree.shellVaryPath : process.env.__NEXT_VARY_PARAMS && varyParams !== null ? (0, _varypath.getFulfilledSegmentVaryPath)(node.tree.varyPath, varyParams) : (0, _varypath.getSegmentVaryPathForRequest)(_types.FetchStrategy.PPR, node.tree);
++        const payloadVaryPath = process.env.__NEXT_VARY_PARAMS && varyParams !== null ? (0, _varypath.getFulfilledSegmentVaryPath)(node.tree.varyPath, varyParams) : (0, _varypath.getSegmentVaryPathForRequest)(payloadFetchStrategy, node.tree);
+@@ -1810,17 +1810 @@ payloadFetchStrategy) {
+-            if (fetchStrategy === _types.FetchStrategy.StaticShell) {
+-                // Re-key at the shell vary path, mirroring the RuntimeShell re-key
+-                // in fulfillEntrySpawnedByRuntimePrefetch. Usually the entry already
+-                // lives there, but the scheduler can also upgrade a pre-existing
+-                // Empty entry at a more concrete path in place, so the re-key is
+-                // load-bearing. The shadow eviction keeps a stale settled entry at
+-                // a more specific path from hiding the shell entry (the just-written
+-                // full payload's entry is preferred and survives it). Routed through
+-                // the upsert rather than a bare set so the usual precedence rules
+-                // apply: a concurrent task's response (e.g. a RuntimeShell entry)
+-                // can land in the shell slot first, and this write must not
+-                // downgrade it. (In the common case the slot already holds this
+-                // very entry, which the upsert replaces in place.)
+-                if (process.env.__NEXT_VARY_PARAMS) {
+-                    upsertSegmentEntry(now, node.tree.shellVaryPath, fulfilledEntry, node.tree.varyPath);
+-                }
+-            } else {
++            {
+@@ -2713 +2697,0 @@ if ((typeof exports.default === 'function' || typeof exports.default === 'object
+-//# sourceMappingURL=cache.js.map
+diff --git a/dist/esm/client/components/segment-cache/cache.js b/dist/esm/client/components/segment-cache/cache.js
+--- a/dist/esm/client/components/segment-cache/cache.js
++++ b/dist/esm/client/components/segment-cache/cache.js
+@@ -1690 +1690 @@ payloadFetchStrategy) {
+-        const payloadVaryPath = fetchStrategy === FetchStrategy.StaticShell ? node.tree.shellVaryPath : process.env.__NEXT_VARY_PARAMS && varyParams !== null ? getFulfilledSegmentVaryPath(node.tree.varyPath, varyParams) : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree);
++        const payloadVaryPath = process.env.__NEXT_VARY_PARAMS && varyParams !== null ? getFulfilledSegmentVaryPath(node.tree.varyPath, varyParams) : getSegmentVaryPathForRequest(payloadFetchStrategy, node.tree);
+@@ -1695,17 +1695 @@ payloadFetchStrategy) {
+-            if (fetchStrategy === FetchStrategy.StaticShell) {
+-                // Re-key at the shell vary path, mirroring the RuntimeShell re-key
+-                // in fulfillEntrySpawnedByRuntimePrefetch. Usually the entry already
+-                // lives there, but the scheduler can also upgrade a pre-existing
+-                // Empty entry at a more concrete path in place, so the re-key is
+-                // load-bearing. The shadow eviction keeps a stale settled entry at
+-                // a more specific path from hiding the shell entry (the just-written
+-                // full payload's entry is preferred and survives it). Routed through
+-                // the upsert rather than a bare set so the usual precedence rules
+-                // apply: a concurrent task's response (e.g. a RuntimeShell entry)
+-                // can land in the shell slot first, and this write must not
+-                // downgrade it. (In the common case the slot already holds this
+-                // very entry, which the upsert replaces in place.)
+-                if (process.env.__NEXT_VARY_PARAMS) {
+-                    upsertSegmentEntry(now, node.tree.shellVaryPath, fulfilledEntry, node.tree.varyPath);
+-                }
+-            } else {
++            {
+@@ -2657 +2641,0 @@ export default function createCacheKey(originalHref, nextUrl) {
+-//# sourceMappingURL=cache.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,11 @@ overrides:
   posthog-js@1.414.0>dompurify: ^3.4.13
   read-yaml-file@1.1.0>js-yaml: 3.15.1
 
+patchedDependencies:
+  next@16.3.0:
+    hash: 69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136
+    path: patches/next.patch
+
 importers:
 
   .:
@@ -100,7 +105,7 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
+        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
       '@nakafa/aksara-contracts':
         specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.11.0/nakafa-aksara-contracts-0.11.0.tgz
         version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.11.0/nakafa-aksara-contracts-0.11.0.tgz(effect@3.22.1)
@@ -124,7 +129,7 @@ importers:
         version: 0.13.11(typescript@7.0.2)(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       convex:
         specifier: ^1.43.0
         version: 1.43.0(react@19.2.8)
@@ -133,7 +138,7 @@ importers:
         version: 3.22.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -231,7 +236,7 @@ importers:
         version: 5.2.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -274,7 +279,7 @@ importers:
         version: 4.0.61(react@19.2.8)(zod@4.4.3)
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
+        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
       '@effect/platform':
         specifier: 0.97.1
         version: 0.97.1(effect@3.22.1)
@@ -364,7 +369,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -394,16 +399,16 @@ importers:
         version: 6.0.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuqs:
         specifier: ^2.9.5
-        version: 2.9.5(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.9.5(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -558,7 +563,7 @@ importers:
         version: 0.13.11(typescript@7.0.2)(zod@4.4.3)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       effect:
         specifier: 'catalog:'
         version: 3.22.1
@@ -592,7 +597,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
@@ -604,7 +609,7 @@ importers:
         version: 0.2.2(convex@1.43.0(react@19.2.8))
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)
+        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)
       '@convex-dev/resend':
         specifier: ^0.2.6
         version: 0.2.6(@react-email/render@2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(convex-helpers@0.1.122(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)(zod@4.4.3))(convex@1.43.0(react@19.2.8))(react@19.2.8)
@@ -649,7 +654,7 @@ importers:
         version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -692,7 +697,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       auth:
         specifier: ~1.6.26
-        version: 1.6.26(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.26(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       convex-test:
         specifier: ^0.0.55
         version: 0.0.55(convex@1.43.0(react@19.2.8))
@@ -786,7 +791,7 @@ importers:
         version: 9.5.1(react@19.2.8)
       '@next/third-parties':
         specifier: 16.3.0
-        version: 16.3.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@number-flow/react':
         specifier: ^0.6.2
         version: 0.6.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -837,7 +842,7 @@ importers:
         version: 0.3.0(react@19.2.8)(typescript@7.0.2)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 1.7.2(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       harden-react-markdown:
         specifier: ^1.1.8
         version: 1.1.8(react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
@@ -861,10 +866,10 @@ importers:
         version: 6.0.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1016,10 +1021,10 @@ importers:
         version: link:../utilities
       next:
         specifier: 16.3.0
-        version: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(@swc/helpers@0.5.23)(@typescript/typescript6@6.0.2)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 4.13.5(@swc/helpers@0.5.23)(@typescript/typescript6@6.0.2)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
@@ -1079,7 +1084,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
@@ -1103,10 +1108,10 @@ importers:
         version: 4.6.2
       next:
         specifier: 16.3.0
-        version: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -8448,10 +8453,10 @@ snapshots:
       convex: 1.43.0(react@19.2.8)
       react: 19.2.8
 
-  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)':
+  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       common-tags: 1.8.2
       convex: 1.43.0(react@19.2.8)
       convex-helpers: 0.1.122(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)(zod@4.4.3)
@@ -8466,10 +8471,10 @@ snapshots:
       - hono
       - typescript
 
-  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
+  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       common-tags: 1.8.2
       convex: 1.43.0(react@19.2.8)
       convex-helpers: 0.1.122(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)(zod@4.4.3)
@@ -8484,10 +8489,10 @@ snapshots:
       - hono
       - typescript
 
-  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
+  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       common-tags: 1.8.2
       convex: 1.43.0(react@19.2.8)
       convex-helpers: 0.1.122(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)(zod@4.4.3)
@@ -9307,9 +9312,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
-  '@next/third-parties@16.3.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@next/third-parties@16.3.0(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       third-party-capital: 1.0.20
 
@@ -9450,7 +9455,7 @@ snapshots:
   '@react-email/ui@6.9.2(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       esbuild: 0.28.1
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
       - '@opentelemetry/api'
@@ -10239,9 +10244,9 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.8
 
-  '@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/analytics@2.0.1(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@vercel/cli-config@0.2.2':
@@ -10492,7 +10497,7 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
-  auth@1.6.26(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  auth@1.6.26(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
@@ -10502,7 +10507,7 @@ snapshots:
       '@better-auth/utils': 0.4.2
       '@clack/prompts': 1.7.0
       '@mrleebo/prisma-ast': 0.13.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       c12: 3.3.4(magicast@0.5.3)
       chalk: 5.6.2
       commander: 12.1.0
@@ -10570,7 +10575,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -10590,7 +10595,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vitest: 4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
@@ -10598,7 +10603,7 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -10618,7 +10623,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vitest: 4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
@@ -11694,9 +11699,9 @@ snapshots:
 
   function-timeout@0.1.1: {}
 
-  geist@1.7.2(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
+  geist@1.7.2(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   gensync@1.0.0-beta.2: {}
 
@@ -12958,14 +12963,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.5: {}
 
-  next-intl@4.13.5(@swc/helpers@0.5.23)(@typescript/typescript6@6.0.2)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  next-intl@4.13.5(@swc/helpers@0.5.23)(@typescript/typescript6@6.0.2)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
       icu-minify: 4.13.5
       negotiator: 1.0.0
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.5
       po-parser: 2.1.1
       react: 19.2.8
@@ -12975,14 +12980,14 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
       icu-minify: 4.13.5
       negotiator: 1.0.0
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.5
       po-parser: 2.1.1
       react: 19.2.8
@@ -12992,14 +12997,14 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
       icu-minify: 4.13.5
       negotiator: 1.0.0
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.5
       po-parser: 2.1.1
       react: 19.2.8
@@ -13014,7 +13019,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -13042,7 +13047,7 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
-  next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -13070,7 +13075,7 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
-  next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -13132,12 +13137,12 @@ snapshots:
     dependencies:
       esm-env: 1.2.2
 
-  nuqs@2.9.5(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  nuqs@2.9.5(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     dependencies:
       '@standard-schema/spec': 1.1.0
       react: 19.2.8
     optionalDependencies:
-      next: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   nypm@0.6.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,12 @@ overrides:
   "posthog-js@1.414.0>dompurify": "^3.4.13"
   "read-yaml-file@1.1.0>js-yaml": "3.15.1"
 
+# Backports Next.js #96553 while npm latest remains stable 16.3.0.
+# Source maps are disabled for this patched module until that fix reaches stable.
+# Remove after a stable release contains commit 5f735c1ac56b93bc28cd3af86961c47c838fb077.
+patchedDependencies:
+  next@16.3.0: patches/next.patch
+
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true


### PR DESCRIPTION
## What changed

- backport the exact client segment-cache correction from Next.js PR #96553 to the installed stable `next@16.3.0`
- scope the pnpm patch to exactly `next@16.3.0` so the lockfile applies it to every workspace consumer
- remove stale source-map pointers from the two patched vendor modules instead of publishing incorrect mappings
- replace the mutable curriculum header ReactNode branch with named function components while preserving the established DOM and data reads

## Root cause

Next.js 16.3.0 can cache a fully prerendered optional catch-all result as a parameter-independent app shell. On the curriculum route, a client navigation from the track index to a grade could update the URL while retaining the index cards and sending no destination request.

This repository has the exact affected shape: Cache Components, Partial Prefetching, and `[curriculum]/[[...path]]`. The upstream fix is merged as commit `5f735c1ac56b93bc28cd3af86961c47c838fb077`, but npm latest is still stable 16.3.0. No canary dependency is installed or referenced.

## Runtime and cost

- instant navigation and Partial Prefetching remain enabled
- no `instant = false`, forced reload, `connection()`, route split, or eager grid prefetch was added
- descendant curriculum routes still avoid the track catalog query
- the rendered curriculum structure and copy are unchanged
- the patch is temporary and must be removed when a stable Next release contains the upstream commit
- stack frames inside the patched vendor module are intentionally unsourcemapped until removal because the original 16.3.0 maps describe code that no longer exists

## Verification

- frozen offline pnpm install passed and the patch hash matches the lockfile
- every workspace resolves only stable Next.js 16.3.0
- patched CJS and ESM syntax and functional cache-key assertions passed
- www 179 files and 1,100 tests passed with 100% coverage
- www, api, mcp, and design-system typechecks passed
- dependency security audit passed
- lint, formatting, diff check, and changed-scope React Doctor passed at 100/100
- full production build passed 5/5 tasks with WWW generating 1,303/1,303 pages
- in-app Browser and Chrome passed index to Kelas 10 to Matematika, Kelas 11, Kelas 12, and back/forward navigation with no stale sibling content
- Chrome reported zero console warnings and zero console errors
- changed tracked paths contain zero canary references and zero em dash characters

## Upstream

- https://github.com/vercel/next.js/pull/96553
- https://github.com/vercel/next.js/commit/5f735c1ac56b93bc28cd3af86961c47c838fb077
