### PR TITLE
Keep rich 3D labels visible

### DIFF
--- a/packages/design-system/components/contents/snbt/quantitative/set-8/question-20.tsx
+++ b/packages/design-system/components/contents/snbt/quantitative/set-8/question-20.tsx
@@ -28,6 +28,12 @@ export function Graph({
               offset: [-1, 0, 0],
               color: getColor("INDIGO"),
             },
+            {
+              text: <InlineMath math="Q" />,
+              at: 2,
+              offset: [0, 1, 0],
+              color: getColor("INDIGO"),
+            },
           ],
           showPoints: false,
         },
@@ -73,19 +79,6 @@ export function Graph({
           ],
           showPoints: false,
         },
-        // Label Q
-        {
-          points: [
-            { x: -5, y: 4, z: 0 },
-            { x: -5, y: 4, z: 0 },
-          ], // Point above top
-          color: "transparent",
-          labels: [
-            { text: <InlineMath math="Q" />, at: 0, color: getColor("INDIGO") },
-          ],
-          showPoints: false,
-        },
-
         // Triangle R (Right)
         // Left side: (2, -2) to (5, 3)
         {
@@ -100,6 +93,12 @@ export function Graph({
               text: <InlineMath math="13" />,
               at: 1,
               offset: [-1, 0, 0],
+              color: getColor("TEAL"),
+            },
+            {
+              text: <InlineMath math="R" />,
+              at: 2,
+              offset: [0, 1, 0],
               color: getColor("TEAL"),
             },
           ],
@@ -144,18 +143,6 @@ export function Graph({
               offset: [0, 1.5, 0],
               color: getColor("TEAL"),
             }, // Center label
-          ],
-          showPoints: false,
-        },
-        // Label R
-        {
-          points: [
-            { x: 5, y: 4, z: 0 },
-            { x: 5, y: 4, z: 0 },
-          ], // Point above top
-          color: "transparent",
-          labels: [
-            { text: <InlineMath math="R" />, at: 0, color: getColor("TEAL") },
           ],
           showPoints: false,
         },

--- a/packages/design-system/components/three/label.tsx
+++ b/packages/design-system/components/three/label.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Billboard, Html } from "@react-three/drei";
+import { Html } from "@react-three/drei";
 import { useThree } from "@react-three/fiber";
 import {
   resolveThreeFontSize,
@@ -10,7 +10,6 @@ import { type ComponentProps, type ReactNode, useEffect } from "react";
 import { Color } from "three";
 
 type HtmlProps = ComponentProps<typeof Html>;
-type BillboardProps = ComponentProps<typeof Billboard>;
 type LabelAnchorX = "center" | "left" | "right";
 type LabelAnchorY = "bottom" | "middle" | "top";
 
@@ -24,7 +23,7 @@ interface ThreeLabelProps {
   occlude?: HtmlProps["occlude"];
   outlineColor?: string;
   outlineWidth?: number;
-  position: BillboardProps["position"];
+  position: HtmlProps["position"];
   /** Screen-plane rotation in radians. */
   rotation?: number;
   visible?: boolean;
@@ -90,32 +89,29 @@ export function ThreeLabel({
   }
 
   return (
-    <Billboard position={position}>
-      <Html
-        distanceFactor={distanceFactor}
-        occlude={occlude}
-        pointerEvents="none"
-        style={{
-          WebkitTextStroke:
-            outlineColor && outlineWidthEm > 0
-              ? `${outlineWidthEm}em ${outlineColor}`
-              : undefined,
-          color: labelColor,
-          fontFamily: "var(--font-mono)",
-          fontSize: LABEL_BASE_FONT_SIZE,
-          lineHeight: 1,
-          paintOrder: "stroke fill",
-          pointerEvents: "none",
-          transform: `translate(${anchorOffset(anchorX)}, ${anchorOffset(anchorY)}) rotate(${rotation}rad)`,
-          transformOrigin: `${anchorOrigin(anchorX)} ${anchorOrigin(anchorY)}`,
-          userSelect: "none",
-          whiteSpace: "nowrap",
-        }}
-        transform
-        zIndexRange={LABEL_Z_INDEX_RANGE}
-      >
-        <span aria-hidden="true">{children}</span>
-      </Html>
-    </Billboard>
+    <Html
+      distanceFactor={distanceFactor}
+      occlude={occlude}
+      position={position}
+      style={{
+        WebkitTextStroke:
+          outlineColor && outlineWidthEm > 0
+            ? `${outlineWidthEm}em ${outlineColor}`
+            : undefined,
+        color: labelColor,
+        fontFamily: "var(--font-mono)",
+        fontSize: LABEL_BASE_FONT_SIZE,
+        lineHeight: 1,
+        paintOrder: "stroke fill",
+        pointerEvents: "none",
+        transform: `translate(${anchorOffset(anchorX)}, ${anchorOffset(anchorY)}) rotate(${rotation}rad)`,
+        transformOrigin: `${anchorOrigin(anchorX)} ${anchorOrigin(anchorY)}`,
+        userSelect: "none",
+        whiteSpace: "nowrap",
+      }}
+      zIndexRange={LABEL_Z_INDEX_RANGE}
+    >
+      <span aria-hidden="true">{children}</span>
+    </Html>
   );
 }


### PR DESCRIPTION
## Outcome

- render every rich 3D label through Drei's camera-facing screen-space Html projection
- remove the redundant Billboard plus transform composition that pushed labels off-canvas
- attach the Q and R labels to real triangle vertices instead of zero-length transparent geometry

## Verification

- pnpm lint
- pnpm security:audit
- pnpm test: 12/12 workspace tasks passed
- pnpm --filter @repo/design-system typecheck
- pnpm --filter @repo/design-system test: 31 files, 324 tests, 100% coverage
- pnpm --filter www typecheck
- React Doctor changed scope: no changed www source files
- production-component browser acceptance: QK8 question 20, QK7 questions 13 and 14, and a rotated rich KaTeX triangle label all rendered visibly with no runtime errors
- git diff --check

## Scope

Two production files only. No content, backend, schema, locale, or deployment mutation.