### PR TITLE
fix(i18n): preserve localized German tryout images

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/[exam]/page.tsx
@@ -25,8 +25,6 @@ export async function generateMetadata({
   const locale = getLocaleOrThrow(localeParam);
 
   return generateTryoutRouteMetadata({
-    countryKey: country,
-    examKey: exam,
     kind: "exam",
     locale,
     publicPath: getTryoutHref({ country, exam }).slice(1),

--- a/apps/www/components/tryout/catalog/metadata.test.ts
+++ b/apps/www/components/tryout/catalog/metadata.test.ts
@@ -61,6 +61,7 @@ describe("try-out route metadata", () => {
         ],
         description: "Signed section description",
         publicPath: "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge",
+        socialImageIdentity: null,
         title: "Quantitative Knowledge",
       },
     });
@@ -107,13 +108,15 @@ describe("try-out route metadata", () => {
         alternates: [],
         description: "Signed SNBT description",
         publicPath: "try-out/indonesia/snbt",
+        socialImageIdentity: {
+          countryKey: "indonesia",
+          examKey: "snbt",
+        },
         title: "SNBT",
       },
     });
 
     const metadata = await generateTryoutRouteMetadata({
-      countryKey: "indonesia",
-      examKey: "snbt",
       kind: "exam",
       locale: "id",
       publicPath: "try-out/indonesia/snbt",
@@ -134,6 +137,36 @@ describe("try-out route metadata", () => {
     });
   });
 
+  it("uses the signed localized path with stable source identity", async () => {
+    runtimeMocks.readTryoutMetadata.mockResolvedValue({
+      route: {
+        alternates: [],
+        description: "Signierte SNBT-Beschreibung",
+        publicPath: "try-out/indonesien/snbt",
+        socialImageIdentity: {
+          countryKey: "indonesia",
+          examKey: "snbt",
+        },
+        title: "SNBT",
+      },
+    });
+
+    const metadata = await generateTryoutRouteMetadata({
+      kind: "exam",
+      locale: "de",
+      publicPath: "try-out/indonesien/snbt",
+    });
+
+    expect(metadata).toMatchObject({
+      openGraph: {
+        images: [{ url: "/de/og/try-out/indonesien/snbt/image.png" }],
+      },
+      twitter: {
+        images: [{ url: "/de/og/try-out/indonesien/snbt/image.png" }],
+      },
+    });
+  });
+
   it.each(["country", "track", "set", "section"] as const)(
     "keeps generated social images for a %s route",
     async (kind) => {
@@ -142,6 +175,7 @@ describe("try-out route metadata", () => {
         route: {
           alternates: [],
           publicPath,
+          socialImageIdentity: null,
           title: "Signed route",
         },
       });
@@ -176,6 +210,7 @@ describe("try-out route metadata", () => {
       route: {
         alternates: [],
         publicPath: "try-out/indonesia",
+        socialImageIdentity: null,
         title: "Indonesia",
       },
     });
@@ -187,6 +222,26 @@ describe("try-out route metadata", () => {
     });
 
     expect(metadata.description).toBe("translated:metadata-description");
+  });
+
+  it("fails closed when a signed exam has no stable image identity", async () => {
+    runtimeMocks.readTryoutMetadata.mockResolvedValue({
+      route: {
+        alternates: [],
+        publicPath: "try-out/indonesien/snbt",
+        socialImageIdentity: null,
+        title: "SNBT",
+      },
+    });
+
+    await expect(
+      generateTryoutRouteMetadata({
+        kind: "exam",
+        locale: "de",
+        publicPath: "try-out/indonesien/snbt",
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(navigationMocks.notFound).toHaveBeenCalledOnce();
   });
 
   it("returns the route-level 404 for an unknown hierarchy path", async () => {

--- a/apps/www/components/tryout/catalog/metadata.ts
+++ b/apps/www/components/tryout/catalog/metadata.ts
@@ -14,19 +14,10 @@ import { createResolvedRouteAlternates } from "@/lib/utils/seo/alternates";
 type TryoutMetadataKind = Parameters<typeof readTryoutMetadata>[0]["kind"];
 
 interface TryoutMetadataQueryInput {
+  readonly kind: TryoutMetadataKind;
   readonly locale: Locale;
   readonly publicPath: string;
 }
-
-type TryoutMetadataInput =
-  | (TryoutMetadataQueryInput & {
-      readonly countryKey: string;
-      readonly examKey: string;
-      readonly kind: "exam";
-    })
-  | (TryoutMetadataQueryInput & {
-      readonly kind: Exclude<TryoutMetadataKind, "exam">;
-    });
 
 interface RetainedTryoutMetadataSource {
   readonly description?: string;
@@ -46,7 +37,7 @@ export function createRetainedTryoutMetadata(
 
 /** Generates exact canonical metadata for one public try-out hierarchy route. */
 export async function generateTryoutRouteMetadata(
-  input: TryoutMetadataInput
+  input: TryoutMetadataQueryInput
 ): Promise<Metadata> {
   const appLocale = AppLocaleSchema.make(input.locale);
   const queryInput = {
@@ -66,17 +57,21 @@ export async function generateTryoutRouteMetadata(
 
   const path = `/${input.locale}/${source.publicPath}`;
   const description = source.description ?? tTryouts("metadata-description");
-  const image =
-    input.kind === "exam"
-      ? Effect.runSync(
-          resolveTryoutExamSocialImage({
-            countryKey: input.countryKey,
-            examKey: input.examKey,
-            appLocale,
-            publicPath: source.publicPath,
-          })
-        )
-      : getOgUrl(input.locale, source.publicPath);
+  let image: string;
+  if (input.kind === "exam") {
+    if (!source.socialImageIdentity) {
+      notFound();
+    }
+    image = Effect.runSync(
+      resolveTryoutExamSocialImage({
+        ...source.socialImageIdentity,
+        appLocale,
+        publicPath: source.publicPath,
+      })
+    );
+  } else {
+    image = getOgUrl(input.locale, source.publicPath);
+  }
 
   return {
     title: { absolute: source.title },

--- a/apps/www/lib/tryout/social-images.test.ts
+++ b/apps/www/lib/tryout/social-images.test.ts
@@ -79,9 +79,22 @@ describe("try-out social images", () => {
           countryKey: "indonesia",
           examKey: "tka",
           appLocale: "de",
-          publicPath: "try-out/indonesia/tka",
+          publicPath: "try-out/indonesien/tka",
         })
-      ).toBe("/de/og/try-out/indonesia/tka/image.png");
+      ).toBe("/de/og/try-out/indonesien/tka/image.png");
+    })
+  );
+
+  it.live("keeps stable source keys separate from localized route slugs", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveTryoutExamSocialImage({
+          countryKey: "indonesia",
+          examKey: "snbt",
+          appLocale: "de",
+          publicPath: "try-out/indonesien/snbt",
+        })
+      ).toBe("/de/og/try-out/indonesien/snbt/image.png");
     })
   );
 
@@ -121,26 +134,25 @@ describe("try-out social images", () => {
       })
   );
 
-  it.live(
-    "rejects a valid identity whose public path belongs to another exam",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* Effect.flip(
-          resolveTryoutExamSocialImage({
-            countryKey: "indonesia",
-            examKey: "tka",
-            appLocale: "id",
-            publicPath: "try-out/indonesia/snbt",
-          })
-        );
+  it.live.each([
+    "try-out",
+    "try-out/indonesien",
+    "try-out/indonesien/snbt/2027",
+  ])("rejects non-exam public path %s", (publicPath) =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        resolveTryoutExamSocialImage({
+          countryKey: "indonesia",
+          examKey: "snbt",
+          appLocale: "de",
+          publicPath,
+        })
+      );
 
-        expect(error).toMatchObject({
-          _tag: "TryoutSocialImageIdentityMismatchError",
-          actualPublicPath: "try-out/indonesia/snbt",
-          expectedPublicPath: "try-out/indonesia/tka",
-          message:
-            "Try-out social image identity does not match its public path",
-        });
-      })
+      expect(error).toMatchObject({
+        _tag: "InvalidTryoutSocialImageIdentityError",
+        message: "Invalid try-out social image identity",
+      });
+    })
   );
 });

--- a/apps/www/lib/tryout/social-images.ts
+++ b/apps/www/lib/tryout/social-images.ts
@@ -46,7 +46,17 @@ const TryoutExamSocialImageIdentitySchema = Schema.Struct({
   countryKey: TryoutKeySchema,
   examKey: TryoutKeySchema,
   appLocale: ActiveAppLocaleSchema,
-  publicPath: PublicPathSchema,
+  publicPath: PublicPathSchema.pipe(
+    Schema.check(
+      Schema.makeFilter(
+        (publicPath) => {
+          const segments = publicPath.split("/");
+          return segments.length === 3 && segments[0] === "try-out";
+        },
+        { message: "Expected one localized try-out exam public path." }
+      )
+    )
+  ),
 });
 export class InvalidTryoutSocialImageIdentityError extends Schema.TaggedError<InvalidTryoutSocialImageIdentityError>()(
   "InvalidTryoutSocialImageIdentityError",
@@ -57,14 +67,6 @@ export class InvalidTryoutSocialImageIdentityError extends Schema.TaggedError<In
 class InvalidReviewedTryoutSocialImageRegistryError extends Schema.TaggedError<InvalidReviewedTryoutSocialImageRegistryError>()(
   "InvalidReviewedTryoutSocialImageRegistryError",
   {
-    message: Schema.String,
-  }
-) {}
-export class TryoutSocialImageIdentityMismatchError extends Schema.TaggedError<TryoutSocialImageIdentityMismatchError>()(
-  "TryoutSocialImageIdentityMismatchError",
-  {
-    actualPublicPath: Schema.String,
-    expectedPublicPath: Schema.String,
     message: Schema.String,
   }
 ) {}
@@ -104,7 +106,6 @@ export function resolveTryoutExamSocialImage(
   string,
   | InvalidReviewedTryoutSocialImageRegistryError
   | InvalidTryoutSocialImageIdentityError
-  | TryoutSocialImageIdentityMismatchError
 > {
   const decodedIdentity = decodeTryoutExamSocialImageIdentity(input);
   if (Result.isFailure(decodedIdentity)) {
@@ -115,16 +116,6 @@ export function resolveTryoutExamSocialImage(
     );
   }
   const identity = decodedIdentity.success;
-  const expectedPublicPath = `try-out/${identity.countryKey}/${identity.examKey}`;
-  if (identity.publicPath !== expectedPublicPath) {
-    return Effect.fail(
-      new TryoutSocialImageIdentityMismatchError({
-        actualPublicPath: identity.publicPath,
-        expectedPublicPath,
-        message: "Try-out social image identity does not match its public path",
-      })
-    );
-  }
   /* istanbul ignore next -- invalid authored registry fails every real resolver fixture */
   if (Result.isFailure(reviewedTryoutSocialImageByIdentity)) {
     return Effect.fail(reviewedTryoutSocialImageByIdentity.failure);

--- a/packages/backend/convex/tryouts/catalog/metadata.test.ts
+++ b/packages/backend/convex/tryouts/catalog/metadata.test.ts
@@ -1,4 +1,5 @@
 import { PublicPathSchema } from "@nakafa/aksara-contracts/ids";
+import { TryoutCatalogRowSchema } from "@nakafa/aksara-contracts/tryout/catalog";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
@@ -21,6 +22,7 @@ import {
   TRYOUT_START_TRACK,
 } from "@repo/backend/test/tryout-source";
 import { convexTest } from "convex-test";
+import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
 /** Activates the smallest coherent two-locale catalog. */
@@ -78,6 +80,49 @@ describe("tryouts/catalog/metadata", () => {
           { appLocale: "id", publicPath: "try-out/indonesia" },
         ],
         publicPath: "try-out/indonesia",
+      },
+    });
+  });
+
+  it("returns stable exam identity with a localized German route", async () => {
+    const t = convexTest(schema, convexModules);
+    const catalog = Schema.decodeSync(Schema.Array(TryoutCatalogRowSchema))(
+      makeTryoutStartHierarchy("de", "visible").map((row) => {
+        if (!row.publicPath) {
+          return row;
+        }
+        return {
+          ...row,
+          publicPath: PublicPathSchema.make(
+            row.publicPath.replace("try-out/indonesia", "try-out/indonesien")
+          ),
+        };
+      })
+    );
+    await t.mutation((ctx) =>
+      activateTryoutSnapshot(ctx, {
+        catalog,
+        placements: [makeTryoutStartPlacement("de")],
+      })
+    );
+
+    await expect(
+      t.query((ctx) =>
+        runConvexProgram(
+          readTryoutMetadata(ctx, {
+            kind: "exam",
+            appLocale: "de",
+            publicPath: "try-out/indonesien/tka",
+          })
+        )
+      )
+    ).resolves.toMatchObject({
+      route: {
+        publicPath: "try-out/indonesien/tka",
+        socialImageIdentity: {
+          countryKey: "indonesia",
+          examKey: "tka",
+        },
       },
     });
   });

--- a/packages/backend/convex/tryouts/catalog/metadata.ts
+++ b/packages/backend/convex/tryouts/catalog/metadata.ts
@@ -32,6 +32,10 @@ const tryoutAlternateValidator = v.object({
   appLocale: appLocaleValidator,
   publicPath: v.string(),
 });
+const tryoutSocialImageIdentityValidator = v.object({
+  countryKey: v.string(),
+  examKey: v.string(),
+});
 
 export const tryoutMetadataReturnValidator = v.object({
   route: v.union(
@@ -40,6 +44,10 @@ export const tryoutMetadataReturnValidator = v.object({
       alternates: v.array(tryoutAlternateValidator),
       description: v.optional(v.string()),
       publicPath: v.string(),
+      socialImageIdentity: v.union(
+        v.null(),
+        tryoutSocialImageIdentityValidator
+      ),
       title: v.string(),
     })
   ),
@@ -102,6 +110,13 @@ export const readTryoutMetadata = Effect.fn("tryouts.catalog.readMetadata")(
         alternates,
         description: current.description,
         publicPath: currentPublicPath,
+        socialImageIdentity:
+          current.kind === "exam"
+            ? {
+                countryKey: current.countryKey,
+                examKey: current.examKey,
+              }
+            : null,
         title: current.title,
       },
     };


### PR DESCRIPTION
## Outcome

- Fixes the verified production `TryoutSocialImageIdentityMismatchError` on German try-out routes.
- Keeps stable signed keys such as `countryKey: indonesia` separate from localized signed paths such as `try-out/indonesien/snbt`.
- Uses stable signed identity only to select reviewed static artwork and uses the signed localized public path for generated OG routes.
- Makes Convex return the stable exam identity from the authenticated Aksara catalog row instead of trusting localized URL parameters.
- Fails closed when an exam metadata response lacks its signed stable identity.

## Deployment order

This is a zero-downtime additive backend contract. Deploy Convex first, then deploy WWW. The old frontend ignores the new field, while the new frontend requires it for exam metadata.

## Exact-head verification

Exact head: `4bf86d2808ecf3d04e52b07f2265717684288cfa`.
Exact tree: `166df59bbb80b9d49594e1b67c6329c0078350e0`.

- Frozen `pnpm@11.22.0` install passed.
- All 19 workspace typechecks passed with the validated non-secret PostHog proxy host.
- Full WWW suite passed: 199 files, 1,318 tests, 100% coverage.
- Full backend suite passed: 313 files, 1,265 tests.
- Full root test graph passed: 14 of 14 tasks.
- Focused German identity, localized route, invalid path, and fail-closed tests passed.
- Fresh anonymous local Convex 1.45 Agent Mode deployment in `nakafa:nakafa` accepted the exact head and reached `Convex functions ready!`.
- Lint, test ownership, Effect source identity, workspace boundaries, dependency audit, format doctor, changeset status, and React Doctor 100/100 passed.
- Exact-head protected React Doctor and trusted Agent-Friendly Docs are green.
- Every touched TypeScript module is below 500 LOC.

## Preserved invariants

- `nakafa-lite` remains `google/gemini-3.5-flash-lite`.
- `nakafa-pro` remains `google/gemini-3.7-flash`.
- Vercel AI Gateway, Google or Vertex routing, no-prompt-training policy, and Google Search grounding are unchanged.
- The active signed Aksara release and every consent, legal, renderer, and content-runtime boundary are unchanged.
