### PR TITLE
Pin taxonomy assembly to one signed release

### DIFF
--- a/packages/backend/client/nakafa/release.test.ts
+++ b/packages/backend/client/nakafa/release.test.ts
@@ -1,0 +1,115 @@
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import {
+  readNakafaReleasePin,
+  verifyNakafaReleasePin,
+} from "@repo/backend/client/nakafa/release";
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@repo/backend/client/nakafa/query", () => ({
+  readNakafaRuntimeQuery: queryMock,
+}));
+
+const ACTIVE_RELEASE = {
+  manifestHash: Sha256HashSchema.make(`sha256:${"a".repeat(64)}`),
+  releaseId: ReleaseIdSchema.make("release-current"),
+  sequence: 25,
+};
+
+describe("Nakafa release pin", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it("reads the complete active publication identity", async () => {
+    queryMock.mockReturnValue(Effect.succeed(ACTIVE_RELEASE));
+
+    await expect(
+      Effect.runPromise(readNakafaReleasePin("https://example.convex.cloud"))
+    ).resolves.toEqual(ACTIVE_RELEASE);
+    expect(readNakafaRuntimeQuery).toHaveBeenCalledWith(
+      "https://example.convex.cloud",
+      expect.anything(),
+      {}
+    );
+  });
+
+  it("rejects a malformed active publication identity", async () => {
+    queryMock.mockReturnValue(
+      Effect.succeed({ ...ACTIVE_RELEASE, manifestHash: "not-a-hash" })
+    );
+
+    await expect(
+      Effect.runPromise(
+        readNakafaReleasePin("https://example.convex.cloud").pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({
+      _tag: "NakafaAgentDataReadError",
+      message: "Unable to decode the active Nakafa content release.",
+    });
+  });
+
+  it("accepts stable active and empty publication identities", async () => {
+    for (const identity of [ACTIVE_RELEASE, null]) {
+      queryMock.mockReturnValue(Effect.succeed(identity));
+
+      await expect(
+        Effect.runPromise(
+          verifyNakafaReleasePin("https://example.convex.cloud", identity)
+        )
+      ).resolves.toEqual(identity);
+    }
+  });
+
+  it.each([
+    [
+      "manifest hash",
+      {
+        ...ACTIVE_RELEASE,
+        manifestHash: Sha256HashSchema.make(`sha256:${"b".repeat(64)}`),
+      },
+    ],
+    [
+      "release ID",
+      { ...ACTIVE_RELEASE, releaseId: ReleaseIdSchema.make("release-next") },
+    ],
+    ["sequence", { ...ACTIVE_RELEASE, sequence: 26 }],
+    ["missing publication", null],
+  ])("rejects a changed %s", async (_label, actual) => {
+    queryMock.mockReturnValue(Effect.succeed(actual));
+
+    await expect(
+      Effect.runPromise(
+        verifyNakafaReleasePin(
+          "https://example.convex.cloud",
+          ACTIVE_RELEASE
+        ).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({
+      _tag: "NakafaAgentDataReadError",
+      message: "Unable to complete one release-pinned Nakafa content read.",
+    });
+  });
+
+  it("rejects activation from an empty publication", async () => {
+    queryMock.mockReturnValue(Effect.succeed(ACTIVE_RELEASE));
+
+    await expect(
+      Effect.runPromise(
+        verifyNakafaReleasePin("https://example.convex.cloud", null).pipe(
+          Effect.flip
+        )
+      )
+    ).resolves.toMatchObject({
+      _tag: "NakafaAgentDataReadError",
+      message: "Unable to complete one release-pinned Nakafa content read.",
+    });
+  });
+});
+
+import {
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";

--- a/packages/backend/client/nakafa/release.ts
+++ b/packages/backend/client/nakafa/release.ts
@@ -1,0 +1,82 @@
+import {
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";
+import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import { api } from "@repo/backend/convex/_generated/api";
+import {
+  getUnknownErrorMessage,
+  NakafaAgentDataReadError,
+} from "@repo/contents/_lib/agent/errors";
+import { Effect, Schema } from "effect";
+
+const NakafaReleasePinSchema = Schema.NullOr(
+  Schema.Struct({
+    manifestHash: Sha256HashSchema,
+    releaseId: ReleaseIdSchema,
+    sequence: Schema.Number.pipe(Schema.int(), Schema.positive()),
+  })
+);
+
+type NakafaReleasePin = typeof NakafaReleasePinSchema.Type;
+
+/** Reads the complete active publication identity for a multi-query operation. */
+export const readNakafaReleasePin = Effect.fn("NakafaContent.readReleasePin")(
+  function* (convexUrl: string) {
+    const identity = yield* readNakafaRuntimeQuery(
+      convexUrl,
+      api.contentRelease.runtime.active.read,
+      {}
+    );
+
+    return yield* Schema.decodeUnknown(NakafaReleasePinSchema)(identity).pipe(
+      Effect.mapError(
+        (error) =>
+          new NakafaAgentDataReadError({
+            cause: getUnknownErrorMessage(error),
+            message: "Unable to decode the active Nakafa content release.",
+          })
+      )
+    );
+  }
+);
+
+/** Verifies a multi-query read stayed on one exact publication generation. */
+export const verifyNakafaReleasePin = Effect.fn(
+  "NakafaContent.verifyReleasePin"
+)(function* (convexUrl: string, expected: NakafaReleasePin) {
+  const actual = yield* readNakafaReleasePin(convexUrl);
+  if (!hasSameReleaseIdentity(expected, actual)) {
+    return yield* new NakafaAgentDataReadError({
+      cause: `Active content release changed from ${formatReleaseIdentity(expected)} to ${formatReleaseIdentity(actual)}.`,
+      message: "Unable to complete one release-pinned Nakafa content read.",
+    });
+  }
+
+  return actual;
+});
+
+/** Compares every signed field that identifies one active publication. */
+function hasSameReleaseIdentity(
+  expected: NakafaReleasePin,
+  actual: NakafaReleasePin
+) {
+  if (expected === null || actual === null) {
+    return expected === actual;
+  }
+
+  return (
+    expected.manifestHash === actual.manifestHash &&
+    expected.releaseId === actual.releaseId &&
+    expected.sequence === actual.sequence
+  );
+}
+
+/** Formats one public release identity for a typed consistency diagnostic. */
+function formatReleaseIdentity(identity: NakafaReleasePin) {
+  if (identity === null) {
+    return "none";
+  }
+
+  return `${identity.releaseId}@${identity.sequence} (${identity.manifestHash})`;
+}

--- a/packages/backend/client/nakafa/taxonomy.test.ts
+++ b/packages/backend/client/nakafa/taxonomy.test.ts
@@ -23,6 +23,11 @@ vi.mock("@repo/backend/client/runtime", () => ({
 
 const quranSnapshotId = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
 const APP_LOCALE_PATTERN = /^(?:en|id)$/u;
+const ACTIVE_RELEASE = {
+  manifestHash: `sha256:${"c".repeat(64)}`,
+  releaseId: "release-current",
+  sequence: 25,
+};
 
 beforeEach(() => {
   runtimeMocks.runtimeQuery.mockReset();
@@ -63,6 +68,12 @@ describe("readNakafaTaxonomy", () => {
     expect(calledRuntimeQueries()).toContain(
       getFunctionName(api.contentRelease.tryout.taxonomy)
     );
+    expect(
+      calledRuntimeQueries().filter(
+        (name) =>
+          name === getFunctionName(api.contentRelease.runtime.active.read)
+      )
+    ).toHaveLength(4);
   });
 
   it("fails closed when an article or material family is unmanaged", async () => {
@@ -176,6 +187,37 @@ describe("readNakafaTaxonomy", () => {
       },
     });
   });
+
+  it("fails closed when the active publication changes during assembly", async () => {
+    let activeReadCount = 0;
+    runtimeMocks.runtimeQuery.mockImplementation((convexUrl, query, args) => {
+      if (
+        getFunctionName(query) ===
+        getFunctionName(api.contentRelease.runtime.active.read)
+      ) {
+        activeReadCount += 1;
+        return Promise.resolve(
+          activeReadCount === 1
+            ? ACTIVE_RELEASE
+            : { ...ACTIVE_RELEASE, sequence: 26 }
+        );
+      }
+
+      return readRuntimeFixture(convexUrl, query, args);
+    });
+
+    await expect(
+      Effect.runPromise(
+        Effect.either(readNakafaTaxonomy("https://example.convex.cloud", "id"))
+      )
+    ).resolves.toMatchObject({
+      _tag: "Left",
+      left: {
+        _tag: "NakafaAgentDataReadError",
+        message: "Unable to complete one release-pinned Nakafa content read.",
+      },
+    });
+  });
 });
 
 /** Builds one authenticated article category page fixture. */
@@ -208,6 +250,13 @@ function readRuntimeFixture(
   query: FunctionReference<"query">,
   args: unknown
 ) {
+  if (
+    getFunctionName(query) ===
+    getFunctionName(api.contentRelease.runtime.active.read)
+  ) {
+    return Promise.resolve(ACTIVE_RELEASE);
+  }
+
   if (
     getFunctionName(query) === getFunctionName(api.contentRelease.quran.surahs)
   ) {

--- a/packages/backend/client/nakafa/taxonomy.ts
+++ b/packages/backend/client/nakafa/taxonomy.ts
@@ -3,6 +3,10 @@ import {
   toNakafaQuranDataReadError,
 } from "@repo/backend/client/nakafa/decode";
 import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
+import {
+  readNakafaReleasePin,
+  verifyNakafaReleasePin,
+} from "@repo/backend/client/nakafa/release";
 import { decodePublishedQuranCatalog } from "@repo/backend/client/quran/decode";
 import { api } from "@repo/backend/convex/_generated/api";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
@@ -49,6 +53,7 @@ export function readNakafaTaxonomy(
   locale: Locale = defaultLocale
 ) {
   return Effect.gen(function* () {
+    const releasePin = yield* readNakafaReleasePin(convexUrl);
     const [articleCategories, signedInventory, quranResult] = yield* Effect.all(
       [
         readSignedArticleCategories(convexUrl, locale),
@@ -63,6 +68,7 @@ export function readNakafaTaxonomy(
       ...item,
       count: item.count + quran.surahs.length,
     }));
+    yield* verifyNakafaReleasePin(convexUrl, releasePin);
 
     return yield* decodeNakafaTaxonomy({
       articles: {


### PR DESCRIPTION
## Summary

- restore a complete active publication pin around the multi-query taxonomy assembly
- compare `manifestHash`, `releaseId`, and `sequence`, including null transitions
- decode the pin through Aksara identity schemas and fail through the typed agent error channel
- restore regression coverage for activation during taxonomy assembly

This is the validated follow-up to the remaining Codex review thread on #301. It is not the root cause of the current maintenance outage, but it must land before public traffic reopens.

## Verification

- `pnpm --filter @repo/backend exec vitest run client/nakafa/release.test.ts client/nakafa/taxonomy.test.ts --coverage.enabled=false --maxWorkers=1`
- `pnpm --filter @repo/backend test -- --maxWorkers=4 --testTimeout=15000` (308 files, 1,272 tests)
- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter mcp typecheck`
- `POSTHOG_PROXY_HOST=https://example.invalid pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm effect:source:check`
- `pnpm check:tests`
- changed-scope React Doctor
- independent thermonuclear review: no P0, P1, or P2 findings