### PR TITLE
Add EUR pricing for Nakafa Pro

### DIFF
--- a/apps/www/components/marketing/about/pricing-display.test.ts
+++ b/apps/www/components/marketing/about/pricing-display.test.ts
@@ -42,8 +42,31 @@ describe("marketing/about/pricing-display", () => {
     );
   });
 
-  it("falls back to USD pricing outside Indonesia", () => {
-    const countryPrice = getProPricingDisplay("US");
+  it("formats euro pricing for Polar EUR countries and territories", () => {
+    const countryPrice = getProPricingDisplay("DE");
+    const lowercasePrice = getProPricingDisplay("de");
+    const territoryPrice = getProPricingDisplay("AX");
+    const formatter = new Intl.NumberFormat(
+      countryPrice.pro.locales,
+      countryPrice.pro.format
+    );
+
+    expect(countryPrice.pro).toMatchObject({
+      locales: "de-DE",
+      value: 8.99,
+    });
+    expect(formatter.format(countryPrice.free.value).replace(/\s+/g, " ")).toBe(
+      "0,00 €"
+    );
+    expect(formatter.format(countryPrice.pro.value).replace(/\s+/g, " ")).toBe(
+      "8,99 €"
+    );
+    expect(lowercasePrice).toEqual(countryPrice);
+    expect(territoryPrice).toEqual(countryPrice);
+  });
+
+  it("falls back to USD pricing when Polar has no matching price", () => {
+    const countryPrice = getProPricingDisplay("PL");
     const fallbackPrice = getProPricingDisplay(null);
     const formatter = new Intl.NumberFormat(
       countryPrice.pro.locales,

--- a/apps/www/components/marketing/about/pricing-display.ts
+++ b/apps/www/components/marketing/about/pricing-display.ts
@@ -2,13 +2,73 @@ import { products } from "@repo/backend/convex/utils/polar/products";
 
 export const pricingCountryHeaderName = "x-vercel-ip-country";
 
+/**
+ * Territory codes that Polar currently maps to EUR through Babel's territory
+ * currency data. Keeping the same mapping prevents the marketing price from
+ * disagreeing with the checkout currency selected from the forwarded IP.
+ *
+ * References:
+ * - https://github.com/polarsource/polar/blob/11d0edae5ebad634a21c8fbe6bafc5626055951e/server/polar/kit/currency.py
+ * - https://github.com/polarsource/polar/blob/11d0edae5ebad634a21c8fbe6bafc5626055951e/server/tests/kit/test_currency.py
+ */
+const polarEuroTerritoryCodes = new Set([
+  "AD",
+  "AT",
+  "AX",
+  "BE",
+  "BL",
+  "CY",
+  "DE",
+  "EA",
+  "EE",
+  "ES",
+  "EU",
+  "FI",
+  "FR",
+  "GF",
+  "GP",
+  "GR",
+  "HR",
+  "IC",
+  "IE",
+  "IT",
+  "LT",
+  "LU",
+  "LV",
+  "MC",
+  "ME",
+  "MF",
+  "MQ",
+  "MT",
+  "NL",
+  "PM",
+  "PT",
+  "RE",
+  "SI",
+  "SK",
+  "SM",
+  "TF",
+  "VA",
+  "XK",
+  "YT",
+]);
+
 /** Selects the Polar catalog price for the request country. */
 function getProMonthlyPrice(countryCode: string | null) {
-  if (countryCode?.toUpperCase() === "ID") {
-    return products.pro.monthlyPrices.ID;
+  const normalizedCountryCode = countryCode?.toUpperCase();
+
+  if (normalizedCountryCode === "ID") {
+    return products.pro.monthlyPrices.IDR;
   }
 
-  return products.pro.monthlyPrices.default;
+  if (
+    normalizedCountryCode &&
+    polarEuroTerritoryCodes.has(normalizedCountryCode)
+  ) {
+    return products.pro.monthlyPrices.EUR;
+  }
+
+  return products.pro.monthlyPrices.USD;
 }
 
 /**

--- a/packages/backend/convex/utils/polar/products.test.ts
+++ b/packages/backend/convex/utils/polar/products.test.ts
@@ -6,17 +6,23 @@ async function loadProducts() {
 }
 
 const expectedMonthlyPrices = {
-  default: {
+  EUR: {
     amount: 8.99,
-    currency: "USD",
+    currency: "EUR",
     fractionDigits: 2,
-    locale: "en-US",
+    locale: "de-DE",
   },
-  ID: {
+  IDR: {
     amount: 69_000,
     currency: "IDR",
     fractionDigits: 0,
     locale: "id-ID",
+  },
+  USD: {
+    amount: 8.99,
+    currency: "USD",
+    fractionDigits: 2,
+    locale: "en-US",
   },
 };
 

--- a/packages/backend/convex/utils/polar/products.ts
+++ b/packages/backend/convex/utils/polar/products.ts
@@ -11,17 +11,23 @@ export const products = {
       ? "db602388-ef0c-4a88-92fa-c785f3230c45"
       : "5435bfd4-ca2a-4f97-ae7b-27d65907e49b",
     monthlyPrices: {
-      default: {
+      EUR: {
         amount: 8.99,
-        currency: "USD",
+        currency: "EUR",
         fractionDigits: 2,
-        locale: "en-US",
+        locale: "de-DE",
       },
-      ID: {
+      IDR: {
         amount: 69_000,
         currency: "IDR",
         fractionDigits: 0,
         locale: "id-ID",
+      },
+      USD: {
+        amount: 8.99,
+        currency: "USD",
+        fractionDigits: 2,
+        locale: "en-US",
       },
     },
     slug: "pro",


### PR DESCRIPTION
## Summary\n\n- add EUR 8.99 monthly pricing to the shared Nakafa Pro catalog\n- mirror Polar's current EUR territory mapping in the Vercel country display\n- preserve IDR 69,000 and USD 8.99 fallback behavior\n- rename catalog keys to their currency codes so all three prices use one clear shape\n\n## Live Polar state\n\nThe production Nakafa Pro product now has fixed monthly prices for USD 8.99, IDR 69,000, and EUR 8.99. The EUR value was reloaded from the saved editor state. Existing subscriptions keep their original prices.\n\n## Verification\n\n- backend focused: 2 tests passed\n- www focused: 5 tests passed\n- backend full: 303 files, 1,226 tests passed with maxWorkers 4 and 15 second timeout\n- www full: 188 files, 1,165 tests passed with 100 percent coverage\n- backend and www typechecks passed\n- lint, test ownership, boundaries, diff check passed\n- React Doctor changed scope: 100/100\n\nThe default 5 second backend run had one unrelated attachment-route timeout after 1,225 tests passed. Its isolated suite passed 9/9, and the full backend suite then passed cleanly with the repository's machine-load-safe 15 second timeout.