### PR TITLE
perf(tryout): stream signed review content

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/[section]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/[section]/page.tsx
@@ -10,10 +10,6 @@ import {
   readTryoutSectionAttemptPage,
   readTryoutSectionPage,
 } from "@/components/tryout/catalog/server";
-import type {
-  TryoutAnswerContent,
-  TryoutQuestionContent,
-} from "@/components/tryout/content/model";
 import { loadSignedTryoutContent } from "@/components/tryout/content/signed";
 import { selectTryoutSectionReturnHref } from "@/components/tryout/route/owner";
 import {
@@ -160,19 +156,15 @@ async function TryoutSectionRoute({
     publicHref: getTryoutHref({ country, exam, set, track }),
   });
 
-  let questions: readonly TryoutQuestionContent[] = [];
-  let answers: readonly TryoutAnswerContent[] = [];
-
-  if (attemptPage?.content.kind === "signed") {
-    const content = await Effect.runPromise(
-      loadSignedTryoutContent({
-        answers: attemptPage.content.answers,
-        questions: attemptPage.content.questions,
-      })
-    );
-    questions = content.questions;
-    answers = content.answers;
-  }
+  const content =
+    attemptPage?.content.kind === "signed"
+      ? Effect.runPromise(
+          loadSignedTryoutContent({
+            answers: attemptPage.content.answers,
+            questions: attemptPage.content.questions,
+          })
+        )
+      : null;
 
   return (
     <TryoutSectionPageClient
@@ -187,7 +179,7 @@ async function TryoutSectionRoute({
             }
           : null
       }
-      content={{ answers, questions }}
+      content={content}
       page={page}
       route={{ country, exam, locale, section, set, track }}
       setHref={setHref}

--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/page.tsx
@@ -10,10 +10,6 @@ import {
   readTryoutSetAttemptPage,
   readTryoutSetPage,
 } from "@/components/tryout/catalog/server";
-import type {
-  TryoutAnswerContent,
-  TryoutQuestionContent,
-} from "@/components/tryout/content/model";
 import { loadSignedTryoutContent } from "@/components/tryout/content/signed";
 import {
   createTryoutSetRestartTarget,
@@ -136,19 +132,15 @@ async function TryoutSetRoute({ params, searchParams }: TryoutSetPageProps) {
   }
   const { page, restartTarget } = pages;
 
-  let questions: readonly TryoutQuestionContent[] = [];
-  let answers: readonly TryoutAnswerContent[] = [];
-
-  if (attemptPage?.content.kind === "signed") {
-    const content = await Effect.runPromise(
-      loadSignedTryoutContent({
-        answers: attemptPage.content.answers,
-        questions: attemptPage.content.questions,
-      })
-    );
-    questions = content.questions;
-    answers = content.answers;
-  }
+  const content =
+    attemptPage?.content.kind === "signed"
+      ? Effect.runPromise(
+          loadSignedTryoutContent({
+            answers: attemptPage.content.answers,
+            questions: attemptPage.content.questions,
+          })
+        )
+      : null;
 
   return (
     <TryoutSetPageClient
@@ -161,7 +153,7 @@ async function TryoutSetRoute({ params, searchParams }: TryoutSetPageProps) {
             }
           : null
       }
-      content={{ entryAnswers: answers, entryQuestions: questions }}
+      content={content}
       page={page}
       restartTarget={restartTarget}
       route={{ country, exam, locale, set, track }}

--- a/apps/www/components/tryout/content/model.ts
+++ b/apps/www/components/tryout/content/model.ts
@@ -27,6 +27,12 @@ export interface TryoutAnswerContent {
   readonly sourceRevision: string;
 }
 
+/** Rendered signed content needed by one exact try-out runtime. */
+export interface TryoutRuntimeContent {
+  readonly answers: readonly TryoutAnswerContent[];
+  readonly questions: readonly TryoutQuestionContent[];
+}
+
 /** Exact signed question selector authorized by Convex. */
 export type TryoutQuestionSelector = SignedContentAccess["questions"][number];
 

--- a/apps/www/components/tryout/section/client.tsx
+++ b/apps/www/components/tryout/section/client.tsx
@@ -6,11 +6,8 @@ import { getMaterialIcon } from "@repo/contents/_lib/curriculum/material";
 import { useQuery } from "convex/react";
 import type { Locale } from "next-intl";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
-import type {
-  TryoutAnswerContent,
-  TryoutQuestionContent,
-} from "@/components/tryout/content/model";
+import { Suspense, use, useState } from "react";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
 import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
 import {
   getTryoutAttemptHref,
@@ -45,7 +42,7 @@ type SectionState = TryoutSectionInitialState | null;
 
 interface TryoutSectionPageClientProps {
   binding: TryoutSectionRouteBinding;
-  content: TryoutSectionAssets;
+  content: Promise<TryoutRuntimeContent> | null;
   page: TryoutSectionPage;
   route: TryoutSectionRoute;
   setHref: string;
@@ -57,11 +54,6 @@ type TryoutSectionRouteBinding = {
   startHref: string | null;
 } | null;
 
-interface TryoutSectionAssets {
-  answers: readonly TryoutAnswerContent[];
-  questions: readonly TryoutQuestionContent[];
-}
-
 interface TryoutSectionRoute {
   country: string;
   exam: string;
@@ -69,6 +61,19 @@ interface TryoutSectionRoute {
   section: string;
   set: string;
   track: string;
+}
+
+interface TryoutSectionBodyValue {
+  actionAttempt: TryoutSectionAttempt | null;
+  activeAttempt: TryoutSectionAttempt | null;
+  content: Promise<TryoutRuntimeContent> | null;
+  page: TryoutSectionPage;
+  route: TryoutSectionRoute;
+  runtimeReturnHref: string;
+  runtimeState: TryoutRuntimeState<TryoutSectionRuntime>;
+  sectionStatus: ReturnType<typeof getTryoutFinishedSectionStatus>;
+  setHref: string;
+  startDestination: TryoutStartDestination | null;
 }
 
 /** Renders one stable page with an active-only mutable subscription. */
@@ -196,10 +201,6 @@ function ResolvedTryoutSectionPage({
     return null;
   }
 
-  if (runtimeState.kind !== "none" && content.questions.length === 0) {
-    return <TryoutContentRefresh />;
-  }
-
   const sectionStatus = getTryoutFinishedSectionStatus(sectionAttempt);
   const sectionFinished = sectionStatus !== null;
   const sectionTimeExpired = sectionStatus === "expired";
@@ -271,55 +272,24 @@ function ResolvedTryoutSectionPage({
 }
 
 /** Composes active runtime, terminal summary, and review content explicitly. */
-function TryoutSectionBody({
-  value,
-}: {
-  value: {
-    actionAttempt: TryoutSectionAttempt | null;
-    activeAttempt: TryoutSectionAttempt | null;
-    content: TryoutSectionAssets;
-    page: TryoutSectionPage;
-    route: TryoutSectionRoute;
-    runtimeReturnHref: string;
-    runtimeState: TryoutRuntimeState<TryoutSectionRuntime>;
-    sectionStatus: ReturnType<typeof getTryoutFinishedSectionStatus>;
-    setHref: string;
-    startDestination: TryoutStartDestination | null;
-  };
-}) {
+function TryoutSectionBody({ value }: { value: TryoutSectionBodyValue }) {
   if (value.runtimeState.kind === "active") {
     return (
-      <TryoutRuntime
-        value={{
-          answers: value.content.answers,
-          expired: false,
-          questions: value.content.questions,
-          returnHref: value.runtimeReturnHref,
-          runtime: value.runtimeState.runtime,
-        }}
-      />
+      <Suspense fallback={null}>
+        <TryoutSectionRuntimeContent value={value} />
+      </Suspense>
     );
   }
 
   if (value.runtimeState.kind === "pending") {
     return (
-      <TryoutRuntime
-        value={{
-          answers: value.content.answers,
-          expired: true,
-          questions: value.content.questions,
-          returnHref: value.runtimeReturnHref,
-          runtime: value.runtimeState.runtime,
-        }}
-      />
+      <Suspense fallback={null}>
+        <TryoutSectionRuntimeContent value={value} />
+      </Suspense>
     );
   }
 
   if (value.runtimeState.kind === "review") {
-    if (value.content.answers.length === 0) {
-      return <TryoutContentRefresh />;
-    }
-
     return (
       <>
         <TryoutVisibleSummary
@@ -333,15 +303,9 @@ function TryoutSectionBody({
             startDestination: value.startDestination,
           }}
         />
-        <TryoutRuntime
-          value={{
-            answers: value.content.answers,
-            expired: true,
-            questions: value.content.questions,
-            returnHref: value.runtimeReturnHref,
-            runtime: value.runtimeState.runtime,
-          }}
-        />
+        <Suspense fallback={null}>
+          <TryoutSectionRuntimeContent value={value} />
+        </Suspense>
       </>
     );
   }
@@ -356,6 +320,40 @@ function TryoutSectionBody({
         returnHref: value.setHref,
         sectionStatus: value.sectionStatus,
         startDestination: value.startDestination,
+      }}
+    />
+  );
+}
+
+/** Resolves signed content only inside the section runtime region. */
+function TryoutSectionRuntimeContent({
+  value,
+}: {
+  value: TryoutSectionBodyValue;
+}) {
+  if (!value.content) {
+    return <TryoutContentRefresh />;
+  }
+
+  const content = use(value.content);
+  if (content.questions.length === 0) {
+    return <TryoutContentRefresh />;
+  }
+  if (value.runtimeState.kind === "none") {
+    return null;
+  }
+  if (value.runtimeState.kind === "review" && content.answers.length === 0) {
+    return <TryoutContentRefresh />;
+  }
+
+  return (
+    <TryoutRuntime
+      value={{
+        answers: content.answers,
+        expired: value.runtimeState.kind !== "active",
+        questions: content.questions,
+        returnHref: value.runtimeReturnHref,
+        runtime: value.runtimeState.runtime,
       }}
     />
   );

--- a/apps/www/components/tryout/set/client.tsx
+++ b/apps/www/components/tryout/set/client.tsx
@@ -4,7 +4,7 @@ import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
 import { useState } from "react";
-import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
 import { selectTryoutTrackReturnHref } from "@/components/tryout/route/owner";
 import {
   getTryoutAttemptHref,
@@ -22,7 +22,6 @@ import type {
   LoadedRuntime,
   SetEntrySection,
   SetPage,
-  TryoutSetContent,
   TryoutSetInitialState,
   TryoutSetRestartTarget,
   TryoutSetRoute,
@@ -40,7 +39,7 @@ interface TryoutSetPageBinding {
 
 interface TryoutSetPageClientProps {
   binding: TryoutSetPageBinding | null;
-  content: TryoutSetContent;
+  content: Promise<TryoutRuntimeContent> | null;
   page: SetPage;
   restartTarget: TryoutSetRestartTarget | null;
   route: TryoutSetRoute;
@@ -216,7 +215,7 @@ function TryoutInternalSet({
   value,
 }: {
   value: {
-    content: TryoutSetContent;
+    content: Promise<TryoutRuntimeContent> | null;
     entrySection: SetEntrySection;
     now: number;
     runtime: LoadedRuntime | null;
@@ -229,25 +228,11 @@ function TryoutInternalSet({
     runtime: value.runtime,
   });
 
-  if (
-    runtimeState.kind !== "none" &&
-    value.content.entryQuestions.length === 0
-  ) {
-    return <TryoutContentRefresh />;
-  }
-
-  if (
-    runtimeState.kind === "review" &&
-    value.content.entryAnswers.length === 0
-  ) {
-    return <TryoutContentRefresh />;
-  }
-
   return (
     <TryoutSetEntry
+      content={value.content}
       value={{
         ...value.view,
-        content: value.content,
         entrySection: value.entrySection,
         runtimeState,
       }}

--- a/apps/www/components/tryout/set/entry.tsx
+++ b/apps/www/components/tryout/set/entry.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { Suspense, use } from "react";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
+import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
 import { getTryoutAttemptHref } from "@/components/tryout/route/path";
 import { TryoutRuntime } from "@/components/tryout/runtime/client";
 import { TryoutAttemptResults } from "@/components/tryout/score/history.client";
@@ -17,7 +20,13 @@ import { TryoutPageHeader } from "@/components/tryout/shell/header";
 import { TryoutMeta } from "@/components/tryout/shell/meta";
 
 /** Renders a no-nested-section set as the directly startable section surface. */
-export function TryoutSetEntry({ value }: { value: TryoutInternalSetView }) {
+export function TryoutSetEntry({
+  content,
+  value,
+}: {
+  content: Promise<TryoutRuntimeContent> | null;
+  value: TryoutInternalSetView;
+}) {
   const tCommon = useTranslations("Common");
   const tTryouts = useTranslations("Tryouts");
   const sectionAttempt =
@@ -70,7 +79,7 @@ export function TryoutSetEntry({ value }: { value: TryoutInternalSetView }) {
         <div className="space-y-12">
           <TryoutEntryResult value={value} />
 
-          <TryoutEntryRuntime value={value} />
+          <TryoutEntryRuntime content={content} value={value} />
         </div>
       </div>
     </div>
@@ -171,17 +180,56 @@ function TryoutEntryAction({ value }: { value: TryoutInternalSetView }) {
 }
 
 /** Renders the direct-entry question runtime when Convex has one. */
-function TryoutEntryRuntime({ value }: { value: TryoutInternalSetView }) {
+function TryoutEntryRuntime({
+  content,
+  value,
+}: {
+  content: Promise<TryoutRuntimeContent> | null;
+  value: TryoutInternalSetView;
+}) {
   if (value.runtimeState.kind === "none") {
     return null;
   }
 
   return (
+    <Suspense fallback={null}>
+      <TryoutEntryRuntimeContent content={content} value={value} />
+    </Suspense>
+  );
+}
+
+/** Resolves signed content only inside the direct-entry runtime region. */
+function TryoutEntryRuntimeContent({
+  content,
+  value,
+}: {
+  content: Promise<TryoutRuntimeContent> | null;
+  value: TryoutInternalSetView;
+}) {
+  if (value.runtimeState.kind === "none") {
+    return null;
+  }
+  if (!content) {
+    return <TryoutContentRefresh />;
+  }
+
+  const resolvedContent = use(content);
+  if (resolvedContent.questions.length === 0) {
+    return <TryoutContentRefresh />;
+  }
+  if (
+    value.runtimeState.kind === "review" &&
+    resolvedContent.answers.length === 0
+  ) {
+    return <TryoutContentRefresh />;
+  }
+
+  return (
     <TryoutRuntime
       value={{
-        answers: value.content.entryAnswers,
+        answers: resolvedContent.answers,
         expired: value.runtimeState.kind !== "active",
-        questions: value.content.entryQuestions,
+        questions: resolvedContent.questions,
         returnHref: getTryoutAttemptHref(
           value.page.set.publicPath,
           value.runtimeState.runtime.attemptId

--- a/apps/www/components/tryout/set/model.ts
+++ b/apps/www/components/tryout/set/model.ts
@@ -1,10 +1,6 @@
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import type { Locale } from "next-intl";
-import type {
-  TryoutAnswerContent,
-  TryoutQuestionContent,
-} from "@/components/tryout/content/model";
 import type { TryoutRuntimeState } from "@/components/tryout/runtime/state";
 
 /** Convex query contract for the set discovery page. */
@@ -39,12 +35,6 @@ export type LoadedRuntime = NonNullable<
     FunctionReturnType<typeof api.tryouts.queries.runtime.getSetAttemptState>
   >["runtime"]
 >;
-
-/** Static MDX content needed by a direct-entry runtime. */
-export interface TryoutSetContent {
-  entryAnswers: readonly TryoutAnswerContent[];
-  entryQuestions: readonly TryoutQuestionContent[];
-}
 
 /** URL route coordinates for one try-out set page. */
 export interface TryoutSetRoute {
@@ -85,7 +75,6 @@ export interface TryoutSetView {
 
 /** Render model for sets whose only section is the set entry itself. */
 export interface TryoutInternalSetView extends TryoutSetView {
-  content: TryoutSetContent;
   entrySection: SetEntrySection;
   runtimeState: TryoutRuntimeState<LoadedRuntime>;
 }


### PR DESCRIPTION
## Summary

- start the single signed review Promise only after authenticated attempt ownership and frozen page verification
- stream truthful header, completion status, score, history, and actions before the signed runtime finishes
- contain the completion refresh inside a null Suspense runtime seam so terminal status and score do not flicker away
- preserve the existing protected-content loader, signed snapshot checks, question and answer gating, and active-only subscription behavior

## Production evidence

- completed TKA Set 1 previously delivered its RSC stream in 5.013 seconds with about 2.19 MB decoded
- the exact attemptPage query took about 0.66 seconds, while protected signed review fetched 80 selectors in the expected 64 plus 16 batches
- terminal pages have no live runtime subscription, which isolates the delay to route bootstrap, signed artifact evaluation, and RSC serialization

## Verification

- pnpm lint
- pnpm --filter www typecheck
- pnpm --filter www test, 184 files and 1,135 tests, 100 percent coverage
- backend attemptPage focused tests
- production-data pnpm --filter www build, 1,303 static pages
- React Doctor changed scope, 100 out of 100
- git diff --check

No Convex backend contract or production deployment changes are included.