### PR TITLE
fix(content): verify inherited material references

### DIFF
--- a/packages/backend/convex/contentRelease/cutover/materialAssets.test.ts
+++ b/packages/backend/convex/contentRelease/cutover/materialAssets.test.ts
@@ -5,6 +5,7 @@ import {
   MATERIAL_PROOF_ROW_READ_LIMIT,
 } from "@repo/backend/convex/contentRelease/cutover/materialAssets";
 import {
+  MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT,
   MATERIAL_REFERENCE_DOCUMENT_READ_CEILING,
   MATERIAL_REFERENCE_PAGE_LIMIT,
 } from "@repo/backend/convex/contentRelease/cutover/materialTopics";
@@ -16,8 +17,11 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeMaterialProjection } from "@repo/backend/test/content-material";
+import type { TestIdentity } from "@repo/backend/test/content-state";
 import {
+  activateInheritedMaterialCatalog,
   activateMaterialCatalog,
+  INHERITED_MATERIAL_IDENTITY,
   MATERIAL_IDENTITY,
 } from "@repo/backend/test/material-catalog";
 import type { TestConvex } from "convex-test";
@@ -30,14 +34,15 @@ const TOPIC_COUNT = 2;
 describe("contentRelease/cutover/materialAssets", () => {
   it("keeps one proof page below the reserved transaction read budget", () => {
     expect(MATERIAL_PROOF_ROW_READ_LIMIT).toBe(
-      MATERIAL_REFERENCE_PAGE_LIMIT * 6
+      MATERIAL_REFERENCE_PAGE_LIMIT *
+        (6 + MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT)
     );
     expect(MATERIAL_PROOF_READ_CEILING).toBe(
       MATERIAL_REFERENCE_PAGE_LIMIT *
-        6 *
+        (6 + MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT) *
         MATERIAL_REFERENCE_DOCUMENT_READ_CEILING
     );
-    expect(MATERIAL_PROOF_READ_CEILING).toBe(294_912);
+    expect(MATERIAL_PROOF_READ_CEILING).toBe(491_520);
     expect(MATERIAL_PROOF_READ_CEILING).toBeLessThanOrEqual(
       TRANSACTION_READ_LIMIT - TRANSACTION_READ_HEADROOM
     );
@@ -119,6 +124,50 @@ describe("contentRelease/cutover/materialAssets", () => {
       TOPIC_COUNT
     );
     expect(indexed.topic?.topicAssetId).toBe(indexed.row.topicAssetId);
+  });
+
+  it("proves inherited rows from two generations at the effective active sequence", async () => {
+    const t = convexTest(schema, convexModules);
+    await activateInheritedMaterialCatalog(t);
+    await t.mutation((ctx) =>
+      insertQuiescentCheckpointFor(ctx, INHERITED_MATERIAL_IDENTITY)
+    );
+
+    const first = await t.mutation((ctx) =>
+      runConvexProgram(
+        checkpointMaterialReferencePage(ctx, MATERIAL_COUNT, TOPIC_COUNT)
+      )
+    );
+    const progress = await t.run((ctx) =>
+      ctx.db.query("contentCutoverState").unique()
+    );
+    const receipts = [
+      first,
+      ...(await completeCheckpoint(t, MATERIAL_COUNT, TOPIC_COUNT)),
+    ];
+    const rows = await t.run((ctx) =>
+      ctx.db.query("materialCatalog").take(MATERIAL_COUNT)
+    );
+
+    expect(first).toMatchObject({
+      checked: MATERIAL_REFERENCE_PAGE_LIMIT,
+      complete: false,
+      phase: "stage",
+    });
+    expect(progress?.materialReferenceProgress).toMatchObject({
+      checked: MATERIAL_REFERENCE_PAGE_LIMIT,
+      phase: "stage",
+    });
+    expect(receipts.at(-1)).toMatchObject({
+      checked: MATERIAL_COUNT,
+      complete: true,
+      phase: "complete",
+      topics: TOPIC_COUNT,
+    });
+    expect(new Set(rows.map((row) => row.sequence))).toEqual(new Set([1, 2]));
+    expect(
+      rows.every((row) => row.sequence < INHERITED_MATERIAL_IDENTITY.sequence)
+    ).toBe(true);
   });
 
   it("rejects duplicate authenticated lesson identities", async () => {
@@ -221,12 +270,19 @@ async function completeCheckpoint(
 }
 
 async function insertQuiescentCheckpoint(ctx: MutationCtx) {
+  await insertQuiescentCheckpointFor(ctx, MATERIAL_IDENTITY);
+}
+
+async function insertQuiescentCheckpointFor(
+  ctx: MutationCtx,
+  identity: TestIdentity
+) {
   await ctx.db.insert("contentCutoverState", {
-    auditedActiveReleaseId: MATERIAL_IDENTITY.releaseId,
-    auditedActiveSequence: MATERIAL_IDENTITY.sequence,
+    auditedActiveReleaseId: identity.releaseId,
+    auditedActiveSequence: identity.sequence,
     auditedAt: 1,
     auditedLegacyWriteVersion: 0,
-    auditedNextSequence: MATERIAL_IDENTITY.sequence + 1,
+    auditedNextSequence: identity.sequence + 1,
     currentDeleted: 0,
     currentTableDeleted: 0,
     currentTableIndex: 0,

--- a/packages/backend/convex/contentRelease/cutover/materialAssets.ts
+++ b/packages/backend/convex/contentRelease/cutover/materialAssets.ts
@@ -6,6 +6,7 @@ import {
   AUDITED_MATERIAL_TOPIC_COUNT,
 } from "@repo/backend/convex/contentRelease/cutover/inventory";
 import {
+  MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT,
   MATERIAL_REFERENCE_DOCUMENT_READ_CEILING,
   MATERIAL_REFERENCE_PAGE_LIMIT,
   requireAuditedMaterialOwner,
@@ -16,12 +17,13 @@ import { persistReferenceProof } from "@repo/backend/convex/contentRelease/cutov
 import { requireCutoverPhase } from "@repo/backend/convex/contentRelease/cutover/state";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { deriveMaterialTopicReference } from "@repo/backend/convex/contentRelease/material/topic";
-import { verifyMaterial } from "@repo/backend/convex/contentRelease/material/verify";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { v } from "convex/values";
 import { Effect } from "effect";
 
-export const MATERIAL_PROOF_ROW_READ_LIMIT = MATERIAL_REFERENCE_PAGE_LIMIT * 6;
+export const MATERIAL_PROOF_ROW_READ_LIMIT =
+  MATERIAL_REFERENCE_PAGE_LIMIT *
+  (6 + MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT);
 export const MATERIAL_PROOF_READ_CEILING =
   MATERIAL_PROOF_ROW_READ_LIMIT * MATERIAL_REFERENCE_DOCUMENT_READ_CEILING;
 
@@ -109,8 +111,7 @@ export const checkpointMaterialReferencePage = Effect.fn(
   let activeTopic = progress.activeTopic;
   let topics = progress.topics;
   for (const row of stored.page) {
-    yield* requireAuditedMaterialRow(row, state);
-    const { projection } = yield* verifyMaterial(row);
+    const { projection } = yield* requireAuditedMaterialRow(ctx, row, state);
     const topic = yield* deriveMaterialTopicReference(projection);
     if (row.topicAssetId !== topic.graph.assetId) {
       return yield* materialAssetFailure(

--- a/packages/backend/convex/contentRelease/cutover/materialTopics.test.ts
+++ b/packages/backend/convex/contentRelease/cutover/materialTopics.test.ts
@@ -1,7 +1,9 @@
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
+  MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT,
   MATERIAL_REFERENCE_PAGE_LIMIT,
   MATERIAL_STAGE_READ_CEILING,
+  MATERIAL_STAGE_ROW_READ_LIMIT,
   stageMaterialTopicPage,
 } from "@repo/backend/convex/contentRelease/cutover/materialTopics";
 import {
@@ -23,7 +25,13 @@ const PAGED_MATERIAL_COUNT = MATERIAL_REFERENCE_PAGE_LIMIT + 1;
 
 describe("contentRelease/cutover/materialTopics", () => {
   it("keeps one page below the reserved transaction read budget", () => {
-    expect(MATERIAL_STAGE_READ_CEILING).toBe(65_536);
+    expect(MATERIAL_STAGE_ROW_READ_LIMIT).toBe(
+      MATERIAL_REFERENCE_PAGE_LIMIT +
+        1 +
+        MATERIAL_REFERENCE_PAGE_LIMIT *
+          MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT
+    );
+    expect(MATERIAL_STAGE_READ_CEILING).toBe(262_144);
     expect(MATERIAL_STAGE_READ_CEILING).toBeLessThanOrEqual(
       TRANSACTION_READ_LIMIT - TRANSACTION_READ_HEADROOM
     );

--- a/packages/backend/convex/contentRelease/cutover/materialTopics.ts
+++ b/packages/backend/convex/contentRelease/cutover/materialTopics.ts
@@ -8,15 +8,19 @@ import {
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { loadMaterialCatalogOwner } from "@repo/backend/convex/contentRelease/material/owner";
 import { deriveMaterialTopicReference } from "@repo/backend/convex/contentRelease/material/topic";
-import { verifyMaterial } from "@repo/backend/convex/contentRelease/material/verify";
+import { verifyEffectiveMaterial } from "@repo/backend/convex/contentRelease/material/verify";
 import { Effect } from "effect";
 
 export const MATERIAL_REFERENCE_DOCUMENT_READ_CEILING =
   READ_MODEL_DOCUMENT_LIMIT;
 export const MATERIAL_REFERENCE_PAGE_LIMIT = 3;
+export const MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT = 4;
+export const MATERIAL_STAGE_ROW_READ_LIMIT =
+  MATERIAL_REFERENCE_PAGE_LIMIT +
+  1 +
+  MATERIAL_REFERENCE_PAGE_LIMIT * MATERIAL_EFFECTIVE_PROJECTION_ROW_READ_LIMIT;
 export const MATERIAL_STAGE_READ_CEILING =
-  (MATERIAL_REFERENCE_PAGE_LIMIT + 1) *
-  MATERIAL_REFERENCE_DOCUMENT_READ_CEILING;
+  MATERIAL_STAGE_ROW_READ_LIMIT * MATERIAL_REFERENCE_DOCUMENT_READ_CEILING;
 
 /** Stages one bounded page of authenticated material topic identities. */
 export const stageMaterialTopicPage = Effect.fn(
@@ -51,8 +55,7 @@ export const stageMaterialTopicPage = Effect.fn(
 
   let staged = 0;
   for (const row of page) {
-    yield* requireAuditedMaterialRow(row, state);
-    const { projection } = yield* verifyMaterial(row);
+    const { projection } = yield* requireAuditedMaterialRow(ctx, row, state);
     const topic = yield* deriveMaterialTopicReference(projection);
     const topicAssetId = topic.graph.assetId;
     if (row.topicAssetId !== undefined && row.topicAssetId !== topicAssetId) {
@@ -124,15 +127,12 @@ export const requireAuditedMaterialOwner = Effect.fn(
 
 export const requireAuditedMaterialRow = Effect.fn(
   "contentRelease.cutover.requireAuditedMaterialRow"
-)(function* (row: Doc<"materialCatalog">, state: Doc<"contentCutoverState">) {
-  if (
-    row.releaseId !== state.auditedActiveReleaseId ||
-    row.sequence !== state.auditedActiveSequence
-  ) {
-    return yield* materialTopicFailure(
-      `Material ${row.contentKey}/${row.locale} belongs to another release.`
-    );
-  }
+)(function* (
+  ctx: MutationCtx,
+  row: Doc<"materialCatalog">,
+  state: Doc<"contentCutoverState">
+) {
+  return yield* verifyEffectiveMaterial(ctx, row, state.auditedActiveSequence);
 });
 
 function readMaterialPage(ctx: MutationCtx, afterAssetId?: string) {

--- a/packages/backend/convex/contentRelease/cutover/phase1.md
+++ b/packages/backend/convex/contentRelease/cutover/phase1.md
@@ -103,12 +103,13 @@ pnpm --filter @repo/backend exec convex run contentRelease/cutover/materialAsset
 ```
 
 Each transaction processes at most three material rows. The staging phase may
-read at most four 16 KiB rows, and the proof phase may read at most 18 16 KiB
-rows across its page and exact index checks, for a 294,912-byte ceiling. Accept
-only monotonically increasing staging and proof counts, a terminal `checked:
-766`, exactly 72 localized topic identities, and both count-766 lesson and
-count-72 topic proof receipts. Repeating the terminal command must return
-`complete: true` with zero processed or staged rows.
+read at most 16 16 KiB rows across its page and effective-publication checks,
+for a 262,144-byte ceiling. The proof phase may read at most 30 16 KiB rows
+across its page, effective-publication checks, and exact index checks, for a
+491,520-byte ceiling. Accept only monotonically increasing staging and proof
+counts, a terminal `checked: 766`, exactly 72 localized topic identities, and
+both count-766 lesson and count-72 topic proof receipts. Repeating the terminal
+command must return `complete: true` with zero processed or staged rows.
 
 ## Stage signed snapshot reference identities
 

--- a/packages/backend/convex/contentRelease/cutover/phase1.md
+++ b/packages/backend/convex/contentRelease/cutover/phase1.md
@@ -106,10 +106,13 @@ Each transaction processes at most three material rows. The staging phase may
 read at most 16 16 KiB rows across its page and effective-publication checks,
 for a 262,144-byte ceiling. The proof phase may read at most 30 16 KiB rows
 across its page, effective-publication checks, and exact index checks, for a
-491,520-byte ceiling. Accept only monotonically increasing staging and proof
-counts, a terminal `checked: 766`, exactly 72 localized topic identities, and
-both count-766 lesson and count-72 topic proof receipts. Repeating the terminal
-command must return `complete: true` with zero processed or staged rows.
+491,520-byte ceiling. The staging bound counts four page reads plus four
+effective-publication reads for each of three rows. The proof bound counts six
+page and index reads plus four effective-publication reads for each of three
+rows. Accept only monotonically increasing staging and proof counts, a terminal
+`checked: 766`, exactly 72 localized topic identities, and both count-766
+lesson and count-72 topic proof receipts. Repeating the terminal command must
+return `complete: true` with zero processed or staged rows.
 
 ## Stage signed snapshot reference identities
 

--- a/packages/backend/convex/contentRelease/material/verify.ts
+++ b/packages/backend/convex/contentRelease/material/verify.ts
@@ -1,12 +1,18 @@
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
 import { getHashBucket } from "@repo/backend/convex/contentRelease/bucket";
+import { resolvePublicProjection } from "@repo/backend/convex/contentRelease/catalog";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { decodeProjectionJson } from "@repo/backend/convex/contentRelease/parse";
 import { Effect } from "effect";
 
 type MaterialRow = Doc<"materialCatalog">;
+type ReadCtx = MutationCtx | QueryCtx;
 
 /** Authenticates one self-contained active material read-model row. */
 export const verifyMaterial = Effect.fn("contentRelease.verifyMaterial")(
@@ -44,3 +50,29 @@ export const verifyMaterial = Effect.fn("contentRelease.verifyMaterial")(
     return { projection, projectionJson };
   }
 );
+
+/** Authenticates one material row against its effective active publication. */
+export const verifyEffectiveMaterial = Effect.fn(
+  "contentRelease.verifyEffectiveMaterial"
+)(function* (ctx: ReadCtx, row: MaterialRow, activeSequence: number) {
+  const [{ projection, projectionJson }, resolved] = yield* Effect.all([
+    verifyMaterial(row),
+    resolvePublicProjection(ctx, row.contentKey, row.locale, activeSequence),
+  ]);
+  if (
+    resolved?.family !== "material" ||
+    resolved.projectionHash !== row.projectionHash ||
+    resolved.projectionJson !== projectionJson ||
+    resolved.publicPath !== row.publicPath ||
+    resolved.releaseId !== row.releaseId ||
+    resolved.rendererDomain !== row.rendererDomain ||
+    resolved.sequence !== row.sequence ||
+    resolved.sourcePath !== row.sourcePath
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Active material ${row.contentKey}/${row.locale} disagrees with its effective publication.`
+    );
+  }
+  return { projection, resolved };
+});

--- a/packages/backend/test/material-catalog.ts
+++ b/packages/backend/test/material-catalog.ts
@@ -39,6 +39,12 @@ const NEXT_MATERIAL_IDENTITY = {
   sequence: 2,
 } satisfies TestIdentity;
 
+export const INHERITED_MATERIAL_IDENTITY = {
+  manifestHash: Sha256HashSchema.make(`sha256:${"4".repeat(64)}`),
+  releaseId: ReleaseIdSchema.make("release-inherited"),
+  sequence: 3,
+} satisfies TestIdentity;
+
 /** Inserts one projection into the immutable head and active material model. */
 export async function insertMaterialProjection(
   ctx: MutationCtx,
@@ -131,6 +137,44 @@ export async function advanceMaterialCatalog(
       materialReleaseId: NEXT_MATERIAL_IDENTITY.releaseId,
       materialSequence: NEXT_MATERIAL_IDENTITY.sequence,
       nextSequence: 3,
+    });
+  });
+}
+
+/** Activates material rows inherited from two earlier physical generations. */
+export async function activateInheritedMaterialCatalog(
+  target: TestConvex<typeof schema>
+) {
+  await activateMaterialCatalog(target);
+  await advanceMaterialCatalog(target);
+  await target.mutation(async (ctx) => {
+    await insertMaterialProjection(
+      ctx,
+      makeMaterialProjection("en", 1),
+      NEXT_MATERIAL_IDENTITY
+    );
+    await insertZeroRelease(ctx, {
+      ...INHERITED_MATERIAL_IDENTITY,
+      base: NEXT_MATERIAL_IDENTITY,
+      ownership: { base: ["material"], result: ["material"] },
+      role: "candidate",
+      status: "completed",
+    });
+    const state = await ctx.db.query("contentState").unique();
+    if (!state) {
+      throw new Error("Expected one active content state.");
+    }
+    await ctx.db.patch("contentState", state._id, {
+      activeManifestHash: INHERITED_MATERIAL_IDENTITY.manifestHash,
+      activeReleaseId: INHERITED_MATERIAL_IDENTITY.releaseId,
+      activeSequence: INHERITED_MATERIAL_IDENTITY.sequence,
+      materialManifestHash: INHERITED_MATERIAL_IDENTITY.manifestHash,
+      materialOwnerManifestHash: INHERITED_MATERIAL_IDENTITY.manifestHash,
+      materialOwnerReleaseId: INHERITED_MATERIAL_IDENTITY.releaseId,
+      materialOwnerSequence: INHERITED_MATERIAL_IDENTITY.sequence,
+      materialReleaseId: INHERITED_MATERIAL_IDENTITY.releaseId,
+      materialSequence: INHERITED_MATERIAL_IDENTITY.sequence,
+      nextSequence: INHERITED_MATERIAL_IDENTITY.sequence + 1,
     });
   });
 }


### PR DESCRIPTION
## Summary

Phase 1 material reference staging assumed every `materialCatalog` row belonged to the global active release and sequence. Production correctly retains unchanged signed material rows from earlier generations, so the first checkpoint invocation failed atomically before changing any row.

This hotfix authenticates each row against its effective public projection at the frozen audited sequence. It preserves the row's historical release and sequence and requires exact agreement across projection JSON and hash, route, renderer, source path, family, content key, and locale.

## Exact head

- head: `d6d654139aa448c57a906def0624f71f7a4d5208`
- base: `de5e56f849399d7c0ccdf4875a6a9f535fe59bdc`
- seven files changed
- no schema or index change

## Production evidence

- active material rows: 766
- current-generation rows: 0
- inherited rows: 766
- stored generations: 2
- missing, duplicate, or mismatched effective heads and route bindings: 0
- durable material checkpoint progress: absent
- rows changed by the rejected checkpoint: 0

The checkpoint can safely restart from zero after deploying this code.

## Bounded reads

- staging ceiling: 16 documents, 262,144 bytes
- proof ceiling: 30 documents, 491,520 bytes
- both remain below the reserved transaction budget
- the Phase 1 runbook now records the exact effective-publication read calculation

## Verification

- focused material cutover: 2 files, 9 tests
- full backend: 376 files, 1,529 tests
- backend typecheck
- full root lint across 3,092 files
- Effect source, patch policy, test ownership, Ultracite, diff, LOC, and technical-debt scans
- all touched TypeScript modules are 298 LOC or fewer
- exact-head production dry-run completed schema validation, deleted no index, and ended with `Would have deployed Convex functions`

No schema, index, environment, Vercel, or production data mutation is included in this PR.