### PR TITLE
Reduce terminal try-out hydration with an immutable review Module

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/[section]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/[section]/page.tsx
@@ -11,6 +11,7 @@ import {
   readTryoutSectionPage,
 } from "@/components/tryout/catalog/server";
 import { loadSignedTryoutContent } from "@/components/tryout/content/signed";
+import { TryoutReview } from "@/components/tryout/review/server";
 import { selectTryoutSectionReturnHref } from "@/components/tryout/route/owner";
 import {
   getTryoutAttemptAuthHref,
@@ -156,7 +157,7 @@ async function TryoutSectionRoute({
     publicHref: getTryoutHref({ country, exam, set, track }),
   });
 
-  const content =
+  const signedContent =
     attemptPage?.content.kind === "signed"
       ? Effect.runPromise(
           loadSignedTryoutContent({
@@ -164,6 +165,11 @@ async function TryoutSectionRoute({
             questions: attemptPage.content.questions,
           })
         )
+      : null;
+  const reviewRuntime =
+    attemptPage?.content.kind === "signed" &&
+    attemptPage.content.answers.length > 0
+      ? attemptPage.initialState.runtime
       : null;
 
   return (
@@ -179,11 +185,15 @@ async function TryoutSectionRoute({
             }
           : null
       }
-      content={content}
+      content={reviewRuntime ? null : signedContent}
       page={page}
       route={{ country, exam, locale, section, set, track }}
       setHref={setHref}
-    />
+    >
+      {signedContent && reviewRuntime ? (
+        <TryoutReview content={signedContent} runtime={reviewRuntime} />
+      ) : null}
+    </TryoutSectionPageClient>
   );
 }
 

--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/[track]/[set]/page.tsx
@@ -11,6 +11,7 @@ import {
   readTryoutSetPage,
 } from "@/components/tryout/catalog/server";
 import { loadSignedTryoutContent } from "@/components/tryout/content/signed";
+import { TryoutReview } from "@/components/tryout/review/server";
 import {
   createTryoutSetRestartTarget,
   selectTryoutFrozenPage,
@@ -132,7 +133,7 @@ async function TryoutSetRoute({ params, searchParams }: TryoutSetPageProps) {
   }
   const { page, restartTarget } = pages;
 
-  const content =
+  const signedContent =
     attemptPage?.content.kind === "signed"
       ? Effect.runPromise(
           loadSignedTryoutContent({
@@ -140,6 +141,11 @@ async function TryoutSetRoute({ params, searchParams }: TryoutSetPageProps) {
             questions: attemptPage.content.questions,
           })
         )
+      : null;
+  const reviewRuntime =
+    attemptPage?.content.kind === "signed" &&
+    attemptPage.content.answers.length > 0
+      ? attemptPage.initialState.runtime
       : null;
 
   return (
@@ -153,11 +159,15 @@ async function TryoutSetRoute({ params, searchParams }: TryoutSetPageProps) {
             }
           : null
       }
-      content={content}
+      content={reviewRuntime ? null : signedContent}
       page={page}
       restartTarget={restartTarget}
       route={{ country, exam, locale, set, track }}
-    />
+    >
+      {signedContent && reviewRuntime ? (
+        <TryoutReview content={signedContent} runtime={reviewRuntime} />
+      ) : null}
+    </TryoutSetPageClient>
   );
 }
 

--- a/apps/www/components/tryout/review/model.test.ts
+++ b/apps/www/components/tryout/review/model.test.ts
@@ -1,0 +1,191 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
+import { projectTryoutReview } from "@/components/tryout/review/model";
+
+const FIRST_IDENTITY = {
+  contentHash: "content-1",
+  sourcePath: "questions/1",
+  sourceRevision: "revision-1",
+};
+const SECOND_IDENTITY = {
+  contentHash: "content-2",
+  sourcePath: "questions/2",
+  sourceRevision: "revision-2",
+};
+
+describe("projectTryoutReview", () => {
+  it("pairs signed questions and answers in frozen runtime order", async () => {
+    const content = createContent([SECOND_IDENTITY, FIRST_IDENTITY]);
+    const questions = [
+      createRuntimeQuestion(FIRST_IDENTITY, 1),
+      createRuntimeQuestion(SECOND_IDENTITY, 2),
+    ];
+
+    await expect(
+      Effect.runPromise(projectTryoutReview({ content, questions }))
+    ).resolves.toEqual([
+      {
+        answer: "answer:questions/1",
+        choices: [{ isCorrect: true, label: "A", optionKey: "a", order: 1 }],
+        content: "question:questions/1",
+        questionOrder: 1,
+        response: {
+          answeredAt: 10,
+          selectedOptionId: "a",
+          updatedAt: 10,
+        },
+      },
+      {
+        answer: "answer:questions/2",
+        choices: [{ isCorrect: true, label: "A", optionKey: "a", order: 1 }],
+        content: "question:questions/2",
+        questionOrder: 2,
+        response: {
+          answeredAt: 20,
+          selectedOptionId: "a",
+          updatedAt: 20,
+        },
+      },
+    ]);
+  });
+
+  it("fails with a typed error when one signed answer is missing", async () => {
+    const content = createContent([FIRST_IDENTITY]);
+    const incompleteContent = {
+      ...content,
+      answers: [],
+    } satisfies TryoutRuntimeContent;
+
+    await expect(
+      Effect.runPromise(
+        Effect.flip(
+          projectTryoutReview({
+            content: incompleteContent,
+            questions: [createRuntimeQuestion(FIRST_IDENTITY, 1)],
+          })
+        )
+      )
+    ).resolves.toMatchObject({
+      _tag: "TryoutReviewProjectionError",
+      code: "TRYOUT_REVIEW_PROJECTION",
+    });
+  });
+
+  it("fails with a typed error when one signed question is missing", async () => {
+    await expectProjectionError({
+      content: createContent([]),
+      questions: [createRuntimeQuestion(FIRST_IDENTITY, 1)],
+    });
+  });
+
+  it("fails with a typed error for duplicate content identity", async () => {
+    const content = createContent([FIRST_IDENTITY, FIRST_IDENTITY]);
+
+    await expect(
+      Effect.runPromise(
+        Effect.flip(
+          projectTryoutReview({
+            content,
+            questions: [
+              createRuntimeQuestion(FIRST_IDENTITY, 1),
+              createRuntimeQuestion(SECOND_IDENTITY, 2),
+            ],
+          })
+        )
+      )
+    ).resolves.toMatchObject({
+      _tag: "TryoutReviewProjectionError",
+      code: "TRYOUT_REVIEW_PROJECTION",
+    });
+  });
+
+  it("fails with a typed error for duplicate answer identity", async () => {
+    const content = createContent([FIRST_IDENTITY, SECOND_IDENTITY]);
+
+    await expectProjectionError({
+      content: {
+        ...content,
+        answers: [content.answers[0], content.answers[0]],
+      },
+      questions: [
+        createRuntimeQuestion(FIRST_IDENTITY, 1),
+        createRuntimeQuestion(SECOND_IDENTITY, 2),
+      ],
+    });
+  });
+
+  it("fails with a typed error for duplicate runtime order", async () => {
+    await expectProjectionError({
+      content: createContent([FIRST_IDENTITY, SECOND_IDENTITY]),
+      questions: [
+        createRuntimeQuestion(FIRST_IDENTITY, 1),
+        createRuntimeQuestion(SECOND_IDENTITY, 1),
+      ],
+    });
+  });
+
+  it("fails with a typed error for runtime and signed identity drift", async () => {
+    await expectProjectionError({
+      content: createContent([FIRST_IDENTITY]),
+      questions: [createRuntimeQuestion(SECOND_IDENTITY, 1)],
+    });
+  });
+
+  it("fails with a typed error for empty signed answer content", async () => {
+    const content = createContent([FIRST_IDENTITY]);
+
+    await expectProjectionError({
+      content: {
+        ...content,
+        answers: [{ ...content.answers[0], answer: null }],
+      },
+      questions: [createRuntimeQuestion(FIRST_IDENTITY, 1)],
+    });
+  });
+});
+
+/** Expects the review projection to fail through its typed Effect channel. */
+async function expectProjectionError(
+  input: Parameters<typeof projectTryoutReview>[0]
+) {
+  await expect(
+    Effect.runPromise(Effect.flip(projectTryoutReview(input)))
+  ).resolves.toMatchObject({
+    _tag: "TryoutReviewProjectionError",
+    code: "TRYOUT_REVIEW_PROJECTION",
+  });
+}
+
+/** Creates rendered signed content in an explicit storage order. */
+function createContent(
+  identities: readonly (typeof FIRST_IDENTITY)[]
+): TryoutRuntimeContent {
+  return {
+    answers: identities.map((identity) => ({
+      answer: `answer:${identity.sourcePath}`,
+      ...identity,
+    })),
+    questions: identities.map((identity) => ({
+      content: `question:${identity.sourcePath}`,
+      ...identity,
+    })),
+  };
+}
+
+/** Creates one frozen runtime question without unrelated attempt fields. */
+function createRuntimeQuestion(
+  identity: typeof FIRST_IDENTITY,
+  questionOrder: number
+) {
+  return {
+    choices: [{ isCorrect: true, label: "A", optionKey: "a", order: 1 }],
+    ...identity,
+    questionOrder,
+    response: {
+      answeredAt: questionOrder * 10,
+      selectedOptionId: "a",
+      updatedAt: questionOrder * 10,
+    },
+  };
+}

--- a/apps/www/components/tryout/review/model.ts
+++ b/apps/www/components/tryout/review/model.ts
@@ -1,0 +1,126 @@
+import { Effect, Schema } from "effect";
+import type { ReactNode } from "react";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
+import type {
+  TryoutRuntimeChoice,
+  TryoutRuntimeQuestion,
+} from "@/components/tryout/runtime/types";
+
+interface ReviewContentIdentity {
+  readonly contentHash: string;
+  readonly sourcePath: string;
+  readonly sourceRevision: string;
+}
+
+interface ReviewRuntimeQuestion extends ReviewContentIdentity {
+  readonly choices: readonly TryoutRuntimeChoice[];
+  readonly questionOrder: number;
+  readonly response: TryoutRuntimeQuestion["response"];
+}
+
+/** One immutable reviewed question ready for read-only composition. */
+export interface TryoutReviewQuestion {
+  readonly answer: ReactNode;
+  readonly choices: readonly TryoutRuntimeChoice[];
+  readonly content: ReactNode;
+  readonly questionOrder: number;
+  readonly response: TryoutRuntimeQuestion["response"];
+}
+
+/** Fails closed when signed review content no longer matches frozen runtime. */
+export class TryoutReviewProjectionError extends Schema.TaggedError<TryoutReviewProjectionError>()(
+  "TryoutReviewProjectionError",
+  {
+    code: Schema.Literal("TRYOUT_REVIEW_PROJECTION"),
+    message: Schema.String,
+  }
+) {}
+
+/** Pairs one terminal runtime with its exact signed questions and answers. */
+export const projectTryoutReview = Effect.fn("TryoutReview.project")(function* <
+  Question extends ReviewRuntimeQuestion,
+>(input: {
+  readonly content: TryoutRuntimeContent;
+  readonly questions: readonly Question[];
+}) {
+  if (
+    input.content.questions.length !== input.questions.length ||
+    input.content.answers.length !== input.questions.length
+  ) {
+    return yield* projectionError(
+      "Terminal review content count does not match its frozen runtime."
+    );
+  }
+
+  const questionContent = new Map(
+    input.content.questions.map((question) => [
+      getContentIdentity(question),
+      question,
+    ])
+  );
+  const answerContent = new Map(
+    input.content.answers.map((answer) => [getContentIdentity(answer), answer])
+  );
+
+  if (
+    questionContent.size !== input.content.questions.length ||
+    answerContent.size !== input.content.answers.length
+  ) {
+    return yield* projectionError(
+      "Terminal review content contains a duplicate frozen identity."
+    );
+  }
+
+  const questionOrders = new Set<number>();
+  const reviewQuestions: TryoutReviewQuestion[] = [];
+
+  for (const question of input.questions) {
+    if (questionOrders.has(question.questionOrder)) {
+      return yield* projectionError(
+        "Terminal review runtime contains a duplicate question order."
+      );
+    }
+    questionOrders.add(question.questionOrder);
+
+    const identity = getContentIdentity(question);
+    const signedQuestion = questionContent.get(identity);
+    const signedAnswer = answerContent.get(identity);
+    if (!(signedQuestion && signedAnswer)) {
+      return yield* projectionError(
+        "Terminal review content lost a frozen question or answer."
+      );
+    }
+    if (!signedAnswer.answer) {
+      return yield* projectionError(
+        "Terminal review content contains an empty signed answer."
+      );
+    }
+
+    reviewQuestions.push({
+      answer: signedAnswer.answer,
+      choices: question.choices,
+      content: signedQuestion.content,
+      questionOrder: question.questionOrder,
+      response: question.response,
+    });
+  }
+
+  return reviewQuestions;
+});
+
+/** Builds one collision-safe key from an already trusted content identity. */
+function getContentIdentity(identity: ReviewContentIdentity) {
+  return JSON.stringify([
+    identity.sourcePath,
+    identity.contentHash,
+    identity.sourceRevision,
+  ]);
+}
+
+/** Creates one typed terminal-review projection failure. */
+function projectionError(message: string) {
+  return new TryoutReviewProjectionError({
+    code: "TRYOUT_REVIEW_PROJECTION",
+    message,
+  });
+}

--- a/apps/www/components/tryout/review/server.tsx
+++ b/apps/www/components/tryout/review/server.tsx
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { Effect } from "effect";
+import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
+import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
+import { projectTryoutReview } from "@/components/tryout/review/model";
+import { TryoutReviewedChoice } from "@/components/tryout/runtime/choice-surface.client";
+import {
+  TryoutReviewQuestionExplanation,
+  TryoutReviewQuestionShell,
+} from "@/components/tryout/runtime/question-shell.client";
+import type { TryoutSectionRuntime } from "@/components/tryout/runtime/types";
+
+/** Renders one immutable terminal review outside the active runtime Module. */
+export async function TryoutReview({
+  content,
+  runtime,
+}: {
+  readonly content: Promise<TryoutRuntimeContent>;
+  readonly runtime: TryoutSectionRuntime;
+}) {
+  const resolvedContent = await content;
+  const questions = await Effect.runPromise(
+    projectTryoutReview({
+      content: resolvedContent,
+      questions: runtime.questions,
+    }).pipe(
+      Effect.catchTag("TryoutReviewProjectionError", () =>
+        Effect.logWarning(
+          "Terminal try-out review projection failed closed."
+        ).pipe(Effect.as(null))
+      )
+    )
+  );
+
+  if (!questions) {
+    return <TryoutContentRefresh />;
+  }
+
+  return (
+    <section className="space-y-12">
+      {questions.map((question) => (
+        <TryoutReviewQuestionShell
+          key={question.questionOrder}
+          questionOrder={question.questionOrder}
+        >
+          <section className="my-6">{question.content}</section>
+          <section className="my-8">
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              {question.choices.map((choice) => (
+                <TryoutReviewedChoice
+                  checked={
+                    question.response?.selectedOptionId === choice.optionKey
+                  }
+                  id={`review-question-${question.questionOrder}-${choice.optionKey}`}
+                  isCorrect={choice.isCorrect}
+                  key={choice.optionKey}
+                  label={choice.label}
+                />
+              ))}
+            </div>
+          </section>
+          <TryoutReviewQuestionExplanation
+            questionOrder={question.questionOrder}
+          >
+            {question.answer}
+          </TryoutReviewQuestionExplanation>
+        </TryoutReviewQuestionShell>
+      ))}
+    </section>
+  );
+}

--- a/apps/www/components/tryout/runtime/choice-surface.client.tsx
+++ b/apps/www/components/tryout/runtime/choice-surface.client.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Response } from "@repo/design-system/components/ai/response";
+import { Checkbox } from "@repo/design-system/components/ui/checkbox";
+import { Label } from "@repo/design-system/components/ui/label";
+import { buttonVariants } from "@repo/design-system/lib/button";
+import { cn } from "@repo/design-system/lib/utils";
+import type { ReactNode } from "react";
+import {
+  getTryoutReviewedChoiceVariant,
+  getTryoutSelectableChoiceVariant,
+} from "@/lib/tryout/choice-variant";
+
+interface TryoutSelectableChoiceProps {
+  checked: boolean;
+  disabled: boolean;
+  id: string;
+  label: string;
+  onSelect: () => void;
+}
+
+/** Renders one selectable choice without revealing answer correctness. */
+export function TryoutSelectableChoice({
+  checked,
+  disabled,
+  id,
+  label,
+  onSelect,
+}: TryoutSelectableChoiceProps) {
+  return (
+    <TryoutChoiceFrame
+      id={id}
+      label={label}
+      variant={getTryoutSelectableChoiceVariant({ checked })}
+    >
+      <TryoutChoiceCheckbox
+        checked={checked}
+        disabled={disabled}
+        id={id}
+        onSelect={onSelect}
+      />
+    </TryoutChoiceFrame>
+  );
+}
+
+interface TryoutRevealedChoiceProps extends TryoutSelectableChoiceProps {
+  isCorrect: boolean | undefined;
+}
+
+/** Renders one selectable preview choice with correctness revealed. */
+export function TryoutRevealedChoice({
+  checked,
+  disabled,
+  id,
+  isCorrect,
+  label,
+  onSelect,
+}: TryoutRevealedChoiceProps) {
+  return (
+    <TryoutChoiceFrame
+      id={id}
+      label={label}
+      variant={getTryoutReviewedChoiceVariant({ checked, isCorrect })}
+    >
+      <TryoutChoiceCheckbox
+        checked={checked}
+        disabled={disabled}
+        id={id}
+        onSelect={onSelect}
+      />
+    </TryoutChoiceFrame>
+  );
+}
+
+interface TryoutReviewedChoiceProps {
+  checked: boolean;
+  id: string;
+  isCorrect: boolean | undefined;
+  label: string;
+}
+
+/** Renders one locked terminal choice without a mutation Interface. */
+export function TryoutReviewedChoice({
+  checked,
+  id,
+  isCorrect,
+  label,
+}: TryoutReviewedChoiceProps) {
+  return (
+    <TryoutChoiceFrame
+      id={id}
+      label={label}
+      variant={getTryoutReviewedChoiceVariant({ checked, isCorrect })}
+    >
+      <Checkbox
+        aria-labelledby={`${id}-label`}
+        checked={checked}
+        className="mt-1 shrink-0 cursor-pointer"
+        disabled
+      />
+    </TryoutChoiceFrame>
+  );
+}
+
+interface TryoutChoiceCheckboxProps {
+  checked: boolean;
+  disabled: boolean;
+  id: string;
+  onSelect: () => void;
+}
+
+/** Owns the checkbox interaction shared by active and preview choices. */
+function TryoutChoiceCheckbox({
+  checked,
+  disabled,
+  id,
+  onSelect,
+}: TryoutChoiceCheckboxProps) {
+  return (
+    <Checkbox
+      aria-labelledby={`${id}-label`}
+      checked={checked}
+      className="mt-1 shrink-0 cursor-pointer"
+      disabled={disabled}
+      onCheckedChange={(nextChecked) => {
+        if (nextChecked) {
+          onSelect();
+        }
+      }}
+    />
+  );
+}
+
+type ButtonVariantOptions = NonNullable<Parameters<typeof buttonVariants>[0]>;
+
+interface TryoutChoiceFrameProps {
+  children: ReactNode;
+  id: string;
+  label: string;
+  variant: NonNullable<ButtonVariantOptions["variant"]>;
+}
+
+/** Owns the shared visual composition for every explicit choice variant. */
+function TryoutChoiceFrame({
+  children,
+  id,
+  label,
+  variant,
+}: TryoutChoiceFrameProps) {
+  const labelId = `${id}-label`;
+
+  return (
+    <Label
+      className={cn(
+        buttonVariants({ variant }),
+        "h-auto min-w-0 whitespace-normal text-left font-normal text-base"
+      )}
+    >
+      {children}
+      <div className="min-w-0 flex-1" id={labelId}>
+        <Response className="wrap-anywhere h-auto whitespace-normal" id={id}>
+          {label}
+        </Response>
+      </div>
+    </Label>
+  );
+}

--- a/apps/www/components/tryout/runtime/choice-surface.client.tsx
+++ b/apps/www/components/tryout/runtime/choice-surface.client.tsx
@@ -6,7 +6,9 @@ import { Label } from "@repo/design-system/components/ui/label";
 import { buttonVariants } from "@repo/design-system/lib/button";
 import { cn } from "@repo/design-system/lib/utils";
 import type { ReactNode } from "react";
+import type { TryoutPreviewChoiceAppearance } from "@/lib/tryout/choice-variant";
 import {
+  getTryoutPreviewChoiceVariant,
   getTryoutReviewedChoiceVariant,
   getTryoutSelectableChoiceVariant,
 } from "@/lib/tryout/choice-variant";
@@ -43,24 +45,27 @@ export function TryoutSelectableChoice({
   );
 }
 
-interface TryoutRevealedChoiceProps extends TryoutSelectableChoiceProps {
-  isCorrect: boolean | undefined;
+interface TryoutPreviewChoiceProps extends TryoutSelectableChoiceProps {
+  appearance: TryoutPreviewChoiceAppearance;
 }
 
-/** Renders one selectable preview choice with correctness revealed. */
-export function TryoutRevealedChoice({
+/** Keeps one stable preview choice while its correctness appearance changes. */
+export function TryoutPreviewChoice({
+  appearance,
   checked,
   disabled,
   id,
-  isCorrect,
   label,
   onSelect,
-}: TryoutRevealedChoiceProps) {
+}: TryoutPreviewChoiceProps) {
   return (
     <TryoutChoiceFrame
       id={id}
       label={label}
-      variant={getTryoutReviewedChoiceVariant({ checked, isCorrect })}
+      variant={getTryoutPreviewChoiceVariant({
+        appearance,
+        checked,
+      })}
     >
       <TryoutChoiceCheckbox
         checked={checked}

--- a/apps/www/components/tryout/runtime/choice.tsx
+++ b/apps/www/components/tryout/runtime/choice.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { api } from "@repo/backend/convex/_generated/api";
-import { Response } from "@repo/design-system/components/ai/response";
-import { Checkbox } from "@repo/design-system/components/ui/checkbox";
-import { Label } from "@repo/design-system/components/ui/label";
-import { buttonVariants } from "@repo/design-system/lib/button";
-import { cn } from "@repo/design-system/lib/utils";
 import { useMutation } from "convex/react";
 import type { FunctionArgs } from "convex/server";
 import { ConvexError } from "convex/values";
 import { Effect } from "effect";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { TryoutSelectableChoice } from "@/components/tryout/runtime/choice-surface.client";
 import type {
   TryoutRuntimeChoice,
   TryoutRuntimeQuestion,
   TryoutSectionRuntime,
 } from "@/components/tryout/runtime/types";
 import { reportClientException } from "@/lib/analytics/client";
-import { getTryoutChoiceVariant } from "@/lib/tryout/choice-variant";
 
 type SaveResponseArgs = FunctionArgs<
   typeof api.tryouts.mutations.responses.save
@@ -27,7 +22,6 @@ type SaveResponseArgs = FunctionArgs<
 interface TryoutChoicesValue {
   locked: boolean;
   question: TryoutRuntimeQuestion;
-  reviewMode: boolean;
 }
 
 /** Renders and saves selectable answers for one runtime question. */
@@ -112,7 +106,6 @@ export function TryoutChoices({ value }: { value: TryoutChoicesValue }) {
             disabled: locked,
             onSelect: () => saveChoice(choice),
             question,
-            reviewMode: value.reviewMode,
           }}
         />
       ))}
@@ -122,73 +115,17 @@ export function TryoutChoices({ value }: { value: TryoutChoicesValue }) {
 
 /** Renders one selectable answer option in the production exercise style. */
 function TryoutChoice({ value }: { value: TryoutChoiceValue }) {
-  const { choice, disabled, onSelect, question, reviewMode } = value;
+  const { choice, disabled, onSelect, question } = value;
   const checked = question.response?.selectedOptionId === choice.optionKey;
 
   return (
-    <TryoutChoiceSurface
+    <TryoutSelectableChoice
       checked={checked}
       disabled={disabled}
       id={`${question.placementId}-${choice.optionKey}`}
-      isCorrect={choice.isCorrect}
       label={choice.label}
       onSelect={onSelect}
-      reviewMode={reviewMode}
     />
-  );
-}
-
-interface TryoutChoiceSurfaceProps {
-  checked: boolean;
-  disabled: boolean;
-  id: string;
-  isCorrect: boolean | undefined;
-  label: string;
-  onSelect: () => void;
-  reviewMode: boolean;
-}
-
-/** Renders the shared production choice surface without owning persistence. */
-export function TryoutChoiceSurface({
-  checked,
-  disabled,
-  id,
-  isCorrect,
-  label,
-  onSelect,
-  reviewMode,
-}: TryoutChoiceSurfaceProps) {
-  const labelId = `${id}-label`;
-  const variant = getTryoutChoiceVariant({
-    checked,
-    isCorrect,
-    reviewMode,
-  });
-
-  return (
-    <Label
-      className={cn(
-        buttonVariants({ variant }),
-        "h-auto min-w-0 whitespace-normal text-left font-normal text-base"
-      )}
-    >
-      <Checkbox
-        aria-labelledby={labelId}
-        checked={checked}
-        className="mt-1 shrink-0 cursor-pointer"
-        disabled={disabled}
-        onCheckedChange={(nextChecked) => {
-          if (nextChecked) {
-            onSelect();
-          }
-        }}
-      />
-      <div className="min-w-0 flex-1" id={labelId}>
-        <Response className="wrap-anywhere h-auto whitespace-normal" id={id}>
-          {label}
-        </Response>
-      </div>
-    </Label>
   );
 }
 
@@ -197,7 +134,6 @@ interface TryoutChoiceValue {
   disabled: boolean;
   onSelect: () => void;
   question: TryoutRuntimeQuestion;
-  reviewMode: boolean;
 }
 
 /** Applies a Convex optimistic answer snapshot to the matching runtime query. */

--- a/apps/www/components/tryout/runtime/client.tsx
+++ b/apps/www/components/tryout/runtime/client.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import type {
-  TryoutAnswerContent,
-  TryoutQuestionContent,
-} from "@/components/tryout/content/model";
+import type { TryoutQuestionContent } from "@/components/tryout/content/model";
 import { useTryoutClock } from "@/components/tryout/runtime/clock";
 import { TryoutRuntimeControls } from "@/components/tryout/runtime/controls.client";
-import { TryoutRuntimeQuestion } from "@/components/tryout/runtime/question.client";
+import { TryoutActiveQuestion } from "@/components/tryout/runtime/question.client";
 import type { TryoutSectionRuntime } from "@/components/tryout/runtime/types";
 
 /** Cohesive render model for one loaded try-out runtime. */
 export interface TryoutRuntimeValue {
-  answers: readonly TryoutAnswerContent[];
   expired: boolean;
   questions: readonly TryoutQuestionContent[];
   returnHref: string;
@@ -20,20 +16,16 @@ export interface TryoutRuntimeValue {
 
 /** Renders the active Convex-backed try-out section runtime. */
 export function TryoutRuntime({ value }: { value: TryoutRuntimeValue }) {
-  const { answers, expired, questions, runtime } = value;
+  const { expired, questions, runtime } = value;
   const isActive = runtime.section.status === "in-progress";
   const questionBySnapshot = new Map(
     questions.map((question) => [getQuestionContentKey(question), question])
-  );
-  const answerBySnapshot = new Map(
-    answers.map((answer) => [getQuestionContentKey(answer), answer.answer])
   );
   const runtimeQuestions = runtime.questions.map((question) => {
     const key = getQuestionContentKey(question);
     const content = questionBySnapshot.get(key);
 
     return {
-      answer: answerBySnapshot.get(key) ?? null,
       content: content?.content ?? null,
       question,
     };
@@ -42,8 +34,7 @@ export function TryoutRuntime({ value }: { value: TryoutRuntimeValue }) {
   if (runtimeQuestions.some(({ content }) => content === null)) {
     return null;
   }
-
-  if (!isActive && runtimeQuestions.some(({ answer }) => answer === null)) {
+  if (!isActive) {
     return null;
   }
 
@@ -51,16 +42,12 @@ export function TryoutRuntime({ value }: { value: TryoutRuntimeValue }) {
     <section className="space-y-12">
       <TryoutRuntimeActions value={value} />
 
-      {runtimeQuestions.map(({ answer, content, question }) => (
-        <TryoutRuntimeQuestion
+      {runtimeQuestions.map(({ content, question }) => (
+        <TryoutActiveQuestion
+          content={content}
           key={question.placementId}
-          value={{
-            answer,
-            content,
-            locked: expired || !isActive,
-            question,
-            reviewMode: !isActive,
-          }}
+          locked={expired}
+          question={question}
         />
       ))}
     </section>

--- a/apps/www/components/tryout/runtime/preview.client.tsx
+++ b/apps/www/components/tryout/runtime/preview.client.tsx
@@ -4,7 +4,10 @@ import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { TryoutChoiceSurface } from "@/components/tryout/runtime/choice";
+import {
+  TryoutRevealedChoice,
+  TryoutSelectableChoice,
+} from "@/components/tryout/runtime/choice-surface.client";
 
 type FeaturedChoice = FunctionReturnType<
   typeof api.tryouts.queries.catalog.getFeaturedQuestion
@@ -27,18 +30,28 @@ export function TryoutChoicePreview({
   return (
     <>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        {choices.map((choice) => (
-          <TryoutChoiceSurface
-            checked={selectedOptionKey === choice.optionKey}
-            disabled={false}
-            id={`features-tryout-choice-${choice.optionKey}`}
-            isCorrect={choice.isCorrect}
-            key={choice.optionKey}
-            label={choice.label}
-            onSelect={() => setSelectedOptionKey(choice.optionKey)}
-            reviewMode={selectedOptionKey !== null}
-          />
-        ))}
+        {choices.map((choice) =>
+          selectedOptionKey === null ? (
+            <TryoutSelectableChoice
+              checked={false}
+              disabled={false}
+              id={`features-tryout-choice-${choice.optionKey}`}
+              key={choice.optionKey}
+              label={choice.label}
+              onSelect={() => setSelectedOptionKey(choice.optionKey)}
+            />
+          ) : (
+            <TryoutRevealedChoice
+              checked={selectedOptionKey === choice.optionKey}
+              disabled={false}
+              id={`features-tryout-choice-${choice.optionKey}`}
+              isCorrect={choice.isCorrect}
+              key={choice.optionKey}
+              label={choice.label}
+              onSelect={() => setSelectedOptionKey(choice.optionKey)}
+            />
+          )
+        )}
       </div>
       <p aria-live="polite" className="sr-only" role="status">
         {selectedChoice

--- a/apps/www/components/tryout/runtime/preview.client.tsx
+++ b/apps/www/components/tryout/runtime/preview.client.tsx
@@ -4,10 +4,7 @@ import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import {
-  TryoutRevealedChoice,
-  TryoutSelectableChoice,
-} from "@/components/tryout/runtime/choice-surface.client";
+import { TryoutPreviewChoice } from "@/components/tryout/runtime/choice-surface.client";
 
 type FeaturedChoice = FunctionReturnType<
   typeof api.tryouts.queries.catalog.getFeaturedQuestion
@@ -30,28 +27,21 @@ export function TryoutChoicePreview({
   return (
     <>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        {choices.map((choice) =>
-          selectedOptionKey === null ? (
-            <TryoutSelectableChoice
-              checked={false}
-              disabled={false}
-              id={`features-tryout-choice-${choice.optionKey}`}
-              key={choice.optionKey}
-              label={choice.label}
-              onSelect={() => setSelectedOptionKey(choice.optionKey)}
-            />
-          ) : (
-            <TryoutRevealedChoice
-              checked={selectedOptionKey === choice.optionKey}
-              disabled={false}
-              id={`features-tryout-choice-${choice.optionKey}`}
-              isCorrect={choice.isCorrect}
-              key={choice.optionKey}
-              label={choice.label}
-              onSelect={() => setSelectedOptionKey(choice.optionKey)}
-            />
-          )
-        )}
+        {choices.map((choice) => (
+          <TryoutPreviewChoice
+            appearance={
+              selectedOptionKey === null
+                ? { kind: "selectable" }
+                : { isCorrect: choice.isCorrect, kind: "revealed" }
+            }
+            checked={selectedOptionKey === choice.optionKey}
+            disabled={false}
+            id={`features-tryout-choice-${choice.optionKey}`}
+            key={choice.optionKey}
+            label={choice.label}
+            onSelect={() => setSelectedOptionKey(choice.optionKey)}
+          />
+        ))}
       </div>
       <p aria-live="polite" className="sr-only" role="status">
         {selectedChoice

--- a/apps/www/components/tryout/runtime/question-shell.client.tsx
+++ b/apps/www/components/tryout/runtime/question-shell.client.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@repo/design-system/components/ui/button";
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from "@repo/design-system/components/ui/collapsible";
+import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
+import { Separator } from "@repo/design-system/components/ui/separator";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+interface TryoutQuestionShellProps {
+  readonly children: ReactNode;
+  readonly questionOrder: number;
+}
+
+/** Composes one active question without terminal-review behavior. */
+export function TryoutActiveQuestionShell({
+  children,
+  questionOrder,
+}: TryoutQuestionShellProps) {
+  const tExercises = useTranslations("Exercises");
+
+  return (
+    <Collapsible disabled>
+      <TryoutQuestionArticle questionOrder={questionOrder}>
+        <TryoutQuestionHeader questionOrder={questionOrder}>
+          <CollapsibleTrigger
+            className="group"
+            render={<Button disabled type="button" variant="outline" />}
+          >
+            {tExercises("explanation")}
+            <HugeIcons
+              className="transition-transform ease-out group-data-[panel-open]:rotate-180"
+              icon={ArrowDown01Icon}
+            />
+          </CollapsibleTrigger>
+        </TryoutQuestionHeader>
+        {children}
+      </TryoutQuestionArticle>
+    </Collapsible>
+  );
+}
+
+/** Composes one immutable review question with explanation disclosure. */
+export function TryoutReviewQuestionShell({
+  children,
+  questionOrder,
+}: TryoutQuestionShellProps) {
+  const tExercises = useTranslations("Exercises");
+
+  return (
+    <Collapsible>
+      <TryoutQuestionArticle questionOrder={questionOrder}>
+        <TryoutQuestionHeader questionOrder={questionOrder}>
+          <CollapsibleTrigger
+            className="group"
+            render={<Button type="button" variant="outline" />}
+          >
+            {tExercises("explanation")}
+            <HugeIcons
+              className="transition-transform ease-out group-data-[panel-open]:rotate-180"
+              icon={ArrowDown01Icon}
+            />
+          </CollapsibleTrigger>
+        </TryoutQuestionHeader>
+        {children}
+      </TryoutQuestionArticle>
+    </Collapsible>
+  );
+}
+
+/** Renders authorized explanation content inside one review question. */
+export function TryoutReviewQuestionExplanation({
+  children,
+  questionOrder,
+}: TryoutQuestionShellProps) {
+  const tExercises = useTranslations("Exercises");
+  const explanationId = `question-${questionOrder}-explanation`;
+
+  return (
+    <CollapsiblePanel>
+      <section aria-labelledby={explanationId} className="space-y-6 pb-8">
+        <Separator />
+        <h3 className="scroll-mt-44 font-medium text-lg" id={explanationId}>
+          {tExercises("explanation")}
+        </h3>
+        {children}
+      </section>
+    </CollapsiblePanel>
+  );
+}
+
+/** Owns the stable article identity shared by both explicit variants. */
+function TryoutQuestionArticle({
+  children,
+  questionOrder,
+}: TryoutQuestionShellProps) {
+  const id = `question-${questionOrder}`;
+
+  return (
+    <article aria-labelledby={`${id}-title`} id={`exercise-${id}`}>
+      {children}
+    </article>
+  );
+}
+
+/** Composes the stable question anchor with a variant-owned action. */
+function TryoutQuestionHeader({
+  children,
+  questionOrder,
+}: TryoutQuestionShellProps) {
+  const tExercises = useTranslations("Exercises");
+  const id = `question-${questionOrder}`;
+
+  return (
+    <div className="flex items-center gap-4">
+      <a
+        className="flex w-full flex-1 shrink-0 scroll-mt-44 outline-none ring-0"
+        href={`#${id}`}
+        id={id}
+      >
+        <div className="flex size-9 items-center justify-center rounded-full border border-primary bg-secondary text-secondary-foreground">
+          <span className="font-mono text-xs tracking-tighter">
+            {questionOrder}
+          </span>
+          <h2 className="sr-only" id={`${id}-title`}>
+            {tExercises("number-count", { count: questionOrder })}
+          </h2>
+        </div>
+      </a>
+      {children}
+    </div>
+  );
+}

--- a/apps/www/components/tryout/runtime/question.client.tsx
+++ b/apps/www/components/tryout/runtime/question.client.tsx
@@ -1,119 +1,28 @@
 "use client";
 
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
-import { Button } from "@repo/design-system/components/ui/button";
-import {
-  Collapsible,
-  CollapsiblePanel,
-  CollapsibleTrigger,
-} from "@repo/design-system/components/ui/collapsible";
-import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
-import { Separator } from "@repo/design-system/components/ui/separator";
-import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import { TryoutChoices } from "@/components/tryout/runtime/choice";
+import { TryoutActiveQuestionShell } from "@/components/tryout/runtime/question-shell.client";
 import type { TryoutRuntimeQuestion as RuntimeQuestion } from "@/components/tryout/runtime/types";
 
-interface TryoutRuntimeQuestionValue {
-  answer: ReactNode | null;
+interface TryoutActiveQuestionProps {
   content: ReactNode;
   locked: boolean;
   question: RuntimeQuestion;
-  reviewMode: boolean;
 }
 
-/** Renders one question with the original production exercise answer styling. */
-export function TryoutRuntimeQuestion({
-  value,
-}: {
-  value: TryoutRuntimeQuestionValue;
-}) {
-  const tExercises = useTranslations("Exercises");
-  const { answer, content, locked, question, reviewMode } = value;
-  const id = `question-${question.questionOrder}`;
-  const explanationId = `${id}-explanation`;
-
+/** Renders one mutable attempt question through the active-only Adapter. */
+export function TryoutActiveQuestion({
+  content,
+  locked,
+  question,
+}: TryoutActiveQuestionProps) {
   return (
-    <Collapsible disabled={!(reviewMode && answer)}>
-      <article aria-labelledby={`${id}-title`} id={`exercise-${id}`}>
-        <div className="flex items-center gap-4">
-          <a
-            className="flex w-full flex-1 shrink-0 scroll-mt-44 outline-none ring-0"
-            href={`#${id}`}
-            id={id}
-          >
-            <div className="flex size-9 items-center justify-center rounded-full border border-primary bg-secondary text-secondary-foreground">
-              <span className="font-mono text-xs tracking-tighter">
-                {question.questionOrder}
-              </span>
-              <h2 className="sr-only" id={`${id}-title`}>
-                {tExercises("number-count", { count: question.questionOrder })}
-              </h2>
-            </div>
-          </a>
-
-          <CollapsibleTrigger
-            className="group"
-            render={
-              <Button disabled={!reviewMode} type="button" variant="outline" />
-            }
-          >
-            {tExercises("explanation")}
-            <HugeIcons
-              className="transition-transform ease-out group-data-[panel-open]:rotate-180"
-              icon={ArrowDown01Icon}
-            />
-          </CollapsibleTrigger>
-        </div>
-
-        <section className="my-6">{content}</section>
-
-        <section className="my-8">
-          <TryoutChoices
-            value={{
-              locked,
-              question,
-              reviewMode,
-            }}
-          />
-        </section>
-
-        <TryoutQuestionExplanation
-          value={{ answer, explanationId, reviewMode }}
-        />
-      </article>
-    </Collapsible>
-  );
-}
-
-/** Renders authored answer content only in an authorized review runtime. */
-function TryoutQuestionExplanation({
-  value,
-}: {
-  value: {
-    answer: ReactNode | null;
-    explanationId: string;
-    reviewMode: boolean;
-  };
-}) {
-  const tExercises = useTranslations("Exercises");
-
-  if (!(value.reviewMode && value.answer)) {
-    return null;
-  }
-
-  return (
-    <CollapsiblePanel>
-      <section aria-labelledby={value.explanationId} className="space-y-6 pb-8">
-        <Separator />
-        <h3
-          className="scroll-mt-44 font-medium text-lg"
-          id={value.explanationId}
-        >
-          {tExercises("explanation")}
-        </h3>
-        {value.answer}
+    <TryoutActiveQuestionShell questionOrder={question.questionOrder}>
+      <section className="my-6">{content}</section>
+      <section className="my-8">
+        <TryoutChoices value={{ locked, question }} />
       </section>
-    </CollapsiblePanel>
+    </TryoutActiveQuestionShell>
   );
 }

--- a/apps/www/components/tryout/section/client.tsx
+++ b/apps/www/components/tryout/section/client.tsx
@@ -6,7 +6,7 @@ import { getMaterialIcon } from "@repo/contents/_lib/curriculum/material";
 import { useQuery } from "convex/react";
 import type { Locale } from "next-intl";
 import { useTranslations } from "next-intl";
-import { Suspense, use, useState } from "react";
+import { type ReactNode, Suspense, use, useState } from "react";
 import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
 import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
 import {
@@ -42,6 +42,7 @@ type SectionState = TryoutSectionInitialState | null;
 
 interface TryoutSectionPageClientProps {
   binding: TryoutSectionRouteBinding;
+  children: ReactNode;
   content: Promise<TryoutRuntimeContent> | null;
   page: TryoutSectionPage;
   route: TryoutSectionRoute;
@@ -79,6 +80,7 @@ interface TryoutSectionBodyValue {
 /** Renders one stable page with an active-only mutable subscription. */
 export function TryoutSectionPageClient({
   binding,
+  children,
   content,
   page,
   route,
@@ -93,7 +95,9 @@ export function TryoutSectionPageClient({
         route={route}
         setHref={setHref}
         state={null}
-      />
+      >
+        {children}
+      </ResolvedTryoutSectionPage>
     );
   }
 
@@ -106,7 +110,9 @@ export function TryoutSectionPageClient({
         route={route}
         setHref={setHref}
         state={binding.initialState}
-      />
+      >
+        {children}
+      </ResolvedTryoutSectionPage>
     );
   }
 
@@ -118,15 +124,20 @@ export function TryoutSectionPageClient({
       page={page}
       route={route}
       setHref={setHref}
-    />
+    >
+      {children}
+    </LiveTryoutSectionPage>
   );
 }
 
 /** Owns one active subscription and skips it after a terminal update. */
 function LiveTryoutSectionPage({
   binding,
+  children,
+  content,
   page,
-  ...props
+  route,
+  setHref,
 }: TryoutSectionPageClientProps & {
   binding: NonNullable<TryoutSectionRouteBinding>;
 }) {
@@ -160,17 +171,22 @@ function LiveTryoutSectionPage({
   }
   return (
     <ResolvedTryoutSectionPage
-      {...props}
       binding={binding}
+      content={content}
       page={page}
+      route={route}
+      setHref={setHref}
       state={state}
-    />
+    >
+      {children}
+    </ResolvedTryoutSectionPage>
   );
 }
 
 /** Renders the stable section UI from one cohesive reactive state. */
 function ResolvedTryoutSectionPage({
   binding,
+  children,
   content,
   page,
   route,
@@ -264,7 +280,9 @@ function ResolvedTryoutSectionPage({
               setHref,
               startDestination,
             }}
-          />
+          >
+            {children}
+          </TryoutSectionBody>
         </div>
       </div>
     </div>
@@ -272,7 +290,13 @@ function ResolvedTryoutSectionPage({
 }
 
 /** Composes active runtime, terminal summary, and review content explicitly. */
-function TryoutSectionBody({ value }: { value: TryoutSectionBodyValue }) {
+function TryoutSectionBody({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: TryoutSectionBodyValue;
+}) {
   if (value.runtimeState.kind === "active") {
     return (
       <Suspense fallback={null}>
@@ -304,7 +328,7 @@ function TryoutSectionBody({ value }: { value: TryoutSectionBodyValue }) {
           }}
         />
         <Suspense fallback={null}>
-          <TryoutSectionRuntimeContent value={value} />
+          {children ?? <TryoutContentRefresh />}
         </Suspense>
       </>
     );
@@ -342,14 +366,12 @@ function TryoutSectionRuntimeContent({
   if (value.runtimeState.kind === "none") {
     return null;
   }
-  if (value.runtimeState.kind === "review" && content.answers.length === 0) {
+  if (value.runtimeState.kind === "review") {
     return <TryoutContentRefresh />;
   }
-
   return (
     <TryoutRuntime
       value={{
-        answers: content.answers,
         expired: value.runtimeState.kind !== "active",
         questions: content.questions,
         returnHref: value.runtimeReturnHref,

--- a/apps/www/components/tryout/set/client.tsx
+++ b/apps/www/components/tryout/set/client.tsx
@@ -3,7 +3,7 @@
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
 import { selectTryoutTrackReturnHref } from "@/components/tryout/route/owner";
 import {
@@ -39,6 +39,7 @@ interface TryoutSetPageBinding {
 
 interface TryoutSetPageClientProps {
   binding: TryoutSetPageBinding | null;
+  children: ReactNode;
   content: Promise<TryoutRuntimeContent> | null;
   page: SetPage;
   restartTarget: TryoutSetRestartTarget | null;
@@ -48,6 +49,7 @@ interface TryoutSetPageClientProps {
 /** Renders one stable page with an active-only mutable subscription. */
 export function TryoutSetPageClient({
   binding,
+  children,
   content,
   page,
   restartTarget,
@@ -62,7 +64,9 @@ export function TryoutSetPageClient({
         restartTarget={restartTarget}
         route={route}
         state={null}
-      />
+      >
+        {children}
+      </ResolvedTryoutSetPage>
     );
   }
 
@@ -75,7 +79,9 @@ export function TryoutSetPageClient({
         restartTarget={restartTarget}
         route={route}
         state={binding.initialState}
-      />
+      >
+        {children}
+      </ResolvedTryoutSetPage>
     );
   }
 
@@ -87,14 +93,20 @@ export function TryoutSetPageClient({
       page={page}
       restartTarget={restartTarget}
       route={route}
-    />
+    >
+      {children}
+    </LiveTryoutSetPage>
   );
 }
 
 /** Owns one active subscription and skips it after a terminal update. */
 function LiveTryoutSetPage({
   binding,
-  ...props
+  children,
+  content,
+  page,
+  restartTarget,
+  route,
 }: TryoutSetPageClientProps & { binding: TryoutSetPageBinding }) {
   const [terminalState, setTerminalState] = useState<SetState | undefined>();
   const liveState = useQuery(
@@ -117,12 +129,24 @@ function LiveTryoutSetPage({
   if (terminalState !== undefined) {
     state = terminalState;
   }
-  return <ResolvedTryoutSetPage {...props} binding={binding} state={state} />;
+  return (
+    <ResolvedTryoutSetPage
+      binding={binding}
+      content={content}
+      page={page}
+      restartTarget={restartTarget}
+      route={route}
+      state={state}
+    >
+      {children}
+    </ResolvedTryoutSetPage>
+  );
 }
 
 /** Renders one stable set view from its exact mutable state. */
 function ResolvedTryoutSetPage({
   binding,
+  children,
   content,
   page,
   restartTarget,
@@ -203,7 +227,9 @@ function ResolvedTryoutSetPage({
           runtime,
           view,
         }}
-      />
+      >
+        {children}
+      </TryoutInternalSet>
     );
   }
 
@@ -212,8 +238,10 @@ function ResolvedTryoutSetPage({
 
 /** Renders one direct-entry runtime from its exact authenticated query. */
 function TryoutInternalSet({
+  children,
   value,
 }: {
+  children: ReactNode;
   value: {
     content: Promise<TryoutRuntimeContent> | null;
     entrySection: SetEntrySection;
@@ -236,7 +264,9 @@ function TryoutInternalSet({
         entrySection: value.entrySection,
         runtimeState,
       }}
-    />
+    >
+      {children}
+    </TryoutSetEntry>
   );
 }
 

--- a/apps/www/components/tryout/set/entry.tsx
+++ b/apps/www/components/tryout/set/entry.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Suspense, use } from "react";
+import { type ReactNode, Suspense, use } from "react";
 import type { TryoutRuntimeContent } from "@/components/tryout/content/model";
 import { TryoutContentRefresh } from "@/components/tryout/content/refresh.client";
 import { getTryoutAttemptHref } from "@/components/tryout/route/path";
@@ -21,9 +21,11 @@ import { TryoutMeta } from "@/components/tryout/shell/meta";
 
 /** Renders a no-nested-section set as the directly startable section surface. */
 export function TryoutSetEntry({
+  children,
   content,
   value,
 }: {
+  children: ReactNode;
   content: Promise<TryoutRuntimeContent> | null;
   value: TryoutInternalSetView;
 }) {
@@ -79,7 +81,9 @@ export function TryoutSetEntry({
         <div className="space-y-12">
           <TryoutEntryResult value={value} />
 
-          <TryoutEntryRuntime content={content} value={value} />
+          <TryoutEntryRuntime content={content} value={value}>
+            {children}
+          </TryoutEntryRuntime>
         </div>
       </div>
     </div>
@@ -181,14 +185,23 @@ function TryoutEntryAction({ value }: { value: TryoutInternalSetView }) {
 
 /** Renders the direct-entry question runtime when Convex has one. */
 function TryoutEntryRuntime({
+  children,
   content,
   value,
 }: {
+  children: ReactNode;
   content: Promise<TryoutRuntimeContent> | null;
   value: TryoutInternalSetView;
 }) {
   if (value.runtimeState.kind === "none") {
     return null;
+  }
+  if (value.runtimeState.kind === "review") {
+    return (
+      <Suspense fallback={null}>
+        {children ?? <TryoutContentRefresh />}
+      </Suspense>
+    );
   }
 
   return (
@@ -209,6 +222,9 @@ function TryoutEntryRuntimeContent({
   if (value.runtimeState.kind === "none") {
     return null;
   }
+  if (value.runtimeState.kind === "review") {
+    return <TryoutContentRefresh />;
+  }
   if (!content) {
     return <TryoutContentRefresh />;
   }
@@ -217,17 +233,10 @@ function TryoutEntryRuntimeContent({
   if (resolvedContent.questions.length === 0) {
     return <TryoutContentRefresh />;
   }
-  if (
-    value.runtimeState.kind === "review" &&
-    resolvedContent.answers.length === 0
-  ) {
-    return <TryoutContentRefresh />;
-  }
 
   return (
     <TryoutRuntime
       value={{
-        answers: resolvedContent.answers,
         expired: value.runtimeState.kind !== "active",
         questions: resolvedContent.questions,
         returnHref: getTryoutAttemptHref(

--- a/apps/www/lib/tryout/choice-variant.test.ts
+++ b/apps/www/lib/tryout/choice-variant.test.ts
@@ -1,18 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { getTryoutChoiceVariant } from "@/lib/tryout/choice-variant";
+import {
+  getTryoutReviewedChoiceVariant,
+  getTryoutSelectableChoiceVariant,
+} from "@/lib/tryout/choice-variant";
 
-describe("getTryoutChoiceVariant", () => {
+describe("getTryoutSelectableChoiceVariant", () => {
   it.each([
-    [false, undefined, false, "outline"],
-    [true, undefined, false, "default-outline"],
-    [false, false, true, "outline"],
-    [true, false, true, "destructive-outline"],
-    [false, true, true, "success-outline"],
-    [true, true, true, "success-outline"],
+    [false, "outline"],
+    [true, "default-outline"],
+  ] as const)("maps checked=%s to %s", (checked, expected) => {
+    expect(getTryoutSelectableChoiceVariant({ checked })).toBe(expected);
+  });
+});
+
+describe("getTryoutReviewedChoiceVariant", () => {
+  it.each([
+    [false, false, "outline"],
+    [true, false, "destructive-outline"],
+    [false, true, "success-outline"],
+    [true, true, "success-outline"],
   ] as const)(
-    "maps checked=%s correct=%s review=%s to %s",
-    (checked, isCorrect, reviewMode, expected) => {
-      expect(getTryoutChoiceVariant({ checked, isCorrect, reviewMode })).toBe(
+    "maps checked=%s correct=%s to %s",
+    (checked, isCorrect, expected) => {
+      expect(getTryoutReviewedChoiceVariant({ checked, isCorrect })).toBe(
         expected
       );
     }

--- a/apps/www/lib/tryout/choice-variant.test.ts
+++ b/apps/www/lib/tryout/choice-variant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getTryoutPreviewChoiceVariant,
   getTryoutReviewedChoiceVariant,
   getTryoutSelectableChoiceVariant,
 } from "@/lib/tryout/choice-variant";
@@ -23,6 +24,24 @@ describe("getTryoutReviewedChoiceVariant", () => {
     "maps checked=%s correct=%s to %s",
     (checked, isCorrect, expected) => {
       expect(getTryoutReviewedChoiceVariant({ checked, isCorrect })).toBe(
+        expected
+      );
+    }
+  );
+});
+
+describe("getTryoutPreviewChoiceVariant", () => {
+  it.each([
+    [false, { kind: "selectable" }, "outline"],
+    [true, { kind: "selectable" }, "default-outline"],
+    [false, { isCorrect: false, kind: "revealed" }, "outline"],
+    [true, { isCorrect: false, kind: "revealed" }, "destructive-outline"],
+    [false, { isCorrect: true, kind: "revealed" }, "success-outline"],
+    [true, { isCorrect: true, kind: "revealed" }, "success-outline"],
+  ] as const)(
+    "maps checked=%s appearance=%o to %s",
+    (checked, appearance, expected) => {
+      expect(getTryoutPreviewChoiceVariant({ appearance, checked })).toBe(
         expected
       );
     }

--- a/apps/www/lib/tryout/choice-variant.ts
+++ b/apps/www/lib/tryout/choice-variant.ts
@@ -3,22 +3,23 @@ import type { buttonVariants } from "@repo/design-system/lib/button";
 type ButtonVariantOptions = NonNullable<Parameters<typeof buttonVariants>[0]>;
 type ButtonVariant = NonNullable<ButtonVariantOptions["variant"]>;
 
-interface TryoutChoiceVariantInput {
+/** Selects the answer-option appearance while a choice remains selectable. */
+export function getTryoutSelectableChoiceVariant({
+  checked,
+}: {
   checked: boolean;
-  isCorrect: boolean | undefined;
-  reviewMode: boolean;
+}): ButtonVariant {
+  return checked ? "default-outline" : "outline";
 }
 
-/** Selects the answer-option appearance for active and completed tryouts. */
-export function getTryoutChoiceVariant({
+/** Selects the answer-option appearance after correctness is authorized. */
+export function getTryoutReviewedChoiceVariant({
   checked,
   isCorrect,
-  reviewMode,
-}: TryoutChoiceVariantInput): ButtonVariant {
-  if (!reviewMode) {
-    return checked ? "default-outline" : "outline";
-  }
-
+}: {
+  checked: boolean;
+  isCorrect: boolean | undefined;
+}): ButtonVariant {
   if (checked && !isCorrect) {
     return "destructive-outline";
   }

--- a/apps/www/lib/tryout/choice-variant.ts
+++ b/apps/www/lib/tryout/choice-variant.ts
@@ -3,6 +3,13 @@ import type { buttonVariants } from "@repo/design-system/lib/button";
 type ButtonVariantOptions = NonNullable<Parameters<typeof buttonVariants>[0]>;
 type ButtonVariant = NonNullable<ButtonVariantOptions["variant"]>;
 
+export type TryoutPreviewChoiceAppearance =
+  | { readonly kind: "selectable" }
+  | {
+      readonly isCorrect: boolean | undefined;
+      readonly kind: "revealed";
+    };
+
 /** Selects the answer-option appearance while a choice remains selectable. */
 export function getTryoutSelectableChoiceVariant({
   checked,
@@ -10,6 +17,24 @@ export function getTryoutSelectableChoiceVariant({
   checked: boolean;
 }): ButtonVariant {
   return checked ? "default-outline" : "outline";
+}
+
+/** Selects the preview appearance without replacing its interactive surface. */
+export function getTryoutPreviewChoiceVariant({
+  appearance,
+  checked,
+}: {
+  appearance: TryoutPreviewChoiceAppearance;
+  checked: boolean;
+}): ButtonVariant {
+  if (appearance.kind === "selectable") {
+    return getTryoutSelectableChoiceVariant({ checked });
+  }
+
+  return getTryoutReviewedChoiceVariant({
+    checked,
+    isCorrect: appearance.isCorrect,
+  });
 }
 
 /** Selects the answer-option appearance after correctness is authorized. */


### PR DESCRIPTION
## Outcome

This PR reduces terminal try-out browser work by moving the immutable signed review out of the active response-mutation Client Module and into a dedicated server `TryoutReview` Module.

The primary gains are terminal hydration performance, clearer architecture, stronger signed-runtime integrity, and easier maintenance. It does not reduce protected transport bytes, MDX evaluation time, Convex reads, or infrastructure cost.

## Before and after

| Area | Before | After | Concrete advantage |
| --- | --- | --- | --- |
| Terminal ownership | A completed review rendered through the same broad Client Module that owns active response mutation | A named server `TryoutReview` Module owns immutable terminal composition | Terminal review no longer executes active-attempt behavior |
| Signed content | The Client Module unwrapped the signed-content Promise and rebuilt question and answer maps in the browser | The server Module awaits signed content at the existing Suspense Seam and runs one typed projection | Removes terminal content reconstruction from the browser and centralizes integrity |
| Response hooks | Every locked reviewed question mounted `useMutation(responses.save)` and its optimistic updater | Only active questions own response mutation; `TryoutReviewedChoice` has no mutation Interface | Removes one unreachable mutation hook and updater closure per terminal question |
| Component composition | Mode booleans selected active and review behavior through shared components | Named function components express active, preview, and reviewed variants | Invalid active and terminal prop combinations are harder to represent and easier to review |
| Preview interaction | Revealing correctness replaced the focused preview choice with another component type | One stable named `TryoutPreviewChoice` changes an explicit discriminated `appearance` | Keyboard and pointer focus stay on the activated checkbox |
| Product UI | Score and truthful summary streamed before the signed review | Score, status, summary, history, actions, questions, choices, answers, explanations, and navigation keep the same order and presentation | No intentional styling, copy, layout, or journey change |

## Why the change is necessary

Candidate 1 measured a large terminal tail after the truthful summary was already visible:

| Stage or milestone | Production attribution |
| --- | --- |
| Warm truthful summary | about 1.81 to 2.99 seconds |
| Warm complete review | about 4.21 to 6.58 seconds |
| Post-summary tail | about 2.40 to 3.59 seconds |
| Protected HTTP batches | about 580 and 689 milliseconds, in parallel |
| Internal Convex queries | about 197 and 245 milliseconds |
| Decoded Flight payload | about 2.19 MB |
| TKA browser review remount gap | about 3.36 seconds |
| SNBT browser review remount gap | about 2.13 seconds |

The browser trace showed signed review content entering the DOM, disappearing during hydration, and returning. Source tracing found that terminal review crossed the active Client Module, reconstructed signed content maps, and created response-mutation hooks for locked questions. This PR removes that ownership contradiction at the real server and client Seam.

Temporary timing instrumentation was used only for attribution and is not retained.

## What improves

### Performance

- Removes client-side terminal question and answer map reconstruction.
- Removes one `useMutation` hook and optimistic updater per locked reviewed question. A 40-question terminal TKA review previously mounted 40 unreachable response-mutation hooks.
- Removes Client Component Promise unwrapping for terminal signed content.
- Keeps truthful score, status, summary, history, and actions outside the signed-content Suspense boundary.
- Keeps active attempt rendering and mutation behavior unchanged.

This is a measured structural improvement to browser work. It does not claim a new production millisecond result because this exact commit has not been deployed, and this task will not create a Vercel deployment.

### Architecture and DX

- **Module:** `TryoutReview` owns immutable terminal composition.
- **Interface:** reviewed choices expose only read-only review data, never a response mutation callback.
- **Implementation:** `projectTryoutReview` is a named Effect program with a typed `TryoutReviewProjectionError`.
- **Seam:** the server awaits signed content and passes rendered nodes through standard React children composition.
- **Depth:** one projection owns count, identity, order, pairing, and non-empty-answer invariants.
- **Leverage:** both set and retained-section terminal routes use the same review contract.
- **Locality:** active mutation stays under `runtime/`; immutable review stays under `review/`.

The composition follows the repository and Vercel guidance:

- named function components only
- no component or JSX stored in a variable
- explicit variants instead of boolean mode props
- no fake Context or provider
- state remains in the nearest owner
- server-rendered content is passed to Client Components through children slots
- pure projection behavior is tested in a colocated `.ts` Module test, with no TSX tests

### Cost

There is no infrastructure cost-saving claim.

- No new Convex query, mutation, action, subscription, index, schema, document, or migration.
- No new Vercel Function invocation, cache layer, background job, preview, or production deployment.
- Signed `use cache` behavior and protected transport are unchanged.
- One bounded in-process server projection replaces terminal browser reconstruction inside the existing request.

## Integrity and UX invariants

- verified terminal score and completed status stay visible before signed review content
- questions, selected answers, correct answers, explanations, history, actions, and navigation remain present
- active attempts receive zero signed answers
- terminal pages keep zero live Convex subscriptions
- signed integrity, retained capability authorization, and public direct routes are unchanged
- projection drift fails closed without rendering mismatched signed content
- preview answer revelation preserves focus

## Version-matched references

Implementation was checked against the installed Next.js 16.3.0, React 19.2.8, Convex 1.43.0, and Effect 3.22.1 sources and declarations.

- [Next.js 16.3.0 source: Server and Client Components](https://github.com/vercel/next.js/blob/v16.3.0/docs/01-app/01-getting-started/05-server-and-client-components.mdx#L342-L478)
- [Next.js docs: reducing client JavaScript and interleaving Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components#reducing-js-bundle-size)
- [React docs: resolving a Promise in a Server versus Client Component](https://react.dev/reference/react/use#should-i-resolve-a-promise-in-a-server-or-client-component)
- [Convex 1.43.0 source: `useMutation`](https://github.com/get-convex/convex-js/blob/npm/1.43.0/src/react/client.ts#L1045-L1067)
- [Convex docs: editing data with `useMutation`](https://docs.convex.dev/client/react/overview#editing-data)
- [Repository composition skill at this exact head](https://github.com/nakafaai/nakafa.com/blob/e883d45ac66374cef204e18eebc5706346975de5/.agents/skills/vercel-composition-patterns/SKILL.md)
- [Repository Next.js skill at this exact head](https://github.com/nakafaai/nakafa.com/blob/e883d45ac66374cef204e18eebc5706346975de5/.agents/skills/nextjs/SKILL.md)
- [Repository Cache Components skill at this exact head](https://github.com/nakafaai/nakafa.com/blob/e883d45ac66374cef204e18eebc5706346975de5/.agents/skills/next-cache-components/SKILL.md)
- [Repository React performance skill at this exact head](https://github.com/nakafaai/nakafa.com/blob/e883d45ac66374cef204e18eebc5706346975de5/.agents/skills/vercel-react-best-practices/SKILL.md)

Installed source paths inspected locally:

```text
next@16.3.0/dist/docs/01-app/01-getting-started/05-server-and-client-components.md
convex@1.43.0/src/react/client.ts
repos/effect/packages/effect/src/Effect.ts
```

## Verification for exact source at `e883d45ac6`

- focused choice projection test: 12 tests passed with 100% statement, branch, function, and line coverage
- full `www` suite: 186 files and 1,151 tests passed with 100% coverage
- targeted backend `attemptPage` suite: 4 tests passed
- `www` typecheck: passed
- Ultracite lint: passed
- workspace boundaries: passed
- React Doctor changed scope: 100/100 with no findings
- optimized Next.js 16.3 production build: passed with all 1,303 static pages generated
- local production-mode public SNBT set route: HTTP 200
- local Codex review first found a focus regression in the preview choice transition; the regression was fixed and retested
- local Codex review after the fix: no actionable regressions

The source tested locally is byte-for-byte the source committed at `e883d45ac6`; the final commit only recorded the already-tested files.

## Browser journey acceptance

The exact candidate source was exercised in the in-app Browser against the isolated anonymous local Convex deployment. Production Convex was not used and no Vercel deployment was created.

### TKA

- navigated through the public catalog to a direct set route
- started, answered, and completed the local fixture attempt
- verified terminal score, completed status, question, locked selected answer, correct-answer styling, signed explanation, history, actions, and navigation
- verified retained-route hard reload and public completed-route hard reload
- verified the year view preserved score and `Selesai`

### SNBT

- navigated through the public catalog to a sectioned set
- started a section, verified active direct and retained reload, and confirmed explanations stayed unavailable while active
- selected and completed the local fixture section
- verified terminal set score, completed status, section navigation, locked answers, signed explanation, actions, retained completed reload, public direct navigation, and public hard reload

Mutation controls were clicked only against the isolated local fixture. No production attempt was started, answered, submitted, restarted, or otherwise mutated.

A fresh production-mode Browser tab did not inherit the local development session and correctly redirected to `/id/auth`. No cookie copying, token inspection, auth workaround, production Convex use, or deployment was used to manufacture a production-mode authenticated claim. The production build, public production-mode route, exact-source Browser journeys, and exact-head CI are the acceptance surfaces available without deploying the candidate.

One earlier build attempt hit an unrelated transient Convex fetch failure while prerendering a mathematics material route. The immediate retry generated all 1,303 pages successfully.
