### PR TITLE
Keep 2D graph labels unobstructed

### DIFF
--- a/packages/design-system/components/contents/mathematics/line-equation.tsx
+++ b/packages/design-system/components/contents/mathematics/line-equation.tsx
@@ -51,7 +51,11 @@ export function LineEquation({
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent>
-        <CoordinateSystem cameraPosition={cameraPosition} showZAxis={showZAxis}>
+        <CoordinateSystem
+          cameraPosition={cameraPosition}
+          showGizmo={showZAxis}
+          showZAxis={showZAxis}
+        >
           {lines.map((item) => (
             <LineEquation3D
               key={`line-${item.points.map((p) => `${p.x},${p.y},${p.z}`).join(";")}`}

--- a/packages/design-system/components/three/coordinate-system.tsx
+++ b/packages/design-system/components/three/coordinate-system.tsx
@@ -237,16 +237,17 @@ export function CoordinateSystem({
           {children}
 
           {/* Orientation Helper */}
-          <GizmoHelper
-            alignment="bottom-right"
-            margin={[GIZMO_MARGIN, GIZMO_MARGIN]}
-            visible={showGizmo}
-          >
-            <GizmoViewport
-              axisColors={[COLORS.RED, COLORS.GREEN, COLORS.BLUE]}
-              labelColor={ORIGIN_COLOR.LIGHT}
-            />
-          </GizmoHelper>
+          {showGizmo ? (
+            <GizmoHelper
+              alignment="bottom-right"
+              margin={[GIZMO_MARGIN, GIZMO_MARGIN]}
+            >
+              <GizmoViewport
+                axisColors={[COLORS.RED, COLORS.GREEN, COLORS.BLUE]}
+                labelColor={ORIGIN_COLOR.LIGHT}
+              />
+            </GizmoHelper>
+          ) : null}
         </Suspense>
       </ThreeCanvas>
 


### PR DESCRIPTION
## Summary

- hide the orientation gizmo when a coordinate system is intentionally rendered as a 2D graph
- pass the existing `showZAxis` policy from `LineEquation` into `CoordinateSystem`
- remove a mobile overlap where the gizmo covered a labeled point in educational content

## Root cause

`CoordinateSystem` always mounted `GizmoHelper` and attempted to hide it through a `visible` prop. That prop did not suppress the rendered overlay. The 2D `LineEquation` surface therefore displayed a 3D navigation affordance that could cover graph labels on narrow screens.

## Verification

- production content checked at desktop and 390 px mobile widths
- affected point label is fully visible after the fix
- rich mathematical graph labels remain legible
- `pnpm format`
- `pnpm --filter @repo/design-system typecheck`
- design-system tests: 31 files, 324 tests, 100% statement, branch, function, and line coverage
- `pnpm --filter www typecheck`
- `pnpm lint`
- React Doctor on the exact changed scope: 98/100, no issues

Head: `1ce8a7476734f9ff7548c5fa19a4638c58604086`