### PR TITLE
feat(consent): add account-bound current API

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -127,6 +127,7 @@ import type * as classes_utils from "../classes/utils.js";
 import type * as classes_validators from "../classes/validators.js";
 import type * as comments_mutations from "../comments/mutations.js";
 import type * as comments_queries from "../comments/queries.js";
+import type * as consents_current from "../consents/current.js";
 import type * as consents_impl from "../consents/impl.js";
 import type * as consents_mutations from "../consents/mutations.js";
 import type * as consents_queries from "../consents/queries.js";
@@ -686,6 +687,7 @@ declare const fullApi: ApiFromModules<{
   "classes/validators": typeof classes_validators;
   "comments/mutations": typeof comments_mutations;
   "comments/queries": typeof comments_queries;
+  "consents/current": typeof consents_current;
   "consents/impl": typeof consents_impl;
   "consents/mutations": typeof consents_mutations;
   "consents/queries": typeof consents_queries;

--- a/packages/backend/convex/consents/current.test.ts
+++ b/packages/backend/convex/consents/current.test.ts
@@ -5,14 +5,12 @@ import {
   ANALYTICS_CONSENT_NOTICE_VERSION,
 } from "@repo/analytics/consent";
 import { api } from "@repo/backend/convex/_generated/api";
-import { consentWriteValidator } from "@repo/backend/convex/consents/schema";
 import {
   createConvexTestWithBetterAuth,
   seedAnalyticsConsent,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
 import type { FunctionArgs } from "convex/server";
-import { validate } from "convex-helpers/validators";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 20, 16, 0, 0);
@@ -313,35 +311,5 @@ describe("consents/current", () => {
     expect(first.decidedAt).toBe(NOW);
     expect(stored.current).toHaveLength(1);
     expect(stored.history).toHaveLength(1);
-  });
-
-  it("rejects stale notice versions before the handler runs", () => {
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: true,
-        mechanism: ANALYTICS_CONSENT_MECHANISM,
-        noticeVersion: "privacy-stale",
-      })
-    ).toBe(false);
-  });
-
-  it("accepts only a denial from a browser privacy signal", () => {
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: false,
-        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
-        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
-      })
-    ).toBe(true);
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: true,
-        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
-        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
-      })
-    ).toBe(false);
   });
 });

--- a/packages/backend/convex/consents/current.test.ts
+++ b/packages/backend/convex/consents/current.test.ts
@@ -1,0 +1,347 @@
+import {
+  ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+  ANALYTICS_CONSENT_CATEGORY,
+  ANALYTICS_CONSENT_MECHANISM,
+  ANALYTICS_CONSENT_NOTICE_VERSION,
+} from "@repo/analytics/consent";
+import { api } from "@repo/backend/convex/_generated/api";
+import { consentWriteValidator } from "@repo/backend/convex/consents/schema";
+import {
+  createConvexTestWithBetterAuth,
+  seedAnalyticsConsent,
+  seedAuthenticatedUser,
+} from "@repo/backend/convex/test.helpers";
+import type { FunctionArgs } from "convex/server";
+import { validate } from "convex-helpers/validators";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const NOW = Date.UTC(2026, 7, 20, 16, 0, 0);
+const analyticsCategory = ANALYTICS_CONSENT_CATEGORY;
+
+describe("consents/current", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requires authentication to read", async () => {
+    const t = createConvexTestWithBetterAuth();
+
+    await expect(
+      t.query(api.consents.current.get, {
+        category: analyticsCategory,
+      })
+    ).rejects.toThrow();
+  });
+
+  it("returns the current notice and explicit account decision", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const seeded = await seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-query",
+      });
+      await seedAnalyticsConsent(ctx, {
+        decidedAt: NOW,
+        userId: seeded.userId,
+      });
+      return seeded;
+    });
+    const authenticated = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+
+    await expect(
+      authenticated.query(api.consents.current.get, {
+        category: analyticsCategory,
+      })
+    ).resolves.toEqual({
+      currentNoticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      decision: {
+        category: analyticsCategory,
+        decidedAt: NOW,
+        granted: true,
+        mechanism: ANALYTICS_CONSENT_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      },
+    });
+  });
+
+  it("returns no decision for an account that has not decided", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-missing",
+      })
+    );
+
+    await expect(
+      t
+        .withIdentity({
+          sessionId: identity.sessionId,
+          subject: identity.authUserId,
+        })
+        .query(api.consents.current.get, {
+          category: analyticsCategory,
+        })
+    ).resolves.toEqual({
+      currentNoticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      decision: null,
+    });
+  });
+
+  it("fails through the typed domain channel for duplicate state", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation(async (ctx) => {
+      const seeded = await seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-duplicate",
+      });
+      await seedAnalyticsConsent(ctx, {
+        decidedAt: NOW,
+        userId: seeded.userId,
+      });
+      await seedAnalyticsConsent(ctx, {
+        decidedAt: NOW + 1,
+        userId: seeded.userId,
+      });
+      return seeded;
+    });
+
+    await expect(
+      t
+        .withIdentity({
+          sessionId: identity.sessionId,
+          subject: identity.authUserId,
+        })
+        .query(api.consents.current.get, {
+          category: analyticsCategory,
+        })
+    ).rejects.toMatchObject({
+      data: {
+        code: "CONSENT_PERSISTENCE_FAILED",
+        message: "Unable to read or persist account consent.",
+      },
+    });
+  });
+
+  it("requires authentication to write", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-unauthorized",
+      })
+    );
+
+    await expect(
+      t.mutation(api.consents.current.set, {
+        decision: {
+          category: analyticsCategory,
+          granted: true,
+          mechanism: ANALYTICS_CONSENT_MECHANISM,
+          noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+        },
+        expectedUserId: identity.userId,
+      })
+    ).rejects.toThrow();
+  });
+
+  it("rejects a decision queued by a different account", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const original = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-original",
+      })
+    );
+    const current = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-active",
+      })
+    );
+    const authenticated = t.withIdentity({
+      sessionId: current.sessionId,
+      subject: current.authUserId,
+    });
+
+    await expect(
+      authenticated.mutation(api.consents.current.set, {
+        decision: {
+          category: analyticsCategory,
+          granted: true,
+          mechanism: ANALYTICS_CONSENT_MECHANISM,
+          noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+        },
+        expectedUserId: original.userId,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONSENT_ACCOUNT_CHANGED" },
+    });
+    const stored = await t.query(async (ctx) =>
+      ctx.db.query("accountConsentDecisions").take(1)
+    );
+    expect(stored).toEqual([]);
+  });
+
+  it("atomically records grant and withdrawal", async () => {
+    vi.setSystemTime(new Date(NOW));
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-write",
+      })
+    );
+    const authenticated = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+
+    const granted = await authenticated.mutation(api.consents.current.set, {
+      decision: {
+        category: analyticsCategory,
+        granted: true,
+        mechanism: ANALYTICS_CONSENT_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      },
+      expectedUserId: identity.userId,
+    });
+    vi.setSystemTime(new Date(NOW + 1000));
+    const denied = await authenticated.mutation(api.consents.current.set, {
+      decision: {
+        category: analyticsCategory,
+        granted: false,
+        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      },
+      expectedUserId: identity.userId,
+    });
+    const stored = await t.query(async (ctx) => ({
+      current: await ctx.db
+        .query("accountConsents")
+        .withIndex("by_userId_and_category", (query) =>
+          query.eq("userId", identity.userId).eq("category", analyticsCategory)
+        )
+        .take(2),
+      history: await ctx.db
+        .query("accountConsentDecisions")
+        .withIndex("by_userId_and_category_and_decidedAt", (query) =>
+          query.eq("userId", identity.userId).eq("category", analyticsCategory)
+        )
+        .order("asc")
+        .take(3),
+    }));
+
+    expect(granted).toMatchObject({
+      decidedAt: NOW,
+      granted: true,
+      mechanism: ANALYTICS_CONSENT_MECHANISM,
+    });
+    expect(denied).toEqual({
+      category: analyticsCategory,
+      decidedAt: NOW + 1000,
+      granted: false,
+      mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+      noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+    });
+    expect(stored.current).toEqual([
+      expect.objectContaining({
+        ...denied,
+        userId: identity.userId,
+      }),
+    ]);
+    expect(stored.history).toEqual([
+      expect.objectContaining({
+        ...granted,
+        userId: identity.userId,
+      }),
+      expect.objectContaining({
+        ...denied,
+        userId: identity.userId,
+      }),
+    ]);
+  });
+
+  it("returns an exact repeated decision without appending history", async () => {
+    vi.setSystemTime(new Date(NOW));
+    const t = createConvexTestWithBetterAuth();
+    const identity = await t.mutation((ctx) =>
+      seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "consent-current-idempotent",
+      })
+    );
+    const authenticated = t.withIdentity({
+      sessionId: identity.sessionId,
+      subject: identity.authUserId,
+    });
+    const input: FunctionArgs<typeof api.consents.current.set> = {
+      decision: {
+        category: analyticsCategory,
+        granted: true,
+        mechanism: ANALYTICS_CONSENT_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      },
+      expectedUserId: identity.userId,
+    };
+
+    const first = await authenticated.mutation(api.consents.current.set, input);
+    vi.setSystemTime(new Date(NOW + 1000));
+    const repeated = await authenticated.mutation(
+      api.consents.current.set,
+      input
+    );
+    const stored = await t.query(async (ctx) => ({
+      current: await ctx.db
+        .query("accountConsents")
+        .withIndex("by_userId_and_category", (query) =>
+          query.eq("userId", identity.userId).eq("category", analyticsCategory)
+        )
+        .take(2),
+      history: await ctx.db
+        .query("accountConsentDecisions")
+        .withIndex("by_userId_and_category_and_decidedAt", (query) =>
+          query.eq("userId", identity.userId).eq("category", analyticsCategory)
+        )
+        .take(2),
+    }));
+
+    expect(repeated).toEqual(first);
+    expect(first.decidedAt).toBe(NOW);
+    expect(stored.current).toHaveLength(1);
+    expect(stored.history).toHaveLength(1);
+  });
+
+  it("rejects stale notice versions before the handler runs", () => {
+    expect(
+      validate(consentWriteValidator, {
+        category: analyticsCategory,
+        granted: true,
+        mechanism: ANALYTICS_CONSENT_MECHANISM,
+        noticeVersion: "privacy-stale",
+      })
+    ).toBe(false);
+  });
+
+  it("accepts only a denial from a browser privacy signal", () => {
+    expect(
+      validate(consentWriteValidator, {
+        category: analyticsCategory,
+        granted: false,
+        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      })
+    ).toBe(true);
+    expect(
+      validate(consentWriteValidator, {
+        category: analyticsCategory,
+        granted: true,
+        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/backend/convex/consents/current.ts
+++ b/packages/backend/convex/consents/current.ts
@@ -1,0 +1,60 @@
+import { ANALYTICS_CONSENT_NOTICE_VERSION } from "@repo/analytics/consent";
+import { query } from "@repo/backend/convex/_generated/server";
+import {
+  readCurrentConsent,
+  saveCurrentConsent,
+} from "@repo/backend/convex/consents/impl";
+import {
+  consentCategoryValidator,
+  consentDecisionValidator,
+  consentWriteValidator,
+  currentConsentStateValidator,
+} from "@repo/backend/convex/consents/schema";
+import { mutation } from "@repo/backend/convex/functions";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { requireAuth } from "@repo/backend/convex/lib/helpers/auth";
+import { ConvexError, v } from "convex/values";
+
+/** Returns one authenticated account's current consent decision. */
+export const get = query({
+  args: {
+    category: consentCategoryValidator,
+  },
+  returns: currentConsentStateValidator,
+  handler: async (ctx, args) => {
+    const { appUser } = await requireAuth(ctx);
+    const decision = await runConvexProgram(
+      readCurrentConsent(ctx, appUser._id, args.category)
+    );
+
+    return {
+      currentNoticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      decision,
+    };
+  },
+});
+
+/** Records a decision only when the initiating account is still active. */
+export const set = mutation({
+  args: {
+    decision: consentWriteValidator,
+    expectedUserId: v.id("users"),
+  },
+  returns: consentDecisionValidator,
+  handler: async (ctx, { decision, expectedUserId }) => {
+    const { appUser } = await requireAuth(ctx);
+    if (appUser._id !== expectedUserId) {
+      throw new ConvexError({
+        code: "CONSENT_ACCOUNT_CHANGED",
+        message: "The active account changed before consent could be saved.",
+      });
+    }
+
+    return await runConvexProgram(
+      saveCurrentConsent(ctx, {
+        ...decision,
+        userId: appUser._id,
+      })
+    );
+  },
+});

--- a/packages/backend/convex/consents/mutations.test.ts
+++ b/packages/backend/convex/consents/mutations.test.ts
@@ -5,12 +5,10 @@ import {
   ANALYTICS_CONSENT_NOTICE_VERSION,
 } from "@repo/analytics/consent";
 import { api } from "@repo/backend/convex/_generated/api";
-import { consentWriteValidator } from "@repo/backend/convex/consents/schema";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { validate } from "convex-helpers/validators";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 20, 16, 0, 0);
@@ -163,35 +161,5 @@ describe("consents/mutations", () => {
     expect(first.decidedAt).toBe(NOW);
     expect(stored.current).toHaveLength(1);
     expect(stored.history).toHaveLength(1);
-  });
-
-  it("rejects stale notice versions before the handler runs", () => {
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: true,
-        mechanism: ANALYTICS_CONSENT_MECHANISM,
-        noticeVersion: "privacy-stale",
-      })
-    ).toBe(false);
-  });
-
-  it("accepts only a denial from a browser privacy signal", () => {
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: false,
-        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
-        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
-      })
-    ).toBe(true);
-    expect(
-      validate(consentWriteValidator, {
-        category: analyticsCategory,
-        granted: true,
-        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
-        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
-      })
-    ).toBe(false);
   });
 });

--- a/packages/backend/convex/consents/schema.test.ts
+++ b/packages/backend/convex/consents/schema.test.ts
@@ -1,0 +1,41 @@
+import {
+  ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+  ANALYTICS_CONSENT_CATEGORY,
+  ANALYTICS_CONSENT_MECHANISM,
+  ANALYTICS_CONSENT_NOTICE_VERSION,
+} from "@repo/analytics/consent";
+import { consentWriteValidator } from "@repo/backend/convex/consents/schema";
+import { validate } from "convex-helpers/validators";
+import { describe, expect, it } from "vitest";
+
+describe("consent schema", () => {
+  it("rejects stale notice versions", () => {
+    expect(
+      validate(consentWriteValidator, {
+        category: ANALYTICS_CONSENT_CATEGORY,
+        granted: true,
+        mechanism: ANALYTICS_CONSENT_MECHANISM,
+        noticeVersion: "privacy-stale",
+      })
+    ).toBe(false);
+  });
+
+  it("accepts only a denial from a browser privacy signal", () => {
+    expect(
+      validate(consentWriteValidator, {
+        category: ANALYTICS_CONSENT_CATEGORY,
+        granted: false,
+        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      })
+    ).toBe(true);
+    expect(
+      validate(consentWriteValidator, {
+        category: ANALYTICS_CONSENT_CATEGORY,
+        granted: true,
+        mechanism: ANALYTICS_BROWSER_SIGNAL_MECHANISM,
+        noticeVersion: ANALYTICS_CONSENT_NOTICE_VERSION,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Outcome

- Adds one cohesive `consents/current` query and mutation capability.
- Requires the authenticated account to match the account that initiated a queued consent write.
- Keeps authorization and the persisted user ID server-owned.
- Prevents an offline choice initiated by account A from being written to account B after an auth switch.

## Zero-downtime cutover

This PR adds the final account-bound endpoint without changing the existing endpoint contract. After this exact backend is deployed, PR #327 will switch every client to `consents/current` and delete the old `consents/queries` and `consents/mutations` routes and tests. The final main branch will contain no compatibility endpoint.

## Exact-head proof

Head: `24d9b0a49b697db0842427e70475ac1e928e7b45`

- Rebased without conflict onto main `dfc686eaa7`, including the reviewed dependency refresh from PR #328.
- Frozen install passed with pnpm 11.23.0.
- Backend coverage passed: 315 files and 1,273 tests.
- Backend TypeScript passed.
- Root lint passed across 2,826 files.
- Workspace boundaries passed across 2,750 files.
- Dependency audit reported no known vulnerabilities.
- Ultracite Doctor passed with four checks, no warnings, and no failures.
- Isolated Convex 1.45 compiled the complete backend and reported `Convex functions ready!`.
- Exact-head function metadata exposes both the temporary old routes and final `consents/current` route, with required `expectedUserId: Id<"users">` on the final mutation.
- Shared validator assertions live only in the colocated `schema.test.ts` owner.
- All touched hand-written TypeScript modules are below 500 lines.

Fresh protected exact-head CI and review are required again after the rebase before merge.
