### PR TITLE
feat(tryouts): add backend-first identity history contract

### DIFF
--- a/docs/adr/0003-tryout.md
+++ b/docs/adr/0003-tryout.md
@@ -60,13 +60,24 @@ correctness from the signed choice snapshot. The transaction validates attempt,
 section, placement, and response ownership before it updates the response and
 parent activity counters.
 
-Two explicitly temporary migration boundaries remain in this intermediate
-slice. The live web caller still reaches `attempts.saveResponse`, which ignores
-client timing and delegates to the canonical response transaction. Historical
-`textAnswer` response rows remain readable by integrity validation until dev and
-production data prove that field empty. Remove the adapter after the web cutover,
-then remove the field and integrity branch after the data proof. Neither boundary
-is a supported long-term compatibility API.
+Explicitly temporary migration boundaries remain during the web cutover. The
+live web caller still reaches `attempts.saveResponse` during the additive
+backend phase. The web cutover will save through `responses.save` directly,
+while `attempts.saveResponse` stays registered for already-open clients and
+rollback.
+The same temporary rule applies to `history.list`, `runtime.getSetState`,
+`runtime.getSectionState`, `retained.getAttemptSetRoute`,
+`retained.getAttemptSectionRoute`, and `attempt.isLockedByPublicPath`. The new
+web uses `history.bySet`, exact attempt-page reads, exact attempt-state reads,
+and exact attempt-ID locking instead.
+
+Deploy additive backend contracts first, then deploy the web cutover. Keep the
+old contracts through exact production acceptance, the rollback window, and
+the already-open client window. Remove them only after production traffic proves
+the new web no longer calls them. Historical `textAnswer` response rows remain
+readable by integrity validation until dev and production data prove that field
+empty. Remove that field and its integrity branch only after the data proof.
+None of these boundaries is a supported long-term compatibility API.
 
 Section completion, attempt completion, and expiry load bounded indexed
 placement and response graphs. They reject missing, duplicate, or mismatched
@@ -83,6 +94,11 @@ Restart actions and retained-route destinations resolve separately from the
 active signed catalog in the same Convex query transaction, so a catalog rename
 or entry revision cannot silently change the frozen review or send a new attempt
 to an obsolete route.
+
+After the cutover, the web bootstraps that exact attempt page, then subscribes only to
+`getSetAttemptState` or `getSectionAttemptState` while the attempt can still
+change. Frozen display stays separate from the active signed restart and
+navigation destinations. Terminal pages stop their mutable subscriptions.
 
 ### Freemium Access
 

--- a/packages/backend/convex/tryouts/attemptPage/spec.ts
+++ b/packages/backend/convex/tryouts/attemptPage/spec.ts
@@ -5,22 +5,17 @@ import {
   publicTryoutSetValidator,
   publicTryoutTrackValidator,
 } from "@repo/backend/convex/tryouts/queries/catalogModel";
-import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
+import {
+  tryoutRouteKeyValidator,
+  tryoutSetIdentityValidator,
+} from "@repo/backend/convex/tryouts/route";
 import { tryoutSectionContentAccessValidator } from "@repo/backend/convex/tryouts/runtime/content";
 import { tryoutRuntimeStateValidator } from "@repo/backend/convex/tryouts/runtime/spec";
 import { type Infer, v } from "convex/values";
 
-const setIdentityFields = {
-  countryKey: tryoutRouteKeyValidator,
-  examKey: tryoutRouteKeyValidator,
-  locale: localeValidator,
-  setKey: tryoutRouteKeyValidator,
-  trackKey: tryoutRouteKeyValidator,
-};
-
 const currentSetRequestValidator = v.object({
   kind: v.literal("current"),
-  ...setIdentityFields,
+  ...tryoutSetIdentityValidator.fields,
 });
 
 const retainedRequestFields = {
@@ -44,7 +39,7 @@ export type TryoutSetAttemptPageRequest = Infer<
 const currentSectionRequestValidator = v.object({
   kind: v.literal("current"),
   sectionKey: tryoutRouteKeyValidator,
-  ...setIdentityFields,
+  ...tryoutSetIdentityValidator.fields,
 });
 
 const retainedSectionRequestValidator = v.object(retainedRequestFields);

--- a/packages/backend/convex/tryouts/queries/attemptPage.test.ts
+++ b/packages/backend/convex/tryouts/queries/attemptPage.test.ts
@@ -91,6 +91,37 @@ describe("tryouts/queries/attemptPage", () => {
     });
     expect(active).not.toHaveProperty("setIdentity");
 
+    const historicalAnswerTime = TRYOUT_START_NOW + 1000;
+    await t.mutation(async (ctx) => {
+      const placement = await ctx.db
+        .query("tryoutAttemptPlacements")
+        .withIndex("by_tryoutAttemptId_and_questionOrder", (query) =>
+          query.eq("tryoutAttemptId", started.attemptId)
+        )
+        .unique();
+      const section = await ctx.db
+        .query("tryoutSectionAttempts")
+        .withIndex("by_tryoutAttemptId_and_sectionKey", (query) =>
+          query
+            .eq("tryoutAttemptId", started.attemptId)
+            .eq("sectionKey", TRYOUT_START_SECTION)
+        )
+        .unique();
+      if (!(placement && section)) {
+        throw new Error("Expected one historical response target.");
+      }
+      await ctx.db.insert("tryoutResponses", {
+        answeredAt: historicalAnswerTime,
+        isCorrect: false,
+        placementId: placement._id,
+        textAnswer: "historical answer",
+        timeSpent: 1000,
+        tryoutAttemptId: started.attemptId,
+        tryoutSectionAttemptId: section._id,
+        updatedAt: historicalAnswerTime,
+      });
+    });
+
     await authed.mutation(api.tryouts.mutations.sections.complete, {
       attemptId: started.attemptId,
       sectionKey: TRYOUT_START_SECTION,
@@ -129,6 +160,10 @@ describe("tryouts/queries/attemptPage", () => {
       throw new Error("Expected signed terminal set content.");
     }
     expect(terminal.content.answers).toHaveLength(1);
+    expect(terminal.initialState.runtime?.questions.at(0)?.response).toEqual({
+      answeredAt: historicalAnswerTime,
+      updatedAt: historicalAnswerTime,
+    });
   });
 
   it("rejects progress that disagrees with its latest attempt", async () => {

--- a/packages/backend/convex/tryouts/queries/history.test.ts
+++ b/packages/backend/convex/tryouts/queries/history.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@repo/backend/convex/test.helpers";
 import { TEST_RELEASE_ID } from "@repo/backend/test/content-release";
 import {
+  activateRenamedTryoutStartSource,
   activateTryoutStartSource,
   TRYOUT_START_COUNTRY,
   TRYOUT_START_EXAM,
@@ -77,7 +78,7 @@ async function insertHistoryAttempt(
 }
 
 describe("tryouts/queries/history", () => {
-  it("returns authenticated score snapshots newest first", async () => {
+  it("preserves path reads and keeps identity history after a rename", async () => {
     vi.setSystemTime(new Date(NOW));
 
     const t = createConvexTestWithBetterAuth();
@@ -89,7 +90,7 @@ describe("tryouts/queries/history", () => {
       const source = await activateTryoutStartSource(ctx, "visible");
       const firstAttemptId = await insertHistoryAttempt(ctx, {
         attemptNumber: 1,
-        publishedScore: 70,
+        publishedScore: 0,
         setIdentity: source.setIdentity,
         startedAt: NOW - 20_000,
         tryoutSnapshotId: source.snapshotId,
@@ -103,7 +104,6 @@ describe("tryouts/queries/history", () => {
         tryoutSnapshotId: source.snapshotId,
         userId: identity.userId,
       });
-
       return { firstAttemptId, identity, secondAttemptId };
     });
     const authed = t.withIdentity({
@@ -111,10 +111,37 @@ describe("tryouts/queries/history", () => {
       subject: seeded.identity.authUserId,
     });
 
-    const history = await authed.query(api.tryouts.queries.history.list, {
+    const pathHistory = await authed.query(api.tryouts.queries.history.list, {
       locale: "id",
       paginationOpts: { cursor: null, numItems: 25 },
       publicPath: SET_PATH,
+    });
+
+    expect(pathHistory.isDone).toBe(true);
+    expect(pathHistory.page).toEqual([
+      expect.objectContaining({
+        attemptId: seeded.secondAttemptId,
+        attemptNumber: 2,
+        score: expect.objectContaining({ publishedScore: 90 }),
+        status: "completed",
+      }),
+      expect.objectContaining({
+        attemptId: seeded.firstAttemptId,
+        attemptNumber: 1,
+        score: expect.objectContaining({ publishedScore: 0 }),
+        status: "completed",
+      }),
+    ]);
+
+    await t.mutation((ctx) => activateRenamedTryoutStartSource(ctx));
+
+    const history = await authed.query(api.tryouts.queries.history.bySet, {
+      countryKey: TRYOUT_START_COUNTRY,
+      examKey: TRYOUT_START_EXAM,
+      locale: "id",
+      paginationOpts: { cursor: null, numItems: 25 },
+      setKey: TRYOUT_START_SET,
+      trackKey: TRYOUT_START_TRACK,
     });
 
     expect(history.isDone).toBe(true);
@@ -128,13 +155,13 @@ describe("tryouts/queries/history", () => {
       expect.objectContaining({
         attemptId: seeded.firstAttemptId,
         attemptNumber: 1,
-        score: expect.objectContaining({ publishedScore: 70 }),
+        score: expect.objectContaining({ publishedScore: 0 }),
         status: "completed",
       }),
     ]);
   });
 
-  it("returns an empty page when the active set does not exist", async () => {
+  it("keeps empty legacy paths and immutable set identities isolated", async () => {
     const t = createConvexTestWithBetterAuth();
     const identity = await t.mutation(async (ctx) => {
       const user = await seedAuthenticatedUser(ctx, {
@@ -149,20 +176,28 @@ describe("tryouts/queries/history", () => {
       subject: identity.authUserId,
     });
 
-    const history = await authed.query(api.tryouts.queries.history.list, {
+    const pathHistory = await authed.query(api.tryouts.queries.history.list, {
       locale: "id",
       paginationOpts: { cursor: null, numItems: 25 },
-      publicPath: "try-out/indonesia/tka/matematika/missing",
+      publicPath: `${SET_PATH}-missing`,
     });
+    const identityHistory = await authed.query(
+      api.tryouts.queries.history.bySet,
+      {
+        countryKey: TRYOUT_START_COUNTRY,
+        examKey: TRYOUT_START_EXAM,
+        locale: "id",
+        paginationOpts: { cursor: null, numItems: 25 },
+        setKey: "missing",
+        trackKey: TRYOUT_START_TRACK,
+      }
+    );
 
-    expect(history).toEqual({
-      continueCursor: "",
-      isDone: true,
-      page: [],
-    });
+    expect(pathHistory).toMatchObject({ isDone: true, page: [] });
+    expect(identityHistory).toMatchObject({ isDone: true, page: [] });
   });
 
-  it("caps each requested page at twenty-five attempts", async () => {
+  it("limits legacy and identity page reads to twenty-five attempts", async () => {
     const t = createConvexTestWithBetterAuth();
     const seeded = await t.mutation(async (ctx) => {
       const identity = await seedAuthenticatedUser(ctx, {
@@ -189,14 +224,56 @@ describe("tryouts/queries/history", () => {
       subject: seeded.authUserId,
     });
 
-    const history = await authed.query(api.tryouts.queries.history.list, {
+    const pathHistory = await authed.query(api.tryouts.queries.history.list, {
       locale: "id",
       paginationOpts: { cursor: null, numItems: 100 },
       publicPath: SET_PATH,
     });
+    const identityHistory = await authed.query(
+      api.tryouts.queries.history.bySet,
+      {
+        countryKey: TRYOUT_START_COUNTRY,
+        examKey: TRYOUT_START_EXAM,
+        locale: "id",
+        paginationOpts: { cursor: null, numItems: 100 },
+        setKey: TRYOUT_START_SET,
+        trackKey: TRYOUT_START_TRACK,
+      }
+    );
 
-    expect(history.isDone).toBe(false);
-    expect(history.page).toHaveLength(25);
-    expect(history.page.at(0)?.attemptNumber).toBe(26);
+    for (const history of [pathHistory, identityHistory]) {
+      expect(history.isDone).toBe(false);
+      expect(history.page).toHaveLength(25);
+      expect(history.page.at(0)?.attemptNumber).toBe(26);
+    }
+  });
+
+  it("rejects malformed authored set identity keys", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "tryout-history-invalid",
+      })
+    );
+    const authed = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+
+    for (const setKey of ["Set-1", "set\0one", "s".repeat(129)]) {
+      await expect(
+        authed.query(api.tryouts.queries.history.bySet, {
+          countryKey: TRYOUT_START_COUNTRY,
+          examKey: TRYOUT_START_EXAM,
+          locale: "id",
+          paginationOpts: { cursor: null, numItems: 25 },
+          setKey,
+          trackKey: TRYOUT_START_TRACK,
+        })
+      ).rejects.toMatchObject({
+        data: { code: "TRYOUT_ROUTE_INVALID" },
+      });
+    }
   });
 });

--- a/packages/backend/convex/tryouts/queries/history.ts
+++ b/packages/backend/convex/tryouts/queries/history.ts
@@ -1,20 +1,31 @@
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { query } from "@repo/backend/convex/_generated/server";
+import type { TryoutSetIdentity } from "@repo/backend/convex/contentRelease/tryout/set";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { requireAuth } from "@repo/backend/convex/lib/helpers/auth";
 import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
+import {
+  decodeTryoutSetIdentity,
+  tryoutSetIdentityValidator,
+} from "@repo/backend/convex/tryouts/route";
 import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
-import { readAttemptHistoryPage } from "@repo/backend/convex/tryouts/runtime/lookup";
+import {
+  readAttemptHistoryPage,
+  readAttemptHistoryPageBySet,
+} from "@repo/backend/convex/tryouts/runtime/lookup";
 import { tryoutScoreResultValidator } from "@repo/backend/convex/tryouts/score";
 import { loadAttemptScoreResult } from "@repo/backend/convex/tryouts/score/result";
 import { tryoutStatusValidator } from "@repo/backend/convex/tryouts/status";
 import {
+  type PaginationOptions,
   paginationOptsValidator,
   paginationResultValidator,
 } from "convex/server";
 import { v } from "convex/values";
 import { Effect } from "effect";
 
-const MAX_HISTORY_PAGE_SIZE = 25;
+const MAX_HISTORY_ROWS_READ = 25;
 
 const historyRowValidator = v.object({
   attemptId: v.id("tryoutAttempts"),
@@ -25,7 +36,88 @@ const historyRowValidator = v.object({
   status: tryoutStatusValidator,
 });
 
-/** Returns the current user's bounded newest-first score history for one set. */
+type HistoryRequest =
+  | {
+      readonly kind: "path";
+      readonly path: {
+        readonly locale: TryoutSetIdentity["locale"];
+        readonly publicPath: string;
+      };
+    }
+  | {
+      readonly identity: TryoutSetIdentity;
+      readonly kind: "set";
+    };
+
+/** Selects the deployed path reader or the exact logical-identity reader. */
+const readHistoryAttempts = Effect.fn("tryouts.queries.history.readAttempts")(
+  function* (
+    ctx: QueryCtx,
+    request: HistoryRequest,
+    userId: Id<"users">,
+    pagination: PaginationOptions
+  ) {
+    if (request.kind === "path") {
+      return yield* readAttemptHistoryPage(
+        ctx,
+        request.path,
+        userId,
+        pagination
+      );
+    }
+
+    return yield* readAttemptHistoryPageBySet(
+      ctx,
+      request.identity,
+      userId,
+      pagination
+    );
+  }
+);
+
+/** Loads and projects one bounded history page for the current app user. */
+const readHistoryPage = Effect.fn("tryouts.queries.history.readPage")(
+  function* (
+    ctx: QueryCtx,
+    request: HistoryRequest,
+    paginationOpts: PaginationOptions
+  ) {
+    const { appUser } = yield* tryRuntimePromise(() => requireAuth(ctx));
+    const pagination = {
+      ...paginationOpts,
+      maximumRowsRead: Math.min(
+        paginationOpts.maximumRowsRead ?? MAX_HISTORY_ROWS_READ,
+        MAX_HISTORY_ROWS_READ
+      ),
+      numItems: Math.min(paginationOpts.numItems, MAX_HISTORY_ROWS_READ),
+    };
+    const history = yield* readHistoryAttempts(
+      ctx,
+      request,
+      appUser._id,
+      pagination
+    );
+    const page = yield* Effect.forEach(
+      history.page,
+      (attempt) =>
+        loadAttemptScoreResult(ctx, attempt).pipe(
+          Effect.map((score) => ({
+            attemptId: attempt._id,
+            attemptNumber: attempt.attemptNumber,
+            completedAt: attempt.completedAt,
+            score,
+            startedAt: attempt.startedAt,
+            status: attempt.status,
+          }))
+        ),
+      { concurrency: "unbounded" }
+    );
+
+    return { ...history, page };
+  }
+);
+
+/** Keeps the deployed public-path history contract for active browser tabs. */
 export const list = query({
   args: {
     locale: localeValidator,
@@ -35,32 +127,36 @@ export const list = query({
   returns: paginationResultValidator(historyRowValidator),
   handler: (ctx, args) =>
     runConvexProgram(
-      Effect.gen(function* () {
-        const { appUser } = yield* tryRuntimePromise(() => requireAuth(ctx));
-        const history = yield* readAttemptHistoryPage(ctx, args, appUser._id, {
-          ...args.paginationOpts,
-          numItems: Math.min(
-            args.paginationOpts.numItems,
-            MAX_HISTORY_PAGE_SIZE
-          ),
-        });
-        const page = yield* Effect.forEach(
-          history.page,
-          (attempt) =>
-            loadAttemptScoreResult(ctx, attempt).pipe(
-              Effect.map((score) => ({
-                attemptId: attempt._id,
-                attemptNumber: attempt.attemptNumber,
-                completedAt: attempt.completedAt,
-                score,
-                startedAt: attempt.startedAt,
-                status: attempt.status,
-              }))
-            ),
-          { concurrency: "unbounded" }
-        );
-
-        return { ...history, page };
-      })
+      readHistoryPage(
+        ctx,
+        {
+          kind: "path",
+          path: { locale: args.locale, publicPath: args.publicPath },
+        },
+        args.paginationOpts
+      )
     ),
+});
+
+/** Returns bounded score history through one immutable signed set identity. */
+export const bySet = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    ...tryoutSetIdentityValidator.fields,
+  },
+  returns: paginationResultValidator(historyRowValidator),
+  handler: (ctx, args) => {
+    const { paginationOpts, ...identity } = args;
+    return runConvexProgram(
+      decodeTryoutSetIdentity(identity).pipe(
+        Effect.flatMap((decodedIdentity) =>
+          readHistoryPage(
+            ctx,
+            { identity: decodedIdentity, kind: "set" },
+            paginationOpts
+          )
+        )
+      )
+    );
+  },
 });

--- a/packages/backend/convex/tryouts/route.ts
+++ b/packages/backend/convex/tryouts/route.ts
@@ -1,4 +1,51 @@
+import { ContentLocaleSchema } from "@nakafa/aksara-contracts/content";
+import { TryoutKeySchema } from "@nakafa/aksara-contracts/tryout/key";
+import type { ConvexTaggedError } from "@repo/backend/convex/lib/effect";
+import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
 import { v } from "convex/values";
+import { Effect, Schema } from "effect";
 
-/** Validates one source-owned route identity segment for a try-out. */
+/** Accepts one route key at the Convex transport boundary. */
 export const tryoutRouteKeyValidator = v.string();
+
+/** Accepts the fields that identify one localized try-out set. */
+export const tryoutSetIdentityValidator = v.object({
+  countryKey: tryoutRouteKeyValidator,
+  examKey: tryoutRouteKeyValidator,
+  locale: localeValidator,
+  setKey: tryoutRouteKeyValidator,
+  trackKey: tryoutRouteKeyValidator,
+});
+
+const TryoutSetIdentitySchema = Schema.Struct({
+  countryKey: TryoutKeySchema,
+  examKey: TryoutKeySchema,
+  locale: ContentLocaleSchema,
+  setKey: TryoutKeySchema,
+  trackKey: TryoutKeySchema,
+});
+
+/** Expected failure while decoding one authored try-out route identity. */
+export class TryoutRouteError
+  extends Schema.TaggedError<TryoutRouteError>()("TryoutRouteError", {
+    cause: Schema.optional(Schema.Unknown),
+    code: Schema.Literal("TRYOUT_ROUTE_INVALID"),
+    message: Schema.String,
+  })
+  implements ConvexTaggedError {}
+
+/** Decodes transport strings through the canonical Aksara key contracts. */
+export const decodeTryoutSetIdentity = Effect.fn(
+  "tryouts.route.decodeSetIdentity"
+)(function* (input: unknown) {
+  return yield* Schema.decodeUnknown(TryoutSetIdentitySchema)(input).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TryoutRouteError({
+          cause,
+          code: "TRYOUT_ROUTE_INVALID",
+          message: "Try-out route identity is invalid.",
+        })
+    )
+  );
+});

--- a/packages/backend/convex/tryouts/runtime/lookup.ts
+++ b/packages/backend/convex/tryouts/runtime/lookup.ts
@@ -231,3 +231,24 @@ export const readAttemptHistoryPage = Effect.fn(
       .paginate(pagination)
   );
 });
+
+/** Reads one bounded attempt history page through immutable set keys. */
+export const readAttemptHistoryPageBySet = Effect.fn(
+  "tryouts.runtime.readAttemptHistoryPageBySet"
+)(function* (
+  ctx: QueryCtx,
+  identity: TryoutSetIdentity,
+  userId: UserId,
+  pagination: PaginationOptions
+) {
+  const setIdentity = tryoutCatalogIdentity({ ...identity, kind: "set" });
+  return yield* tryRuntimePromise(() =>
+    ctx.db
+      .query("tryoutAttempts")
+      .withIndex("by_userId_and_setIdentity_and_startedAt", (index) =>
+        index.eq("userId", userId).eq("setIdentity", setIdentity)
+      )
+      .order("desc")
+      .paginate(pagination)
+  );
+});

--- a/packages/backend/convex/tryouts/runtime/section/questions.ts
+++ b/packages/backend/convex/tryouts/runtime/section/questions.ts
@@ -143,7 +143,9 @@ function projectRuntimeQuestions(
       response: response
         ? {
             answeredAt: response.answeredAt,
-            selectedOptionId: response.selectedOptionId,
+            ...(response.selectedOptionId === undefined
+              ? {}
+              : { selectedOptionId: response.selectedOptionId }),
             updatedAt: response.updatedAt,
           }
         : null,


### PR DESCRIPTION
## Summary

- keep the deployed `history.list` public-path contract for already-open tabs and rollback
- add validated `history.bySet` reads through immutable signed set identity
- reuse the existing compound attempt index and cap both requested items and rows read at 25
- preserve historical `textAnswer` response rows at the attempt-page projection boundary
- document backend-first expansion, the web cutover sequence, and temporary compatibility removal gates

## Architecture and cost

`history.bySet` decodes transport fields through the canonical Aksara key and locale schemas before querying. It reads only the authenticated user's matching set attempts through `by_userId_and_setIdentity_and_startedAt`, ordered newest first with native Convex pagination. No table scan, schema change, generated API change, or new index is required.

The existing generated API declaration already imports the complete `tryouts/queries/history` module. Backend TypeScript 7 typecheck proves the additive export is visible without codegen.

## Rollout

This is the additive backend expansion only. Deploy these contracts before the separate web cutover, retain legacy functions through production acceptance and the already-open-client window, then remove them only after traffic proves they are unused.

No Convex deployment, production mutation, seed, sync, or migration was run from this branch.

## Verification

- `pnpm --filter @repo/backend exec vitest run convex/tryouts/queries/attemptPage.test.ts convex/tryouts/queries/history.test.ts`: 2 files, 8 tests passed
- `pnpm --filter @repo/backend test`: 356 files, 1,536 tests passed
- `pnpm --filter @repo/backend typecheck`: passed with native TypeScript 7
- `pnpm check:tests`: passed
- `pnpm boundaries`: 2,976 files across 19 packages, no issues
- `pnpm lint`: passed, including Effect source 3.22.1 match and Ultracite
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`: passed, no changed `apps/www` source
- `git diff --check`: passed
- no em dash in changed files
- touched source and test modules are at or below 500 LOC
