### PR TITLE
Fix collapsed number-line diagrams

### DIFF
--- a/packages/design-system/components/contents/mathematics/number-line.tsx
+++ b/packages/design-system/components/contents/mathematics/number-line.tsx
@@ -169,7 +169,7 @@ export function NumberLine({
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="mx-auto">
+        <div className="w-full">
           <div className="relative h-20 w-full">
             {processedSegments.map((segment) => (
               <div key={`bg-${segment.start}-${segment.end}-${segment.index}`}>


### PR DESCRIPTION
## Outcome

Number-line diagrams now occupy the available card width instead of collapsing around absolutely positioned children.

## Root cause

The sizing wrapper used intrinsic width while every visual child was absolutely positioned. The wrapper therefore contributed no intrinsic width, and percentage positions collapsed into a narrow vertical stack.

## Verification

- `pnpm format`
- `pnpm --filter @repo/design-system typecheck`
- `pnpm --filter @repo/design-system test` (31 files, 324 tests, 100% coverage)
- `pnpm lint`
- `pnpm --filter www typecheck` with the repository-required local environment contract
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`
- production UI composition inspected at 1440 x 900 and 390 x 844
- browser console contained no errors

This PR changes one class on the shared NumberLine wrapper and does not alter content, routes, contracts, or backend state.
