### PR TITLE
fix(ci): isolate public runtime generation

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -91,8 +91,9 @@ jobs:
 
           if [ ! -f "$output" ] || [ -L "$output" ] || \
             [ "$(stat -c '%a' "$output")" != "600" ] || \
-            [ "$(wc -l < "$output")" -ne 1 ] || \
-            ! grep -Exq 'AGENT_DOCS_CONTENT_STATE_HASH=[a-f0-9]{64}' "$output"; then
+            [ "$(wc -l < "$output")" -ne 2 ] || \
+            ! grep -Exq 'AGENT_DOCS_CONTENT_STATE_HASH=[a-f0-9]{64}' "$output" || \
+            ! grep -Exq 'AGENT_DOCS_RUNTIME_SELECTION_HASH=[a-f0-9]{64}' "$output"; then
             echo "Invalid production runtime generation output." >&2
             exit 1
           fi
@@ -230,6 +231,7 @@ jobs:
         if: failure() && steps.production_build.outcome == 'failure'
         env:
           AGENT_DOCS_CONTENT_STATE_HASH: ""
+          AGENT_DOCS_RUNTIME_SELECTION_HASH: ""
           AGENT_DOCS_RUNTIME_SCHEMA_FINGERPRINT: ""
           CONTENT_RUNTIME_TOKEN: ""
           CONVEX_SITE_URL: ""

--- a/packages/backend/convex/contentRelease/spec.ts
+++ b/packages/backend/convex/contentRelease/spec.ts
@@ -80,15 +80,16 @@ export const releaseStatusValidator = literals(
 export const releaseRoleValidator = literals("candidate", "recovery");
 
 /** Ordered durable phases for one crash-safe history compaction cycle. */
-export const compactionPhaseValidator = literals(
+export const COMPACTION_PHASES = [
   "heads",
   "bindings",
   "items",
   "batches",
   "artifacts",
   "snapshots",
-  "releases"
-);
+  "releases",
+] as const;
+export const compactionPhaseValidator = literals(...COMPACTION_PHASES);
 
 /** Implemented content families owned by the shared release contract. */
 export const contentFamilyValidator = literals(...ContentFamilySchema.literals);

--- a/packages/backend/scripts/content-runtime/ci/config.test.ts
+++ b/packages/backend/scripts/content-runtime/ci/config.test.ts
@@ -2,6 +2,7 @@ import {
   CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT,
   clearContentRuntimeSecrets,
   readExportConfig,
+  readProductionSelectionConfig,
   validateProductionDeployKey,
 } from "@repo/backend/scripts/content-runtime/ci/config";
 import { CONTENT_RUNTIME_CACHE_VERSION } from "@repo/backend/scripts/content-runtime/tables";
@@ -74,6 +75,28 @@ describe("content runtime CI config", () => {
       contentStateHash,
     });
   });
+
+  it("reads the public runtime selection independently", async () => {
+    const runtimeSelectionHash = "2".repeat(64);
+    stubProductionConfig();
+    stubRuntimeSelection(runtimeSelectionHash);
+
+    await expect(
+      Effect.runPromise(readProductionSelectionConfig)
+    ).resolves.toMatchObject({ runtimeSelectionHash });
+  });
+
+  it("rejects an invalid public runtime selection identity", async () => {
+    stubProductionConfig();
+    stubRuntimeSelection("invalid-selection");
+
+    await expect(
+      Effect.runPromise(readProductionSelectionConfig.pipe(Effect.flip))
+    ).resolves.toMatchObject({
+      _tag: "ContentRuntimeCiError",
+      message: "AGENT_DOCS_RUNTIME_SELECTION_HASH must be a SHA-256 hash.",
+    });
+  });
 });
 
 function stubProductionConfig() {
@@ -89,4 +112,8 @@ function stubCacheIdentity(contentStateHash: string) {
   vi.stubEnv("AGENT_DOCS_CONTENT_CACHE_VERSION", CONTENT_RUNTIME_CACHE_VERSION);
   vi.stubEnv("AGENT_DOCS_CONTENT_STATE_HASH", contentStateHash);
   vi.stubEnv("AGENT_DOCS_RUNTIME_SCHEMA_FINGERPRINT", "3".repeat(64));
+}
+
+function stubRuntimeSelection(runtimeSelectionHash: string) {
+  vi.stubEnv("AGENT_DOCS_RUNTIME_SELECTION_HASH", runtimeSelectionHash);
 }

--- a/packages/backend/scripts/content-runtime/ci/config.ts
+++ b/packages/backend/scripts/content-runtime/ci/config.ts
@@ -25,16 +25,20 @@ export interface CacheIdentity {
   readonly runtimeSchemaFingerprint: string;
 }
 
+export interface RuntimeSelectionIdentity {
+  readonly runtimeSelectionHash: string;
+}
+
 export interface ProductionConfig {
   readonly deployKey: Redacted.Redacted;
   readonly runnerTemp: string;
 }
 
-export interface ProductionIdentityConfig
+export interface ProductionSelectionConfig
   extends ProductionConfig,
-    CacheIdentity {}
+    RuntimeSelectionIdentity {}
 
-export interface ExportConfig extends ProductionIdentityConfig {
+export interface ExportConfig extends ProductionConfig, CacheIdentity {
   readonly cacheKey: Redacted.Redacted;
   readonly exportLimit: number;
 }
@@ -112,6 +116,18 @@ const readCacheIdentity = Effect.gen(function* () {
   } satisfies CacheIdentity;
 });
 
+const readRuntimeSelectionIdentity = Effect.gen(function* () {
+  const runtimeSelectionHash = yield* Config.nonEmptyString(
+    "AGENT_DOCS_RUNTIME_SELECTION_HASH"
+  ).pipe(
+    Effect.flatMap((value) =>
+      validateHex("AGENT_DOCS_RUNTIME_SELECTION_HASH", value)
+    )
+  );
+
+  return { runtimeSelectionHash } satisfies RuntimeSelectionIdentity;
+});
+
 export const readProductionConfig = Effect.gen(function* () {
   const deployKey = yield* Config.redacted("CONVEX_DEPLOY_KEY");
   const runnerTemp = yield* Config.nonEmptyString("RUNNER_TEMP");
@@ -120,15 +136,19 @@ export const readProductionConfig = Effect.gen(function* () {
   return { deployKey, runnerTemp } satisfies ProductionConfig;
 });
 
-export const readProductionIdentityConfig = Effect.gen(function* () {
+export const readProductionSelectionConfig = Effect.gen(function* () {
   const production = yield* readProductionConfig;
-  const identity = yield* readCacheIdentity;
+  const selectionIdentity = yield* readRuntimeSelectionIdentity;
 
-  return { ...production, ...identity } satisfies ProductionIdentityConfig;
+  return {
+    ...production,
+    ...selectionIdentity,
+  } satisfies ProductionSelectionConfig;
 });
 
 export const readExportConfig = Effect.gen(function* () {
-  const productionIdentity = yield* readProductionIdentityConfig;
+  const production = yield* readProductionConfig;
+  const cacheIdentity = yield* readCacheIdentity;
   const cacheKey = yield* Config.redacted("AGENT_DOCS_CONTENT_CACHE_KEY");
   const exportLimit = yield* Config.integer(
     "CONTENT_RUNTIME_EXPORT_LIMIT"
@@ -144,7 +164,7 @@ export const readExportConfig = Effect.gen(function* () {
       "CONTENT_RUNTIME_EXPORT_LIMIT must be a positive safe integer."
     );
   }
-  return { ...productionIdentity, cacheKey, exportLimit };
+  return { ...production, ...cacheIdentity, cacheKey, exportLimit };
 });
 
 export const readImportConfig = Effect.gen(function* () {

--- a/packages/backend/scripts/content-runtime/ci/export.ts
+++ b/packages/backend/scripts/content-runtime/ci/export.ts
@@ -10,7 +10,7 @@ import type { ExportConfig } from "./config";
 import { contentRuntimeCiError } from "./error";
 import {
   readProductionGenerations,
-  verifyRuntimeGenerations,
+  verifyStableRuntimeExport,
 } from "./generation";
 import { decodeJsonRows } from "./json";
 import {
@@ -109,7 +109,7 @@ export const exportSignedRuntime = Effect.fn(
       { mode: 0o600 }
     );
 
-    yield* verifyRuntimeGenerations(
+    yield* verifyStableRuntimeExport(
       config,
       yield* readProductionGenerations(config)
     );

--- a/packages/backend/scripts/content-runtime/ci/generation.test.ts
+++ b/packages/backend/scripts/content-runtime/ci/generation.test.ts
@@ -1,70 +1,207 @@
 import {
   buildRuntimeGenerations,
   formatGenerationEnvironment,
-  verifyRuntimeGenerations,
+  verifyRuntimeSelection,
+  verifyStableRuntimeExport,
 } from "@repo/backend/scripts/content-runtime/ci/generation";
 import { decodeJsonRows } from "@repo/backend/scripts/content-runtime/ci/json";
 import { CONTENT_RUNTIME_CACHE_VERSION } from "@repo/backend/scripts/content-runtime/tables";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
-const contentState = [
-  {
-    _creationTime: 1,
-    _id: "state-1",
-    activeManifestHash: "a".repeat(64),
-    activeReleaseId: "current-release",
-    activeSequence: 9,
-    key: "primary",
-  },
-];
+const ACTIVE_HASH = `sha256:${"a".repeat(64)}`;
+const NEXT_HASH = `sha256:${"b".repeat(64)}`;
+const contentStateRow = {
+  _creationTime: 1,
+  _id: "state-1",
+  activeManifestHash: ACTIVE_HASH,
+  activeReleaseId: "current-release",
+  activeSequence: 9,
+  articleManifestHash: ACTIVE_HASH,
+  articleReleaseId: "current-release",
+  articleSequence: 9,
+  key: "primary",
+  materialManifestHash: ACTIVE_HASH,
+  materialReleaseId: "current-release",
+  materialSequence: 9,
+  nextSequence: 10,
+  searchManifestHash: ACTIVE_HASH,
+  searchReleaseId: "current-release",
+  searchSequence: 9,
+  updatedAt: 100,
+};
+const contentState = [contentStateRow];
 
 describe("content runtime generations", () => {
-  it("is stable across Convex system fields", async () => {
+  it("separates portable cache state from the public signed selection", async () => {
     const baseline = await Effect.runPromise(
       buildRuntimeGenerations(contentState)
     );
     const systemFieldsChanged = await Effect.runPromise(
       buildRuntimeGenerations([
-        { ...contentState[0], _creationTime: 999, _id: "different" },
+        { ...contentStateRow, _creationTime: 999, _id: "different" },
       ])
     );
     expect(systemFieldsChanged).toEqual(baseline);
     expect(baseline.contentStateHash).toBe(
-      "81b0dcbf693af64c1be78d3c657485632e80f68e84ddc657e970c646137fc680"
+      "21bb4b24ec4dd2151567a1850ab3899b457f01f93f4d9b80f983442a0be6440a"
+    );
+    expect(baseline.runtimeSelectionHash).toBe(
+      "3579932e4fad16d4c08279cb35248e171d5f8b1ce9db4ea4a481acd84112d088"
     );
     expect(formatGenerationEnvironment(baseline)).toBe(
-      `AGENT_DOCS_CONTENT_STATE_HASH=${baseline.contentStateHash}`
+      [
+        `AGENT_DOCS_CONTENT_STATE_HASH=${baseline.contentStateHash}`,
+        `AGENT_DOCS_RUNTIME_SELECTION_HASH=${baseline.runtimeSelectionHash}`,
+      ].join("\n")
     );
   });
 
-  it("changes when the current signed pointer changes", async () => {
+  it("accepts compaction and inactive-slot drift only for runtime selection", async () => {
+    const baseline = await Effect.runPromise(
+      buildRuntimeGenerations(contentState)
+    );
+    const operationalDrift = await Effect.runPromise(
+      buildRuntimeGenerations([
+        {
+          ...contentStateRow,
+          candidateManifestHash: NEXT_HASH,
+          candidateReleaseId: "candidate-release",
+          candidateSequence: 10,
+          compactCursor: "next-page",
+          compactFloor: 9,
+          compactFrom: 0,
+          compactPhase: "heads",
+          compactStartedAt: 200.5,
+          compactedFloor: 0,
+          nextSequence: 12,
+          recoveryManifestHash: `sha256:${"c".repeat(64)}`,
+          recoveryReleaseId: "recovery-release",
+          recoverySequence: 11,
+          updatedAt: 300,
+        },
+      ])
+    );
+
+    expect(operationalDrift.contentStateHash).not.toBe(
+      baseline.contentStateHash
+    );
+    expect(operationalDrift.runtimeSelectionHash).toBe(
+      baseline.runtimeSelectionHash
+    );
+    await expect(
+      Effect.runPromise(
+        verifyRuntimeSelection(
+          { runtimeSelectionHash: baseline.runtimeSelectionHash },
+          operationalDrift
+        )
+      )
+    ).resolves.toBeUndefined();
+    await expect(
+      Effect.runPromise(
+        verifyStableRuntimeExport(
+          cacheIdentity(baseline.contentStateHash),
+          operationalDrift
+        ).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({
+      _tag: "ContentRuntimeCiError",
+      message: "Production content state changed during signed runtime export.",
+    });
+  });
+
+  it("rejects a coherent change to the public signed selection", async () => {
     const baseline = await Effect.runPromise(
       buildRuntimeGenerations(contentState)
     );
     const changed = await Effect.runPromise(
       buildRuntimeGenerations([
-        { ...contentState[0], activeReleaseId: "next-release" },
+        {
+          ...contentStateRow,
+          activeManifestHash: NEXT_HASH,
+          activeReleaseId: "next-release",
+          activeSequence: 10,
+          articleManifestHash: NEXT_HASH,
+          articleReleaseId: "next-release",
+          articleSequence: 10,
+          materialManifestHash: NEXT_HASH,
+          materialReleaseId: "next-release",
+          materialSequence: 10,
+          nextSequence: 11,
+          searchManifestHash: NEXT_HASH,
+          searchReleaseId: "next-release",
+          searchSequence: 10,
+          updatedAt: 200,
+        },
       ])
     );
 
     expect(changed.contentStateHash).not.toBe(baseline.contentStateHash);
-    const verificationFailure = await Effect.runPromise(
-      verifyRuntimeGenerations(
-        {
-          cacheVersion: CONTENT_RUNTIME_CACHE_VERSION,
-          contentStateHash: baseline.contentStateHash,
-          runtimeSchemaFingerprint: "3".repeat(64),
-        },
-        changed
-      ).pipe(Effect.flip)
+    expect(changed.runtimeSelectionHash).not.toBe(
+      baseline.runtimeSelectionHash
     );
-    expect(verificationFailure).toMatchObject({
+    await expect(
+      Effect.runPromise(
+        verifyRuntimeSelection(
+          { runtimeSelectionHash: baseline.runtimeSelectionHash },
+          changed
+        ).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({
       _tag: "ContentRuntimeCiError",
+      message:
+        "Production signed content pointer changed during runtime verification.",
     });
   });
 
-  it("rejects malformed or non-singleton pointer inputs", async () => {
+  it("rejects incomplete slots and unsynchronized read models", async () => {
+    const invalidRows = [
+      { ...contentStateRow, articleSequence: 8 },
+      { ...contentStateRow, candidateReleaseId: "partial-candidate" },
+      { ...contentStateRow, compactPhase: "unknown-phase" },
+      { ...contentStateRow, recoveryManifestHash: NEXT_HASH },
+    ];
+
+    for (const row of invalidRows) {
+      await expect(
+        Effect.runPromise(buildRuntimeGenerations([row]).pipe(Effect.flip))
+      ).resolves.toMatchObject({ _tag: "ContentRuntimeCiError" });
+    }
+  });
+
+  it("rejects partial or invalid compaction identities", async () => {
+    const invalidRows = [
+      { ...contentStateRow, compactFloor: 9 },
+      { ...contentStateRow, compactCursor: "orphaned-cursor" },
+      {
+        ...contentStateRow,
+        compactCursor: "",
+        compactFloor: 9,
+        compactFrom: 0,
+        compactPhase: "heads",
+        compactStartedAt: 200,
+      },
+      {
+        ...contentStateRow,
+        compactFloor: 9,
+        compactFrom: 1,
+        compactPhase: "heads",
+        compactStartedAt: 200,
+        compactedFloor: 0,
+      },
+    ];
+
+    for (const row of invalidRows) {
+      await expect(
+        Effect.runPromise(buildRuntimeGenerations([row]).pipe(Effect.flip))
+      ).resolves.toMatchObject({
+        _tag: "ContentRuntimeCiError",
+        message: "Production contentState has an invalid compaction identity.",
+      });
+    }
+  });
+
+  it("rejects incomplete, malformed, excess, or non-singleton rows", async () => {
     await expect(Effect.runPromise(decodeJsonRows(""))).resolves.toEqual([]);
     await expect(
       Effect.runPromise(buildRuntimeGenerations([]).pipe(Effect.flip))
@@ -77,7 +214,26 @@ describe("content runtime generations", () => {
       )
     ).resolves.toMatchObject({ _tag: "ContentRuntimeCiError" });
     await expect(
+      Effect.runPromise(
+        buildRuntimeGenerations([
+          { ...contentStateRow, unexpectedField: true },
+        ]).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({ _tag: "ContentRuntimeCiError" });
+    const { articleManifestHash: _missing, ...incomplete } = contentStateRow;
+    await expect(
+      Effect.runPromise(buildRuntimeGenerations([incomplete]).pipe(Effect.flip))
+    ).resolves.toMatchObject({ _tag: "ContentRuntimeCiError" });
+    await expect(
       Effect.runPromise(decodeJsonRows("not-json").pipe(Effect.flip))
     ).resolves.toMatchObject({ _tag: "ContentRuntimeCiError" });
   });
 });
+
+function cacheIdentity(contentStateHash: string) {
+  return {
+    cacheVersion: CONTENT_RUNTIME_CACHE_VERSION,
+    contentStateHash,
+    runtimeSchemaFingerprint: "3".repeat(64),
+  };
+}

--- a/packages/backend/scripts/content-runtime/ci/generation.ts
+++ b/packages/backend/scripts/content-runtime/ci/generation.ts
@@ -1,7 +1,16 @@
 import { FileSystem } from "@effect/platform";
-import { Effect, Redacted } from "effect";
+import {
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";
+import { COMPACTION_PHASES } from "@repo/backend/convex/contentRelease/spec";
+import { Effect, Redacted, Schema } from "effect";
 import { runConvexData } from "./command";
-import type { CacheIdentity, ProductionConfig } from "./config";
+import type {
+  CacheIdentity,
+  ProductionConfig,
+  RuntimeSelectionIdentity,
+} from "./config";
 import { contentRuntimeCiError } from "./error";
 import {
   decodeJsonRows,
@@ -10,16 +19,60 @@ import {
   stripConvexSystemFields,
 } from "./json";
 
+const SequenceSchema = Schema.Number.pipe(Schema.int(), Schema.positive());
+const TimestampSchema = Schema.Number.pipe(Schema.int(), Schema.positive());
+const OptionalManifestHashSchema = Schema.optional(Sha256HashSchema);
+const OptionalReleaseIdSchema = Schema.optional(ReleaseIdSchema);
+const OptionalSequenceSchema = Schema.optional(SequenceSchema);
+const CompactionPhaseSchema = Schema.Literal(...COMPACTION_PHASES);
+
+const PublishedContentStateSchema = Schema.Struct({
+  activeManifestHash: Sha256HashSchema,
+  activeReleaseId: ReleaseIdSchema,
+  activeSequence: SequenceSchema,
+  articleManifestHash: Sha256HashSchema,
+  articleReleaseId: ReleaseIdSchema,
+  articleSequence: SequenceSchema,
+  candidateManifestHash: OptionalManifestHashSchema,
+  candidateReleaseId: OptionalReleaseIdSchema,
+  candidateSequence: OptionalSequenceSchema,
+  compactCursor: Schema.optional(Schema.String),
+  compactFloor: Schema.optional(Schema.NonNegativeInt),
+  compactFrom: Schema.optional(Schema.NonNegativeInt),
+  compactPhase: Schema.optional(CompactionPhaseSchema),
+  compactStartedAt: Schema.optional(
+    Schema.JsonNumber.pipe(Schema.nonNegative())
+  ),
+  compactedFloor: Schema.optional(Schema.NonNegativeInt),
+  key: Schema.Literal("primary"),
+  materialManifestHash: Sha256HashSchema,
+  materialReleaseId: ReleaseIdSchema,
+  materialSequence: SequenceSchema,
+  nextSequence: SequenceSchema,
+  recoveryManifestHash: OptionalManifestHashSchema,
+  recoveryReleaseId: OptionalReleaseIdSchema,
+  recoverySequence: OptionalSequenceSchema,
+  searchManifestHash: Sha256HashSchema,
+  searchReleaseId: ReleaseIdSchema,
+  searchSequence: SequenceSchema,
+  updatedAt: TimestampSchema,
+});
+
+type PublishedContentState = Schema.Schema.Type<
+  typeof PublishedContentStateSchema
+>;
+
 export interface RuntimeGenerations {
   readonly contentStateHash: string;
+  readonly runtimeSelectionHash: string;
 }
 
-/** Proves the production generation did not change during the CI run. */
-export const verifyRuntimeGenerations = (
-  expected: CacheIdentity,
+/** Proves the public signed selection did not change during the CI run. */
+export const verifyRuntimeSelection = (
+  expected: RuntimeSelectionIdentity,
   actual: RuntimeGenerations
 ) => {
-  if (expected.contentStateHash === actual.contentStateHash) {
+  if (expected.runtimeSelectionHash === actual.runtimeSelectionHash) {
     return Effect.void;
   }
 
@@ -30,7 +83,120 @@ export const verifyRuntimeGenerations = (
   );
 };
 
-/** Builds the sole mutable generation identity from the signed pointer row. */
+/** Proves no publication or compaction state changed during one export. */
+export const verifyStableRuntimeExport = (
+  expected: CacheIdentity,
+  actual: RuntimeGenerations
+) => {
+  if (expected.contentStateHash === actual.contentStateHash) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    contentRuntimeCiError(
+      "Production content state changed during signed runtime export."
+    )
+  );
+};
+
+/** Returns whether one optional release slot is either absent or complete. */
+function hasCompleteOptionalIdentity(
+  manifestHash: string | undefined,
+  releaseId: string | undefined,
+  sequence: number | undefined
+) {
+  const fields = [manifestHash, releaseId, sequence];
+  const present = fields.filter((field) => field !== undefined).length;
+  return present === 0 || present === fields.length;
+}
+
+/** Mirrors the backend invariant for one resumable compaction cycle. */
+function hasValidCompactionIdentity(state: PublishedContentState) {
+  const compactedFloor = state.compactedFloor ?? 0;
+  if (
+    !Number.isSafeInteger(compactedFloor) ||
+    compactedFloor > state.nextSequence
+  ) {
+    return false;
+  }
+
+  const required = [
+    state.compactFloor,
+    state.compactFrom,
+    state.compactPhase,
+    state.compactStartedAt,
+  ];
+  const present = required.filter((field) => field !== undefined).length;
+  if (present === 0 && state.compactCursor === undefined) {
+    return true;
+  }
+
+  return (
+    present === required.length &&
+    state.compactFloor !== undefined &&
+    state.compactFrom !== undefined &&
+    state.compactPhase !== undefined &&
+    state.compactStartedAt !== undefined &&
+    Number.isSafeInteger(state.compactFloor) &&
+    Number.isSafeInteger(state.compactFrom) &&
+    state.compactFrom === compactedFloor &&
+    state.compactFloor > state.compactFrom &&
+    state.compactFloor <= state.nextSequence &&
+    (state.compactCursor === undefined || state.compactCursor.length > 0)
+  );
+}
+
+/** Returns whether one read model is pinned to the active signed release. */
+function hasActiveIdentity(
+  state: PublishedContentState,
+  manifestHash: string,
+  releaseId: string,
+  sequence: number
+) {
+  return (
+    manifestHash === state.activeManifestHash &&
+    releaseId === state.activeReleaseId &&
+    sequence === state.activeSequence
+  );
+}
+
+/** Decodes the full stored row before classifying generation-neutral fields. */
+const decodePublishedContentState = (row: JsonObject) =>
+  Schema.decodeUnknown(PublishedContentStateSchema)(row, {
+    onExcessProperty: "error",
+  }).pipe(
+    Effect.mapError(() =>
+      contentRuntimeCiError(
+        "Production contentState is not a complete published pointer."
+      )
+    )
+  );
+
+/** Projects only signed identities that can change rendered runtime output. */
+const runtimePointer = (state: PublishedContentState) => ({
+  active: {
+    manifestHash: state.activeManifestHash,
+    releaseId: state.activeReleaseId,
+    sequence: state.activeSequence,
+  },
+  article: {
+    manifestHash: state.articleManifestHash,
+    releaseId: state.articleReleaseId,
+    sequence: state.articleSequence,
+  },
+  material: {
+    manifestHash: state.materialManifestHash,
+    releaseId: state.materialReleaseId,
+    sequence: state.materialSequence,
+  },
+  search: {
+    manifestHash: state.searchManifestHash,
+    releaseId: state.searchReleaseId,
+    sequence: state.searchSequence,
+  },
+});
+
+/** Builds the stable signed generation identity from one complete pointer. */
 export const buildRuntimeGenerations = Effect.fn(
   "contentRuntime.buildGenerations"
 )(function* (contentState: readonly JsonObject[]) {
@@ -47,10 +213,52 @@ export const buildRuntimeGenerations = Effect.fn(
     );
   }
 
+  const storedState = stripConvexSystemFields(activePointer);
+  const state = yield* decodePublishedContentState(storedState);
+  if (!hasValidCompactionIdentity(state)) {
+    return yield* contentRuntimeCiError(
+      "Production contentState has an invalid compaction identity."
+    );
+  }
+  const slotsAreComplete =
+    hasCompleteOptionalIdentity(
+      state.candidateManifestHash,
+      state.candidateReleaseId,
+      state.candidateSequence
+    ) &&
+    hasCompleteOptionalIdentity(
+      state.recoveryManifestHash,
+      state.recoveryReleaseId,
+      state.recoverySequence
+    );
+  const readModelsAreActive =
+    hasActiveIdentity(
+      state,
+      state.articleManifestHash,
+      state.articleReleaseId,
+      state.articleSequence
+    ) &&
+    hasActiveIdentity(
+      state,
+      state.materialManifestHash,
+      state.materialReleaseId,
+      state.materialSequence
+    ) &&
+    hasActiveIdentity(
+      state,
+      state.searchManifestHash,
+      state.searchReleaseId,
+      state.searchSequence
+    );
+  if (!(slotsAreComplete && readModelsAreActive)) {
+    return yield* contentRuntimeCiError(
+      "Production contentState is not synchronized to one signed generation."
+    );
+  }
+
   return {
-    contentStateHash: yield* hashCanonicalJson(
-      stripConvexSystemFields(activePointer)
-    ),
+    contentStateHash: yield* hashCanonicalJson(storedState),
+    runtimeSelectionHash: yield* hashCanonicalJson(runtimePointer(state)),
   } satisfies RuntimeGenerations;
 });
 
@@ -82,4 +290,7 @@ export const readProductionGenerations = Effect.fn(
 });
 
 export const formatGenerationEnvironment = (generations: RuntimeGenerations) =>
-  `AGENT_DOCS_CONTENT_STATE_HASH=${generations.contentStateHash}`;
+  [
+    `AGENT_DOCS_CONTENT_STATE_HASH=${generations.contentStateHash}`,
+    `AGENT_DOCS_RUNTIME_SELECTION_HASH=${generations.runtimeSelectionHash}`,
+  ].join("\n");

--- a/packages/backend/scripts/content-runtime/ci/main.ts
+++ b/packages/backend/scripts/content-runtime/ci/main.ts
@@ -12,14 +12,14 @@ import {
   readExportConfig,
   readImportConfig,
   readProductionConfig,
-  readProductionIdentityConfig,
+  readProductionSelectionConfig,
 } from "./config";
 import { ContentRuntimeCiError, contentRuntimeCiError } from "./error";
 import { exportSignedRuntime } from "./export";
 import {
   formatGenerationEnvironment,
   readProductionGenerations,
-  verifyRuntimeGenerations,
+  verifyRuntimeSelection,
 } from "./generation";
 import { importSignedRuntime } from "./import";
 
@@ -77,9 +77,9 @@ const runMode = (mode: string | undefined) => {
       });
     case "verify-generations":
       return Effect.gen(function* () {
-        const config = yield* readProductionIdentityConfig;
+        const config = yield* readProductionSelectionConfig;
         yield* clearContentRuntimeSecrets;
-        yield* verifyRuntimeGenerations(
+        yield* verifyRuntimeSelection(
           config,
           yield* readProductionGenerations(config)
         );


### PR DESCRIPTION
## Outcome

Fixes the required Agent-Friendly Docs failure from main run 31820746666 without weakening signed-content export integrity.

## Root cause

The workflow compared the full contentState row before and after a long production build. The restored compaction cron legitimately updates only its cursor and timestamps, so the final check failed even though the active signed release and all public read-model pins remained unchanged.

## Design

- Keep the complete stripped contentState hash as the cache identity and export stability fence.
- Add a separate runtime selection hash over the exact active, article, material, and search release identities.
- Verify the full hash around export and snapshot reuse.
- Verify the stable selection hash across the long build and AFDocs run.
- Decode the complete persisted row with Effect Schema and reject excess, missing, partial, or incoherent fields.
- Mirror the backend durable compaction-cycle invariant before classifying compaction fields as generation-neutral.
- Derive compaction phases from one canonical source in the content-release contract.
- Keep export and production-selection environment contracts independent.

## Production-shaped proof

A real scheduled compaction changed the full hash from:

- sha256:936fe1937d4242311ae2de02cd43f013807a0e1cecbe39e0b483eb63eb63ec1e
- to sha256:e6e90d6bb07a4371292861e85ca5b6b219bb9eead27f10aba36c1b31193b1d38

The stable runtime selection hash remained exactly:

- sha256:e29964fc96d71206ba25b4b1e20f7ec62c8a63b4ef36535dba334f3dd350a8fd

## Verification

- Independent thermonuclear review: no P0, P1, or P2 findings
- Local Codex review finding resolved and re-reviewed
- Backend: 303 files, 1,226 tests
- Focused runtime CI tests: green
- Backend typecheck: green
- Full lint and Effect source check: green
- Actionlint: green
- Security audit: zero known vulnerabilities
- Boundaries, patch ownership, test ownership, React Doctor changed scope, and diff check: green