### PR TITLE
fix(auth): preserve SSR origin through Convex ingress

### DIFF
--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment node
 
+import "next/dist/server/node-environment-baseline";
+
+import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
+import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
+import { createRequestStore } from "next/dist/server/async-storage/request-store";
+import { createWorkStore } from "next/dist/server/async-storage/work-store";
 import {
   afterAll,
   afterEach,
@@ -13,6 +19,55 @@ import {
 const CONVEX_SITE_URL = "https://test.convex.site";
 
 let handler: typeof import("./server")["handler"];
+let getToken: typeof import("./server")["getToken"];
+
+const runWithRequestHeaders = (headers: Headers) => {
+  const requestStore = createRequestStore({
+    fallbackParams: null,
+    headers,
+    hmrRefreshHash: undefined,
+    implicitTags: { expirationsByCacheKind: new Map(), tags: [] },
+    isHmrRefresh: false,
+    onUpdateCookies: undefined,
+    phase: "render",
+    previewProps: undefined,
+    resumeDataCache: null,
+    rootParams: {},
+    serverComponentsHmrCache: undefined,
+    url: { pathname: "/test" },
+  });
+  const workStore = createWorkStore({
+    buildId: "test-build",
+    deploymentId: "test-deployment",
+    page: "/test/page",
+    previouslyRevalidatedTags: [],
+    renderOpts: {
+      assetPrefix: "",
+      cacheComponents: true,
+      cacheLifeProfiles: {
+        default: { expire: 31_536_000, revalidate: 900, stale: 300 },
+      },
+      experimental: {
+        authInterrupts: false,
+        isRoutePPREnabled: false,
+        useCacheTimeout: 50,
+      },
+      isBuildTimePrerendering: false,
+      isDebugDynamicAccesses: false,
+      isDraftMode: false,
+      onAfterTaskError: undefined,
+      onClose: () => undefined,
+      staticPageGenerationTimeout: 60,
+      supportsDynamicResponse: true,
+      validationLevel: "warning",
+      waitUntil: undefined,
+    },
+  });
+
+  return workAsyncStorage.run(workStore, () =>
+    workUnitAsyncStorage.run(requestStore, getToken)
+  );
+};
 
 beforeAll(async () => {
   vi.stubEnv("INTERNAL_CONTENT_API_KEY", "test-content-key");
@@ -21,7 +76,7 @@ beforeAll(async () => {
   vi.stubEnv("NEXT_PUBLIC_MCP_URL", "https://test.example.com/mcp");
   vi.stubEnv("SITE_URL", "https://nakafa.com");
 
-  ({ handler } = await import("./server"));
+  ({ getToken, handler } = await import("./server"));
 });
 
 afterEach(() => {
@@ -59,24 +114,31 @@ describe("Better Auth server proxy", () => {
     expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
   });
 
-  it("reads the current Better Auth token through the server boundary", async () => {
-    const componentGetToken = vi.fn().mockResolvedValue("test-token");
+  it("gets the SSR token through the installed adapter", async () => {
+    const cookie = "better-auth.session_token=session-cookie";
+    const requestHeaders = new Headers({
+      cookie,
+      host: "render.internal.example.com",
+      "x-forwarded-host": "nakafa.com",
+      "x-forwarded-proto": "https",
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(Response.json({ token: "test-token" }));
 
-    vi.resetModules();
-    vi.doMock("@convex-dev/better-auth/nextjs", () => ({
-      convexBetterAuthNextJs: () => ({
-        fetchAuthQuery: vi.fn(),
-        getToken: componentGetToken,
-        handler: { GET: vi.fn(), POST: vi.fn() },
-        preloadAuthQuery: vi.fn(),
-      }),
-    }));
+    await expect(runWithRequestHeaders(requestHeaders)).resolves.toBe(
+      "test-token"
+    );
+    const [, init] = fetchSpy.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
 
-    const { getToken } = await import("./server");
-
-    await expect(getToken()).resolves.toBe("test-token");
-    expect(componentGetToken).toHaveBeenCalledOnce();
-
-    vi.doUnmock("@convex-dev/better-auth/nextjs");
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${CONVEX_SITE_URL}/api/auth/convex/token`
+    );
+    expect(headers.get("host")).toBe("test.convex.site");
+    expect(headers.get("x-forwarded-host")).toBeNull();
+    expect(headers.get("x-better-auth-forwarded-host")).toBe("nakafa.com");
+    expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+    expect(headers.get("cookie")).toBe(cookie);
   });
 });

--- a/patches/@convex-dev__better-auth@0.12.5.patch
+++ b/patches/@convex-dev__better-auth@0.12.5.patch
@@ -1,26 +1,117 @@
 diff --git a/dist/nextjs/index.js b/dist/nextjs/index.js
-index e9d357fac1f073aa61c0cdeac36fd4ebb00fe583..d235e3bbf785e67827ca388255c6e5d416fa2760 100644
+index e9d357f..b28f84e 100644
 --- a/dist/nextjs/index.js
 +++ b/dist/nextjs/index.js
-@@ -31,9 +31,12 @@ const handler = async (request, siteUrl) => {
+@@ -23,6 +23,23 @@ const parseConvexSiteUrl = (url) => {
+     }
+     return url;
+ };
++// Convex ingress routes on `x-forwarded-host`, so tunnel the public origin
++// through component-owned headers until the request reaches Better Auth.
++const tunnelPublicOrigin = (headers, host, protocol) => {
++    headers.delete("x-forwarded-host");
++    if (host) {
++        headers.set("x-better-auth-forwarded-host", host);
++    }
++    else {
++        headers.delete("x-better-auth-forwarded-host");
++    }
++    if (protocol) {
++        headers.set("x-better-auth-forwarded-proto", protocol);
++    }
++    else {
++        headers.delete("x-better-auth-forwarded-proto");
++    }
++};
+ const handler = async (request, siteUrl) => {
+     const requestUrl = new URL(request.url);
+     const nextUrl = `${siteUrl}${requestUrl.pathname}${requestUrl.search}`;
+@@ -31,12 +48,11 @@ const handler = async (request, siteUrl) => {
      headers.delete("transfer-encoding");
      headers.delete("content-length");
      headers.delete("connection");
-+    // Convex's edge resolves the deployment from `x-forwarded-host`, so an app
-+    // domain here routes to nothing; the component restores it from
-+    // `x-better-auth-forwarded-host` instead.
-+    headers.delete("x-forwarded-host");
++    const protocol = requestUrl.protocol.replace(/:$/, "");
++    tunnelPublicOrigin(headers, requestUrl.host, protocol);
      headers.set("accept-encoding", "application/json");
      headers.set("host", new URL(siteUrl).host);
 -    headers.set("x-forwarded-host", requestUrl.host);
-     headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
-     headers.set("x-better-auth-forwarded-host", requestUrl.host);
-     headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+-    headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+-    headers.set("x-better-auth-forwarded-host", requestUrl.host);
+-    headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
++    headers.set("x-forwarded-proto", protocol);
+     const init = {
+         headers,
+         method: request.method,
+@@ -62,8 +78,11 @@ export const convexBetterAuthNextJs = (opts) => {
+     const cachedGetToken = cache(async ({ forceRefresh } = {}) => {
+         const headers = await (await import("next/headers.js")).headers();
+         const mutableHeaders = new Headers(headers);
++        const publicHost = mutableHeaders.get("x-forwarded-host") ?? mutableHeaders.get("host");
++        const publicProtocol = mutableHeaders.get("x-forwarded-proto");
+         mutableHeaders.delete("content-length");
+         mutableHeaders.delete("transfer-encoding");
++        tunnelPublicOrigin(mutableHeaders, publicHost, publicProtocol);
+         mutableHeaders.set("accept-encoding", "identity");
+         return getToken(siteUrl, mutableHeaders, { ...opts, forceRefresh });
+     });
+diff --git a/src/client/create-client.test.ts b/src/client/create-client.test.ts
+index 548bdf4..939bdcb 100644
+--- a/src/client/create-client.test.ts
++++ b/src/client/create-client.test.ts
+@@ -109,7 +109,7 @@ describe("createClient route registration", () => {
+     expect(createAuth).toHaveBeenCalledTimes(2);
+   });
+ 
+-  it("restores preserved forwarded host headers before calling auth.handler", async () => {
++  it("restores preserved forwarded origin headers before calling auth.handler", async () => {
+     const client = createClient(component);
+     const http = httpRouter();
+     const handler = vi.fn(async (_request: Request) => new Response("ok"));
+@@ -134,9 +134,10 @@ describe("createClient route registration", () => {
+       new Request("https://adjective-animal-123.convex.site/api/auth/test", {
+         method: "GET",
+         headers: {
++          cookie: "better-auth.session_token=session-cookie",
+           host: "deployment.convex.site",
+           "x-forwarded-host": "deployment.convex.site",
+-          "x-forwarded-proto": "https",
++          "x-forwarded-proto": "http",
+           "x-better-auth-forwarded-host": "app.example.com",
+           "x-better-auth-forwarded-proto": "https",
+         },
+@@ -145,8 +146,13 @@ describe("createClient route registration", () => {
+ 
+     const forwardedRequest = handler.mock.calls[0]?.[0];
+     expect(forwardedRequest).toBeInstanceOf(Request);
+-    expect(forwardedRequest.headers.get("x-forwarded-host")).toBe("app.example.com");
++    expect(forwardedRequest.headers.get("x-forwarded-host")).toBe(
++      "app.example.com"
++    );
+     expect(forwardedRequest.headers.get("x-forwarded-proto")).toBe("https");
++    expect(forwardedRequest.headers.get("cookie")).toBe(
++      "better-auth.session_token=session-cookie"
++    );
+   });
+ 
+   it("registerRoutesLazy resolves trustedOrigins lazily when needed", async () => {
 diff --git a/src/nextjs/index.test.ts b/src/nextjs/index.test.ts
-index 325617029d91d0646973114e413b3d1ce8559bfd..21e705027b8c4e3b04dfa814c0bd62350435ccde 100644
+index 3256170..0468f4d 100644
 --- a/src/nextjs/index.test.ts
 +++ b/src/nextjs/index.test.ts
-@@ -69,12 +69,30 @@ describe("convexBetterAuthNextJs handler", () => {
+@@ -1,6 +1,12 @@
+ import { afterEach, describe, expect, it, vi } from "vitest";
+ import { convexBetterAuthNextJs } from "./index.js";
+ 
++const getRequestHeaders = vi.hoisted(() => vi.fn());
++
++vi.mock("next/headers.js", () => ({
++  headers: getRequestHeaders,
++}));
++
+ const SITE_URL = "https://test.convex.site";
+ const CONVEX_URL = "https://test.convex.cloud";
+ 
+@@ -69,12 +75,30 @@ describe("convexBetterAuthNextJs handler", () => {
      await handler.POST(request);
      const headers = headersOf(fetchSpy);
      expect(headers.get("host")).toBe(new URL(SITE_URL).host);
@@ -30,8 +121,7 @@ index 325617029d91d0646973114e413b3d1ce8559bfd..21e705027b8c4e3b04dfa814c0bd6235
      expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
      expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
    });
--
-+
+ 
 +  it("drops an inbound x-forwarded-host instead of forwarding it", async () => {
 +    const { handler, fetchSpy } = setup();
 +    const request = new Request(
@@ -53,21 +143,107 @@ index 325617029d91d0646973114e413b3d1ce8559bfd..21e705027b8c4e3b04dfa814c0bd6235
    it("buffers POST body and forwards as ArrayBuffer", async () => {
      const { handler, fetchSpy } = setup();
      const body = JSON.stringify({ email: "test@example.com" });
+@@ -107,3 +131,41 @@ describe("convexBetterAuthNextJs handler", () => {
+     expect(initOf(fetchSpy).body).toBeUndefined();
+   });
+ });
++
++describe("convexBetterAuthNextJs getToken", () => {
++  afterEach(() => {
++    vi.restoreAllMocks();
++    getRequestHeaders.mockReset();
++  });
++
++  it("tunnels the public origin without exposing it to Convex ingress", async () => {
++    const cookie = "better-auth.session_token=session-cookie";
++    getRequestHeaders.mockResolvedValue(
++      new Headers({
++        cookie,
++        host: "render.internal.example.com",
++        "x-forwarded-host": "app.example.com",
++        "x-forwarded-proto": "https",
++      })
++    );
++    const fetchSpy = vi
++      .spyOn(globalThis, "fetch")
++      .mockResolvedValue(Response.json({ token: "server-token" }));
++    const auth = convexBetterAuthNextJs({
++      convexUrl: CONVEX_URL,
++      convexSiteUrl: SITE_URL,
++    });
++
++    await expect(auth.getToken()).resolves.toBe("server-token");
++
++    const headers = headersOf(fetchSpy);
++    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
++      `${SITE_URL}/api/auth/convex/token`
++    );
++    expect(headers.get("host")).toBe("test.convex.site");
++    expect(headers.get("x-forwarded-host")).toBeNull();
++    expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
++    expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
++    expect(headers.get("cookie")).toBe(cookie);
++  });
++});
 diff --git a/src/nextjs/index.ts b/src/nextjs/index.ts
-index 1eef064afd063e134be1dabc362979c88f297f45..3742097ec2f5e1ee2904a7c47bbfd249dbd4ee5c 100644
+index 1eef064..ebd158b 100644
 --- a/src/nextjs/index.ts
 +++ b/src/nextjs/index.ts
-@@ -49,9 +49,12 @@ const handler = async (request: Request, siteUrl: string) => {
+@@ -40,6 +40,28 @@ const parseConvexSiteUrl = (url: string) => {
+   return url;
+ };
+ 
++// Convex ingress routes on `x-forwarded-host`, so tunnel the public origin
++// through component-owned headers until the request reaches Better Auth.
++const tunnelPublicOrigin = (
++  headers: Headers,
++  host: string | null,
++  protocol: string | null
++) => {
++  headers.delete("x-forwarded-host");
++
++  if (host) {
++    headers.set("x-better-auth-forwarded-host", host);
++  } else {
++    headers.delete("x-better-auth-forwarded-host");
++  }
++
++  if (protocol) {
++    headers.set("x-better-auth-forwarded-proto", protocol);
++  } else {
++    headers.delete("x-better-auth-forwarded-proto");
++  }
++};
++
+ const handler = async (request: Request, siteUrl: string) => {
+   const requestUrl = new URL(request.url);
+   const nextUrl = `${siteUrl}${requestUrl.pathname}${requestUrl.search}`;
+@@ -49,12 +71,11 @@ const handler = async (request: Request, siteUrl: string) => {
    headers.delete("transfer-encoding");
    headers.delete("content-length");
    headers.delete("connection");
-+  // Convex's edge resolves the deployment from `x-forwarded-host`, so an app
-+  // domain here routes to nothing; the component restores it from
-+  // `x-better-auth-forwarded-host` instead.
-+  headers.delete("x-forwarded-host");
++  const protocol = requestUrl.protocol.replace(/:$/, "");
++  tunnelPublicOrigin(headers, requestUrl.host, protocol);
    headers.set("accept-encoding", "application/json");
    headers.set("host", new URL(siteUrl).host);
 -  headers.set("x-forwarded-host", requestUrl.host);
-   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
-   headers.set("x-better-auth-forwarded-host", requestUrl.host);
-   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+-  headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+-  headers.set("x-better-auth-forwarded-host", requestUrl.host);
+-  headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
++  headers.set("x-forwarded-proto", protocol);
+ 
+   const init: RequestInit = {
+     headers,
+@@ -98,8 +119,12 @@ export const convexBetterAuthNextJs = (
+     async ({ forceRefresh }: { forceRefresh?: boolean } = {}) => {
+       const headers = await (await import("next/headers.js")).headers();
+       const mutableHeaders = new Headers(headers);
++      const publicHost =
++        mutableHeaders.get("x-forwarded-host") ?? mutableHeaders.get("host");
++      const publicProtocol = mutableHeaders.get("x-forwarded-proto");
+       mutableHeaders.delete("content-length");
+       mutableHeaders.delete("transfer-encoding");
++      tunnelPublicOrigin(mutableHeaders, publicHost, publicProtocol);
+       mutableHeaders.set("accept-encoding", "identity");
+       return getToken(siteUrl, mutableHeaders, { ...opts, forceRefresh });
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ overrides:
 
 patchedDependencies:
   '@convex-dev/better-auth@0.12.5':
-    hash: 8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6
+    hash: d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073
     path: patches/@convex-dev__better-auth@0.12.5.patch
   next@16.3.0:
     hash: 69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136
@@ -108,7 +108,7 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
+        version: 0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
       '@nakafa/aksara-contracts':
         specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.11.0/nakafa-aksara-contracts-0.11.0.tgz
         version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.11.0/nakafa-aksara-contracts-0.11.0.tgz(effect@3.22.1)
@@ -282,7 +282,7 @@ importers:
         version: 4.0.61(react@19.2.8)(zod@4.4.3)
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
+        version: 0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)
       '@effect/platform':
         specifier: 0.97.1
         version: 0.97.1(effect@3.22.1)
@@ -612,7 +612,7 @@ importers:
         version: 0.2.2(convex@1.43.0(react@19.2.8))
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)
+        version: 0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)
       '@convex-dev/resend':
         specifier: ^0.2.6
         version: 0.2.6(@react-email/render@2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(convex-helpers@0.1.122(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)(zod@4.4.3))(convex@1.43.0(react@19.2.8))(react@19.2.8)
@@ -8456,7 +8456,7 @@ snapshots:
       convex: 1.43.0(react@19.2.8)
       react: 19.2.8
 
-  '@convex-dev/better-auth@0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)':
+  '@convex-dev/better-auth@0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -8474,7 +8474,7 @@ snapshots:
       - hono
       - typescript
 
-  '@convex-dev/better-auth@0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
+  '@convex-dev/better-auth@0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -8492,7 +8492,7 @@ snapshots:
       - hono
       - typescript
 
-  '@convex-dev/better-auth@0.12.5(patch_hash=8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
+  '@convex-dev/better-auth@0.12.5(patch_hash=d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073)(@standard-schema/spec@1.1.0)(better-auth@1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(convex@1.43.0(react@19.2.8))(hono@4.13.1)(react@19.2.8)(typescript@7.0.2)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.26(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=69c234729b8a9eddad005442418b6c7c6f2fecc62a72fe12db60507ada0c6136)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,8 +33,8 @@ overrides:
   "read-yaml-file@1.1.0>js-yaml": "3.15.1"
 
 patchedDependencies:
-  # Emergency backport of get-convex/better-auth#423 while npm latest is 0.12.5.
-  # Remove with the first stable release containing upstream PR #423.
+  # Emergency backport of get-convex/better-auth#423 plus the reported SSR getToken follow-up.
+  # Remove with the first stable release containing both upstream corrections.
   '@convex-dev/better-auth@0.12.5': patches/@convex-dev__better-auth@0.12.5.patch
   # Backports Next.js #96553 while npm latest remains stable 16.3.0.
   # Source maps are disabled for this patched module until that fix reaches stable.

--- a/scripts/check-patches.mjs
+++ b/scripts/check-patches.mjs
@@ -8,8 +8,9 @@ const BETTER_AUTH_COMPONENT_VERSION = "0.12.5";
 const BETTER_AUTH_COMPONENT_SPECIFIER = `^${BETTER_AUTH_COMPONENT_VERSION}`;
 const BETTER_AUTH_PATCH_PATH = "patches/@convex-dev__better-auth@0.12.5.patch";
 const BETTER_AUTH_PATCH_SHA256 =
-  "8c8d4c7c89624e285967f368f25b1ffd13185fbe2e5bdd5cb12ae12f71c80cb6";
-const BETTER_AUTH_UPSTREAM_FIX = "get-convex/better-auth#423";
+  "d04a5199bf6df27e192599c9ff0ffa22799129204a07f82104ad26f14fe36073";
+const BETTER_AUTH_UPSTREAM_FIX =
+  "get-convex/better-auth#423 plus the reported SSR getToken follow-up";
 const NEXT_VERSION = "16.3.0";
 const NEXT_PATCH_PATH = "patches/next.patch";
 const NEXT_PATCH_SHA256 =


### PR DESCRIPTION
## Summary

- backport the complete Next adapter correction for both the auth route handler and Server Component `cachedGetToken()`
- derive the public host and protocol before removing generic `x-forwarded-host`, then tunnel the origin through component-owned Better Auth headers
- preserve cookies and verify that the component restores the public host and protocol before Better Auth handles the request
- replace the mocked app ownership test with the real installed adapter running inside real Next request stores
- retain an explicit removal gate for the first stable package release containing both upstream corrections

## Production regression

The browser session endpoint remained authenticated, but direct authenticated try-out pages rendered public state. Cache-disabled hard navigation and App Router refresh did not change the result. In the same sanitized production window, the public catalog query executed while authenticated attempt queries never began. The downgrade therefore occurred before current-attempt resolution, at Server Component token acquisition.

`cachedGetToken()` copied the platform request headers, retained the public `x-forwarded-host`, and called the Convex site directly. Convex ingress routed on that generic header and returned an empty 404 before the component. The token fetch reduced that response to an absent token.

Sanitized evidence and the SSR follow-up proposal were posted upstream: https://github.com/get-convex/better-auth/pull/423#issuecomment-5262012091

## Architecture

The package Next adapter remains the owning Module and Interface. A private `tunnelPublicOrigin` implementation normalizes both outbound seams before Convex ingress. It has depth because it hides the routing-sensitive header contract, leverage because both handler and SSR token acquisition use it, and locality because no app wrapper or alternate auth path is introduced. Deleting it would duplicate the same normalization at both callers.

No Convex code or schema changes are included.

## Verification

- clean upstream v0.12.5 build produced byte-identical distributed Next adapter output
- upstream package: 184 passed, 31 skipped, no type errors
- upstream package lint: no errors, 3 pre-existing React hook warnings outside the change
- package regression tests: 12 passed
- installed adapter app integration: 2 passed, 100% coverage
- www suite: 1,137 passed across 185 files, 100% coverage
- `pnpm install --frozen-lockfile`
- `pnpm check:patches`
- `pnpm check:tests`
- `pnpm --filter www typecheck`
- `pnpm --filter @repo/backend typecheck`
- `pnpm lint`
- `pnpm security:audit`
- `pnpm build`, all 19 workspaces passed

React Doctor was not run because no TSX file changed.
