### PR TITLE
fix(ui): restore canonical consent dialog footer

### DIFF
--- a/apps/www/components/analytics/consent/controls.tsx
+++ b/apps/www/components/analytics/consent/controls.tsx
@@ -62,7 +62,6 @@ export function AnalyticsConsentControls() {
       <ResponsiveDialog
         description={<ConsentStatus />}
         footer={<ConsentActions />}
-        footerVariant="bare"
         open={isPreferencesOpen}
         setOpen={setPreferencesOpen}
         title={t("title")}
@@ -111,26 +110,13 @@ function ConsentActions() {
 }
 
 function ConsentDetails() {
-  return (
-    <>
-      <ConsentDisclosure />
-      <ConsentNotices />
-    </>
-  );
-}
-
-function ConsentDisclosure() {
   const t = useTranslations("AnalyticsConsent");
-
-  return <p className="text-muted-foreground text-sm">{t("description")}</p>;
-}
-
-function ConsentNotices() {
   const error = useAnalyticsConsent((state) => state.error);
 
   return (
     <>
-      <ConsentAgeNotice />
+      <p className="text-muted-foreground text-sm">{t("description")}</p>
+      <p className="text-muted-foreground text-sm">{t("age-confirmation")}</p>
       <PrivacyPolicyLink />
       {error ? <ConsentError error={error} /> : null}
     </>
@@ -160,14 +146,6 @@ function PrivacyPolicyLink() {
         ),
       })}
     </p>
-  );
-}
-
-function ConsentAgeNotice() {
-  const t = useTranslations("AnalyticsConsent");
-
-  return (
-    <p className="text-muted-foreground text-sm">{t("age-confirmation")}</p>
   );
 }
 

--- a/packages/design-system/components/ui/responsive-dialog.tsx
+++ b/packages/design-system/components/ui/responsive-dialog.tsx
@@ -25,7 +25,6 @@ interface Props {
   children?: ReactNode;
   description?: ReactNode;
   footer?: ReactNode;
-  footerVariant?: "bare" | "default";
   open: boolean;
   setOpen: (open: boolean) => void;
   title: ReactNode;
@@ -38,7 +37,6 @@ export function ResponsiveDialog({
   description,
   children,
   footer,
-  footerVariant = "default",
 }: Props) {
   const isDesktop = useMediaQuery(TAILWIND_MEDIA_QUERIES.mdAndUp);
 
@@ -53,9 +51,7 @@ export function ResponsiveDialog({
             )}
           </DialogHeader>
           {!!children && <DialogPanel>{children}</DialogPanel>}
-          {!!footer && (
-            <DialogFooter variant={footerVariant}>{footer}</DialogFooter>
-          )}
+          {!!footer && <DialogFooter>{footer}</DialogFooter>}
         </DialogContent>
       </Dialog>
     );
@@ -73,9 +69,7 @@ export function ResponsiveDialog({
         <div className={cn("min-h-0 flex-1", !children && "hidden")}>
           <DrawerPanel>{children}</DrawerPanel>
         </div>
-        {!!footer && (
-          <DrawerFooter variant={footerVariant}>{footer}</DrawerFooter>
-        )}
+        {!!footer && <DrawerFooter>{footer}</DrawerFooter>}
       </DrawerPopup>
     </Drawer>
   );

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -892,10 +892,10 @@
   "AnalyticsConsent": {
     "title": "Nutzungsdaten",
     "prompt-description": "Du entscheidest, ob du sie teilen möchtest.",
-    "description": "Wenn du zustimmst, sehen wir, was genutzt wird und was wir verbessern müssen. Wir zeichnen deinen Bildschirm nie auf. Auch wenn du ablehnst, kann Nakafa erfahren, dass etwas nicht funktioniert, aber der Bericht ist nicht mit deinem Konto oder Browser verknüpft.",
+    "description": "Mit deiner Erlaubnis sieht Nakafa, welche Funktionen du nutzt und was verbessert werden muss. Wir zeichnen deinen Bildschirm nie auf.",
     "allow": "Erlauben",
     "decline": "Ablehnen",
-    "age-confirmation": "Wähle Erlauben nur, wenn du mindestens 18 bist. Mit 13 bis 17 Jahren brauchst du die Zustimmung eines Elternteils oder deiner gesetzlichen Vertretung.",
+    "age-confirmation": "Erlaube dies nur, wenn du mindestens 18 bist. Mit 13 bis 17 Jahren brauchst du die Zustimmung eines Elternteils oder deiner gesetzlichen Vertretung.",
     "manage": "Nutzungsdaten",
     "status-granted": "Nutzungsdaten werden geteilt",
     "status-denied": "Nutzungsdaten werden nicht geteilt",

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -892,10 +892,10 @@
   "AnalyticsConsent": {
     "title": "Usage data",
     "prompt-description": "Sharing it is optional.",
-    "description": "If you allow it, we can see which features people use and what needs fixing. We never record your screen. Nakafa may still learn that something broke, even when you decline, but the report is not linked to your account or browser.",
+    "description": "Allow Nakafa to see which features you use and what needs fixing. We never record your screen.",
     "allow": "Allow",
     "decline": "Decline",
-    "age-confirmation": "Choose Allow only if you are 18 or older, or 13 to 17 with approval from a parent or legal guardian.",
+    "age-confirmation": "Allow only if you are 18 or older, or 13 to 17 with a parent or legal guardian's approval.",
     "manage": "Usage data",
     "status-granted": "Usage sharing is on",
     "status-denied": "Usage sharing is off",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -892,10 +892,10 @@
   "AnalyticsConsent": {
     "title": "Data penggunaan",
     "prompt-description": "Kamu bebas memilih apakah ingin membagikannya.",
-    "description": "Jika kamu mengizinkannya, kami dapat melihat fitur yang digunakan dan bagian yang perlu diperbaiki. Kami tidak pernah merekam layarmu. Meski kamu menolak, Nakafa mungkin tetap mengetahui bahwa ada masalah, tetapi laporannya tidak terhubung ke akun atau browsermu.",
+    "description": "Izinkan Nakafa melihat fitur yang kamu gunakan dan bagian yang perlu diperbaiki. Kami tidak pernah merekam layarmu.",
     "allow": "Izinkan",
     "decline": "Tolak",
-    "age-confirmation": "Pilih Izinkan hanya jika kamu berusia minimal 18 tahun, atau berusia 13 sampai 17 tahun dengan persetujuan orang tua atau wali sah.",
+    "age-confirmation": "Izinkan hanya jika kamu berusia minimal 18 tahun, atau 13 sampai 17 tahun dengan persetujuan orang tua atau wali sah.",
     "manage": "Data penggunaan",
     "status-granted": "Data penggunaan diizinkan",
     "status-denied": "Data penggunaan ditolak",


### PR DESCRIPTION
## Outcome

Restores the analytics preferences dialog to Nakafa's canonical responsive dialog composition:

- shared header with title and current status
- concise, scrollable body
- shared bordered footer with Decline as outline and Allow as the primary action

## Root cause

PR #323 introduced a consent-only `footerVariant="bare"` escape hatch. That bypassed the shared bordered footer used by every other `ResponsiveDialog`. This change removes the exception from the responsive dialog interface and leaves the shared dialog styling untouched.

The consent body now states only the optional choice, its purpose, the screen-recording boundary, the age condition, and the privacy-policy link. Detailed operational error reporting remains documented in the signed privacy policy. The consent scope, processing purpose, and notice version do not change.

## Architecture

- removes three shallow consent wrapper components
- keeps one cohesive `ConsentDetails` body reused by the first prompt and preferences dialog
- removes the one-off footer override from the shared responsive composition
- preserves responsive desktop dialog and mobile drawer behavior
- preserves exact Vercel AI Gateway Gemini routing

## Verification

- `pnpm test`: 14 of 14 tasks passed
- web: 199 files, 1,318 tests, 100% coverage
- design system: 31 files, 319 tests, 100% coverage
- internationalization: 1 file, 13 tests, 100% coverage
- web, design-system, and internationalization typechecks passed
- `pnpm lint` passed across 2,823 files
- `pnpm boundaries` passed across 2,780 files
- `pnpm security:audit`: no known vulnerabilities
- Ultracite Doctor: 4 passed, 0 warnings
- React Doctor changed scope: 100/100
- exact Gemini routing diff: empty
