### PR TITLE
refactor(apps): use named function components

### DIFF
--- a/apps/www/components/ai/chat-error.tsx
+++ b/apps/www/components/ai/chat-error.tsx
@@ -28,28 +28,30 @@ interface AiChatErrorSurfaceProps {
   message: string;
 }
 
-const AiChatErrorSurface = ({ children, message }: AiChatErrorSurfaceProps) => (
-  <Empty className="rounded-xl border bg-card text-card-foreground">
-    <EmptyHeader>
-      <EmptyMedia className="bg-destructive/5" variant="icon">
-        <HugeIcons className="text-destructive" icon={Alert02Icon} />
-      </EmptyMedia>
-      <EmptyDescription>{message}</EmptyDescription>
-    </EmptyHeader>
-    {children}
-  </Empty>
-);
+function AiChatErrorSurface({ children, message }: AiChatErrorSurfaceProps) {
+  return (
+    <Empty className="rounded-xl border bg-card text-card-foreground">
+      <EmptyHeader>
+        <EmptyMedia className="bg-destructive/5" variant="icon">
+          <HugeIcons className="text-destructive" icon={Alert02Icon} />
+        </EmptyMedia>
+        <EmptyDescription>{message}</EmptyDescription>
+      </EmptyHeader>
+      {children}
+    </Empty>
+  );
+}
 AiChatErrorSurface.displayName = "AiChatErrorSurface";
 
 /** Shows a persisted assistant generation failure after chat refresh. */
-export const AiChatPersistedError = () => {
+export function AiChatPersistedError() {
   const t = useTranslations("Ai");
 
   return <AiChatErrorSurface message={t("error-message")} />;
-};
+}
 AiChatPersistedError.displayName = "AiChatPersistedError";
 
-export const AiChatError = () => {
+export function AiChatError() {
   const t = useTranslations("Ai");
 
   const error = useChat((state) => state.chat.error);
@@ -72,10 +74,10 @@ export const AiChatError = () => {
       {isInsufficientCredits ? <ButtonCheckout /> : <ButtonRegenerate />}
     </AiChatErrorSurface>
   );
-};
+}
 AiChatError.displayName = "AiChatError";
 
-const ButtonCheckout = () => {
+function ButtonCheckout() {
   const locale = useLocale();
   const t = useTranslations("Auth");
 
@@ -133,10 +135,10 @@ const ButtonCheckout = () => {
       </Activity>
     </div>
   );
-};
+}
 ButtonCheckout.displayName = "ButtonCheckout";
 
-const ButtonRegenerate = () => {
+function ButtonRegenerate() {
   const t = useTranslations("Ai");
 
   const regenerate = useChat((state) => state.chat.regenerate);
@@ -146,5 +148,5 @@ const ButtonRegenerate = () => {
       {t("retry")}
     </Button>
   );
-};
+}
 ButtonRegenerate.displayName = "ButtonRegenerate";

--- a/apps/www/components/ai/chat-message.tsx
+++ b/apps/www/components/ai/chat-message.tsx
@@ -18,22 +18,24 @@ interface Props {
   message: MyUIMessage;
 }
 
-export const AiChatMessage = ({ message }: Props) => (
-  <MessageProvider message={message}>
-    <div className="flex size-full flex-col gap-3 group-[.is-user]:items-end group-[.is-user]:justify-end">
-      <AiChatMessageBody />
-      <div className="flex items-center justify-between gap-4">
-        <AiChatMessageActions />
-        <AiChatMessageCredits />
+export function AiChatMessage({ message }: Props) {
+  return (
+    <MessageProvider message={message}>
+      <div className="flex size-full flex-col gap-3 group-[.is-user]:items-end group-[.is-user]:justify-end">
+        <AiChatMessageBody />
+        <div className="flex items-center justify-between gap-4">
+          <AiChatMessageActions />
+          <AiChatMessageCredits />
+        </div>
+        <AiChatMessageSuggestions />
       </div>
-      <AiChatMessageSuggestions />
-    </div>
-  </MessageProvider>
-);
+    </MessageProvider>
+  );
+}
 
 AiChatMessage.displayName = "AiChatMessage";
 
-const AiChatMessageBody = () => {
+function AiChatMessageBody() {
   const isFailedAssistantResponse = useMessage(
     (state) =>
       state.message.role === "assistant" &&
@@ -45,5 +47,5 @@ const AiChatMessageBody = () => {
   }
 
   return <AiChatMessageContent />;
-};
+}
 AiChatMessageBody.displayName = "AiChatMessageBody";

--- a/apps/www/components/ai/chat-pending.tsx
+++ b/apps/www/components/ai/chat-pending.tsx
@@ -5,7 +5,7 @@ import { TypingLoader } from "@repo/design-system/components/ui/typing-loader";
 
 import { useChat } from "@/components/ai/context/use-chat";
 
-export const AiChatPending = () => {
+export function AiChatPending() {
   const status = useChat((state) => state.chat.status);
   const messages = useChat((state) => state.chat.messages);
 
@@ -28,5 +28,5 @@ export const AiChatPending = () => {
       </div>
     </Message>
   );
-};
+}
 AiChatPending.displayName = "AiChatPending";

--- a/apps/www/components/ai/chat.tsx
+++ b/apps/www/components/ai/chat.tsx
@@ -21,12 +21,12 @@ import { AiChatError } from "@/components/ai/chat-error";
 import { AiChatHeader } from "@/components/ai/chat-header";
 import { AiChatMessage } from "@/components/ai/chat-message";
 import { AiChatModel } from "@/components/ai/chat-model";
-import { AiChatPaginationTrigger } from "@/components/ai/chat-pagination-trigger";
 import { AiChatPending } from "@/components/ai/chat-pending";
 import { ChatSpacing } from "@/components/ai/chat-spacing";
 import { useAi } from "@/components/ai/context/use-ai";
 import { useChat } from "@/components/ai/context/use-chat";
 import { useCurrentChat } from "@/components/ai/context/use-current-chat";
+import { AiChatPaginationTrigger } from "@/components/ai/pagination-trigger";
 import { useUser } from "@/lib/context/use-user";
 
 export function AiChat() {
@@ -41,7 +41,7 @@ export function AiChat() {
   );
 }
 
-const AiChatConversation = () => {
+function AiChatConversation() {
   const messages = useChat((state) => state.chat.messages);
 
   return (
@@ -66,10 +66,10 @@ const AiChatConversation = () => {
       <ConversationScrollButton />
     </Conversation>
   );
-};
+}
 AiChatConversation.displayName = "AiChatConversation";
 
-const AiChatToolbar = () => {
+function AiChatToolbar() {
   const t = useTranslations("Ai");
 
   const router = useRouter();
@@ -141,5 +141,5 @@ const AiChatToolbar = () => {
       </PromptInput>
     </div>
   );
-};
+}
 AiChatToolbar.displayName = "AIChatToolbar";

--- a/apps/www/components/ai/message-actions.tsx
+++ b/apps/www/components/ai/message-actions.tsx
@@ -16,7 +16,7 @@ import { useCurrentChat } from "@/components/ai/context/use-current-chat";
 import { useMessage } from "@/components/ai/context/use-message";
 import { useUser } from "@/lib/context/use-user";
 
-export const AiChatMessageActions = () => {
+export function AiChatMessageActions() {
   const t = useTranslations("Ai");
 
   const messageId = useMessage((state) => state.message.id);
@@ -71,5 +71,5 @@ export const AiChatMessageActions = () => {
       ) : null}
     </Actions>
   );
-};
+}
 AiChatMessageActions.displayName = "AiChatMessageActions";

--- a/apps/www/components/ai/message-credits.tsx
+++ b/apps/www/components/ai/message-credits.tsx
@@ -20,7 +20,7 @@ import { useState } from "react";
 import { useMessage } from "@/components/ai/context/use-message";
 import { getAiModel } from "@/lib/data/models";
 
-export const AiChatMessageCredits = () => {
+export function AiChatMessageCredits() {
   const t = useTranslations("Ai");
 
   const credits = useMessage((state) => state.message.metadata?.credits);
@@ -130,5 +130,5 @@ export const AiChatMessageCredits = () => {
       </PopoverContent>
     </Popover>
   );
-};
+}
 AiChatMessageCredits.displayName = "AiChatMessageCredits";

--- a/apps/www/components/ai/message-loading.tsx
+++ b/apps/www/components/ai/message-loading.tsx
@@ -5,7 +5,7 @@ import { TypingLoader } from "@repo/design-system/components/ui/typing-loader";
 import { useChat } from "@/components/ai/context/use-chat";
 import { useMessage } from "@/components/ai/context/use-message";
 
-export const AiChatMessageLoading = () => {
+export function AiChatMessageLoading() {
   const status = useChat((state) => state.chat.status);
   const messages = useChat((state) => state.chat.messages);
   const currentMessage = useMessage((state) => state.message);
@@ -38,5 +38,5 @@ export const AiChatMessageLoading = () => {
   }
 
   return null;
-};
+}
 AiChatMessageLoading.displayName = "AiChatMessageLoading";

--- a/apps/www/components/ai/message-part/index.tsx
+++ b/apps/www/components/ai/message-part/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 /** Renders one typed Nina response part with its production presentation. */
-export const AiMessagePart = ({ part, partIndex }: Props) => {
+export function AiMessagePart({ part, partIndex }: Props) {
   const messageId = useMessage((state) => state.message.id);
 
   switch (part.type) {
@@ -63,5 +63,5 @@ export const AiMessagePart = ({ part, partIndex }: Props) => {
     default:
       return null;
   }
-};
+}
 AiMessagePart.displayName = "AiMessagePart";

--- a/apps/www/components/ai/message-part/math.tsx
+++ b/apps/www/components/ai/message-part/math.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 /** Renders one deterministic math evidence part in the chat transcript. */
-export const MathPart = ({ message }: Props) => {
+export function MathPart({ message }: Props) {
   const t = useTranslations("Ai");
   const [expanded, { set }] = useDisclosure(false);
 
@@ -52,5 +52,5 @@ export const MathPart = ({ message }: Props) => {
       </CollapsibleContent>
     </Collapsible>
   );
-};
+}
 MathPart.displayName = "MathPart";

--- a/apps/www/components/ai/message-part/nakafa.tsx
+++ b/apps/www/components/ai/message-part/nakafa.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 /** Renders one persisted Nakafa data envelope through its kind-specific UI. */
-export const NakafaPart = ({ message }: Props) => {
+export function NakafaPart({ message }: Props) {
   const t = useTranslations("Ai");
 
   if (message.kind === "taxonomy") {
@@ -56,7 +56,7 @@ export const NakafaPart = ({ message }: Props) => {
     default:
       return null;
   }
-};
+}
 NakafaPart.displayName = "NakafaPart";
 
 /** Returns a localized label for one Nakafa data kind. */

--- a/apps/www/components/ai/message-part/nakafa/content.tsx
+++ b/apps/www/components/ai/message-part/nakafa/content.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 /** Renders a bounded preview for one retrieved Nakafa content page. */
-export const ContentPart = ({ message }: Props) => {
+export function ContentPart({ message }: Props) {
   const t = useTranslations("Ai");
   const [open, setOpen] = useState(true);
 
@@ -56,5 +56,5 @@ export const ContentPart = ({ message }: Props) => {
       </CollapsibleContent>
     </Collapsible>
   );
-};
+}
 ContentPart.displayName = "ContentPart";

--- a/apps/www/components/ai/message-part/nakafa/quran.tsx
+++ b/apps/www/components/ai/message-part/nakafa/quran.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 /** Renders a compact Quran reference preview. */
-export const QuranPart = ({ message }: Props) => {
+export function QuranPart({ message }: Props) {
   const t = useTranslations("Ai");
 
   return (
@@ -53,5 +53,5 @@ export const QuranPart = ({ message }: Props) => {
       />
     </div>
   );
-};
+}
 QuranPart.displayName = "QuranPart";

--- a/apps/www/components/ai/message-part/nakafa/search.tsx
+++ b/apps/www/components/ai/message-part/nakafa/search.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 /** Renders Nakafa search results with a bounded default list. */
-export const SearchPart = ({ message }: Props) => {
+export function SearchPart({ message }: Props) {
   const t = useTranslations("Ai");
   const [expanded, { toggle }] = useDisclosure(false);
   const items = expanded
@@ -77,10 +77,10 @@ export const SearchPart = ({ message }: Props) => {
       )}
     </div>
   );
-};
+}
 SearchPart.displayName = "SearchPart";
 
-const SearchPartQueries = ({ message }: Props) => {
+function SearchPartQueries({ message }: Props) {
   const queries = Array.from(
     new Set(
       (message.input.queries ?? []).flatMap((query) => {
@@ -106,7 +106,7 @@ const SearchPartQueries = ({ message }: Props) => {
       ))}
     </div>
   );
-};
+}
 SearchPartQueries.displayName = "SearchPartQueries";
 
 function SearchQueryText({ query }: { query: string }) {

--- a/apps/www/components/ai/message-part/scrape-url.tsx
+++ b/apps/www/components/ai/message-part/scrape-url.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 /** Renders one inspected source URL used by the research agent. */
-export const ScrapeUrlPart = ({ message }: Props) => {
+export function ScrapeUrlPart({ message }: Props) {
   const t = useTranslations("Ai");
 
   if (message.status === "loading") {
@@ -53,19 +53,21 @@ export const ScrapeUrlPart = ({ message }: Props) => {
       <ScrapeUrlSource message={message} />
     </div>
   );
-};
+}
 ScrapeUrlPart.displayName = "ScrapeUrlPart";
 
-const ScrapeUrlSource = ({ message }: Props) => (
-  <Source href={message.url}>
-    <SourceTrigger faviconUrl={message.favicon} showFavicon />
-    <SourceContent
-      description={message.description}
-      faviconUrl={message.favicon}
-      title={getSourceTitle(message)}
-    />
-  </Source>
-);
+function ScrapeUrlSource({ message }: Props) {
+  return (
+    <Source href={message.url}>
+      <SourceTrigger faviconUrl={message.favicon} showFavicon />
+      <SourceContent
+        description={message.description}
+        faviconUrl={message.favicon}
+        title={getSourceTitle(message)}
+      />
+    </Source>
+  );
+}
 ScrapeUrlSource.displayName = "ScrapeUrlSource";
 
 /** Returns a compact source title for hover content. */

--- a/apps/www/components/ai/message-part/suggestions.tsx
+++ b/apps/www/components/ai/message-part/suggestions.tsx
@@ -11,7 +11,7 @@ interface Props {
   message: DataPart["suggestions"];
 }
 
-export const SuggestionsPart = ({ message }: Props) => {
+export function SuggestionsPart({ message }: Props) {
   const t = useTranslations("Ai");
   const suggestions = message.data;
 
@@ -28,14 +28,14 @@ export const SuggestionsPart = ({ message }: Props) => {
       </div>
     </div>
   );
-};
+}
 SuggestionsPart.displayName = "SuggestionsPart";
 
-const SuggestionsPartButton = ({
+function SuggestionsPartButton({
   suggestion,
 }: {
   suggestion: DataPart["suggestions"]["data"][number];
-}) => {
+}) {
   const { sendMessage, status } = useChat((state) => state.chat);
 
   const disabled = status === "submitted" || status === "streaming";
@@ -51,8 +51,10 @@ const SuggestionsPartButton = ({
       <HugeIcons className="size-4 text-primary" icon={Add01Icon} />
     </button>
   );
-};
+}
 SuggestionsPartButton.displayName = "SuggestionsPartButton";
 
-const SuggestionsPartContent = ({ content }: { content: string }) => content;
+function SuggestionsPartContent({ content }: { content: string }) {
+  return content;
+}
 SuggestionsPartContent.displayName = "SuggestionsPartContent";

--- a/apps/www/components/ai/message-part/web-search.tsx
+++ b/apps/www/components/ai/message-part/web-search.tsx
@@ -16,7 +16,7 @@ interface Props {
   message: DataPart["web-search"];
 }
 
-export const WebSearchPart = ({ message }: Props) => {
+export function WebSearchPart({ message }: Props) {
   const t = useTranslations("Ai");
 
   const isLoading = message.status === "loading";
@@ -69,10 +69,10 @@ export const WebSearchPart = ({ message }: Props) => {
       />
     </div>
   );
-};
+}
 WebSearchPart.displayName = "WebSearchPart";
 
-const WebSearchPartQueries = ({ queries }: { queries: string[] }) => {
+function WebSearchPartQueries({ queries }: { queries: string[] }) {
   if (queries.length === 0) {
     return null;
   }
@@ -84,20 +84,20 @@ const WebSearchPartQueries = ({ queries }: { queries: string[] }) => {
       ))}
     </div>
   );
-};
+}
 WebSearchPartQueries.displayName = "WebSearchPartQueries";
 
 function WebSearchQueryText({ query }: { query: string }) {
   return <p className="text-muted-foreground text-sm">{`"${query}"`}</p>;
 }
 
-const WebSearchPartPreview = ({
+function WebSearchPartPreview({
   emptyLabel,
   results,
 }: {
   emptyLabel: string;
   results: DataPart["web-search"]["sources"];
-}) => {
+}) {
   if (results.length === 0) {
     return <p className="text-muted-foreground text-sm">{emptyLabel}</p>;
   }
@@ -112,5 +112,5 @@ const WebSearchPartPreview = ({
       ))}
     </div>
   );
-};
+}
 WebSearchPartPreview.displayName = "WebSearchPartPreview";

--- a/apps/www/components/ai/message-parts.tsx
+++ b/apps/www/components/ai/message-parts.tsx
@@ -7,7 +7,7 @@ import { AiMessagePart } from "@/components/ai/message-part";
 import { SuggestionsPart } from "@/components/ai/message-part/suggestions";
 import { useUser } from "@/lib/context/use-user";
 
-export const AiChatMessageContent = () => {
+export function AiChatMessageContent() {
   const parts = useMessage((state) =>
     state.message.parts.filter(
       (p) => p.type !== "step-start" && p.type !== "data-suggestions"
@@ -27,10 +27,10 @@ export const AiChatMessageContent = () => {
       <AiChatMessageLoading />
     </div>
   );
-};
+}
 AiChatMessageContent.displayName = "AiChatMessageContent";
 
-export const AiChatMessageSuggestions = () => {
+export function AiChatMessageSuggestions() {
   const chat = useCurrentChat((s) => s.chat);
 
   const currentUser = useUser((s) => s.user);
@@ -45,5 +45,5 @@ export const AiChatMessageSuggestions = () => {
   }
 
   return <SuggestionsPart message={suggestions} />;
-};
+}
 AiChatMessageSuggestions.displayName = "AiChatMessageSuggestions";

--- a/apps/www/components/ai/pagination-trigger.tsx
+++ b/apps/www/components/ai/pagination-trigger.tsx
@@ -5,7 +5,7 @@ import { Intersection } from "@repo/design-system/components/ui/intersection";
 
 import { useCurrentChat } from "@/components/ai/context/use-current-chat";
 
-export const AiChatPaginationTrigger = () => {
+export function AiChatPaginationTrigger() {
   const status = useCurrentChat((state) => state.messageStatus);
   const loadMoreMessages = useCurrentChat((state) => state.loadMoreMessages);
 
@@ -18,6 +18,6 @@ export const AiChatPaginationTrigger = () => {
       onIntersect={() => loadMoreMessages(CHAT_MESSAGES_PAGE_SIZE)}
     />
   );
-};
+}
 
 AiChatPaginationTrigger.displayName = "AiChatPaginationTrigger";

--- a/apps/www/components/ai/sheet-history.tsx
+++ b/apps/www/components/ai/sheet-history.tsx
@@ -26,7 +26,7 @@ import { useAi } from "@/components/ai/context/use-ai";
 import { useUser } from "@/lib/context/use-user";
 
 /** Opens the recent Nina chat list when a user is signed in. */
-export const SheetHistory = () => {
+export function SheetHistory() {
   const { isPending, user } = useUser((state) => ({
     isPending: state.isPending,
     user: state.user,
@@ -51,10 +51,10 @@ export const SheetHistory = () => {
       </Authenticated>
     </DropdownMenu>
   );
-};
+}
 
 /** Renders recent Nina chats in the header menu. */
-const SheetHistoryContent = () => {
+function SheetHistoryContent() {
   const t = useTranslations("Ai");
   const activeChatId = useAi((state) => state.activeChatId);
   const setActiveChatId = useAi((state) => state.setActiveChatId);
@@ -99,4 +99,4 @@ const SheetHistoryContent = () => {
       </DropdownMenuGroup>
     </DropdownMenuContent>
   );
-};
+}

--- a/apps/www/components/ai/sheet-input.tsx
+++ b/apps/www/components/ai/sheet-input.tsx
@@ -30,12 +30,7 @@ interface Props {
 }
 
 /** Renders Nina prompt input and the empty-chat suggestion stack. */
-export const SheetInput = ({
-  disabled,
-  isPending,
-  onSubmit,
-  status,
-}: Props) => {
+export function SheetInput({ disabled, isPending, onSubmit, status }: Props) {
   const t = useTranslations("Ai");
 
   const activeChatId = useAi((state) => state.activeChatId);
@@ -116,4 +111,4 @@ export const SheetInput = ({
       </PromptInput>
     </div>
   );
-};
+}

--- a/apps/www/components/ai/sheet-main.tsx
+++ b/apps/www/components/ai/sheet-main.tsx
@@ -14,12 +14,12 @@ import {
 
 import { AiChatError } from "@/components/ai/chat-error";
 import { AiChatMessage } from "@/components/ai/chat-message";
-import { AiChatPaginationTrigger } from "@/components/ai/chat-pagination-trigger";
 import { AiChatPending } from "@/components/ai/chat-pending";
 import { ChatSpacing } from "@/components/ai/chat-spacing";
 import { useAi } from "@/components/ai/context/use-ai";
 import { ChatProvider, useChat } from "@/components/ai/context/use-chat";
 import { useCurrentChat } from "@/components/ai/context/use-current-chat";
+import { AiChatPaginationTrigger } from "@/components/ai/pagination-trigger";
 import { SheetInput } from "@/components/ai/sheet-input";
 import { useUser } from "@/lib/context/use-user";
 
@@ -29,7 +29,7 @@ function ignorePlaceholderSubmit() {
 }
 
 /** Connects the selected chat document to the sheet chat UI. */
-export const SheetMain = () => {
+export function SheetMain() {
   const chat = useCurrentChat((state) => state.chat);
   const messages = useCurrentChat((state) => state.messages);
 
@@ -42,29 +42,31 @@ export const SheetMain = () => {
       <SheetConversation />
     </ChatProvider>
   );
-};
+}
 
 /** Keeps the sheet stable while the active chat loads. */
-const SheetMainPlaceholder = () => (
-  <div className="relative flex size-full flex-col overflow-hidden">
-    <Conversation>
-      <ConversationContent>
-        <div />
-      </ConversationContent>
-      <ConversationScrollButton />
-    </Conversation>
+function SheetMainPlaceholder() {
+  return (
+    <div className="relative flex size-full flex-col overflow-hidden">
+      <Conversation>
+        <ConversationContent>
+          <div />
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
 
-    <SheetInput
-      disabled={true}
-      isPending={true}
-      key="ai-sheet-input"
-      onSubmit={ignorePlaceholderSubmit}
-    />
-  </div>
-);
+      <SheetInput
+        disabled={true}
+        isPending={true}
+        key="ai-sheet-input"
+        onSubmit={ignorePlaceholderSubmit}
+      />
+    </div>
+  );
+}
 
 /** Renders messages and the active chat input inside Nina sheet. */
-const SheetConversation = () => {
+function SheetConversation() {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -135,4 +137,4 @@ const SheetConversation = () => {
       />
     </div>
   );
-};
+}

--- a/apps/www/components/ai/sheet-new.tsx
+++ b/apps/www/components/ai/sheet-new.tsx
@@ -26,7 +26,7 @@ import { SheetInput } from "@/components/ai/sheet-input";
 import { useUser } from "@/lib/context/use-user";
 
 /** Renders Nina's empty state and starts a new study chat. */
-export const SheetNew = () => {
+export function SheetNew() {
   const t = useTranslations("Ai");
 
   const router = useRouter();
@@ -113,4 +113,4 @@ export const SheetNew = () => {
       />
     </div>
   );
-};
+}

--- a/apps/www/components/ai/sheet.tsx
+++ b/apps/www/components/ai/sheet.tsx
@@ -99,4 +99,6 @@ export function AiSheet() {
 }
 
 /** Keeps private-chat errors visually empty while the sheet resets. */
-const SheetError = () => null;
+function SheetError() {
+  return null;
+}

--- a/apps/www/components/marketing/shared/header-cta.tsx
+++ b/apps/www/components/marketing/shared/header-cta.tsx
@@ -7,14 +7,9 @@ import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { useUser } from "@/lib/context/use-user";
 
-/**
- * Routes authenticated users home and clears stale marketing fragments for
- * signed-out visitors.
- */
-export function LogoCta() {
-  const currentUser = useUser((state) => state.user);
-  const locale = useLocale();
-  const content = (
+/** Renders the shared Nakafa mark used by both logo destinations. */
+function LogoContent() {
+  return (
     <>
       <Image
         alt="Nakafa"
@@ -26,18 +21,27 @@ export function LogoCta() {
       <span className="font-medium">Nakafa</span>
     </>
   );
+}
+
+/**
+ * Routes authenticated users home and clears stale marketing fragments for
+ * signed-out visitors.
+ */
+export function LogoCta() {
+  const currentUser = useUser((state) => state.user);
+  const locale = useLocale();
 
   if (!currentUser) {
     return (
       <a className="flex items-center gap-2" href={`/${locale}`}>
-        {content}
+        <LogoContent />
       </a>
     );
   }
 
   return (
     <Link className="flex items-center gap-2" href="/home">
-      {content}
+      <LogoContent />
     </Link>
   );
 }

--- a/packages/email/templates/welcome.tsx
+++ b/packages/email/templates/welcome.tsx
@@ -28,165 +28,168 @@ interface WelcomeProps {
 
 const COPYRIGHT_YEAR = new Date().getFullYear();
 
-export const Welcome = ({ name }: WelcomeProps) => (
-  <Html>
-    <Head />
-    <Tailwind>
-      <Body className="bg-background font-sans text-foreground antialiased">
-        <Preview>Welcome to Nakafa - Your journey begins here</Preview>
-        <Container className="mx-auto my-8 max-w-md p-5">
-          <Section className="mt-6">
-            <Img
-              alt="Nakafa"
-              className="mx-auto"
-              height="64"
-              src="https://nakafa.com/logo.png"
-              width="64"
-            />
-          </Section>
+export function Welcome({ name }: WelcomeProps) {
+  return (
+    <Html>
+      <Head />
+      <Tailwind>
+        <Body className="bg-background font-sans text-foreground antialiased">
+          <Preview>Welcome to Nakafa - Your journey begins here</Preview>
+          <Container className="mx-auto my-8 max-w-md p-5">
+            <Section className="mt-6">
+              <Img
+                alt="Nakafa"
+                className="mx-auto"
+                height="64"
+                src="https://nakafa.com/logo.png"
+                width="64"
+              />
+            </Section>
 
-          <Section className="mt-6 text-center">
-            <Text className="m-0 font-semibold text-2xl text-foreground tracking-tight">
-              You're in! Welcome to Nakafa 🚀
-            </Text>
-            <Text className="mt-2 text-muted-foreground text-sm">
-              Let's make learning something you actually enjoy.
-            </Text>
-          </Section>
+            <Section className="mt-6 text-center">
+              <Text className="m-0 font-semibold text-2xl text-foreground tracking-tight">
+                You're in! Welcome to Nakafa 🚀
+              </Text>
+              <Text className="mt-2 text-muted-foreground text-sm">
+                Let's make learning something you actually enjoy.
+              </Text>
+            </Section>
 
-          <Section className="mt-6">
-            <Text className="text-base text-foreground leading-6">
-              Hi {name},
-            </Text>
-            <Text className="mt-4 text-base text-foreground leading-6">
-              So glad you're here. We built Nakafa because we believe
-              high-quality education should be accessible (and fun) for
-              everyone.
-            </Text>
-            <Text className="mt-4 text-base text-foreground leading-6">
-              Whether you're prepping for exams or just curious about how the
-              world works, you've got this.
-            </Text>
-          </Section>
+            <Section className="mt-6">
+              <Text className="text-base text-foreground leading-6">
+                Hi {name},
+              </Text>
+              <Text className="mt-4 text-base text-foreground leading-6">
+                So glad you're here. We built Nakafa because we believe
+                high-quality education should be accessible (and fun) for
+                everyone.
+              </Text>
+              <Text className="mt-4 text-base text-foreground leading-6">
+                Whether you're prepping for exams or just curious about how the
+                world works, you've got this.
+              </Text>
+            </Section>
 
-          <Card
-            className="mt-6 w-full border-border bg-muted/30"
-            style={{ width: "100%" }}
-          >
-            <CardHeader
-              className="w-full border-border/50"
+            <Card
+              className="mt-6 w-full border-border bg-muted/30"
               style={{ width: "100%" }}
             >
-              <CardTitle className="text-lg">Where to start?</CardTitle>
-            </CardHeader>
-            <CardContent className="w-full" style={{ width: "100%" }}>
-              <Section>
-                <Row className="mb-4">
-                  <Column className="w-8 pr-3 align-top">
-                    <WrapperIcon>
-                      <Text className="m-0 text-center text-lg leading-8">
-                        📚
+              <CardHeader
+                className="w-full border-border/50"
+                style={{ width: "100%" }}
+              >
+                <CardTitle className="text-lg">Where to start?</CardTitle>
+              </CardHeader>
+              <CardContent className="w-full" style={{ width: "100%" }}>
+                <Section>
+                  <Row className="mb-4">
+                    <Column className="w-8 pr-3 align-top">
+                      <WrapperIcon>
+                        <Text className="m-0 text-center text-lg leading-8">
+                          📚
+                        </Text>
+                      </WrapperIcon>
+                    </Column>
+                    <Column className="align-top">
+                      <Text className="m-0 font-medium text-sm">
+                        Dive into Subjects
                       </Text>
-                    </WrapperIcon>
-                  </Column>
-                  <Column className="align-top">
-                    <Text className="m-0 font-medium text-sm">
-                      Dive into Subjects
-                    </Text>
-                    <Text className="m-0 text-muted-foreground text-xs">
-                      Find a topic that sparks your interest.
-                    </Text>
-                  </Column>
-                </Row>
-                <Row className="mb-4">
-                  <Column className="w-8 pr-3 align-top">
-                    <WrapperIcon>
-                      <Text className="m-0 text-center text-lg leading-8">
-                        ✍️
+                      <Text className="m-0 text-muted-foreground text-xs">
+                        Find a topic that sparks your interest.
                       </Text>
-                    </WrapperIcon>
-                  </Column>
-                  <Column className="align-top">
-                    <Text className="m-0 font-medium text-sm">
-                      Test Your Knowledge
-                    </Text>
-                    <Text className="m-0 text-muted-foreground text-xs">
-                      Practice with interactive exercises.
-                    </Text>
-                  </Column>
-                </Row>
+                    </Column>
+                  </Row>
+                  <Row className="mb-4">
+                    <Column className="w-8 pr-3 align-top">
+                      <WrapperIcon>
+                        <Text className="m-0 text-center text-lg leading-8">
+                          ✍️
+                        </Text>
+                      </WrapperIcon>
+                    </Column>
+                    <Column className="align-top">
+                      <Text className="m-0 font-medium text-sm">
+                        Test Your Knowledge
+                      </Text>
+                      <Text className="m-0 text-muted-foreground text-xs">
+                        Practice with interactive exercises.
+                      </Text>
+                    </Column>
+                  </Row>
+                  <Row>
+                    <Column className="w-8 pr-3 align-top">
+                      <WrapperIcon>
+                        <Text className="m-0 text-center text-lg leading-8">
+                          🤝
+                        </Text>
+                      </WrapperIcon>
+                    </Column>
+                    <Column className="align-top">
+                      <Text className="m-0 font-medium text-sm">
+                        Meet the Community
+                      </Text>
+                      <Text className="m-0 text-muted-foreground text-xs">
+                        Learn alongside others.
+                      </Text>
+                    </Column>
+                  </Row>
+                </Section>
+              </CardContent>
+            </Card>
+
+            <Section className="mt-6 text-center">
+              <Button href="https://nakafa.com/en" size="lg">
+                Start Learning
+              </Button>
+            </Section>
+
+            <Section className="mt-6">
+              <Text className="mt-4 text-base text-foreground leading-6">
+                Cheers,
+                <br />
+                The Nakafa Team
+              </Text>
+            </Section>
+
+            <Hr className="mx-0 my-6 w-full border border-border" />
+
+            <Section className="text-center">
+              <Text className="m-0 text-muted-foreground text-xs leading-relaxed">
+                © {COPYRIGHT_YEAR} PT. Nakafa Tekno Kreatif. All rights
+                reserved.
+              </Text>
+              <Text className="m-0 mt-1 text-muted-foreground text-xs leading-relaxed">
+                Taman Sukahati Permai H6, Kab. Bogor
+              </Text>
+              <Section align="center" className="mt-4 w-auto">
                 <Row>
-                  <Column className="w-8 pr-3 align-top">
-                    <WrapperIcon>
-                      <Text className="m-0 text-center text-lg leading-8">
-                        🤝
-                      </Text>
-                    </WrapperIcon>
+                  <Column className="pr-2">
+                    <Link
+                      className="text-muted-foreground text-xs"
+                      href="https://nakafa.com/en/privacy-policy"
+                      style={{ textDecoration: "underline" }}
+                    >
+                      Privacy Policy
+                    </Link>
                   </Column>
-                  <Column className="align-top">
-                    <Text className="m-0 font-medium text-sm">
-                      Meet the Community
-                    </Text>
-                    <Text className="m-0 text-muted-foreground text-xs">
-                      Learn alongside others.
-                    </Text>
+                  <Column className="pl-2">
+                    <Link
+                      className="text-muted-foreground text-xs"
+                      href="https://nakafa.com/en/terms-of-service"
+                      style={{ textDecoration: "underline" }}
+                    >
+                      Terms of Service
+                    </Link>
                   </Column>
                 </Row>
               </Section>
-            </CardContent>
-          </Card>
-
-          <Section className="mt-6 text-center">
-            <Button href="https://nakafa.com/en" size="lg">
-              Start Learning
-            </Button>
-          </Section>
-
-          <Section className="mt-6">
-            <Text className="mt-4 text-base text-foreground leading-6">
-              Cheers,
-              <br />
-              The Nakafa Team
-            </Text>
-          </Section>
-
-          <Hr className="mx-0 my-6 w-full border border-border" />
-
-          <Section className="text-center">
-            <Text className="m-0 text-muted-foreground text-xs leading-relaxed">
-              © {COPYRIGHT_YEAR} PT. Nakafa Tekno Kreatif. All rights reserved.
-            </Text>
-            <Text className="m-0 mt-1 text-muted-foreground text-xs leading-relaxed">
-              Taman Sukahati Permai H6, Kab. Bogor
-            </Text>
-            <Section align="center" className="mt-4 w-auto">
-              <Row>
-                <Column className="pr-2">
-                  <Link
-                    className="text-muted-foreground text-xs"
-                    href="https://nakafa.com/en/privacy-policy"
-                    style={{ textDecoration: "underline" }}
-                  >
-                    Privacy Policy
-                  </Link>
-                </Column>
-                <Column className="pl-2">
-                  <Link
-                    className="text-muted-foreground text-xs"
-                    href="https://nakafa.com/en/terms-of-service"
-                    style={{ textDecoration: "underline" }}
-                  >
-                    Terms of Service
-                  </Link>
-                </Column>
-              </Row>
             </Section>
-          </Section>
-        </Container>
-      </Body>
-    </Tailwind>
-  </Html>
-);
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}
 
 Welcome.PreviewProps = {
   name: "Nabil Fatih",


### PR DESCRIPTION
## What changed

- convert 40 module-scoped React component variables in Nakafa AI, marketing, and email surfaces into named function declarations
- extract the header logo branch into a stable named component
- rename the three-word AI pagination module to `pagination-trigger.tsx`
- preserve every public export, prop contract, rendered element, and email preview contract

## Why

Named function components make ownership and stack traces explicit without changing the user interface. This slice is limited to app-owned components so it remains independent from the design-system and EvilCharts composition work.

## Verification

- independent AST and semantic review found no ref, generic, lexical `this`, `arguments`, static, export, or render change
- welcome email HTML and plain text are byte-identical to main
- WWW: 179 files and 1,100 tests passed with 100% coverage
- WWW and email typechecks passed
- lint, test ownership, workspace boundaries, targeted Ultracite, and diff checks passed
- local WWW changed-scope React Doctor passed 100/100 with no issues
- hosted exact-head React Doctor succeeded with 0 errors and 0 warnings
- every changed filename is at most two words and every changed file is below 500 LOC
- changed paths contain no em dash
