### PR TITLE
fix(tryout): prioritize restart action and outline set badge

### DIFF
--- a/apps/www/components/shared/catalog/card.tsx
+++ b/apps/www/components/shared/catalog/card.tsx
@@ -36,7 +36,7 @@ export function CatalogCard({
         </CardTitle>
         {badge ? (
           <CardAction>
-            <Badge variant="secondary">{badge}</Badge>
+            <Badge variant="outline">{badge}</Badge>
           </CardAction>
         ) : null}
       </CardHeader>

--- a/apps/www/components/tryout/score/history.client.tsx
+++ b/apps/www/components/tryout/score/history.client.tsx
@@ -238,6 +238,7 @@ export function TryoutAttemptResults({
         value={{ score: visibleAttempt.score, status: visibleAttempt.status }}
       />
       <div className="flex min-h-9 w-full flex-wrap items-center gap-3">
+        {children}
         <TryoutAttemptHistory
           value={{
             attempts,
@@ -248,7 +249,6 @@ export function TryoutAttemptResults({
             status: history.status,
           }}
         />
-        {children}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- place the primary start or restart action before the attempt history picker
- render catalog count badges with the existing outline variant

## Why

The completed try-out summary currently puts attempt history on the left even though restarting is the primary action. The catalog count badge also uses a filled secondary treatment instead of the requested outline treatment.

## Impact

- "Mulai lagi" and its equivalent action stay on the left when attempt history is available
- set-count badges use a transparent outlined style on shared catalog cards
- no route, data contract, query, mutation, or Convex schema changes

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm --filter www typecheck`
- `pnpm --filter www test`, 1,137 tests and 100% coverage
- `pnpm run doctor --verbose --scope changed --base 4911268a10c679f27f3d64a0fc92de5d6d373c2f`, 100/100
- `pnpm boundaries`, 3,039 files
- `pnpm --filter www build`, 1,303 of 1,303 pages
- `pnpm agent-docs`, 23 of 23 checks against the production server
- desktop and mobile browser acceptance for the catalog badge, CTA route, overflow, overlays, console, and page errors
- authenticated production baseline confirmed for the existing attempt history and restart layout
- Convex production health inspected read-only, with no permanent OCC or resource-limit failures