### PR TITLE
fix(ci): serialize anonymous content builds

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -198,11 +198,11 @@ const nextConfig = {
     instantInsights: {
       validationLevel: "warning",
     },
-    // Anonymous Convex shares this runner, so cap each Next worker at one page.
+    // Anonymous Convex shares this runner, so use one worker with one page.
     // Production keeps Next.js' default static-generation concurrency.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(configEnv.CONVEX_AGENT_MODE === "anonymous"
-      ? { staticGenerationMaxConcurrency: 1 }
+      ? { cpus: 1, staticGenerationMaxConcurrency: 1 }
       : {}),
   },
 } satisfies NextConfig;


### PR DESCRIPTION
## What changed

- run anonymous Agent Mode builds with one Next.js worker
- keep static generation limited to one page inside that worker
- preserve normal production worker and page concurrency

## Root cause

Next.js 16.3 defines `staticGenerationMaxConcurrency` per worker. Agent Docs limited each worker to one page but still created three workers beside the runner-local Convex backend. PR #287 then failed twice at `contentRelease.material.route` on different pages and progress points.

Historical Agent Docs run 31366044821 exposed the same query failure class as `Function execution timed out (maximum duration: 1s)` under three workers. Current logs sanitize the underlying query error, so timeout is the strongest source-backed mechanism rather than a claimed decoded exception.

This PR fixes the worker topology. It adds no query retry, page retry, content fallback, or integrity change.

## Verification

- anonymous resolved config: `cpus=1`, `staticGenerationMaxConcurrency=1`
- normal resolved config keeps Next.js defaults
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`: 100/100, 0 errors, 0 warnings

## Exact-head acceptance

Agent-Friendly Docs must complete all 1,303 WWW pages and show one worker for page-data collection and static generation. A second exact-head Agent Docs attempt will confirm the intermittent timeout class stays absent before merge.