### PR TITLE
fix(content): scope tryout reference proof to active snapshot

### DIFF
--- a/packages/backend/convex/contentRelease/cutover/inventory.test.ts
+++ b/packages/backend/convex/contentRelease/cutover/inventory.test.ts
@@ -1,11 +1,24 @@
 import {
   AUDIT_INVENTORY,
+  AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT,
+  AUDITED_PHYSICAL_TRYOUT_CATALOG_COUNT,
+  CURRENT_INVENTORY,
   RETIRED_PROGRAM_INVENTORY,
 } from "@repo/backend/convex/contentRelease/cutover/inventory";
 import { RETIRED_PROGRAM_ZERO_RECEIPT } from "@repo/backend/convex/contentRelease/cutover/retiredPrograms";
 import { describe, expect, it } from "vitest";
 
 describe("contentRelease/cutover/inventory", () => {
+  it("separates the active signed try-out catalog from physical retention", () => {
+    const tryoutCatalog = CURRENT_INVENTORY.find(
+      ({ table }) => table === "tryoutCatalog"
+    );
+
+    expect(AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT).toBe(54);
+    expect(AUDITED_PHYSICAL_TRYOUT_CATALOG_COUNT).toBe(108);
+    expect(tryoutCatalog?.expected).toBe(AUDITED_PHYSICAL_TRYOUT_CATALOG_COUNT);
+  });
+
   it("requires every retired synthetic program table to stay empty", () => {
     expect(RETIRED_PROGRAM_INVENTORY).toEqual([
       { batchSize: 1, expected: 0, table: "learningProgramCoverage" },

--- a/packages/backend/convex/contentRelease/cutover/inventory.ts
+++ b/packages/backend/convex/contentRelease/cutover/inventory.ts
@@ -26,7 +26,8 @@ export const AUDITED_ARTICLE_COUNT = 14;
 export const AUDITED_MATERIAL_COUNT = 766;
 export const AUDITED_MATERIAL_TOPIC_COUNT = 72;
 export const AUDITED_QURAN_SEARCH_COUNT = 228;
-export const AUDITED_TRYOUT_CATALOG_COUNT = 108;
+export const AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT = RETAINED_CATALOG_COUNT;
+export const AUDITED_PHYSICAL_TRYOUT_CATALOG_COUNT = 108;
 
 export interface InventoryEntry<TableName extends TableNames = TableNames> {
   readonly batchSize: number;
@@ -102,7 +103,7 @@ export const CURRENT_INVENTORY = [
   },
   {
     batchSize: 20,
-    expected: AUDITED_TRYOUT_CATALOG_COUNT,
+    expected: AUDITED_PHYSICAL_TRYOUT_CATALOG_COUNT,
     table: "tryoutCatalog",
   },
   { batchSize: 20, expected: 1680, table: "tryoutPlacements" },

--- a/packages/backend/convex/contentRelease/cutover/phase1.md
+++ b/packages/backend/convex/contentRelease/cutover/phase1.md
@@ -130,15 +130,16 @@ signed snapshot cursor. Accept only monotonically increasing `checked` counts,
 terminal command must return `complete: true`, `checked: 228`, and zero
 processed or staged rows.
 
-Then backfill the exact 108 try-out asset IDs from their authenticated signed
-catalog rows:
+Then backfill the exact 54 active try-out asset IDs from their authenticated
+signed catalog rows. The separate audited table inventory remains 108 because
+it includes 54 rows from the retained prior snapshot generation:
 
 ```sh
 pnpm --filter @repo/backend exec convex run contentRelease/cutover/tryoutAssets:stage '{}' --prod
 ```
 
-Accept only `complete: true`, `total: 108`, and an `updated` plus `unchanged`
-sum of 108. Repeating the command must report all 108 rows unchanged.
+Accept only `complete: true`, `total: 54`, and an `updated` plus `unchanged`
+sum of 54. Repeating the command must report all 54 active rows unchanged.
 
 ## Prove all reference indexes in isolated transactions
 
@@ -152,7 +153,7 @@ pnpm --filter @repo/backend exec convex run contentRelease/cutover/articleAssets
 pnpm --filter @repo/backend exec convex run contentRelease/cutover/tryoutAssets:prove '{}' --prod
 ```
 
-Accept only article and try-out receipts with counts 14 and 108. Together with
+Accept only article and try-out receipts with counts 14 and 54. Together with
 the completed material lesson count-766, material topic count-72, and Quran
 count-228 receipts, the checkpoint must hold exactly five reference receipts
 across four families. Every proof authenticates its complete active inventory,

--- a/packages/backend/convex/contentRelease/cutover/tryoutAssets.test.ts
+++ b/packages/backend/convex/contentRelease/cutover/tryoutAssets.test.ts
@@ -18,6 +18,65 @@ import { describe, expect, it } from "vitest";
 const TRYOUT_CATALOG_COUNT = 2;
 
 describe("contentRelease/cutover/tryoutAssets", () => {
+  it("stages only the active snapshot while a retained generation remains", async () => {
+    const t = convexTest(schema, convexModules);
+    const snapshotIds = await t.mutation(async (ctx) => {
+      const activeSnapshotId = await activateTechnicalTryout(ctx);
+      const retainedSnapshotId = `sha256:${"a".repeat(64)}`;
+      const activeRows = await ctx.db.query("tryoutCatalog").collect();
+      for (const [index, row] of activeRows.entries()) {
+        const { _creationTime: _ignoredTime, _id: _ignoredId, ...stored } = row;
+        await ctx.db.patch("tryoutCatalog", row._id, { assetId: undefined });
+        await ctx.db.insert("tryoutCatalog", {
+          ...stored,
+          assetId:
+            index === 0 ? "asset:en:tryout:retained:tampered" : undefined,
+          snapshotId: retainedSnapshotId,
+        });
+      }
+      await insertQuiescentCheckpoint(ctx);
+      return { activeSnapshotId, retainedSnapshotId };
+    });
+
+    const receipt = await t.mutation((ctx) =>
+      runConvexProgram(stageTryoutAssetIds(ctx, TRYOUT_CATALOG_COUNT))
+    );
+    const proved = await t.query((ctx) =>
+      runConvexProgram(proveTryoutAssetIdsComplete(ctx, TRYOUT_CATALOG_COUNT))
+    );
+    const stored = await t.run(async (ctx) => ({
+      active: await ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_index", (index) =>
+          index.eq("snapshotId", snapshotIds.activeSnapshotId)
+        )
+        .collect(),
+      retained: await ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_index", (index) =>
+          index.eq("snapshotId", snapshotIds.retainedSnapshotId)
+        )
+        .collect(),
+    }));
+
+    expect(receipt).toEqual({
+      complete: true,
+      total: TRYOUT_CATALOG_COUNT,
+      unchanged: 0,
+      updated: TRYOUT_CATALOG_COUNT,
+    });
+    expect(proved).toBe(TRYOUT_CATALOG_COUNT);
+    expect(stored.active).toHaveLength(2);
+    expect(stored.active.every(({ assetId }) => assetId !== undefined)).toBe(
+      true
+    );
+    expect(stored.retained).toHaveLength(2);
+    expect(stored.retained.map(({ assetId }) => assetId)).toEqual([
+      "asset:en:tryout:retained:tampered",
+      undefined,
+    ]);
+  });
+
   it("stages exact authenticated try-out asset identities idempotently", async () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(async (ctx) => {

--- a/packages/backend/convex/contentRelease/cutover/tryoutAssets.ts
+++ b/packages/backend/convex/contentRelease/cutover/tryoutAssets.ts
@@ -4,7 +4,7 @@ import type {
   QueryCtx,
 } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/_generated/server";
-import { AUDITED_TRYOUT_CATALOG_COUNT } from "@repo/backend/convex/contentRelease/cutover/inventory";
+import { AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT } from "@repo/backend/convex/contentRelease/cutover/inventory";
 import { persistReferenceProof } from "@repo/backend/convex/contentRelease/cutover/referenceProofs";
 import { referenceProofReceiptValidator } from "@repo/backend/convex/contentRelease/cutover/schema";
 import { requireCutoverPhase } from "@repo/backend/convex/contentRelease/cutover/state";
@@ -57,7 +57,12 @@ const authenticateTryoutAssets = Effect.fn(
   }
 
   const rows = yield* Effect.promise(() =>
-    ctx.db.query("tryoutCatalog").take(expectedCount + 1)
+    ctx.db
+      .query("tryoutCatalog")
+      .withIndex("by_snapshotId_and_index", (index) =>
+        index.eq("snapshotId", selected.snapshotId)
+      )
+      .take(expectedCount + 1)
   );
   if (rows.length !== expectedCount) {
     return yield* tryoutAssetFailure(
@@ -180,7 +185,9 @@ export const stage = internalMutation({
   args: {},
   returns: tryoutAssetReceiptValidator,
   handler: (ctx) =>
-    runConvexProgram(stageTryoutAssetIds(ctx, AUDITED_TRYOUT_CATALOG_COUNT)),
+    runConvexProgram(
+      stageTryoutAssetIds(ctx, AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT)
+    ),
 });
 
 /** Stores the exact try-out reference proof in its own transaction. */
@@ -189,7 +196,7 @@ export const prove = internalMutation({
   returns: referenceProofReceiptValidator,
   handler: (ctx) =>
     runConvexProgram(
-      checkpointTryoutAssetIds(ctx, AUDITED_TRYOUT_CATALOG_COUNT)
+      checkpointTryoutAssetIds(ctx, AUDITED_ACTIVE_TRYOUT_CATALOG_COUNT)
     ),
 });
 


### PR DESCRIPTION
## Summary

- separate the active signed try-out catalog count (54) from the retained physical table inventory (108)
- scope reference staging and proof to the selected active snapshot through `by_snapshotId_and_index`
- retain the exact 108-row whole-table audit and later drain invariant
- add a two-generation regression test proving an inactive tampered snapshot is neither staged nor authenticated
- correct the Phase 1 operator receipts to 54 active rows

## Production evidence

Production `tryoutCatalog` contains two snapshot partitions of 54 rows each. The active verified snapshot declares and authenticates 54 rows across both locales. The other 54 rows belong to an inactive retained generation. The earlier `tryoutAssets:stage` call rejected the signed count before its first database write, so there is no partial state to repair.

This change is code and documentation only. It adds no schema or index and deletes no index.

## Verification

- backend full suite: 376 files, 1,530 tests passed
- focused inventory and try-out cutover: 2 files, 6 tests passed
- backend typecheck passed
- root lint passed across 3,092 files
- Effect source, patch policy, test ownership, Ultracite, and CAS lint passed
- `git diff --check` passed
- exact-tree Convex production dry run passed with no index deletion and no mutation

## Rollout

After exact-head CI and review, deploy this code-only backend change to production, rerun `tryoutAssets:stage` and its idempotent retry, then persist the 54-row proof. Phase 2 must consume the same active count before reader acceptance.