### PR TITLE
fix(tryout): restore catalog card composition

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/try-out/[country]/page.tsx
@@ -96,7 +96,10 @@ async function TryoutCountryRoute({
           }}
         />
         <LayoutContent>
-          <TryoutCountryPageClient page={page} />
+          <TryoutCountryPageClient
+            actionLabel={tTryouts("open-exam-cta")}
+            page={page}
+          />
         </LayoutContent>
         <FooterContent>
           <RefContent githubUrl={sourceUrl} />

--- a/apps/www/components/tryout/catalog/country.client.tsx
+++ b/apps/www/components/tryout/catalog/country.client.tsx
@@ -3,22 +3,23 @@
 import type { api } from "@repo/backend/convex/_generated/api";
 import { IntentLink } from "@repo/design-system/components/ui/intent-link";
 import type { FunctionReturnType } from "convex/server";
-import { ChoiceCardContent } from "@/components/shared/choice/card";
-import { choiceCardVariants } from "@/components/shared/choice/variants";
 import {
-  ChoiceCardIcon,
-  ChoiceCardVisual,
-} from "@/components/shared/choice/visual";
+  CatalogCard,
+  CatalogCardGradient,
+} from "@/components/shared/catalog/card";
+import { ChoiceCardIcon } from "@/components/shared/choice/visual";
 import { ComingSoon } from "@/components/shared/coming-soon";
 import { getTryoutExamIcon } from "@/components/tryout/catalog/icons";
 import { getTryoutPublicPathHref } from "@/components/tryout/route/path";
 
 type CountryPageQuery = typeof api.tryouts.queries.catalog.getCountryPage;
 
-/** Renders one compact exam chooser with identity-owned gradient icons. */
+/** Renders one signed try-out country catalog with gradient exam artwork. */
 export function TryoutCountryPageClient({
+  actionLabel,
   page,
 }: {
+  actionLabel: string;
   page: {
     readonly exams: NonNullable<FunctionReturnType<CountryPageQuery>>["exams"];
   };
@@ -28,20 +29,20 @@ export function TryoutCountryPageClient({
   }
 
   return (
-    <div className="grid grid-cols-2 gap-4 pt-6 pb-24 md:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 pt-6 pb-24 sm:grid-cols-2">
       {page.exams.map((exam) => (
-        <IntentLink
-          className={choiceCardVariants()}
-          href={getTryoutPublicPathHref(exam.publicPath)}
+        <CatalogCard
+          action={
+            <IntentLink href={getTryoutPublicPathHref(exam.publicPath)} />
+          }
+          actionLabel={actionLabel}
           key={exam.examKey}
+          title={exam.title}
         >
-          <ChoiceCardVisual seed={exam.publicPath}>
+          <CatalogCardGradient seed={exam.publicPath}>
             <ChoiceCardIcon icon={getTryoutExamIcon(exam.examKey)} />
-          </ChoiceCardVisual>
-          <ChoiceCardContent>
-            <h2>{exam.title}</h2>
-          </ChoiceCardContent>
-        </IntentLink>
+          </CatalogCardGradient>
+        </CatalogCard>
       ))}
     </div>
   );

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -345,6 +345,7 @@
     "exam-count": "{count, plural, =0 {Noch keine Prüfungen} =1 {# Prüfung} other {# Prüfungen}}",
     "set-count": "{count, plural, =0 {Noch keine Aufgabensätze} =1 {# Aufgabensatz} other {# Aufgabensätze}}",
     "open-country-cta": "Prüfungen anzeigen",
+    "open-exam-cta": "Optionen anzeigen",
     "open-set-cta": "Aufgabensätze anzeigen",
     "open-section-cta": "Abschnitt öffnen",
     "back-to-tryout": "Zurück zu den Probetests",

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -345,6 +345,7 @@
     "exam-count": "{count, plural, =0 {No exams yet} =1 {# exam} other {# exams}}",
     "set-count": "{count, plural, =0 {No sets yet} =1 {# set} other {# sets}}",
     "open-country-cta": "View exams",
+    "open-exam-cta": "View options",
     "open-set-cta": "View sets",
     "open-section-cta": "Open section",
     "back-to-tryout": "Back to tryout",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -345,6 +345,7 @@
     "exam-count": "{count, plural, =0 {Belum ada ujian} =1 {# ujian} other {# ujian}}",
     "set-count": "{count, plural, =0 {Belum ada set} =1 {# set} other {# set}}",
     "open-country-cta": "Lihat ujian",
+    "open-exam-cta": "Lihat pilihan",
     "open-set-cta": "Lihat set",
     "open-section-cta": "Buka bagian",
     "back-to-tryout": "Kembali ke try out",


### PR DESCRIPTION
## Summary

- restore the established shared `CatalogCard` composition for the country exam chooser
- keep the existing title and localized CTA sections from the pre-#323 card
- replace only the card artwork with `CatalogCardGradient` and the centered SNBT or TKA icon
- keep generated Open Graph images exclusively in route metadata
- preserve the existing one-column mobile and two-column desktop catalog layout

## Root cause

PR #323 removed the Open Graph card image by replacing the entire catalog card with the older compact `ChoiceCard` surface. The requested correction is narrower: preserve the catalog card and replace only its artwork.

## Scope

Five files:

- country route passes the existing localized exam CTA
- country client reuses `CatalogCard`, `CatalogCardGradient`, `ChoiceCardIcon`, and `IntentLink`
- EN, ID, and DE restore the existing `open-exam-cta` key

No consent, analytics behavior, content runtime, metadata generation, backend, dependency, or AI routing change. Gemini routing is unchanged.

## Verification

- internationalization: 13 tests, 100% coverage
- www: 199 files, 1,318 tests, 100% coverage
- internationalization and www typechecks
- root lint
- boundaries
- security audit with no advisories
- Ultracite Doctor: 4 passed
- React Doctor: 100/100
- Next 16.3.2 dev MCP: no compilation or runtime issues
- browser checks for EN, ID, and DE
- desktop and 390 by 844 mobile layouts
- exactly two catalog cards and zero Open Graph images in the card DOM
- localized CTA navigation verified
- WCAG 2 A and AA audit: zero violations
- browser console and page errors clean
