### PR TITLE
refactor(design-system): compose named components

### DIFF
--- a/packages/design-system/components/ai/actions.tsx
+++ b/packages/design-system/components/ai/actions.tsx
@@ -8,59 +8,60 @@ import {
   TooltipTrigger,
 } from "@repo/design-system/components/ui/tooltip";
 import { cn } from "@repo/design-system/lib/utils";
-import { type ComponentProps, memo } from "react";
+import type { ComponentProps } from "react";
 
 export type ActionsProps = ComponentProps<typeof ButtonGroup>;
 
-export const Actions = memo(
-  ({ className, children, ...props }: ActionsProps) => (
+/** Groups adjacent response actions. */
+export function Actions({ className, children, ...props }: ActionsProps) {
+  return (
     <ButtonGroup className={cn(className)} {...props}>
       {children}
     </ButtonGroup>
-  )
-);
-Actions.displayName = "Actions";
+  );
+}
 
 export type ActionProps = ComponentProps<typeof Button> & {
   tooltip?: string;
   label?: string;
 };
 
-export const Action = memo(
-  ({
-    tooltip,
-    children,
-    label,
-    className,
-    variant = "outline",
-    size = "icon",
-    ...props
-  }: ActionProps) => {
-    const button = (
-      <Button
-        className={cn(className)}
-        size={size}
-        type="button"
-        variant={variant}
-        {...props}
-      >
-        {children}
-        <span className="sr-only">{label || tooltip}</span>
-      </Button>
-    );
+/** Renders the button owned by one response action. */
+function ActionButton({
+  tooltip,
+  children,
+  label,
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: ActionProps) {
+  return (
+    <Button
+      className={cn(className)}
+      size={size}
+      type="button"
+      variant={variant}
+      {...props}
+    >
+      {children}
+      <span className="sr-only">{label || tooltip}</span>
+    </Button>
+  );
+}
 
-    if (tooltip) {
-      return (
-        <Tooltip>
-          <TooltipTrigger render={button} />
-          <TooltipContent side="bottom">
-            <p>{tooltip}</p>
-          </TooltipContent>
-        </Tooltip>
-      );
-    }
-
-    return button;
+/** Renders one response action with optional tooltip context. */
+export function Action(props: ActionProps) {
+  if (!props.tooltip) {
+    return <ActionButton {...props} />;
   }
-);
-Action.displayName = "Action";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<ActionButton {...props} />} />
+      <TooltipContent side="bottom">
+        <p>{props.tooltip}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/design-system/components/ai/code-block.tsx
+++ b/packages/design-system/components/ai/code-block.tsx
@@ -51,14 +51,14 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
 });
 
 /** Renders highlighted code with paired light and dark Shiki themes. */
-export const CodeBlock = ({
+export function CodeBlock({
   code,
   language,
   className,
   children,
   preClassName,
   ...rest
-}: CodeBlockProps) => {
+}: CodeBlockProps) {
   const [lightTheme, darkTheme] = use(ShikiThemeContext);
   const codeContextValue = useMemo(() => ({ code }), [code]);
   const codeThemes = useMemo(
@@ -113,7 +113,7 @@ export const CodeBlock = ({
       </div>
     </CodeBlockContext.Provider>
   );
-};
+}
 
 /** Copy-button callbacks and duration for its transient success state. */
 export type CodeBlockCopyButtonProps = ComponentProps<"button"> & {
@@ -129,7 +129,7 @@ export type CodeBlockDownloadButtonProps = ComponentProps<"button"> & {
 };
 
 /** Downloads the current code sample with an extension derived from its language. */
-export const CodeBlockDownloadButton = ({
+export function CodeBlockDownloadButton({
   onDownload,
   onError,
   language,
@@ -140,7 +140,7 @@ export const CodeBlockDownloadButton = ({
 }: CodeBlockDownloadButtonProps & {
   code?: string;
   language?: string;
-}) => {
+}) {
   const contextCode = use(CodeBlockContext).code;
   const code = propCode ?? contextCode;
   const extension = getCodeFileExtension(language);
@@ -178,10 +178,10 @@ export const CodeBlockDownloadButton = ({
       )}
     </Button>
   );
-};
+}
 
 /** Copies the current code sample and exposes a temporary success state. */
-export const CodeBlockCopyButton = ({
+export function CodeBlockCopyButton({
   onCopy,
   onError,
   timeout = 2000,
@@ -189,7 +189,7 @@ export const CodeBlockCopyButton = ({
   className,
   code: propCode,
   ...props
-}: CodeBlockCopyButtonProps & { code?: string }) => {
+}: CodeBlockCopyButtonProps & { code?: string }) {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef(0);
   const contextCode = use(CodeBlockContext).code;
@@ -248,4 +248,4 @@ export const CodeBlockCopyButton = ({
       {children ?? <HugeIcons className="size-4 shrink-0" icon={icon} />}
     </Button>
   );
-};
+}

--- a/packages/design-system/components/ai/input-controls.tsx
+++ b/packages/design-system/components/ai/input-controls.tsx
@@ -237,6 +237,37 @@ export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
   isPending?: boolean;
 };
 
+type PromptInputSubmitState = "pending" | "ready" | "streaming";
+
+/** Resolves the visible submit state with pending work taking precedence. */
+function getPromptInputSubmitState(
+  status: ChatStatus | undefined,
+  isPending: boolean | undefined
+): PromptInputSubmitState {
+  if (status === "submitted" || isPending) {
+    return "pending";
+  }
+
+  if (status === "streaming") {
+    return "streaming";
+  }
+
+  return "ready";
+}
+
+/** Renders the icon for one resolved prompt submit state. */
+function PromptInputSubmitIcon({ state }: { state: PromptInputSubmitState }) {
+  if (state === "pending") {
+    return <Spinner />;
+  }
+
+  if (state === "streaming") {
+    return <HugeIcons className="size-4" icon={StopIcon} />;
+  }
+
+  return <HugeIcons className="size-4" icon={ArrowUp02Icon} />;
+}
+
 /** Renders the send, pending, or stop state for a prompt submission. */
 export function PromptInputSubmit({
   className,
@@ -247,15 +278,8 @@ export function PromptInputSubmit({
   children,
   ...props
 }: PromptInputSubmitProps) {
-  let icon = <HugeIcons className="size-4" icon={ArrowUp02Icon} />;
-  let statusVariant = variant;
-
-  if (status === "submitted" || isPending) {
-    icon = <Spinner />;
-  } else if (status === "streaming") {
-    icon = <HugeIcons className="size-4" icon={StopIcon} />;
-    statusVariant = "destructive";
-  }
+  const submitState = getPromptInputSubmitState(status, isPending);
+  const statusVariant = submitState === "streaming" ? "destructive" : variant;
 
   return (
     <InputGroupButton
@@ -266,7 +290,7 @@ export function PromptInputSubmit({
       variant={statusVariant}
       {...props}
     >
-      {children ?? icon}
+      {children ?? <PromptInputSubmitIcon state={submitState} />}
     </InputGroupButton>
   );
 }

--- a/packages/design-system/components/ai/input.tsx
+++ b/packages/design-system/components/ai/input.tsx
@@ -180,8 +180,8 @@ export function PromptInput({
     fiber.addObserver(() => submitFibersRef.current.delete(fiber));
   };
 
-  const inner = (
-    <>
+  return (
+    <PromptInputAttachmentsProvider attachments={attachments}>
       <input
         accept={accept}
         aria-label="Upload files"
@@ -195,12 +195,6 @@ export function PromptInput({
       <form className="w-full" onSubmit={handleSubmit} ref={formRef} {...props}>
         <InputGroup className={cn("bg-card", className)}>{children}</InputGroup>
       </form>
-    </>
-  );
-
-  return (
-    <PromptInputAttachmentsProvider attachments={attachments}>
-      {inner}
     </PromptInputAttachmentsProvider>
   );
 }

--- a/packages/design-system/components/ai/mermaid.tsx
+++ b/packages/design-system/components/ai/mermaid.tsx
@@ -96,7 +96,7 @@ interface MermaidProps {
 /**
  * Renders Mermaid chart markup with a cached last-good SVG fallback.
  */
-export const Mermaid = ({ chart, className, config, label }: MermaidProps) => {
+export function Mermaid({ chart, className, config, label }: MermaidProps) {
   const componentId = useId();
   const { resolvedTheme } = useTheme();
   const renderId = getMermaidRenderId(componentId, chart);
@@ -199,4 +199,4 @@ export const Mermaid = ({ chart, className, config, label }: MermaidProps) => {
       role="img"
     />
   );
-};
+}

--- a/packages/design-system/components/ai/response.tsx
+++ b/packages/design-system/components/ai/response.tsx
@@ -7,7 +7,7 @@ import { normalizeText } from "@repo/design-system/lib/markdown/normalize";
 import { cn } from "@repo/design-system/lib/utils";
 import hardenReactMarkdown from "harden-react-markdown";
 import type { ComponentProps } from "react";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -68,118 +68,119 @@ function hashString(value: string) {
   return hash.toString(36);
 }
 
-const Block = memo(
-  ({
-    children,
-    ...props
-  }: HardenedMarkdownProps & Pick<ResponseProps, "children">) => {
-    const parsedContent = useMemo(
-      () => preprocessLaTeX(children.trim()),
-      [children]
-    );
+/** Renders one normalized markdown block. */
+function Block({
+  children,
+  ...props
+}: HardenedMarkdownProps & Pick<ResponseProps, "children">) {
+  const parsedContent = useMemo(
+    () => preprocessLaTeX(children.trim()),
+    [children]
+  );
 
-    // Return null if content is empty after trimming whitespace
-    if (!parsedContent.trim()) {
-      return null;
-    }
+  if (!parsedContent.trim()) {
+    return null;
+  }
+
+  return (
+    <MemoizedHardenedMarkdown
+      components={reactMdxComponents}
+      remarkPlugins={REMARK_PLUGINS}
+      skipHtml
+      {...props}
+    >
+      {parsedContent}
+    </MemoizedHardenedMarkdown>
+  );
+}
+
+const MemoizedBlock = memo(
+  Block,
+  (prevProps, nextProps) => prevProps.children === nextProps.children
+);
+
+/** Splits a response into stable markdown blocks for streaming updates. */
+function Blocks({
+  id,
+  children,
+  ...props
+}: HardenedMarkdownProps & Pick<ResponseProps, "children" | "id">) {
+  const blocks = useMemo(() => parseMarkdownIntoBlocks(children), [children]);
+  const blockOccurrences = new Map<string, number>();
+
+  return blocks.map((block) => {
+    const duplicateIndex = blockOccurrences.get(block) ?? 0;
+    blockOccurrences.set(block, duplicateIndex + 1);
 
     return (
-      <MemoizedHardenedMarkdown
-        components={reactMdxComponents}
-        remarkPlugins={REMARK_PLUGINS}
-        skipHtml
+      <MemoizedBlock
+        key={getMarkdownBlockKey(id, block, duplicateIndex)}
         {...props}
       >
-        {parsedContent}
-      </MemoizedHardenedMarkdown>
+        {block}
+      </MemoizedBlock>
     );
-  },
+  });
+}
+
+const MemoizedBlocks = memo(
+  Blocks,
   (prevProps, nextProps) => prevProps.children === nextProps.children
 );
-Block.displayName = "Block";
 
-const Blocks = memo(
-  ({
-    id,
-    children,
-    ...props
-  }: HardenedMarkdownProps & Pick<ResponseProps, "children" | "id">) => {
-    const blocks = useMemo(() => parseMarkdownIntoBlocks(children), [children]);
-    const blockOccurrences = new Map<string, number>();
-
-    return blocks.map((block) => {
-      const duplicateIndex = blockOccurrences.get(block) ?? 0;
-      blockOccurrences.set(block, duplicateIndex + 1);
-
-      return (
-        <Block key={getMarkdownBlockKey(id, block, duplicateIndex)} {...props}>
-          {block}
-        </Block>
-      );
-    });
-  },
-  (prevProps, nextProps) => prevProps.children === nextProps.children
-);
-Blocks.displayName = "Blocks";
-
-const ResponseContent = memo(
-  ({
-    className,
-    children,
-    allowedImagePrefixes = DEFAULT_ALLOWED_PREFIXES,
-    allowedLinkPrefixes = DEFAULT_ALLOWED_PREFIXES,
-    defaultOrigin = "https://nakafa.com",
-    ...props
-  }: ResponseProps) => (
+/** Renders the hardened block collection for one response. */
+function ResponseContent({
+  className,
+  children,
+  allowedImagePrefixes = DEFAULT_ALLOWED_PREFIXES,
+  allowedLinkPrefixes = DEFAULT_ALLOWED_PREFIXES,
+  defaultOrigin = "https://nakafa.com",
+  ...props
+}: ResponseProps) {
+  return (
     <div
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
     >
-      <Blocks
+      <MemoizedBlocks
         allowedImagePrefixes={allowedImagePrefixes}
         allowedLinkPrefixes={allowedLinkPrefixes}
         defaultOrigin={defaultOrigin}
         {...props}
       >
         {children}
-      </Blocks>
+      </MemoizedBlocks>
     </div>
-  ),
+  );
+}
+
+const MemoizedResponseContent = memo(
+  ResponseContent,
   (prevProps, nextProps) => prevProps.children === nextProps.children
 );
-ResponseContent.displayName = "ResponseContent";
 
-export const Response = memo(
-  ({
-    id,
-    children,
-    className,
-    allowedImagePrefixes,
-    allowedLinkPrefixes,
-    defaultOrigin,
-  }: ResponseProps) => {
-    const wrap = useCallback(
-      (v: string) => {
-        const normalizedChildren = normalizeText(v);
-        return (
-          <ResponseContent
-            allowedImagePrefixes={allowedImagePrefixes}
-            allowedLinkPrefixes={allowedLinkPrefixes}
-            className={className}
-            defaultOrigin={defaultOrigin}
-            id={id}
-          >
-            {normalizedChildren}
-          </ResponseContent>
-        );
-      },
-      [id, className, allowedImagePrefixes, allowedLinkPrefixes, defaultOrigin]
-    );
+/** Normalizes and renders one streamed markdown response. */
+export function Response({
+  id,
+  children,
+  className,
+  allowedImagePrefixes,
+  allowedLinkPrefixes,
+  defaultOrigin,
+}: ResponseProps) {
+  const normalizedChildren = useMemo(() => normalizeText(children), [children]);
 
-    return wrap(children);
-  },
-  (prevProps, nextProps) => prevProps.children === nextProps.children
-);
-Response.displayName = "Response";
+  return (
+    <MemoizedResponseContent
+      allowedImagePrefixes={allowedImagePrefixes}
+      allowedLinkPrefixes={allowedLinkPrefixes}
+      className={className}
+      defaultOrigin={defaultOrigin}
+      id={id}
+    >
+      {normalizedChildren}
+    </MemoizedResponseContent>
+  );
+}

--- a/packages/design-system/components/code-block/body.tsx
+++ b/packages/design-system/components/code-block/body.tsx
@@ -42,11 +42,11 @@ export type CodeBlockBodyProps = Omit<
 };
 
 /** Maps every source into the code block's content region. */
-export const CodeBlockBody = ({ children, ...props }: CodeBlockBodyProps) => {
+export function CodeBlockBody({ children, ...props }: CodeBlockBodyProps) {
   const data = useCodeBlock((state) => state.data);
 
   return <div {...props}>{data.map(children)}</div>;
-};
+}
 
 /** Active-source identity and optional line-number presentation. */
 export type CodeBlockItemProps = HTMLAttributes<HTMLDivElement> & {
@@ -55,13 +55,13 @@ export type CodeBlockItemProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 /** Renders one source only while its value is active. */
-export const CodeBlockItem = ({
+export function CodeBlockItem({
   children,
   lineNumbers = true,
   className,
   value,
   ...props
-}: CodeBlockItemProps) => {
+}: CodeBlockItemProps) {
   const activeValue = useCodeBlock((state) => state.value);
 
   if (value !== activeValue) {
@@ -85,4 +85,4 @@ export const CodeBlockItem = ({
       {children}
     </div>
   );
-};
+}

--- a/packages/design-system/components/code-block/content.tsx
+++ b/packages/design-system/components/code-block/content.tsx
@@ -66,7 +66,7 @@ interface CodeHighlightRequest {
 }
 
 /** Highlights client-rendered code while retaining a safe text fallback. */
-export const CodeBlockContent = ({
+export function CodeBlockContent({
   children,
   themes,
   language,
@@ -74,7 +74,7 @@ export const CodeBlockContent = ({
   syntaxHighlighting = true,
   transparentBackground = false,
   ...props
-}: CodeBlockContentProps) => {
+}: CodeBlockContentProps) {
   const request = useMemo<CodeHighlightRequest>(
     () => ({
       children,
@@ -157,4 +157,4 @@ export const CodeBlockContent = ({
       {...props}
     />
   );
-};
+}

--- a/packages/design-system/components/code-block/copy-button.tsx
+++ b/packages/design-system/components/code-block/copy-button.tsx
@@ -23,14 +23,14 @@ export type CodeBlockCopyButtonProps = ComponentProps<typeof Button> & {
 };
 
 /** Copies the active source and exposes success and failure feedback. */
-export const CodeBlockCopyButton = ({
+export function CodeBlockCopyButton({
   onCopy,
   onError,
   timeout = 2000,
   children,
   className,
   ...props
-}: CodeBlockCopyButtonProps) => {
+}: CodeBlockCopyButtonProps) {
   const [isCopied, setIsCopied] = useState(false);
   const copyFiberRef = useRef<Fiber.RuntimeFiber<void, never> | null>(null);
   const { data, value } = useCodeBlock((state) => ({
@@ -107,4 +107,4 @@ export const CodeBlockCopyButton = ({
       </span>
     </Button>
   );
-};
+}

--- a/packages/design-system/components/code-block/header.tsx
+++ b/packages/design-system/components/code-block/header.tsx
@@ -28,18 +28,17 @@ import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 export type CodeBlockHeaderProps = HTMLAttributes<HTMLDivElement>;
 
 /** Renders the toolbar surface above a code block. */
-export const CodeBlockHeader = ({
-  className,
-  ...props
-}: CodeBlockHeaderProps) => (
-  <div
-    className={cn(
-      "flex flex-row items-center border-b bg-muted/80 p-1",
-      className
-    )}
-    {...props}
-  />
-);
+export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-row items-center border-b bg-muted/80 p-1",
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 /** Render-prop contract for projecting every source into the filename region. */
 export type CodeBlockFilesProps = Omit<
@@ -50,11 +49,11 @@ export type CodeBlockFilesProps = Omit<
 };
 
 /** Maps every source into the code block's filename region. */
-export const CodeBlockFiles = ({
+export function CodeBlockFiles({
   className,
   children,
   ...props
-}: CodeBlockFilesProps) => {
+}: CodeBlockFilesProps) {
   const data = useCodeBlock((state) => state.data);
 
   return (
@@ -65,7 +64,7 @@ export const CodeBlockFiles = ({
       {data.map(children)}
     </div>
   );
-};
+}
 
 /** Filename identity and optional icon override for one source. */
 export type CodeBlockFilenameProps = HTMLAttributes<HTMLDivElement> & {
@@ -74,13 +73,13 @@ export type CodeBlockFilenameProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 /** Shows the filename and programming icon for the active source. */
-export const CodeBlockFilename = ({
+export function CodeBlockFilename({
   className,
   icon,
   value,
   children,
   ...props
-}: CodeBlockFilenameProps) => {
+}: CodeBlockFilenameProps) {
   const activeValue = useCodeBlock((state) => state.value);
   const defaultIcon = Object.entries(filenameIconMap).find(([pattern]) => {
     const regex = new RegExp(
@@ -107,13 +106,13 @@ export const CodeBlockFilename = ({
       <span className="min-w-0 flex-1 truncate">{children}</span>
     </div>
   );
-};
+}
 
 /** Select behavior bound to the active code source. */
 export type CodeBlockSelectProps = ComponentProps<typeof Select>;
 
 /** Binds a language selector to the code block's active source. */
-export const CodeBlockSelect = (props: CodeBlockSelectProps) => {
+export function CodeBlockSelect(props: CodeBlockSelectProps) {
   const { data, value, onValueChange } = useCodeBlock((state) => ({
     data: state.data,
     value: state.value,
@@ -136,33 +135,35 @@ export const CodeBlockSelect = (props: CodeBlockSelectProps) => {
       {...props}
     />
   );
-};
+}
 
 /** Trigger attributes for the compact language selector. */
 export type CodeBlockSelectTriggerProps = ComponentProps<typeof SelectTrigger>;
 
 /** Applies the compact code-block treatment to a select trigger. */
-export const CodeBlockSelectTrigger = ({
+export function CodeBlockSelectTrigger({
   className,
   ...props
-}: CodeBlockSelectTriggerProps) => (
-  <SelectTrigger
-    className={cn(
-      "w-fit border-none text-muted-foreground text-sm shadow-none",
-      className
-    )}
-    size="sm"
-    {...props}
-  />
-);
+}: CodeBlockSelectTriggerProps) {
+  return (
+    <SelectTrigger
+      className={cn(
+        "w-fit border-none text-muted-foreground text-sm shadow-none",
+        className
+      )}
+      size="sm"
+      {...props}
+    />
+  );
+}
 
 /** Value-slot attributes for the selected language label. */
 export type CodeBlockSelectValueProps = ComponentProps<typeof SelectValue>;
 
 /** Displays the selected code language inside its trigger. */
-export const CodeBlockSelectValue = (props: CodeBlockSelectValueProps) => (
-  <SelectValue {...props} />
-);
+export function CodeBlockSelectValue(props: CodeBlockSelectValueProps) {
+  return <SelectValue {...props} />;
+}
 
 /** Render-prop contract for projecting sources into language options. */
 export type CodeBlockSelectContentProps = Omit<
@@ -173,10 +174,10 @@ export type CodeBlockSelectContentProps = Omit<
 };
 
 /** Renders every available language inside the code-block select menu. */
-export const CodeBlockSelectContent = ({
+export function CodeBlockSelectContent({
   children,
   ...props
-}: CodeBlockSelectContentProps) => {
+}: CodeBlockSelectContentProps) {
   const t = useTranslations("Common");
   const data = useCodeBlock((state) => state.data);
 
@@ -188,15 +189,15 @@ export const CodeBlockSelectContent = ({
       </SelectGroup>
     </SelectContent>
   );
-};
+}
 
 /** Menu-item attributes for one selectable language. */
 export type CodeBlockSelectItemProps = ComponentProps<typeof SelectItem>;
 
 /** Applies the code-block typography to one language option. */
-export const CodeBlockSelectItem = ({
+export function CodeBlockSelectItem({
   className,
   ...props
-}: CodeBlockSelectItemProps) => (
-  <SelectItem className={cn("text-sm", className)} {...props} />
-);
+}: CodeBlockSelectItemProps) {
+  return <SelectItem className={cn("text-sm", className)} {...props} />;
+}

--- a/packages/design-system/components/code-block/index.tsx
+++ b/packages/design-system/components/code-block/index.tsx
@@ -18,14 +18,14 @@ export type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 /** Provides code-block tab state and source data to child controls. */
-export const CodeBlock = ({
+export function CodeBlock({
   value: controlledValue,
   onValueChange: controlledOnValueChange,
   defaultValue,
   className,
   data,
   ...props
-}: CodeBlockProps) => {
+}: CodeBlockProps) {
   const [value, onValueChange] = useControllableState({
     defaultProp: defaultValue ?? "",
     prop: controlledValue,
@@ -47,4 +47,4 @@ export const CodeBlock = ({
       />
     </CodeBlockContext.Provider>
   );
-};
+}

--- a/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { Clock04Icon, PauseIcon, PlayIcon } from "@hugeicons/core-free-icons";
 import { useIntersection } from "@mantine/hooks";
-import { Button } from "@repo/design-system/components/ui/button";
+import { BacterialControls } from "@repo/design-system/components/contents/mathematics/bacterial-controls";
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@repo/design-system/components/ui/card";
-import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import {
   AnimatePresence,
   domMax,
@@ -20,23 +17,12 @@ import {
   MotionConfig,
 } from "motion/react";
 import * as m from "motion/react-m";
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 
 const MAX_BACTERIA_COUNT = 100;
 const SPEED_INTERVAL = 1000;
 const STAGGER_DELAY = 0.01;
 const SCALE_INCREASE = 1.1;
-const SPEED_VALUES_DIFFERENCE = 0.25;
-const SPEED_VALUES = Array.from(
-  { length: 5 },
-  (_, i) => SPEED_VALUES_DIFFERENCE * (i + 1)
-);
 
 type FormulaType = "geometric" | "exponential";
 
@@ -172,12 +158,12 @@ export function BacterialGrowth({
     return () => clearInterval(interval);
   }, [deferredAnimating, deferredGeneration, maxGenerations, speed]);
 
-  const resetAnimation = useCallback(() => {
+  function resetAnimation() {
     setGeneration(0);
     setIsPlaying(true);
-  }, []);
+  }
 
-  const togglePlayPause = useCallback(() => {
+  function togglePlayPause() {
     if (!isEffectivelyPlaying && generation >= maxGenerations) {
       // If at max generation and trying to play, restart from beginning
       setGeneration(0);
@@ -186,30 +172,12 @@ export function BacterialGrowth({
     }
 
     setIsPlaying((value) => !value);
-  }, [isEffectivelyPlaying, generation, maxGenerations]);
+  }
 
-  // Generate time buttons
-  const timeButtons = useMemo(
-    () =>
-      Array.from({ length: maxGenerations + 1 }).map((_, i) => {
-        const time = i * timeInterval;
-        return (
-          <Button
-            key={time.toString()}
-            onClick={() => {
-              setGeneration(i);
-              setIsPlaying(false);
-            }}
-            size="sm"
-            variant={generation === i ? "default" : "outline"}
-          >
-            {time}
-            {timeUnit}
-          </Button>
-        );
-      }),
-    [generation, maxGenerations, timeInterval, timeUnit]
-  );
+  function selectGeneration(nextGeneration: number) {
+    setGeneration(nextGeneration);
+    setIsPlaying(false);
+  }
 
   return (
     <Card className="content-auto-card" ref={ref}>
@@ -276,51 +244,18 @@ export function BacterialGrowth({
         </div>
       </CardContent>
 
-      <CardFooter className="flex flex-col gap-4 px-0">
-        <div className="flex w-full flex-col items-center justify-between gap-4 px-6 sm:flex-row">
-          <div className="flex justify-between gap-2">
-            <Button
-              aria-label="Reset"
-              onClick={resetAnimation}
-              size="icon"
-              variant="outline"
-            >
-              <HugeIcons icon={Clock04Icon} />
-              <span className="sr-only">Reset</span>
-            </Button>
-            <Button
-              aria-label={isEffectivelyPlaying ? "Pause" : "Play"}
-              onClick={togglePlayPause}
-              size="icon"
-              variant={isEffectivelyPlaying ? "outline" : "default"}
-            >
-              <HugeIcons icon={isEffectivelyPlaying ? PauseIcon : PlayIcon} />
-              <span className="sr-only">
-                {isEffectivelyPlaying ? "Pause" : "Play"}
-              </span>
-            </Button>
-          </div>
-
-          <div className="flex flex-wrap justify-center gap-2">
-            {SPEED_VALUES.map((speedValue) => (
-              <Button
-                key={speedValue}
-                onClick={() => setSpeed(speedValue)}
-                size="sm"
-                variant={speed === speedValue ? "default" : "outline"}
-              >
-                {speedValue}x
-              </Button>
-            ))}
-          </div>
-        </div>
-
-        <div className="w-full border-t px-6 pt-4">
-          <div className="flex flex-wrap justify-center gap-2">
-            {timeButtons}
-          </div>
-        </div>
-      </CardFooter>
+      <BacterialControls
+        generation={generation}
+        isPlaying={isEffectivelyPlaying}
+        maxGenerations={maxGenerations}
+        onGenerationChange={selectGeneration}
+        onReset={resetAnimation}
+        onSpeedChange={setSpeed}
+        onTogglePlaying={togglePlayPause}
+        speed={speed}
+        timeInterval={timeInterval}
+        timeUnit={timeUnit}
+      />
     </Card>
   );
 }

--- a/packages/design-system/components/contents/mathematics/bacterial-controls.tsx
+++ b/packages/design-system/components/contents/mathematics/bacterial-controls.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Clock04Icon, PauseIcon, PlayIcon } from "@hugeicons/core-free-icons";
+import { Button } from "@repo/design-system/components/ui/button";
+import { CardFooter } from "@repo/design-system/components/ui/card";
+import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
+
+const SPEED_STEP = 0.25;
+const SPEED_VALUES = Array.from(
+  { length: 5 },
+  (_, index) => SPEED_STEP * (index + 1)
+);
+
+interface BacterialControlsProps {
+  generation: number;
+  isPlaying: boolean;
+  maxGenerations: number;
+  onGenerationChange: (generation: number) => void;
+  onReset: () => void;
+  onSpeedChange: (speed: number) => void;
+  onTogglePlaying: () => void;
+  speed: number;
+  timeInterval: number;
+  timeUnit: string;
+}
+
+/** Renders the generation selection controls for the bacterial animation. */
+function GenerationButtons({
+  generation,
+  maxGenerations,
+  onGenerationChange,
+  timeInterval,
+  timeUnit,
+}: Pick<
+  BacterialControlsProps,
+  | "generation"
+  | "maxGenerations"
+  | "onGenerationChange"
+  | "timeInterval"
+  | "timeUnit"
+>) {
+  return Array.from({ length: maxGenerations + 1 }, (_, index) => {
+    const time = index * timeInterval;
+
+    return (
+      <Button
+        key={time.toString()}
+        onClick={() => onGenerationChange(index)}
+        size="sm"
+        variant={generation === index ? "default" : "outline"}
+      >
+        {time}
+        {timeUnit}
+      </Button>
+    );
+  });
+}
+
+/** Owns the playback, speed, and generation controls for bacterial growth. */
+export function BacterialControls({
+  generation,
+  isPlaying,
+  maxGenerations,
+  onGenerationChange,
+  onReset,
+  onSpeedChange,
+  onTogglePlaying,
+  speed,
+  timeInterval,
+  timeUnit,
+}: BacterialControlsProps) {
+  return (
+    <CardFooter className="flex flex-col gap-4 px-0">
+      <div className="flex w-full flex-col items-center justify-between gap-4 px-6 sm:flex-row">
+        <div className="flex justify-between gap-2">
+          <Button
+            aria-label="Reset"
+            onClick={onReset}
+            size="icon"
+            variant="outline"
+          >
+            <HugeIcons icon={Clock04Icon} />
+            <span className="sr-only">Reset</span>
+          </Button>
+          <Button
+            aria-label={isPlaying ? "Pause" : "Play"}
+            onClick={onTogglePlaying}
+            size="icon"
+            variant={isPlaying ? "outline" : "default"}
+          >
+            <HugeIcons icon={isPlaying ? PauseIcon : PlayIcon} />
+            <span className="sr-only">{isPlaying ? "Pause" : "Play"}</span>
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-2">
+          {SPEED_VALUES.map((speedValue) => (
+            <Button
+              key={speedValue}
+              onClick={() => onSpeedChange(speedValue)}
+              size="sm"
+              variant={speed === speedValue ? "default" : "outline"}
+            >
+              {speedValue}x
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="w-full border-t px-6 pt-4">
+        <div className="flex flex-wrap justify-center gap-2">
+          <GenerationButtons
+            generation={generation}
+            maxGenerations={maxGenerations}
+            onGenerationChange={onGenerationChange}
+            timeInterval={timeInterval}
+            timeUnit={timeUnit}
+          />
+        </div>
+      </div>
+    </CardFooter>
+  );
+}

--- a/packages/design-system/components/evilcharts/ui/background.tsx
+++ b/packages/design-system/components/evilcharts/ui/background.tsx
@@ -7,7 +7,7 @@ import { ZIndexLayer } from "recharts";
 // To add a new variant:
 // 1. Add its name to the BackgroundVariant union type below
 // 2. Create a pattern component with PatternProps
-// 3. Register it in PATTERN_MAP
+// 3. Add its explicit BackgroundPattern branch
 
 export type BackgroundVariant =
   | "dots"
@@ -28,236 +28,274 @@ interface PatternProps {
   id: string;
 }
 
-const DotsPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="20"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="20"
-    x="0"
-    y="0"
-  >
-    <circle
-      className="text-border dark:text-border"
-      cx="2"
-      cy="2"
-      fill="currentColor"
-      r="1"
-    />
-  </pattern>
-);
+function DotsPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="20"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="20"
+      x="0"
+      y="0"
+    >
+      <circle
+        className="text-border dark:text-border"
+        cx="2"
+        cy="2"
+        fill="currentColor"
+        r="1"
+      />
+    </pattern>
+  );
+}
 
-const GridPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="20"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="20"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M 20 0 L 0 0 0 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="0.5"
-    />
-  </pattern>
-);
+function GridPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="20"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="20"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M 20 0 L 0 0 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  );
+}
 
-const CrossHatchPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="20"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="20"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border/60 dark:text-border/50"
-      d="M 0 0 L 20 20 M 20 0 L 0 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="0.5"
-    />
-  </pattern>
-);
+function CrossHatchPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="20"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="20"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border/60 dark:text-border/50"
+        d="M 0 0 L 20 20 M 20 0 L 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  );
+}
 
-const DiagonalLinesPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="6"
-    id={id}
-    patternTransform="rotate(45)"
-    patternUnits="userSpaceOnUse"
-    width="6"
-    x="0"
-    y="0"
-  >
-    <line
-      className="text-border dark:text-border"
-      stroke="currentColor"
-      strokeWidth="0.5"
-      x1="0"
-      x2="0"
-      y1="0"
-      y2="6"
-    />
-  </pattern>
-);
+function DiagonalLinesPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="6"
+      id={id}
+      patternTransform="rotate(45)"
+      patternUnits="userSpaceOnUse"
+      width="6"
+      x="0"
+      y="0"
+    >
+      <line
+        className="text-border dark:text-border"
+        stroke="currentColor"
+        strokeWidth="0.5"
+        x1="0"
+        x2="0"
+        y1="0"
+        y2="6"
+      />
+    </pattern>
+  );
+}
 
-const PlusPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="16"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="16"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M 8 4 L 8 12 M 4 8 L 12 8"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeWidth="0.5"
-    />
-  </pattern>
-);
+function PlusPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="16"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="16"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M 8 4 L 8 12 M 4 8 L 12 8"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  );
+}
 
-const FallingTrianglesPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="36"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="18"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M2 6h12L8 18 2 6zm18 36h12l-6 12-6-12z"
-      fill="currentColor"
-      fillOpacity="0.4"
-      transform="scale(0.5)"
-    />
-  </pattern>
-);
+function FallingTrianglesPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="36"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="18"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M2 6h12L8 18 2 6zm18 36h12l-6 12-6-12z"
+        fill="currentColor"
+        fillOpacity="0.4"
+        transform="scale(0.5)"
+      />
+    </pattern>
+  );
+}
 
-const FourPointedStarPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="16"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="16"
-    x="0"
-    y="0"
-  >
-    <polygon
-      className="text-border dark:text-border"
-      fill="currentColor"
-      fillOpacity="0.4"
-      fillRule="evenodd"
-      points="5 3 8 4 5 5 4 8 3 5 0 4 3 3 4 0 5 3"
-    />
-  </pattern>
-);
+function FourPointedStarPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="16"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="16"
+      x="0"
+      y="0"
+    >
+      <polygon
+        className="text-border dark:text-border"
+        fill="currentColor"
+        fillOpacity="0.4"
+        fillRule="evenodd"
+        points="5 3 8 4 5 5 4 8 3 5 0 4 3 3 4 0 5 3"
+      />
+    </pattern>
+  );
+}
 
-const TinyCheckersPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="8"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="8"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M0 0h4v4H0V0zm4 4h4v4H4V4z"
-      fill="currentColor"
-      fillOpacity="0.2"
-      fillRule="evenodd"
-    />
-  </pattern>
-);
+function TinyCheckersPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="8"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="8"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M0 0h4v4H0V0zm4 4h4v4H4V4z"
+        fill="currentColor"
+        fillOpacity="0.2"
+        fillRule="evenodd"
+      />
+    </pattern>
+  );
+}
 
-const OverlappingCirclesPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="40"
-    id={id}
-    patternUnits="userSpaceOnUse"
-    width="40"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M25 25c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5s-5-2.238-5-5 2.238-5 5-5zM5 5c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5S0 12.762 0 10s2.238-5 5-5zm5 4c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4zm20 20c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4z"
-      fill="currentColor"
-      fillOpacity="0.4"
-      fillRule="evenodd"
-    />
-  </pattern>
-);
+function OverlappingCirclesPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="40"
+      id={id}
+      patternUnits="userSpaceOnUse"
+      width="40"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M25 25c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5s-5-2.238-5-5 2.238-5 5-5zM5 5c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5S0 12.762 0 10s2.238-5 5-5zm5 4c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4zm20 20c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4z"
+        fill="currentColor"
+        fillOpacity="0.4"
+        fillRule="evenodd"
+      />
+    </pattern>
+  );
+}
 
-const WiggleLinesPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="26"
-    id={id}
-    patternTransform="scale(0.6)"
-    patternUnits="userSpaceOnUse"
-    width="52"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z"
-      fill="currentColor"
-      fillOpacity="0.4"
-    />
-  </pattern>
-);
+function WiggleLinesPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="26"
+      id={id}
+      patternTransform="scale(0.6)"
+      patternUnits="userSpaceOnUse"
+      width="52"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  );
+}
 
-const BubblesPattern = ({ id }: PatternProps) => (
-  <pattern
-    height="100"
-    id={id}
-    patternTransform="scale(0.6667)"
-    patternUnits="userSpaceOnUse"
-    width="100"
-    x="0"
-    y="0"
-  >
-    <path
-      className="text-border dark:text-border"
-      d="M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z"
-      fill="currentColor"
-      fillOpacity="0.4"
-      fillRule="evenodd"
-    />
-  </pattern>
-);
+function BubblesPattern({ id }: PatternProps) {
+  return (
+    <pattern
+      height="100"
+      id={id}
+      patternTransform="scale(0.6667)"
+      patternUnits="userSpaceOnUse"
+      width="100"
+      x="0"
+      y="0"
+    >
+      <path
+        className="text-border dark:text-border"
+        d="M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z"
+        fill="currentColor"
+        fillOpacity="0.4"
+        fillRule="evenodd"
+      />
+    </pattern>
+  );
+}
 
-// ── Pattern Registry ─────────────────────────────────────────────────────────
-// Map variant names to pattern components
-
-const PATTERN_MAP: Record<BackgroundVariant, React.FC<PatternProps>> = {
-  dots: DotsPattern,
-  grid: GridPattern,
-  plus: PlusPattern,
-  bubbles: BubblesPattern,
-  "cross-hatch": CrossHatchPattern,
-  "diagonal-lines": DiagonalLinesPattern,
-  "falling-triangles": FallingTrianglesPattern,
-  "4-pointed-star": FourPointedStarPattern,
-  "tiny-checkers": TinyCheckersPattern,
-  "overlapping-circles": OverlappingCirclesPattern,
-  "wiggle-lines": WiggleLinesPattern,
-};
+/** Renders the concrete SVG pattern selected by the public variant. */
+function BackgroundPattern({
+  id,
+  variant,
+}: PatternProps & { variant: BackgroundVariant }) {
+  switch (variant) {
+    case "dots":
+      return <DotsPattern id={id} />;
+    case "grid":
+      return <GridPattern id={id} />;
+    case "cross-hatch":
+      return <CrossHatchPattern id={id} />;
+    case "diagonal-lines":
+      return <DiagonalLinesPattern id={id} />;
+    case "plus":
+      return <PlusPattern id={id} />;
+    case "falling-triangles":
+      return <FallingTrianglesPattern id={id} />;
+    case "4-pointed-star":
+      return <FourPointedStarPattern id={id} />;
+    case "tiny-checkers":
+      return <TinyCheckersPattern id={id} />;
+    case "overlapping-circles":
+      return <OverlappingCirclesPattern id={id} />;
+    case "wiggle-lines":
+      return <WiggleLinesPattern id={id} />;
+    case "bubbles":
+      return <BubblesPattern id={id} />;
+    default:
+      return null;
+  }
+}
 
 // ── Main Component ───────────────────────────────────────────────────────────
 // Usage: Place <ChartBackground variant="dots" /> inside any Recharts chart component.
@@ -272,12 +310,10 @@ export function ChartBackground({ variant }: ChartBackgroundProps) {
   const patternId = `${baseId}-bg-${variant}`;
   const maskId = `${baseId}-bg-edge-fade`;
   const filterId = `${baseId}-bg-blur`;
-  const PatternComponent = PATTERN_MAP[variant];
-
   return (
     <ZIndexLayer zIndex={-1}>
       <defs>
-        <PatternComponent id={patternId} />
+        <BackgroundPattern id={patternId} variant={variant} />
         {/* Gaussian blur filter for soft edge fade */}
         <filter id={filterId}>
           <feGaussianBlur stdDeviation="25" />

--- a/packages/design-system/components/evilcharts/ui/brush-paint.tsx
+++ b/packages/design-system/components/evilcharts/ui/brush-paint.tsx
@@ -1,0 +1,142 @@
+import {
+  type ChartConfig,
+  getChartColorVariable,
+  getChartSeriesId,
+  getColorsCount,
+} from "@repo/design-system/components/evilcharts/ui/chart-config";
+import type { EvilBrushVariant } from "@repo/design-system/components/evilcharts/ui/evil-brush";
+
+interface BrushDefinitionsProps {
+  chartConfig: ChartConfig;
+  chartId: string;
+  keys: string[];
+  variant: EvilBrushVariant;
+}
+
+/** Renders the color stops for one brush preview series. */
+function BrushStops({
+  colorsCount,
+  dataKey,
+}: {
+  colorsCount: number;
+  dataKey: string;
+}) {
+  if (colorsCount === 1) {
+    return (
+      <>
+        <stop offset="0%" stopColor={getChartColorVariable(dataKey, 0)} />
+        <stop offset="100%" stopColor={getChartColorVariable(dataKey, 0)} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {Array.from({ length: colorsCount }, (_, index) => {
+        const offset = `${(index / (colorsCount - 1)) * 100}%`;
+
+        return (
+          <stop
+            key={`${dataKey}-${offset}`}
+            offset={offset}
+            stopColor={getChartColorVariable(dataKey, index, 0)}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+/** Renders the gradient and optional area mask for one preview series. */
+function BrushGradient({
+  chartId,
+  colorsCount,
+  dataKey,
+  variant,
+}: {
+  chartId: string;
+  colorsCount: number;
+  dataKey: string;
+  variant: EvilBrushVariant;
+}) {
+  return (
+    <>
+      <linearGradient
+        id={getChartSeriesId(chartId, "zm", dataKey)}
+        x1="0"
+        x2="0"
+        y1="0"
+        y2="1"
+      >
+        <BrushStops colorsCount={colorsCount} dataKey={dataKey} />
+      </linearGradient>
+
+      {variant === "area" ? (
+        <>
+          <mask id={getChartSeriesId(chartId, "zm-fill-mask", dataKey)}>
+            <rect
+              fill={`url(#${chartId}-zm-vertical-fade)`}
+              height="100%"
+              width="100%"
+            />
+          </mask>
+          <pattern
+            height="100%"
+            id={getChartSeriesId(chartId, "zm-fill", dataKey)}
+            patternUnits="userSpaceOnUse"
+            width="100%"
+          >
+            <rect
+              fill={`url(#${getChartSeriesId(chartId, "zm", dataKey)})`}
+              height="100%"
+              mask={`url(#${getChartSeriesId(chartId, "zm-fill-mask", dataKey)})`}
+              width="100%"
+            />
+          </pattern>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/** Renders the SVG definitions shared by every brush preview variant. */
+export function BrushDefinitions({
+  chartConfig,
+  chartId,
+  keys,
+  variant,
+}: BrushDefinitionsProps) {
+  const visibleKeys = new Set(keys);
+
+  return (
+    <>
+      {variant === "area" ? (
+        <linearGradient
+          id={`${chartId}-zm-vertical-fade`}
+          x1="0"
+          x2="0"
+          y1="0"
+          y2="1"
+        >
+          <stop offset="0%" stopColor="white" stopOpacity={0.15} />
+          <stop offset="100%" stopColor="white" stopOpacity={0} />
+        </linearGradient>
+      ) : null}
+      {Object.entries(chartConfig).flatMap(([dataKey, config]) => {
+        if (!visibleKeys.has(dataKey)) {
+          return [];
+        }
+
+        return [
+          <BrushGradient
+            chartId={chartId}
+            colorsCount={getColorsCount(config)}
+            dataKey={dataKey}
+            key={dataKey}
+            variant={variant}
+          />,
+        ];
+      })}
+    </>
+  );
+}

--- a/packages/design-system/components/evilcharts/ui/brush-preview.tsx
+++ b/packages/design-system/components/evilcharts/ui/brush-preview.tsx
@@ -1,6 +1,6 @@
+import { BrushDefinitions } from "@repo/design-system/components/evilcharts/ui/brush-paint";
 import {
   type ChartConfig,
-  getChartColorVariable,
   getChartSeriesId,
   getChartSeriesPaint,
   getColorsCount,
@@ -50,99 +50,10 @@ function renderEvilBrushPreview(
     ResponsiveContainer,
   }: RechartsModule
 ) {
-  const visibleKeys = new Set(keys);
-  const gradients = Object.entries(chartConfig).flatMap(([dataKey, config]) => {
-    if (!visibleKeys.has(dataKey)) {
-      return [];
-    }
-
-    return [{ colorsCount: getColorsCount(config), dataKey }];
-  });
-
   const dashArray =
     strokeVariant === "dashed" || strokeVariant === "animated-dashed"
       ? "4 4"
       : undefined;
-
-  const definitions = (
-    <>
-      {variant === "area" && (
-        <linearGradient
-          id={`${chartId}-zm-vertical-fade`}
-          x1="0"
-          x2="0"
-          y1="0"
-          y2="1"
-        >
-          <stop offset="0%" stopColor="white" stopOpacity={0.15} />
-          <stop offset="100%" stopColor="white" stopOpacity={0} />
-        </linearGradient>
-      )}
-      {gradients.map(({ dataKey, colorsCount }) => {
-        const colorStops =
-          colorsCount === 1 ? (
-            <>
-              <stop offset="0%" stopColor={getChartColorVariable(dataKey, 0)} />
-              <stop
-                offset="100%"
-                stopColor={getChartColorVariable(dataKey, 0)}
-              />
-            </>
-          ) : (
-            Array.from({ length: colorsCount }, (_, index) => {
-              const offset = `${(index / (colorsCount - 1)) * 100}%`;
-
-              return (
-                <stop
-                  key={`${dataKey}-${offset}`}
-                  offset={offset}
-                  stopColor={getChartColorVariable(dataKey, index, 0)}
-                />
-              );
-            })
-          );
-
-        return (
-          <React.Fragment key={dataKey}>
-            <linearGradient
-              id={getChartSeriesId(chartId, "zm", dataKey)}
-              x1="0"
-              x2="0"
-              y1="0"
-              y2="1"
-            >
-              {colorStops}
-            </linearGradient>
-
-            {variant === "area" && (
-              <>
-                <mask id={getChartSeriesId(chartId, "zm-fill-mask", dataKey)}>
-                  <rect
-                    fill={`url(#${chartId}-zm-vertical-fade)`}
-                    height="100%"
-                    width="100%"
-                  />
-                </mask>
-                <pattern
-                  height="100%"
-                  id={getChartSeriesId(chartId, "zm-fill", dataKey)}
-                  patternUnits="userSpaceOnUse"
-                  width="100%"
-                >
-                  <rect
-                    fill={`url(#${getChartSeriesId(chartId, "zm", dataKey)})`}
-                    height="100%"
-                    mask={`url(#${getChartSeriesId(chartId, "zm-fill-mask", dataKey)})`}
-                    width="100%"
-                  />
-                </pattern>
-              </>
-            )}
-          </React.Fragment>
-        );
-      })}
-    </>
-  );
 
   if (variant === "line") {
     return (
@@ -151,7 +62,14 @@ function renderEvilBrushPreview(
           data={data}
           margin={{ top: 4, right: 0, bottom: 0, left: 0 }}
         >
-          <defs>{definitions}</defs>
+          <defs>
+            <BrushDefinitions
+              chartConfig={chartConfig}
+              chartId={chartId}
+              keys={keys}
+              variant={variant}
+            />
+          </defs>
           {keys.map((dataKey) => (
             <Line
               activeDot={false}
@@ -188,7 +106,14 @@ function renderEvilBrushPreview(
           data={data}
           margin={{ top: 2, right: 0, bottom: 0, left: 0 }}
         >
-          <defs>{definitions}</defs>
+          <defs>
+            <BrushDefinitions
+              chartConfig={chartConfig}
+              chartId={chartId}
+              keys={keys}
+              variant={variant}
+            />
+          </defs>
           {keys.map((dataKey) => (
             <Bar
               dataKey={dataKey}
@@ -208,7 +133,14 @@ function renderEvilBrushPreview(
   return (
     <ResponsiveContainer height="100%" width="100%">
       <AreaChart data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
-        <defs>{definitions}</defs>
+        <defs>
+          <BrushDefinitions
+            chartConfig={chartConfig}
+            chartId={chartId}
+            keys={keys}
+            variant={variant}
+          />
+        </defs>
         {keys.map((dataKey) => (
           <Area
             activeDot={false}

--- a/packages/design-system/components/evilcharts/ui/evil-brush.tsx
+++ b/packages/design-system/components/evilcharts/ui/evil-brush.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import type { ChartConfig } from "@repo/design-system/components/evilcharts/ui/chart-config";
-import { ChartStyle } from "@repo/design-system/components/evilcharts/ui/chart-style";
-import { EvilBrushControls } from "@repo/design-system/components/evilcharts/ui/evil-brush-controls";
 import {
   type EvilBrushCurveType,
   EvilBrushPreview,
-} from "@repo/design-system/components/evilcharts/ui/evil-brush-preview";
+} from "@repo/design-system/components/evilcharts/ui/brush-preview";
+import type { ChartConfig } from "@repo/design-system/components/evilcharts/ui/chart-config";
+import { ChartStyle } from "@repo/design-system/components/evilcharts/ui/chart-style";
+import { EvilBrushControls } from "@repo/design-system/components/evilcharts/ui/evil-brush-controls";
 import { useBrushSelection } from "@repo/design-system/components/evilcharts/ui/evil-brush-selection";
 import { cn } from "@repo/design-system/lib/utils";
 import * as React from "react";
@@ -204,7 +204,7 @@ function useEvilBrush<TData extends Record<string, unknown>>({
     [range, data.length]
   );
 
-  // Defer the range used for data slicing — the brush handles move at the
+  // Defer the range used for data slicing because the brush handles move at the
   // immediate `range` cadence while the expensive chart re-render uses the
   // deferred value.  React can skip intermediate slices during fast drags.
   const deferredRange = React.useDeferredValue(clampedRange);

--- a/packages/design-system/components/evilcharts/ui/legend-item.tsx
+++ b/packages/design-system/components/evilcharts/ui/legend-item.tsx
@@ -1,0 +1,220 @@
+import {
+  type ChartConfig,
+  getChartColorVariable,
+  getColorsCount,
+  getPayloadConfigEntry,
+} from "@repo/design-system/components/evilcharts/ui/chart-config";
+import type { ChartLegendVariant } from "@repo/design-system/components/evilcharts/ui/legend";
+import { ChartSeriesCueIndicator } from "@repo/design-system/components/evilcharts/ui/series-cue-indicator";
+import { cn } from "@repo/design-system/lib/utils";
+import type * as React from "react";
+import type * as RechartsPrimitive from "recharts";
+
+type LegendPayloadItem = NonNullable<
+  RechartsPrimitive.DefaultLegendContentProps["payload"]
+>[number];
+
+interface LegendItemProps {
+  config: ChartConfig;
+  hideIcon: boolean;
+  isClickable: boolean | undefined;
+  item: LegendPayloadItem;
+  itemKey: string;
+  onSelectChange: ((selected: string | null) => void) | undefined;
+  selected: string | null | undefined;
+  variant: ChartLegendVariant;
+}
+
+/** Renders the configured cue, icon, or default legend indicator. */
+function LegendItemIndicator({
+  colorsCount,
+  dataKey,
+  hideIcon,
+  itemConfig,
+  variant,
+}: {
+  colorsCount: number;
+  dataKey: string;
+  hideIcon: boolean;
+  itemConfig: ChartConfig[string] | undefined;
+  variant: ChartLegendVariant;
+}) {
+  if (itemConfig?.icon && !hideIcon) {
+    const Icon = itemConfig.icon;
+    return <Icon />;
+  }
+
+  if (itemConfig?.cue && !hideIcon) {
+    return <ChartSeriesCueIndicator cue={itemConfig.cue} dataKey={dataKey} />;
+  }
+
+  return (
+    <LegendIndicator
+      colorsCount={colorsCount}
+      dataKey={dataKey}
+      variant={variant}
+    />
+  );
+}
+
+/** Renders one selectable or read-only legend payload item. */
+function LegendItem({
+  config,
+  hideIcon,
+  isClickable,
+  item,
+  itemKey,
+  onSelectChange,
+  selected,
+  variant,
+}: LegendItemProps) {
+  if (item.type === "none") {
+    return null;
+  }
+
+  // Pie charts use item.value. Radial charts use item.payload[nameKey].
+  // Other charts use item.dataKey.
+  const configEntry = getPayloadConfigEntry(config, item, itemKey);
+  const itemConfig = configEntry?.config;
+  const dataKey = configEntry?.dataKey ?? itemKey;
+  const isSelected =
+    selected === null || selected === undefined || selected === dataKey;
+  const colorsCount = itemConfig ? getColorsCount(itemConfig) : 1;
+  const itemClassName = cn(
+    "flex items-center gap-1.5 transition-colors [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
+    !isSelected && "text-muted-foreground",
+    isClickable &&
+      "cursor-pointer rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+  );
+
+  if (isClickable) {
+    return (
+      <button
+        aria-pressed={selected === dataKey}
+        className={itemClassName}
+        onClick={() => onSelectChange?.(selected === dataKey ? null : dataKey)}
+        type="button"
+      >
+        <LegendItemIndicator
+          colorsCount={colorsCount}
+          dataKey={dataKey}
+          hideIcon={hideIcon}
+          itemConfig={itemConfig}
+          variant={variant}
+        />
+        {itemConfig?.label}
+      </button>
+    );
+  }
+
+  return (
+    <div className={itemClassName}>
+      <LegendItemIndicator
+        colorsCount={colorsCount}
+        dataKey={dataKey}
+        hideIcon={hideIcon}
+        itemConfig={itemConfig}
+        variant={variant}
+      />
+      {itemConfig?.label}
+    </div>
+  );
+}
+
+function LegendIndicator({
+  variant,
+  dataKey,
+  colorsCount,
+}: {
+  variant: ChartLegendVariant;
+  dataKey: string;
+  colorsCount: number;
+}) {
+  const fillStyle = getLegendFillStyle(dataKey, colorsCount);
+  const outlineStyle = getLegendOutlineStyle(dataKey, colorsCount);
+
+  switch (variant) {
+    case "square":
+      return <div className="h-2 w-2 shrink-0" style={fillStyle} />;
+    case "circle":
+      return (
+        <div className="h-2 w-2 shrink-0 rounded-full" style={fillStyle} />
+      );
+    case "circle-outline":
+      return (
+        <div
+          className="h-2.5 w-2.5 shrink-0 rounded-full p-[1.5px]"
+          style={outlineStyle}
+        />
+      );
+    case "vertical-bar":
+      return (
+        <div className="h-3 w-1 shrink-0 rounded-[2px]" style={fillStyle} />
+      );
+    case "horizontal-bar":
+      return (
+        <div className="h-1 w-3 shrink-0 rounded-[2px]" style={fillStyle} />
+      );
+    case "rounded-square-outline":
+      return (
+        <div
+          className="h-2.5 w-2.5 shrink-0 rounded-[3px] p-[1.5px]"
+          style={outlineStyle}
+        />
+      );
+    default:
+      return (
+        <div className="h-2 w-2 shrink-0 rounded-[2px]" style={fillStyle} />
+      );
+  }
+}
+
+/** Solid fill or gradient background for filled variants. */
+function getLegendFillStyle(
+  dataKey: string,
+  colorsCount: number
+): React.CSSProperties {
+  if (colorsCount <= 1) {
+    return { backgroundColor: getChartColorVariable(dataKey, 0) };
+  }
+
+  const stops = Array.from({ length: colorsCount }, (_, index) => {
+    const offset = (index / (colorsCount - 1)) * 100;
+    return `${getChartColorVariable(dataKey, index)} ${offset}%`;
+  }).join(", ");
+
+  return { background: `linear-gradient(to right, ${stops})` };
+}
+
+/** Returns the masked border paint for outlined variants. */
+function getLegendOutlineStyle(
+  dataKey: string,
+  colorsCount: number
+): React.CSSProperties {
+  const maskStyle: React.CSSProperties = {
+    WebkitMask:
+      "linear-gradient(oklch(1 0 0) 0 0) content-box, linear-gradient(oklch(1 0 0) 0 0)",
+    WebkitMaskComposite: "xor",
+    mask: "linear-gradient(oklch(1 0 0) 0 0) content-box, linear-gradient(oklch(1 0 0) 0 0)",
+    maskComposite: "exclude",
+  };
+
+  if (colorsCount <= 1) {
+    return {
+      backgroundColor: getChartColorVariable(dataKey, 0),
+      ...maskStyle,
+    };
+  }
+
+  const stops = Array.from({ length: colorsCount }, (_, index) => {
+    const offset = (index / (colorsCount - 1)) * 100;
+    return `${getChartColorVariable(dataKey, index)} ${offset}%`;
+  }).join(", ");
+
+  return {
+    background: `linear-gradient(to right, ${stops})`,
+    ...maskStyle,
+  };
+}
+
+export { LegendItem };

--- a/packages/design-system/components/evilcharts/ui/legend.tsx
+++ b/packages/design-system/components/evilcharts/ui/legend.tsx
@@ -1,11 +1,6 @@
 import { useChart } from "@repo/design-system/components/evilcharts/ui/chart";
-import {
-  getChartColorVariable,
-  getColorsCount,
-  getPayloadConfigEntry,
-} from "@repo/design-system/components/evilcharts/ui/chart-config";
 import { getChartPayloadStringValue } from "@repo/design-system/components/evilcharts/ui/chart-payload";
-import { ChartSeriesCueIndicator } from "@repo/design-system/components/evilcharts/ui/series-cue-indicator";
+import { LegendItem } from "@repo/design-system/components/evilcharts/ui/legend-item";
 import { cn } from "@repo/design-system/lib/utils";
 import type * as React from "react";
 import * as RechartsPrimitive from "recharts";
@@ -18,6 +13,16 @@ type ChartLegendVariant =
   | "rounded-square-outline"
   | "vertical-bar"
   | "horizontal-bar";
+
+type LegendPayloadItem = NonNullable<
+  RechartsPrimitive.DefaultLegendContentProps["payload"]
+>[number];
+
+/** Resolves the stable key used by one Recharts legend payload item. */
+function getLegendItemKey(item: LegendPayloadItem, nameKey?: string) {
+  const payloadName = getChartPayloadStringValue(item.payload, nameKey);
+  return `${payloadName ?? item.value ?? item.dataKey ?? "value"}`;
+}
 
 function ChartLegendContent({
   className,
@@ -44,83 +49,6 @@ function ChartLegendContent({
     return null;
   }
 
-  const items = payload.flatMap((item) => {
-    if (item.type === "none") {
-      return [];
-    }
-
-    // For pie charts, item.value contains the sector name (e.g., "chrome")
-    // For radial charts, the name is in item.payload[nameKey]
-    // For other charts, item.dataKey contains the series name (e.g., "desktop")
-    const payloadName = getChartPayloadStringValue(item.payload, nameKey);
-    const key = `${payloadName ?? item.value ?? item.dataKey ?? "value"}`;
-    const configEntry = getPayloadConfigEntry(config, item, key);
-    const itemConfig = configEntry?.config;
-    const dataKey = configEntry?.dataKey ?? key;
-    const isSelected =
-      selected === null || selected === undefined || selected === dataKey;
-    const colorsCount = itemConfig ? getColorsCount(itemConfig) : 1;
-    let indicator = (
-      <LegendIndicator
-        colorsCount={colorsCount}
-        dataKey={dataKey}
-        key={`${key}-indicator`}
-        variant={variant}
-      />
-    );
-
-    if (itemConfig?.cue && !hideIcon) {
-      indicator = (
-        <ChartSeriesCueIndicator
-          cue={itemConfig.cue}
-          dataKey={dataKey}
-          key={`${key}-cue`}
-        />
-      );
-    }
-
-    if (itemConfig?.icon && !hideIcon) {
-      const Icon = itemConfig.icon;
-      indicator = <Icon key={`${key}-icon`} />;
-    }
-
-    const content = (
-      <>
-        {indicator}
-        {itemConfig?.label}
-      </>
-    );
-
-    const itemClassName = cn(
-      "flex items-center gap-1.5 transition-colors [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
-      !isSelected && "text-muted-foreground",
-      isClickable &&
-        "cursor-pointer rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    );
-
-    if (isClickable) {
-      return [
-        <button
-          aria-pressed={selected === dataKey}
-          className={itemClassName}
-          key={key}
-          onClick={() =>
-            onSelectChange?.(selected === dataKey ? null : dataKey)
-          }
-          type="button"
-        >
-          {content}
-        </button>,
-      ];
-    }
-
-    return [
-      <div className={itemClassName} key={key}>
-        {content}
-      </div>,
-    ];
-  });
-
   return (
     <div
       className={cn(
@@ -132,124 +60,28 @@ function ChartLegendContent({
         className
       )}
     >
-      {items}
+      {payload.map((item) => {
+        if (item.type === "none") {
+          return null;
+        }
+
+        const itemKey = getLegendItemKey(item, nameKey);
+        return (
+          <LegendItem
+            config={config}
+            hideIcon={hideIcon}
+            isClickable={isClickable}
+            item={item}
+            itemKey={itemKey}
+            key={itemKey}
+            onSelectChange={onSelectChange}
+            selected={selected}
+            variant={variant}
+          />
+        );
+      })}
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Legend indicator — each variant gets its own branch so future variants
-// can diverge freely in markup & style.
-// ---------------------------------------------------------------------------
-
-function LegendIndicator({
-  variant,
-  dataKey,
-  colorsCount,
-}: {
-  variant: ChartLegendVariant;
-  dataKey: string;
-  colorsCount: number;
-}) {
-  const fillStyle = getLegendFillStyle(dataKey, colorsCount);
-  const outlineStyle = getLegendOutlineStyle(dataKey, colorsCount);
-
-  switch (variant) {
-    case "square":
-      return <div className="h-2 w-2 shrink-0" style={fillStyle} />;
-
-    case "circle":
-      return (
-        <div className="h-2 w-2 shrink-0 rounded-full" style={fillStyle} />
-      );
-
-    case "circle-outline":
-      return (
-        <div
-          className="h-2.5 w-2.5 shrink-0 rounded-full p-[1.5px]"
-          style={outlineStyle}
-        />
-      );
-
-    case "vertical-bar":
-      return (
-        <div className="h-3 w-1 shrink-0 rounded-[2px]" style={fillStyle} />
-      );
-
-    case "horizontal-bar":
-      return (
-        <div className="h-1 w-3 shrink-0 rounded-[2px]" style={fillStyle} />
-      );
-
-    case "rounded-square-outline":
-      return (
-        <div
-          className="h-2.5 w-2.5 shrink-0 rounded-[3px] p-[1.5px]"
-          style={outlineStyle}
-        />
-      );
-    default:
-      return (
-        <div className="h-2 w-2 shrink-0 rounded-[2px]" style={fillStyle} />
-      );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Style helpers
-// ---------------------------------------------------------------------------
-
-/** Solid fill / gradient background for filled variants. */
-function getLegendFillStyle(
-  dataKey: string,
-  colorsCount: number
-): React.CSSProperties {
-  if (colorsCount <= 1) {
-    return { backgroundColor: getChartColorVariable(dataKey, 0) };
-  }
-
-  const stops = Array.from({ length: colorsCount }, (_, i) => {
-    const offset = (i / (colorsCount - 1)) * 100;
-    return `${getChartColorVariable(dataKey, i)} ${offset}%`;
-  }).join(", ");
-
-  return { background: `linear-gradient(to right, ${stops})` };
-}
-
-/**
- * Outline style for stroke variants.
- * Uses background + mask-composite to punch out the center, leaving only the
- * "border" visible. Works with both solid colors and gradients, and respects
- * border-radius — unlike plain `border-color`.
- */
-function getLegendOutlineStyle(
-  dataKey: string,
-  colorsCount: number
-): React.CSSProperties {
-  const maskStyle: React.CSSProperties = {
-    WebkitMask:
-      "linear-gradient(oklch(1 0 0) 0 0) content-box, linear-gradient(oklch(1 0 0) 0 0)",
-    WebkitMaskComposite: "xor",
-    mask: "linear-gradient(oklch(1 0 0) 0 0) content-box, linear-gradient(oklch(1 0 0) 0 0)",
-    maskComposite: "exclude",
-  };
-
-  if (colorsCount <= 1) {
-    return {
-      backgroundColor: getChartColorVariable(dataKey, 0),
-      ...maskStyle,
-    };
-  }
-
-  const stops = Array.from({ length: colorsCount }, (_, i) => {
-    const offset = (i / (colorsCount - 1)) * 100;
-    return `${getChartColorVariable(dataKey, i)} ${offset}%`;
-  }).join(", ");
-
-  return {
-    background: `linear-gradient(to right, ${stops})`,
-    ...maskStyle,
-  };
 }
 
 const ChartLegend = RechartsPrimitive.Legend;

--- a/packages/design-system/components/evilcharts/ui/tooltip-item.tsx
+++ b/packages/design-system/components/evilcharts/ui/tooltip-item.tsx
@@ -1,0 +1,239 @@
+import {
+  type ChartConfig,
+  getChartColorVariable,
+  getColorsCount,
+  getPayloadConfigEntry,
+} from "@repo/design-system/components/evilcharts/ui/chart-config";
+import { getChartPayloadStringValue } from "@repo/design-system/components/evilcharts/ui/chart-payload";
+import { cn } from "@repo/design-system/lib/utils";
+import type * as React from "react";
+import type * as RechartsPrimitive from "recharts";
+import type {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+
+type TooltipIndicator = "line" | "dot" | "dashed";
+type TooltipPayload = NonNullable<
+  RechartsPrimitive.DefaultTooltipContentProps<ValueType, NameType>["payload"]
+>;
+type TooltipPayloadItem = TooltipPayload[number];
+type TooltipFormatter = RechartsPrimitive.DefaultTooltipContentProps<
+  ValueType,
+  NameType
+>["formatter"];
+
+interface TooltipLabelProps {
+  config: ChartConfig;
+  hideLabel: boolean;
+  label: React.ReactNode;
+  labelClassName: string | undefined;
+  labelFormatter:
+    | RechartsPrimitive.DefaultTooltipContentProps<
+        ValueType,
+        NameType
+      >["labelFormatter"]
+    | undefined;
+  labelKey: string | undefined;
+  payload: TooltipPayload;
+}
+
+interface TooltipItemProps {
+  config: ChartConfig;
+  formatter: TooltipFormatter;
+  hideIndicator: boolean;
+  index: number;
+  indicator: TooltipIndicator;
+  item: TooltipPayloadItem;
+  labelProps: TooltipLabelProps;
+  nameKey: string | undefined;
+  nestLabel: boolean;
+  selected: string | null | undefined;
+}
+
+/** Renders the configured icon or series indicator for one tooltip row. */
+function TooltipItemIndicator({
+  colorsCount,
+  dataKey,
+  fill,
+  hideIndicator,
+  indicator,
+  itemConfig,
+  nestLabel,
+}: {
+  colorsCount: number;
+  dataKey: string;
+  fill: string | undefined;
+  hideIndicator: boolean;
+  indicator: TooltipIndicator;
+  itemConfig: ChartConfig[string] | undefined;
+  nestLabel: boolean;
+}) {
+  if (itemConfig?.icon) {
+    const Icon = itemConfig.icon;
+    return <Icon />;
+  }
+
+  if (hideIndicator) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("shrink-0 rounded-[2px]", {
+        "h-2.5 w-2.5": indicator === "dot",
+        "w-1": indicator === "line",
+        "w-0 border-[1.5px] border-dashed bg-transparent!":
+          indicator === "dashed",
+        "my-0.5": nestLabel && indicator === "dashed",
+      })}
+      style={getIndicatorColorStyle(dataKey, colorsCount, fill)}
+    />
+  );
+}
+
+/** Renders one visible Recharts tooltip payload item. */
+function TooltipItem({
+  config,
+  formatter,
+  hideIndicator,
+  index,
+  indicator,
+  item,
+  labelProps,
+  nameKey,
+  nestLabel,
+  selected,
+}: TooltipItemProps) {
+  if (item.type === "none") {
+    return null;
+  }
+
+  // Pie charts use item.name. Radial charts use item.payload[nameKey].
+  // Other charts use item.name or item.dataKey.
+  const payloadName = getChartPayloadStringValue(item.payload, nameKey);
+  const key = `${payloadName ?? item.name ?? item.dataKey ?? "value"}`;
+  const configEntry = getPayloadConfigEntry(config, item, key);
+  const itemConfig = configEntry?.config;
+  const dataKey = configEntry?.dataKey ?? key;
+  const payloadFill = getChartPayloadStringValue(item.payload, "fill");
+  const colorsCount = itemConfig ? getColorsCount(itemConfig) : 1;
+  const isDeemphasized = selected != null && selected !== dataKey;
+
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+        indicator === "dot" && "items-center",
+        isDeemphasized && "text-muted-foreground"
+      )}
+    >
+      {formatter && item.value !== undefined && item.name ? (
+        formatter(item.value, item.name, item, index, item.payload)
+      ) : (
+        <>
+          <TooltipItemIndicator
+            colorsCount={colorsCount}
+            dataKey={dataKey}
+            fill={payloadFill}
+            hideIndicator={hideIndicator}
+            indicator={indicator}
+            itemConfig={itemConfig}
+            nestLabel={nestLabel}
+          />
+          <div
+            className={cn(
+              "flex flex-1 justify-between gap-4 leading-none",
+              nestLabel ? "items-end" : "items-center"
+            )}
+          >
+            <div className="grid gap-1.5">
+              {nestLabel ? <TooltipLabel {...labelProps} /> : null}
+              <span className="text-muted-foreground">
+                {itemConfig?.label ?? item.name}
+              </span>
+            </div>
+            {item.value == null ? null : (
+              <span
+                className={cn(
+                  "font-medium font-mono tabular-nums",
+                  isDeemphasized ? "text-muted-foreground" : "text-foreground"
+                )}
+              >
+                {typeof item.value === "number"
+                  ? item.value.toLocaleString()
+                  : String(item.value)}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Renders the formatted tooltip label when it is visible. */
+function TooltipLabel({
+  config,
+  hideLabel,
+  label,
+  labelClassName,
+  labelFormatter,
+  labelKey,
+  payload,
+}: TooltipLabelProps) {
+  if (hideLabel) {
+    return null;
+  }
+
+  const [item] = payload;
+  const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+  const configEntry = getPayloadConfigEntry(config, item, key);
+  const itemConfig = configEntry?.config;
+  const value =
+    !labelKey && typeof label === "string"
+      ? (config[label]?.label ?? label)
+      : itemConfig?.label;
+
+  if (labelFormatter) {
+    return (
+      <div className={cn("font-medium", labelClassName)}>
+        {labelFormatter(value, payload)}
+      </div>
+    );
+  }
+
+  if (!value) {
+    return null;
+  }
+
+  return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+}
+
+function getIndicatorColorStyle(
+  dataKey: string,
+  colorsCount: number,
+  fill?: string
+): React.CSSProperties {
+  if (fill) {
+    return { background: fill };
+  }
+
+  if (colorsCount <= 1) {
+    return { background: getChartColorVariable(dataKey, 0) };
+  }
+
+  const stops = Array.from({ length: colorsCount }, (_, index) => {
+    const offset = (index / (colorsCount - 1)) * 100;
+    return `${getChartColorVariable(dataKey, index)} ${offset}%`;
+  }).join(", ");
+
+  return { background: `linear-gradient(to right, ${stops})` };
+}
+
+export {
+  type TooltipIndicator,
+  TooltipItem,
+  TooltipLabel,
+  type TooltipLabelProps,
+};

--- a/packages/design-system/components/evilcharts/ui/tooltip.tsx
+++ b/packages/design-system/components/evilcharts/ui/tooltip.tsx
@@ -1,11 +1,11 @@
 import { useChart } from "@repo/design-system/components/evilcharts/ui/chart";
-import {
-  type ChartConfig,
-  getChartColorVariable,
-  getColorsCount,
-  getPayloadConfigEntry,
-} from "@repo/design-system/components/evilcharts/ui/chart-config";
 import { getChartPayloadStringValue } from "@repo/design-system/components/evilcharts/ui/chart-payload";
+import {
+  type TooltipIndicator,
+  TooltipItem,
+  TooltipLabel,
+  type TooltipLabelProps,
+} from "@repo/design-system/components/evilcharts/ui/tooltip-item";
 import { cn } from "@repo/design-system/lib/utils";
 import type * as React from "react";
 import * as RechartsPrimitive from "recharts";
@@ -16,6 +16,17 @@ import type {
 
 export type TooltipRoundness = "sm" | "md" | "lg" | "xl";
 export type TooltipVariant = "default" | "frosted-glass";
+
+type TooltipPayloadItem = NonNullable<
+  RechartsPrimitive.DefaultTooltipContentProps<ValueType, NameType>["payload"]
+>[number];
+
+/** Resolves the stable React key for one tooltip payload item. */
+function getTooltipItemKey(item: TooltipPayloadItem, nameKey?: string) {
+  const payloadName = getChartPayloadStringValue(item.payload, nameKey);
+  const key = `${payloadName ?? item.name ?? item.dataKey ?? "value"}`;
+  return `${key}-${String(item.dataKey ?? item.name ?? item.value)}`;
+}
 
 const roundnessMap: Record<TooltipRoundness, string> = {
   sm: "rounded-sm",
@@ -49,7 +60,7 @@ function ChartTooltipContent({
   React.ComponentProps<"div"> & {
     hideLabel?: boolean;
     hideIndicator?: boolean;
-    indicator?: "line" | "dot" | "dashed";
+    indicator?: TooltipIndicator;
     nameKey?: string;
     labelKey?: string;
     selected?: string | null;
@@ -67,7 +78,7 @@ function ChartTooltipContent({
   }
 
   const nestLabel = payload.length === 1 && indicator !== "dot";
-  const tooltipLabel = getTooltipLabel({
+  const labelProps: TooltipLabelProps = {
     config,
     hideLabel,
     label,
@@ -75,88 +86,7 @@ function ChartTooltipContent({
     labelFormatter,
     labelKey,
     payload,
-  });
-
-  const items = payload.flatMap((item, index) => {
-    if (item.type === "none") {
-      return [];
-    }
-
-    // For pie charts, item.name contains the sector name (e.g., "chrome")
-    // For radial charts, the name is in item.payload[nameKey]
-    // For other charts, item.name or item.dataKey contains the series name
-    const payloadName = getChartPayloadStringValue(item.payload, nameKey);
-    const key = `${payloadName ?? item.name ?? item.dataKey ?? "value"}`;
-    const configEntry = getPayloadConfigEntry(config, item, key);
-    const itemConfig = configEntry?.config;
-    const dataKey = configEntry?.dataKey ?? key;
-    const payloadFill = getChartPayloadStringValue(item.payload, "fill");
-    const colorsCount = itemConfig ? getColorsCount(itemConfig) : 1;
-    const isDeemphasized = selected != null && selected !== dataKey;
-
-    return [
-      <div
-        className={cn(
-          "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-          indicator === "dot" && "items-center",
-          isDeemphasized && "text-muted-foreground"
-        )}
-        key={`${key}-${String(item.dataKey ?? item.name ?? item.value)}`}
-      >
-        {formatter && item?.value !== undefined && item.name ? (
-          formatter(item.value, item.name, item, index, item.payload)
-        ) : (
-          <>
-            {itemConfig?.icon ? (
-              <itemConfig.icon />
-            ) : (
-              !hideIndicator && (
-                <div
-                  className={cn("shrink-0 rounded-[2px]", {
-                    "h-2.5 w-2.5": indicator === "dot",
-                    "w-1": indicator === "line",
-                    "w-0 border-[1.5px] border-dashed bg-transparent!":
-                      indicator === "dashed",
-                    "my-0.5": nestLabel && indicator === "dashed",
-                  })}
-                  style={getIndicatorColorStyle(
-                    dataKey,
-                    colorsCount,
-                    payloadFill
-                  )}
-                />
-              )
-            )}
-            <div
-              className={cn(
-                "flex flex-1 justify-between gap-4 leading-none",
-                nestLabel ? "items-end" : "items-center"
-              )}
-            >
-              <div className="grid gap-1.5">
-                {nestLabel ? tooltipLabel : null}
-                <span className="text-muted-foreground">
-                  {itemConfig?.label ?? item.name}
-                </span>
-              </div>
-              {item.value != null && (
-                <span
-                  className={cn(
-                    "font-medium font-mono tabular-nums",
-                    isDeemphasized ? "text-muted-foreground" : "text-foreground"
-                  )}
-                >
-                  {typeof item.value === "number"
-                    ? item.value.toLocaleString()
-                    : String(item.value)}
-                </span>
-              )}
-            </div>
-          </>
-        )}
-      </div>,
-    ];
-  });
+  };
 
   return (
     <div
@@ -167,89 +97,44 @@ function ChartTooltipContent({
         className
       )}
     >
-      {nestLabel ? null : tooltipLabel}
-      <div className="grid gap-1.5">{items}</div>
+      {nestLabel ? null : <TooltipLabel {...labelProps} />}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          if (item.type === "none") {
+            return null;
+          }
+
+          return (
+            <TooltipItem
+              config={config}
+              formatter={formatter}
+              hideIndicator={hideIndicator}
+              index={index}
+              indicator={indicator}
+              item={item}
+              key={getTooltipItemKey(item, nameKey)}
+              labelProps={labelProps}
+              nameKey={nameKey}
+              nestLabel={nestLabel}
+              selected={selected}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }
 
-function getTooltipLabel({
-  config,
-  hideLabel,
-  label,
-  labelClassName,
-  labelFormatter,
-  labelKey,
-  payload,
-}: {
-  config: ChartConfig;
-  hideLabel: boolean;
-  label?: React.ReactNode;
-  labelClassName?: string;
-  labelFormatter?: RechartsPrimitive.DefaultTooltipContentProps<
-    ValueType,
-    NameType
-  >["labelFormatter"];
-  labelKey?: string;
-  payload: NonNullable<
-    RechartsPrimitive.DefaultTooltipContentProps<ValueType, NameType>["payload"]
-  >;
-}) {
-  if (hideLabel) {
-    return null;
-  }
-
-  const [item] = payload;
-  const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
-  const configEntry = getPayloadConfigEntry(config, item, key);
-  const itemConfig = configEntry?.config;
-  const value =
-    !labelKey && typeof label === "string"
-      ? (config[label]?.label ?? label)
-      : itemConfig?.label;
-
-  if (labelFormatter) {
-    return (
-      <div className={cn("font-medium", labelClassName)}>
-        {labelFormatter(value, payload)}
-      </div>
-    );
-  }
-
-  if (!value) {
-    return null;
-  }
-
-  return <div className={cn("font-medium", labelClassName)}>{value}</div>;
-}
-
-function getIndicatorColorStyle(
-  dataKey: string,
-  colorsCount: number,
-  fill?: string
-): React.CSSProperties {
-  if (fill) {
-    return { background: fill };
-  }
-
-  if (colorsCount <= 1) {
-    return { background: getChartColorVariable(dataKey, 0) };
-  }
-
-  // Multiple colors: create linear gradient with evenly distributed stops
-  const stops = Array.from({ length: colorsCount }, (_, index) => {
-    const offset = (index / (colorsCount - 1)) * 100;
-    return `${getChartColorVariable(dataKey, index)} ${offset}%`;
-  }).join(", ");
-
-  return { background: `linear-gradient(to right, ${stops})` };
-}
-
-const ChartTooltip = ({
+function ChartTooltip({
   animationDuration = 200,
   ...props
-}: React.ComponentProps<typeof RechartsPrimitive.Tooltip>) => (
-  <RechartsPrimitive.Tooltip animationDuration={animationDuration} {...props} />
-);
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip>) {
+  return (
+    <RechartsPrimitive.Tooltip
+      animationDuration={animationDuration}
+      {...props}
+    />
+  );
+}
 
 export { ChartTooltip, ChartTooltipContent };

--- a/packages/design-system/components/ui/autocomplete.tsx
+++ b/packages/design-system/components/ui/autocomplete.tsx
@@ -135,16 +135,11 @@ function AutocompletePopup({
   );
 }
 
-function AutocompleteList({
+function AutocompleteItems({
   className,
-  scrollArea = true,
-  scrollAreaClassName,
   ...props
-}: AutocompletePrimitive.List.Props & {
-  scrollArea?: boolean;
-  scrollAreaClassName?: string;
-}) {
-  const list = (
+}: AutocompletePrimitive.List.Props) {
+  return (
     <AutocompletePrimitive.List
       className={cn(
         "max-h-full scroll-py-1 overflow-y-auto overflow-x-hidden p-1 data-empty:p-0",
@@ -155,9 +150,18 @@ function AutocompleteList({
       {...props}
     />
   );
+}
 
+function AutocompleteList({
+  scrollArea = true,
+  scrollAreaClassName,
+  ...props
+}: AutocompletePrimitive.List.Props & {
+  scrollArea?: boolean;
+  scrollAreaClassName?: string;
+}) {
   if (!scrollArea) {
-    return list;
+    return <AutocompleteItems {...props} />;
   }
 
   return (
@@ -166,7 +170,7 @@ function AutocompleteList({
       scrollbarGutter
       scrollFade
     >
-      {list}
+      <AutocompleteItems {...props} />
     </ScrollArea>
   );
 }

--- a/packages/design-system/components/ui/field.tsx
+++ b/packages/design-system/components/ui/field.tsx
@@ -180,6 +180,37 @@ function FieldSeparator({
   );
 }
 
+/** Renders the shared field error container. */
+function FieldErrorRoot({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("font-normal text-destructive text-sm", className)}
+      data-slot="field-error"
+      role="alert"
+      {...props}
+    />
+  );
+}
+
+/** Renders multiple field validation messages in their original order. */
+function FieldErrorList({
+  errors,
+}: {
+  errors: Array<{ message?: string } | undefined>;
+}) {
+  return (
+    <ul className="ml-4 flex list-disc flex-col gap-1">
+      {errors.map(
+        (error, index) =>
+          !!error?.message && (
+            // biome-ignore lint/suspicious/noArrayIndexKey: Error message may repeat, need index for uniqueness
+            <li key={`${error.message}-${index}`}>{error.message}</li>
+          )
+      )}
+    </ul>
+  );
+}
+
 function FieldError({
   className,
   children,
@@ -190,14 +221,9 @@ function FieldError({
 }) {
   if (children) {
     return (
-      <div
-        className={cn("font-normal text-destructive text-sm", className)}
-        data-slot="field-error"
-        role="alert"
-        {...props}
-      >
+      <FieldErrorRoot className={className} {...props}>
         {children}
-      </div>
+      </FieldErrorRoot>
     );
   }
 
@@ -209,34 +235,23 @@ function FieldError({
     ...new Map(errors.map((error) => [error?.message, error])).values(),
   ];
 
-  const content =
-    uniqueErrors.length === 1 ? (
-      uniqueErrors[0]?.message
-    ) : (
-      <ul className="ml-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map(
-          (error, index) =>
-            !!error?.message && (
-              // biome-ignore lint/suspicious/noArrayIndexKey: Error message may repeat, need index for uniqueness
-              <li key={`${error.message}-${index}`}>{error.message}</li>
-            )
-        )}
-      </ul>
-    );
+  if (uniqueErrors.length === 1) {
+    const message = uniqueErrors[0]?.message;
+    if (!message) {
+      return null;
+    }
 
-  if (!content) {
-    return null;
+    return (
+      <FieldErrorRoot className={className} {...props}>
+        {message}
+      </FieldErrorRoot>
+    );
   }
 
   return (
-    <div
-      className={cn("font-normal text-destructive text-sm", className)}
-      data-slot="field-error"
-      role="alert"
-      {...props}
-    >
-      {content}
-    </div>
+    <FieldErrorRoot className={className} {...props}>
+      <FieldErrorList errors={uniqueErrors} />
+    </FieldErrorRoot>
   );
 }
 

--- a/packages/design-system/components/ui/phone-input.tsx
+++ b/packages/design-system/components/ui/phone-input.tsx
@@ -83,7 +83,7 @@ function hasCountryValue(
   return option.value !== undefined;
 }
 
-const CountrySelect = ({ value, onChange, options }: CountrySelectProps) => {
+function CountrySelect({ value, onChange, options }: CountrySelectProps) {
   const t = useTranslations("Common");
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -194,9 +194,9 @@ const CountrySelect = ({ value, onChange, options }: CountrySelectProps) => {
       </PopoverContent>
     </Popover>
   );
-};
+}
 
-const FlagComponent = ({ country, countryName }: RpnInput.FlagProps) => {
+function FlagComponent({ country, countryName }: RpnInput.FlagProps) {
   const Flag = flags[country];
 
   return (
@@ -208,4 +208,4 @@ const FlagComponent = ({ country, countryName }: RpnInput.FlagProps) => {
       )}
     </span>
   );
-};
+}

--- a/packages/design-system/components/ui/sonner.tsx
+++ b/packages/design-system/components/ui/sonner.tsx
@@ -67,7 +67,7 @@ const toasterStyle: ToasterStyle = {
 };
 
 /** Renders app toasts with the active appearance and semantic status colors. */
-const Toaster = ({ ...props }: ToasterProps) => {
+function Toaster({ ...props }: ToasterProps) {
   const { resolvedTheme } = useTheme();
   const appearance = getThemeAppearance(resolvedTheme);
 
@@ -102,6 +102,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
       {...props}
     />
   );
-};
+}
 
 export { Toaster };

--- a/packages/design-system/components/ui/stepper.tsx
+++ b/packages/design-system/components/ui/stepper.tsx
@@ -7,7 +7,6 @@ import { Spinner } from "@repo/design-system/components/ui/spinner";
 import { cn } from "@repo/design-system/lib/utils";
 import { createContext, use, useCallback, useMemo, useState } from "react";
 
-// Types
 interface StepperContextValue {
   activeStep: number;
   orientation: "horizontal" | "vertical";
@@ -23,7 +22,6 @@ interface StepItemContextValue {
 
 type StepState = "active" | "completed" | "inactive" | "loading";
 
-// Contexts
 const StepperContext = createContext<StepperContextValue | undefined>(
   undefined
 );
@@ -49,7 +47,6 @@ const useStepItem = () => {
   return context;
 };
 
-// Components
 interface StepperProps extends React.HTMLAttributes<HTMLDivElement> {
   defaultValue?: number;
   onValueChange?: (value: number) => void;
@@ -102,7 +99,6 @@ function Stepper({
   );
 }
 
-// StepperItem
 interface StepperItemProps extends React.HTMLAttributes<HTMLDivElement> {
   completed?: boolean;
   disabled?: boolean;
@@ -154,7 +150,6 @@ function StepperItem({
   );
 }
 
-// StepperTrigger
 function StepperTrigger({
   className,
   children,
@@ -190,15 +185,15 @@ function StepperTrigger({
   });
 }
 
-// StepperIndicator
-function StepperIndicator({
-  className,
-  children,
-  render,
-  ...props
-}: useRender.ComponentProps<"span">) {
-  const { state, step, isLoading } = useStepItem();
-  const defaultChildren = (
+/** Renders the numbered, completed, or loading indicator content. */
+function StepperDefaultIndicator({
+  isLoading,
+  step,
+}: {
+  isLoading: boolean;
+  step: number;
+}) {
+  return (
     <>
       <span className="transition-all group-data-[step-state=completed]/step:scale-0 group-data-loading/step:scale-0 group-data-[step-state=completed]/step:opacity-0 group-data-loading/step:opacity-0 group-data-loading/step:transition-none">
         {step}
@@ -208,19 +203,30 @@ function StepperIndicator({
         className="absolute size-4 scale-0 opacity-0 transition-all group-data-[step-state=completed]/step:scale-100 group-data-[step-state=completed]/step:opacity-100"
         icon={Tick01Icon}
       />
-      {!!isLoading && (
+      {isLoading ? (
         <span className="absolute transition-all">
           <Spinner aria-hidden="true" className="size-3.5" />
         </span>
-      )}
+      ) : null}
     </>
   );
+}
+
+function StepperIndicator({
+  className,
+  children,
+  render,
+  ...props
+}: useRender.ComponentProps<"span">) {
+  const { state, step, isLoading } = useStepItem();
 
   return useRender({
     defaultTagName: "span",
     render,
     props: {
-      children: children ?? defaultChildren,
+      children: children ?? (
+        <StepperDefaultIndicator isLoading={isLoading} step={step} />
+      ),
       className: cn(
         "relative flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground text-xs data-[step-state=active]:bg-primary data-[step-state=completed]:bg-primary data-[step-state=active]:text-primary-foreground data-[step-state=completed]:text-primary-foreground",
         className
@@ -232,7 +238,6 @@ function StepperIndicator({
   });
 }
 
-// StepperTitle
 function StepperTitle({
   children,
   className,
@@ -249,7 +254,6 @@ function StepperTitle({
   );
 }
 
-// StepperDescription
 function StepperDescription({
   className,
   ...props
@@ -263,7 +267,6 @@ function StepperDescription({
   );
 }
 
-// StepperSeparator
 function StepperSeparator({
   className,
   ...props

--- a/packages/design-system/providers/theme.tsx
+++ b/packages/design-system/providers/theme.tsx
@@ -7,19 +7,18 @@ import type { ThemeProviderProps } from "next-themes";
 import { ThemeProvider as NextThemeProvider } from "next-themes";
 
 /** Configures Nakafa's concrete themes and delegates system resolution to next-themes. */
-export const ThemeProvider = ({
-  children,
-  ...properties
-}: ThemeProviderProps) => (
-  <NextThemeProvider
-    attribute="class"
-    defaultTheme={DEFAULT_THEME}
-    disableTransitionOnChange
-    enableSystem
-    storageKey={THEME_STORAGE_KEY}
-    themes={concreteThemeValues}
-    {...properties}
-  >
-    {children}
-  </NextThemeProvider>
-);
+export function ThemeProvider({ children, ...properties }: ThemeProviderProps) {
+  return (
+    <NextThemeProvider
+      attribute="class"
+      defaultTheme={DEFAULT_THEME}
+      disableTransitionOnChange
+      enableSystem
+      storageKey={THEME_STORAGE_KEY}
+      themes={concreteThemeValues}
+      {...properties}
+    >
+      {children}
+    </NextThemeProvider>
+  );
+}


### PR DESCRIPTION
## What changed

- replace authored component variables with named function declarations across design-system AI, code-block, form, theme, and chart UI capabilities
- extract bacterial controls, brush paint, legend rows, and tooltip rows into domain-owned components
- rename the package-private three-word brush preview module to `brush-preview.tsx`
- replace the chart background component registry with explicit named-component branching
- keep Base UI, Recharts, memo, lazy, and injected icon identities only where those library contracts require them

## Why

The previous modules mixed component identity, conditional JSX values, and reusable capability logic. This slice makes component ownership explicit while preserving the established public APIs, ref merging, generic inference, DOM, and interaction behavior.

## Verification

Exact head: `691fa99569ac77faacf51ea9828cf770b45ec99d` on main `fb9f744c82dc1831032f1e3da1132959dc1d72f5`

- independent semantic review approved the exact 27-file patch with no blockers
- `git range-diff` reports the rebased patch as unchanged; old and new binary diffs share SHA-256 `ff5ae8b01fb6426d4b8220c0debc5341496d298fe427c67c72bb8c2c4300804c`
- exact-head Agent Docs passed the repository test matrix, signed runtime fingerprints, anonymous Convex snapshot restore, and production build
- production build generated 1,303 of 1,303 static pages with one worker
- AFDocs passed 23 of 23 checks against the built application
- React Doctor reported 86/100 overall health with zero new errors and zero new warnings
- design-system passed 32 files and 332 tests with 100% coverage
- design-system TypeScript typecheck passed
- lint, test ownership, workspace boundaries, Ultracite, and diff checks passed
- no authored component variables, nested components, or local JSX variables remain in this slice
- public exports and package consumers remain intact
- every new filename is at most two words and no changed file exceeds 500 LOC
- changed paths contain no em dash
