### PR TITLE
fix(tryout): contain localized table headers

### DIFF
--- a/apps/www/components/tryout/catalog/table/header.tsx
+++ b/apps/www/components/tryout/catalog/table/header.tsx
@@ -89,12 +89,12 @@ export function TryoutSetSortHeader<TValue>({
         render={
           <Button
             aria-label={tTryouts("set-sort-label", { column: label })}
-            className="-ml-2 max-w-full sm:-ml-3"
+            className="-ml-2 min-w-0 max-w-[calc(100%+1rem)] overflow-hidden sm:-ml-3 sm:max-w-[calc(100%+1.75rem)]"
             size="sm"
             type="button"
             variant="ghost"
           >
-            {label}
+            <span className="min-w-0 truncate">{label}</span>
             <HugeIcons data-icon="inline-end" icon={getSortIcon(direction)} />
           </Button>
         }
@@ -147,12 +147,12 @@ export function TryoutSetStatusHeader({
         render={
           <Button
             aria-label={tTryouts("set-filter-label", { column: label })}
-            className="-ml-2 max-w-full sm:-ml-3"
+            className="-ml-2 min-w-0 max-w-[calc(100%+1rem)] overflow-hidden sm:-ml-3 sm:max-w-[calc(100%+1.75rem)]"
             size="sm"
             type="button"
             variant={statusFilter === "all" ? "ghost" : "secondary"}
           >
-            {label}
+            <span className="min-w-0 truncate">{label}</span>
             <HugeIcons data-icon="inline-end" icon={FilterIcon} />
           </Button>
         }


### PR DESCRIPTION
## What changed

- lets sortable and filterable table-header buttons reclaim their cell padding without crossing the cell boundary
- keeps the fixed sort and filter icon inside the hover target
- truncates only the visible localized label when space is genuinely constrained while preserving the full localized accessible label
- reuses the existing shadcn Button, Table, and Base UI dropdown composition

## Root cause

The previous max-width constrained each Button to the table cell content box. The non-wrapping translated label and fixed icon could still paint beyond that smaller button, so hover exposed a background that did not contain its own icon.

## Runtime and cost

- no new component, state, dependency, bundle boundary, request, subscription, or Convex read
- sorting and filtering behavior remain owned by the existing TanStack and Base UI seams
- one existing 214-line component module changes by four insertions and four deletions

## Verification

- English desktop geometry: Questions fully visible; icon and button both remain inside the cell
- 600px geometry: label truncates cleanly; icon remains visible and contained
- Indonesian desktop geometry: all four headers remain fully visible and contained
- deliberately overlong localized-label stress check remains contained
- pointer hover, keyboard sorting, and status-filter menu acceptance passed
- exact-head Agent-Friendly Docs run 31483202355: 12 of 12 workspace tasks, backend 356 files and 1,536 tests, WWW 182 files and 1,113 tests, production build 5 of 5 tasks, WWW 1 worker and 1,303 of 1,303 pages, AFDocs 23 of 23, zero annotations
- exact-head React Doctor run 31483202417: 100 of 100, 0 errors, 0 warnings, zero annotations
- hosted Codex reviewed exact commit ac48008b08 and found no major issues
- no built Vercel preview; API and MCP bookkeeping records were skipped as unaffected
- exact patch SHA-256 5f41f68d2067026b2ace92606daa52792be4ed6ee6e61f07d6fef47777ff8076
- rebase range-diff is patch-identical over protected main