### PR TITLE
perf(backend): remove activation scheduler contention

### DIFF
--- a/apps/www/components/contributor/gallery.tsx
+++ b/apps/www/components/contributor/gallery.tsx
@@ -5,6 +5,7 @@ import {
   Linkedin02Icon,
   NewTwitterIcon,
 } from "@hugeicons/core-free-icons";
+import { useMounted } from "@mantine/hooks";
 import type { Contributor } from "@repo/contents/_types/contributor";
 import { Badge } from "@repo/design-system/components/ui/badge";
 import { Button } from "@repo/design-system/components/ui/button";
@@ -63,6 +64,7 @@ export function ContributorGallery({
 }: ContributorGalleryProps) {
   const t = useTranslations("Common");
   const [contributorDrawer] = useState(() => DrawerCreateHandle<Contributor>());
+  const isMounted = useMounted();
 
   return (
     <>
@@ -73,8 +75,9 @@ export function ContributorGallery({
               render={
                 <DrawerTrigger
                   aria-label={`${t("open")} ${contributor.name}`}
-                  className="cursor-pointer"
+                  className="cursor-pointer disabled:cursor-default"
                   data-contributor-username={contributor.username}
+                  disabled={!isMounted}
                   handle={contributorDrawer}
                   payload={contributor}
                   title={contributor.name}

--- a/apps/www/components/shared/quran/interpretation/button.tsx
+++ b/apps/www/components/shared/quran/interpretation/button.tsx
@@ -4,8 +4,8 @@ import { BookOpen02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
 import {
-  useQuranInterpretationLoading,
   useQuranInterpretationSelection,
+  useQuranInterpretationState,
 } from "@/components/shared/quran/interpretation/context";
 
 /** Renders one tafsir trigger backed by the shared request controller. */
@@ -16,15 +16,17 @@ export function QuranInterpretationButton({
   label: string;
   verseNumber: number;
 }) {
-  const isLoading = useQuranInterpretationLoading(verseNumber);
+  const state = useQuranInterpretationState(verseNumber);
   const selectInterpretation = useQuranInterpretationSelection();
+  const isLoading = state === "loading";
 
   return (
     <Button
       aria-busy={isLoading || undefined}
       aria-label={label}
+      className={state === "inactive" ? "disabled:opacity-100" : undefined}
       data-quran-interpretation-verse={verseNumber}
-      disabled={isLoading}
+      disabled={state !== "idle"}
       onClick={selectInterpretation}
       size="icon"
       type="button"

--- a/apps/www/components/shared/quran/interpretation/button.tsx
+++ b/apps/www/components/shared/quran/interpretation/button.tsx
@@ -4,8 +4,8 @@ import { BookOpen02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
 import {
+  useQuranInterpretationLoading,
   useQuranInterpretationSelection,
-  useQuranInterpretationState,
 } from "@/components/shared/quran/interpretation/context";
 
 /** Renders one tafsir trigger backed by the shared request controller. */
@@ -16,17 +16,15 @@ export function QuranInterpretationButton({
   label: string;
   verseNumber: number;
 }) {
-  const state = useQuranInterpretationState(verseNumber);
+  const isLoading = useQuranInterpretationLoading(verseNumber);
   const selectInterpretation = useQuranInterpretationSelection();
-  const isLoading = state === "loading";
 
   return (
     <Button
       aria-busy={isLoading || undefined}
       aria-label={label}
-      className={state === "inactive" ? "disabled:opacity-100" : undefined}
       data-quran-interpretation-verse={verseNumber}
-      disabled={state !== "idle"}
+      disabled={isLoading}
       onClick={selectInterpretation}
       size="icon"
       type="button"

--- a/apps/www/components/shared/quran/interpretation/context.tsx
+++ b/apps/www/components/shared/quran/interpretation/context.tsx
@@ -8,6 +8,7 @@ const missingQuranInterpretationContext = Symbol(
 );
 
 interface QuranInterpretationContextValue {
+  isActive: boolean;
   pendingVerseNumber: number | null;
   selectInterpretation: MouseEventHandler<HTMLButtonElement>;
 }
@@ -16,26 +17,31 @@ export const QuranInterpretationContext = createContext<
   QuranInterpretationContextValue | typeof missingQuranInterpretationContext
 >(missingQuranInterpretationContext);
 
-/** Reads whether one verse is loading tafsir. */
-export function useQuranInterpretationLoading(verseNumber: number) {
-  const isLoading = useContextSelector(
-    QuranInterpretationContext,
-    (context) => {
-      if (context === missingQuranInterpretationContext) {
-        return missingQuranInterpretationContext;
-      }
-
-      return context.pendingVerseNumber === verseNumber;
+/** Reads whether one tafsir trigger is inactive, idle, or loading. */
+export function useQuranInterpretationState(verseNumber: number) {
+  const state = useContextSelector(QuranInterpretationContext, (context) => {
+    if (context === missingQuranInterpretationContext) {
+      return missingQuranInterpretationContext;
     }
-  );
 
-  if (isLoading === missingQuranInterpretationContext) {
+    if (!context.isActive) {
+      return "inactive";
+    }
+
+    if (context.pendingVerseNumber === verseNumber) {
+      return "loading";
+    }
+
+    return "idle";
+  });
+
+  if (state === missingQuranInterpretationContext) {
     throw new Error(
       "Quran tafsir button must be rendered within QuranInterpretationControls."
     );
   }
 
-  return isLoading;
+  return state;
 }
 
 /** Reads the shared React event handler for selecting tafsir. */

--- a/apps/www/components/shared/quran/interpretation/context.tsx
+++ b/apps/www/components/shared/quran/interpretation/context.tsx
@@ -8,7 +8,6 @@ const missingQuranInterpretationContext = Symbol(
 );
 
 interface QuranInterpretationContextValue {
-  isActive: boolean;
   pendingVerseNumber: number | null;
   selectInterpretation: MouseEventHandler<HTMLButtonElement>;
 }
@@ -17,31 +16,26 @@ export const QuranInterpretationContext = createContext<
   QuranInterpretationContextValue | typeof missingQuranInterpretationContext
 >(missingQuranInterpretationContext);
 
-/** Reads whether one tafsir trigger is inactive, idle, or loading. */
-export function useQuranInterpretationState(verseNumber: number) {
-  const state = useContextSelector(QuranInterpretationContext, (context) => {
-    if (context === missingQuranInterpretationContext) {
-      return missingQuranInterpretationContext;
+/** Reads whether one verse is loading tafsir. */
+export function useQuranInterpretationLoading(verseNumber: number) {
+  const isLoading = useContextSelector(
+    QuranInterpretationContext,
+    (context) => {
+      if (context === missingQuranInterpretationContext) {
+        return missingQuranInterpretationContext;
+      }
+
+      return context.pendingVerseNumber === verseNumber;
     }
+  );
 
-    if (!context.isActive) {
-      return "inactive";
-    }
-
-    if (context.pendingVerseNumber === verseNumber) {
-      return "loading";
-    }
-
-    return "idle";
-  });
-
-  if (state === missingQuranInterpretationContext) {
+  if (isLoading === missingQuranInterpretationContext) {
     throw new Error(
       "Quran tafsir button must be rendered within QuranInterpretationControls."
     );
   }
 
-  return state;
+  return isLoading;
 }
 
 /** Reads the shared React event handler for selecting tafsir. */

--- a/apps/www/components/shared/quran/interpretation/controls.tsx
+++ b/apps/www/components/shared/quran/interpretation/controls.tsx
@@ -184,8 +184,9 @@ export function QuranInterpretationControls({
     startTransition(() => Effect.runPromise(program));
   };
   const selectInterpretation = useCallbackRef(handleInterpretationClick);
-  // Activity reconnects passive effects when this route becomes visible. Keep
-  // this after useCallbackRef so triggers enable only after its handler is live.
+  // Activity defers cleanup updates until this route becomes visible again.
+  // Keep this after useCallbackRef so triggers re-enable only after their
+  // handler is live again.
   // https://react.dev/reference/react/Activity
   useEffect(() => {
     setControllerActive(true);

--- a/apps/www/components/shared/quran/interpretation/controls.tsx
+++ b/apps/www/components/shared/quran/interpretation/controls.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useDisclosure } from "@mantine/hooks";
+import { useDisclosure, useMounted } from "@mantine/hooks";
 import {
   decodePublishedQuranInterpretation,
   isQuranSnapshotConflict,
@@ -60,6 +60,7 @@ export function QuranInterpretationControls({
   const [pendingVerseNumber, setPendingVerseNumber] = useState<number | null>(
     null
   );
+  const isControllerActive = useMounted();
   const [isPending, startTransition] = useTransition();
   const requestSequence = useRef(0);
   const pendingRequestId = useRef<number | null>(null);
@@ -182,6 +183,7 @@ export function QuranInterpretationControls({
     startTransition(() => Effect.runPromise(program));
   };
   const contextValue = {
+    isActive: isControllerActive,
     pendingVerseNumber: isPending ? pendingVerseNumber : null,
     selectInterpretation,
   };

--- a/apps/www/components/shared/quran/interpretation/controls.tsx
+++ b/apps/www/components/shared/quran/interpretation/controls.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallbackRef, useDisclosure } from "@mantine/hooks";
+import { useDisclosure } from "@mantine/hooks";
 import {
   decodePublishedQuranInterpretation,
   isQuranSnapshotConflict,
@@ -18,7 +18,6 @@ import { Effect } from "effect";
 import {
   type MouseEvent,
   type ReactNode,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -61,7 +60,6 @@ export function QuranInterpretationControls({
   const [pendingVerseNumber, setPendingVerseNumber] = useState<number | null>(
     null
   );
-  const [isControllerActive, setControllerActive] = useState(false);
   const [isPending, startTransition] = useTransition();
   const requestSequence = useRef(0);
   const pendingRequestId = useRef<number | null>(null);
@@ -78,12 +76,12 @@ export function QuranInterpretationControls({
     },
     [close, toastId]
   );
-  const handleInterpretationClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const selectInterpretation = (event: MouseEvent<HTMLButtonElement>) => {
     const verseNumber = getVerseNumber(event.currentTarget);
     if (verseNumber === null) {
       return;
     }
-    if (isPending || pendingRequestId.current !== null) {
+    if (pendingRequestId.current !== null) {
       return;
     }
     requestSequence.current += 1;
@@ -183,20 +181,7 @@ export function QuranInterpretationControls({
     );
     startTransition(() => Effect.runPromise(program));
   };
-  const selectInterpretation = useCallbackRef(handleInterpretationClick);
-  // Activity defers cleanup updates until this route becomes visible again.
-  // Keep this after useCallbackRef so triggers re-enable only after their
-  // handler is live again.
-  // https://react.dev/reference/react/Activity
-  useEffect(() => {
-    setControllerActive(true);
-
-    return () => {
-      setControllerActive(false);
-    };
-  }, []);
   const contextValue = {
-    isActive: isControllerActive,
     pendingVerseNumber: isPending ? pendingVerseNumber : null,
     selectInterpretation,
   };

--- a/apps/www/components/shared/quran/interpretation/controls.tsx
+++ b/apps/www/components/shared/quran/interpretation/controls.tsx
@@ -18,6 +18,7 @@ import { Effect } from "effect";
 import {
   type MouseEvent,
   type ReactNode,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -60,6 +61,7 @@ export function QuranInterpretationControls({
   const [pendingVerseNumber, setPendingVerseNumber] = useState<number | null>(
     null
   );
+  const [isControllerActive, setControllerActive] = useState(false);
   const [isPending, startTransition] = useTransition();
   const requestSequence = useRef(0);
   const pendingRequestId = useRef<number | null>(null);
@@ -182,7 +184,18 @@ export function QuranInterpretationControls({
     startTransition(() => Effect.runPromise(program));
   };
   const selectInterpretation = useCallbackRef(handleInterpretationClick);
+  // Activity reconnects passive effects when this route becomes visible. Keep
+  // this after useCallbackRef so triggers enable only after its handler is live.
+  // https://react.dev/reference/react/Activity
+  useEffect(() => {
+    setControllerActive(true);
+
+    return () => {
+      setControllerActive(false);
+    };
+  }, []);
   const contextValue = {
+    isActive: isControllerActive,
     pendingVerseNumber: isPending ? pendingVerseNumber : null,
     selectInterpretation,
   };

--- a/apps/www/e2e/drawer.browser.ts
+++ b/apps/www/e2e/drawer.browser.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { Effect } from "effect";
 import { withObservedPageErrors } from "@/e2e/support/browser-context";
 import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
@@ -6,39 +6,8 @@ import { waitForCommittedAppRouter } from "@/e2e/support/navigation/readiness";
 
 const usageDataName = "Usage data";
 const readinessTimeoutMilliseconds = 15_000;
-
-const waitForReactClick = Effect.fn("NakafaE2E.waitForReactClick")(function* (
-  trigger: Locator
-) {
-  /**
-   * React 19.2.8 stores hydrated host props under `__reactProps$...` and
-   * reads `onClick` from that same store during event dispatch. Waiting for
-   * the exact host prop distinguishes visible server HTML from an
-   * interactive button without adding a product-only readiness marker.
-   *
-   * @see https://github.com/facebook/react/blob/v19.2.8/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
-   * @see https://github.com/facebook/react/blob/v19.2.8/packages/react-dom-bindings/src/events/getListener.js
-   */
-  yield* Effect.promise(() =>
-    trigger.waitForFunction(
-      (element) =>
-        Object.keys(element).some((key) => {
-          if (!key.startsWith("__reactProps$")) {
-            return false;
-          }
-
-          const props = Reflect.get(element, key);
-          if (typeof props !== "object" || props === null) {
-            return false;
-          }
-
-          return typeof Reflect.get(props, "onClick") === "function";
-        }),
-      undefined,
-      { timeout: readinessTimeoutMilliseconds }
-    )
-  );
-});
+const quranIndexUrlPattern = /\/id\/quran$/;
+const quranSurahUrlPattern = /\/id\/quran\/2$/;
 
 const prepareConsentPreferences = Effect.fn(
   "NakafaE2E.prepareDrawerConsentPreferences"
@@ -133,7 +102,7 @@ const verifyQuranInterpretationDrawer = Effect.fn(
 
   const trigger = page.locator("[data-quran-interpretation-verse]").first();
   yield* Effect.promise(() => expect(trigger).toBeVisible({ timeout: 15_000 }));
-  yield* waitForReactClick(trigger);
+  yield* Effect.promise(() => expect(trigger).toBeEnabled({ timeout: 15_000 }));
   yield* Effect.promise(() => trigger.click());
 
   const drawer = page.locator('[data-slot="drawer-popup"]');
@@ -148,6 +117,31 @@ const verifyQuranInterpretationDrawer = Effect.fn(
     expect(drawer.locator('[data-slot="drawer-panel"]')).not.toBeEmpty()
   );
 
+  yield* Effect.promise(() => page.keyboard.press("Escape"));
+  yield* Effect.promise(() => expect(drawer).toHaveCount(0));
+
+  const quranIndexLink = page.locator('a[href="/id/quran"]').first();
+  yield* Effect.promise(() => expect(quranIndexLink).toBeVisible());
+  yield* Effect.promise(() => quranIndexLink.click());
+  yield* Effect.promise(() => expect(page).toHaveURL(quranIndexUrlPattern));
+  yield* Effect.promise(() => expect(trigger).toBeAttached());
+  yield* Effect.promise(() => expect(trigger).toBeHidden());
+  yield* Effect.promise(() => expect(trigger).toBeDisabled());
+  yield* Effect.promise(() => expect(trigger).toHaveCSS("opacity", "1"));
+
+  yield* Effect.promise(() => page.goBack());
+  yield* Effect.promise(() => expect(page).toHaveURL(quranSurahUrlPattern));
+  yield* waitForCommittedAppRouter(
+    page,
+    "/id/quran",
+    "/id/quran/2",
+    readinessTimeoutMilliseconds
+  );
+  yield* Effect.promise(() => expect(trigger).toBeVisible());
+  yield* Effect.promise(() => expect(trigger).toBeEnabled());
+  yield* Effect.promise(() => expect(trigger).toHaveCSS("opacity", "1"));
+  yield* Effect.promise(() => trigger.click());
+  yield* Effect.promise(() => expect(drawer).toBeVisible({ timeout: 15_000 }));
   yield* Effect.promise(() => page.keyboard.press("Escape"));
   yield* Effect.promise(() => expect(drawer).toHaveCount(0));
 });

--- a/apps/www/e2e/drawer.browser.ts
+++ b/apps/www/e2e/drawer.browser.ts
@@ -126,7 +126,6 @@ const verifyQuranInterpretationDrawer = Effect.fn(
   yield* Effect.promise(() => expect(page).toHaveURL(quranIndexUrlPattern));
   yield* Effect.promise(() => expect(trigger).toBeAttached());
   yield* Effect.promise(() => expect(trigger).toBeHidden());
-  yield* Effect.promise(() => expect(trigger).toBeDisabled());
   yield* Effect.promise(() => expect(trigger).toHaveCSS("opacity", "1"));
 
   yield* Effect.promise(() => page.goBack());

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -187,6 +187,7 @@ import type * as contentRelease_ingress_failure from "../contentRelease/ingress/
 import type * as contentRelease_ingress_group from "../contentRelease/ingress/group.js";
 import type * as contentRelease_ingress_lifecycle from "../contentRelease/ingress/lifecycle.js";
 import type * as contentRelease_ingress_read from "../contentRelease/ingress/read.js";
+import type * as contentRelease_ingress_readModels from "../contentRelease/ingress/readModels.js";
 import type * as contentRelease_ingress_response from "../contentRelease/ingress/response.js";
 import type * as contentRelease_ingress_rollback from "../contentRelease/ingress/rollback.js";
 import type * as contentRelease_ingress_route from "../contentRelease/ingress/route.js";
@@ -755,6 +756,7 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/ingress/group": typeof contentRelease_ingress_group;
   "contentRelease/ingress/lifecycle": typeof contentRelease_ingress_lifecycle;
   "contentRelease/ingress/read": typeof contentRelease_ingress_read;
+  "contentRelease/ingress/readModels": typeof contentRelease_ingress_readModels;
   "contentRelease/ingress/response": typeof contentRelease_ingress_response;
   "contentRelease/ingress/rollback": typeof contentRelease_ingress_rollback;
   "contentRelease/ingress/route": typeof contentRelease_ingress_route;

--- a/packages/backend/convex/contentRelease/activate.test.ts
+++ b/packages/backend/convex/contentRelease/activate.test.ts
@@ -103,7 +103,7 @@ describe("contentRelease/activate", () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(seedVerifiedPair);
 
-    const receipt = await t.mutation(activate, {
+    const activation = await t.mutation(activate, {
       manifestHash: CANDIDATE.manifestHash,
       releaseId: CANDIDATE.releaseId,
       rendererJson: testRendererJson(),
@@ -145,9 +145,15 @@ describe("contentRelease/activate", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
     const state = await t.run((ctx) => ctx.db.query("contentState").unique());
 
-    expect(receipt).toEqual(expectedReceipt(CANDIDATE));
-    expect(repeatedPending).toEqual(receipt);
-    expect(repeated).toEqual(receipt);
+    expect(activation).toEqual({
+      kind: "activated",
+      receipt: expectedReceipt(CANDIDATE),
+    });
+    expect(repeatedPending).toEqual({
+      kind: "completed",
+      receipt: activation.receipt,
+    });
+    expect(repeated).toEqual(repeatedPending);
     expect(state).toMatchObject({
       activeManifestHash: CANDIDATE.manifestHash,
       activeReleaseId: CANDIDATE.releaseId,
@@ -226,7 +232,7 @@ describe("contentRelease/activate", () => {
     });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    const receipt = await t.mutation(activateRecovery, {
+    const activation = await t.mutation(activateRecovery, {
       manifestHash: RECOVERY.manifestHash,
       releaseId: RECOVERY.releaseId,
       rendererJson: testRendererJson(),
@@ -234,7 +240,10 @@ describe("contentRelease/activate", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
     const state = await t.run((ctx) => ctx.db.query("contentState").unique());
 
-    expect(receipt).toEqual(expectedReceipt(RECOVERY));
+    expect(activation).toEqual({
+      kind: "activated",
+      receipt: expectedReceipt(RECOVERY),
+    });
     expect(state).toMatchObject({
       activeManifestHash: RECOVERY.manifestHash,
       activeReleaseId: RECOVERY.releaseId,
@@ -269,14 +278,14 @@ describe("contentRelease/activate", () => {
     ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_STATE" } });
   });
 
-  it("restarts a failed model lineage under one new generation", async () => {
+  it("returns completed evidence without rescheduling a failed lineage", async () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(async (ctx) => {
       await seedVerifiedPair(ctx);
       await insertReleaseItem(ctx, CANDIDATE, "test:unexpected", 0);
     });
 
-    await t.mutation(activate, {
+    const activation = await t.mutation(activate, {
       manifestHash: CANDIDATE.manifestHash,
       releaseId: CANDIDATE.releaseId,
       rendererJson: testRendererJson(),
@@ -307,7 +316,7 @@ describe("contentRelease/activate", () => {
     expect(failed.state?.materialReleaseId).toBeUndefined();
     expect(failed.state?.searchReleaseId).toBeUndefined();
 
-    await t.mutation(activate, {
+    const repeated = await t.mutation(activate, {
       manifestHash: CANDIDATE.manifestHash,
       releaseId: CANDIDATE.releaseId,
       rendererJson: testRendererJson(),
@@ -322,9 +331,16 @@ describe("contentRelease/activate", () => {
         .unique(),
     }));
 
-    expect(restarted.jobs).toHaveLength(2);
-    expect(restarted.jobs.at(-1)?.state).toEqual({ kind: "pending" });
-    expect(restarted.release?.syncGeneration).toBe(2);
+    expect(activation.kind).toBe("activated");
+    expect(repeated).toEqual({
+      kind: "completed",
+      receipt: expectedReceipt(CANDIDATE),
+    });
+    expect(restarted.jobs).toHaveLength(1);
+    expect(restarted.jobs.at(-1)?.state).toEqual(
+      expect.objectContaining({ kind: "failed" })
+    );
+    expect(restarted.release?.syncGeneration).toBe(1);
   });
 
   it("rejects renderer drift and a stale active base", async () => {

--- a/packages/backend/convex/contentRelease/activate.ts
+++ b/packages/backend/convex/contentRelease/activate.ts
@@ -10,7 +10,7 @@ import {
   loadRelease,
   loadState,
 } from "@repo/backend/convex/contentRelease/model";
-import { scheduleReadModels } from "@repo/backend/convex/contentRelease/models";
+import { startReadModels } from "@repo/backend/convex/contentRelease/models";
 import {
   decodeReleaseJson,
   decodeRendererJson,
@@ -25,8 +25,20 @@ import { publicationReceiptValidator } from "@repo/backend/convex/contentRelease
 import { retainActivatedTryoutBundle } from "@repo/backend/convex/contentRelease/tryout/bundle";
 import { encodeRendererJson } from "@repo/backend/convex/contentRelease/wire";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
-import { v } from "convex/values";
+import { type Infer, v } from "convex/values";
 import { Effect } from "effect";
+
+const activationResultValidator = v.union(
+  v.object({
+    kind: v.literal("activated"),
+    receipt: publicationReceiptValidator,
+  }),
+  v.object({
+    kind: v.literal("completed"),
+    receipt: publicationReceiptValidator,
+  })
+);
+export type ActivationResult = Infer<typeof activationResultValidator>;
 
 /** Confirms one activation request uses the frozen live renderer envelope. */
 const validateRenderer = Effect.fn("contentRelease.validateActivationRenderer")(
@@ -106,8 +118,7 @@ const activateCandidate = Effect.fn("contentRelease.activateCandidate")(
         release.sequence,
         release
       );
-      yield* scheduleReadModels(ctx, releaseId);
-      return receipt;
+      return { kind: "completed", receipt } satisfies ActivationResult;
     }
     const state = yield* loadState(ctx);
     if (
@@ -181,8 +192,8 @@ const activateCandidate = Effect.fn("contentRelease.activateCandidate")(
         updatedAt: now,
       })
     );
-    yield* scheduleReadModels(ctx, releaseId);
-    return receipt;
+    yield* startReadModels(ctx, releaseId);
+    return { kind: "activated", receipt } satisfies ActivationResult;
   }
 );
 
@@ -209,8 +220,7 @@ const activateRecoveryProgram = Effect.fn("contentRelease.activateRecovery")(
         release.sequence,
         release
       );
-      yield* scheduleReadModels(ctx, releaseId);
-      return receipt;
+      return { kind: "completed", receipt } satisfies ActivationResult;
     }
     const state = yield* loadState(ctx);
     if (
@@ -252,8 +262,8 @@ const activateRecoveryProgram = Effect.fn("contentRelease.activateRecovery")(
         updatedAt: now,
       })
     );
-    yield* scheduleReadModels(ctx, releaseId);
-    return receipt;
+    yield* startReadModels(ctx, releaseId);
+    return { kind: "activated", receipt } satisfies ActivationResult;
   }
 );
 
@@ -264,7 +274,7 @@ export const activate = internalMutation({
     releaseId: v.string(),
     rendererJson: v.string(),
   },
-  returns: publicationReceiptValidator,
+  returns: activationResultValidator,
   handler: (ctx, args) =>
     runConvexProgram(
       activateCandidate(
@@ -283,7 +293,7 @@ export const activateRecovery = internalMutation({
     releaseId: v.string(),
     rendererJson: v.string(),
   },
-  returns: publicationReceiptValidator,
+  returns: activationResultValidator,
   handler: (ctx, args) =>
     runConvexProgram(
       activateRecoveryProgram(

--- a/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
@@ -4,9 +4,16 @@ import {
   Ed25519SignatureSchema,
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
+import {
+  ContentReleaseManifestSchema,
+  RollbackSignedContentReleaseSchema,
+  type SignedContentRelease,
+} from "@nakafa/aksara-contracts/release";
+import { PublicationScopeSchema } from "@nakafa/aksara-contracts/release/snapshot/spec";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { advancePublication } from "@repo/backend/convex/contentRelease/ingress/lifecycle";
+import { encodeRendererJson } from "@repo/backend/convex/contentRelease/wire";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -17,10 +24,14 @@ import {
   testSignedRelease,
 } from "@repo/backend/test/content-proof";
 import { insertSignedCandidate } from "@repo/backend/test/content-stage";
+import {
+  insertTestState,
+  insertZeroRelease,
+} from "@repo/backend/test/content-state";
 import { completeContentProof } from "@repo/backend/test/content-verify";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_RESOLVER } = await import(
@@ -31,6 +42,9 @@ vi.mock("@repo/backend/content/trust", async () => {
 
 const releaseId = ReleaseIdSchema.make("release-lifecycle-ingress");
 const release = testSignedRelease(testEmptyManifest(releaseId));
+const recoveryReleaseId = ReleaseIdSchema.make(
+  "release-lifecycle-ingress-recovery"
+);
 
 /** Inserts one verified release with explicit frozen renderer bytes. */
 async function insertRelease(ctx: MutationCtx, rendererJson: string) {
@@ -70,6 +84,85 @@ async function insertRelease(ctx: MutationCtx, rendererJson: string) {
   });
 }
 
+/** Inserts one authenticated zero-impact candidate and its exact inverse. */
+async function insertActivationPair(
+  ctx: MutationCtx,
+  candidate: SignedContentRelease,
+  recovery: SignedContentRelease
+) {
+  const candidateIdentity = {
+    manifestHash: candidate.manifestHash,
+    releaseId: candidate.manifest.releaseId,
+    sequence: 1,
+  };
+  const recoveryIdentity = {
+    manifestHash: recovery.manifestHash,
+    releaseId: recovery.manifest.releaseId,
+    sequence: 2,
+  };
+  await insertZeroRelease(ctx, {
+    ...candidateIdentity,
+    ownership: { base: [], result: [] },
+    role: "candidate",
+    scope: candidate.manifest.scope,
+    snapshots: candidate.manifest.snapshots,
+    status: "verified",
+  });
+  await insertZeroRelease(ctx, {
+    ...recoveryIdentity,
+    base: candidateIdentity,
+    originReleaseId: candidate.manifest.releaseId,
+    ownership: { base: [], result: [] },
+    role: "recovery",
+    scope: recovery.manifest.scope,
+    snapshots: recovery.manifest.snapshots,
+    status: "verified",
+  });
+  const rendererJson = encodeRendererJson(TEST_PROOF_RENDERER);
+  const releases = await ctx.db.query("contentReleases").collect();
+  for (const stored of releases) {
+    const signed =
+      stored.releaseId === candidate.manifest.releaseId ? candidate : recovery;
+    await ctx.db.patch("contentReleases", stored._id, {
+      releaseJson: JSON.stringify(signed),
+      rendererJson,
+    });
+  }
+  await insertTestState(ctx, {
+    candidate: candidateIdentity,
+    nextSequence: 3,
+    recovery: recoveryIdentity,
+  });
+}
+
+/** Creates signed zero-impact manifests that complete read models immediately. */
+function makeActivationPair() {
+  const scope = PublicationScopeSchema.make({
+    content: [],
+    families: ["page"],
+    snapshots: [],
+  });
+  const candidateManifest = ContentReleaseManifestSchema.make({
+    ...testEmptyManifest(releaseId),
+    scope,
+  });
+  const candidate = testSignedRelease(candidateManifest);
+  const recoveryManifest = ContentReleaseManifestSchema.make({
+    ...testEmptyManifest(recoveryReleaseId),
+    baseActiveAppLocales: candidateManifest.activeAppLocales,
+    baseManifestHash: candidate.manifestHash,
+    baseReleaseId: releaseId,
+    origin: { kind: "rollback", releaseId },
+    scope,
+  });
+  return {
+    candidate,
+    recovery: RollbackSignedContentReleaseSchema.make(
+      testSignedRelease(recoveryManifest)
+    ),
+  };
+}
+
 /** Runs one lifecycle program through the explicit technical verification key. */
 function runLifecycle<A, E>(
   program: Effect.Effect<A, E, ContentVerificationKeyResolver>
@@ -80,6 +173,8 @@ function runLifecycle<A, E>(
     )
   );
 }
+
+afterEach(() => vi.useRealTimers());
 
 describe("content release lifecycle ingress", () => {
   it("returns authenticated evidence after durable proof completion", async () => {
@@ -193,5 +288,77 @@ describe("content release lifecycle ingress", () => {
         )
       )
     ).rejects.toThrow("Content release verification failed");
+  });
+
+  it("keeps the external activation receipt unchanged", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, convexModules);
+    const pair = makeActivationPair();
+    await t.mutation((ctx) =>
+      insertActivationPair(ctx, pair.candidate, pair.recovery)
+    );
+
+    const activated = await t.action((ctx) =>
+      runLifecycle(
+        advancePublication(ctx, {
+          operation: "activate",
+          release: pair.candidate,
+        })
+      )
+    );
+    const repeated = await t.action((ctx) =>
+      runLifecycle(
+        advancePublication(ctx, {
+          operation: "activate",
+          release: pair.candidate,
+        })
+      )
+    );
+
+    expect(activated).toEqual(repeated);
+    expect(activated).toMatchObject({
+      ok: true,
+      operation: "activate",
+      value: {
+        manifestHash: pair.candidate.manifestHash,
+        releaseId,
+      },
+    });
+    expect(activated.value).not.toHaveProperty("kind");
+    await expect(
+      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+    ).resolves.toHaveLength(1);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const recovered = await t.action((ctx) =>
+      runLifecycle(
+        advancePublication(ctx, {
+          operation: "activateRecovery",
+          release: pair.recovery,
+        })
+      )
+    );
+    expect(recovered).toMatchObject({
+      ok: true,
+      operation: "activateRecovery",
+      value: {
+        manifestHash: pair.recovery.manifestHash,
+        releaseId: recoveryReleaseId,
+      },
+    });
+    expect(recovered.value).not.toHaveProperty("kind");
+    const repeatedRecovery = await t.action((ctx) =>
+      runLifecycle(
+        advancePublication(ctx, {
+          operation: "activateRecovery",
+          release: pair.recovery,
+        })
+      )
+    );
+    expect(repeatedRecovery).toEqual(recovered);
+    await expect(
+      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+    ).resolves.toHaveLength(2);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
 });

--- a/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
@@ -31,7 +31,7 @@ import {
 import { completeContentProof } from "@repo/backend/test/content-verify";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_RESOLVER } = await import(
@@ -174,8 +174,6 @@ function runLifecycle<A, E>(
   );
 }
 
-afterEach(() => vi.useRealTimers());
-
 describe("content release lifecycle ingress", () => {
   it("returns authenticated evidence after durable proof completion", async () => {
     const t = convexTest(schema, convexModules);
@@ -291,7 +289,6 @@ describe("content release lifecycle ingress", () => {
   });
 
   it("keeps the external activation receipt unchanged", async () => {
-    vi.useFakeTimers();
     const t = convexTest(schema, convexModules);
     const pair = makeActivationPair();
     await t.mutation((ctx) =>
@@ -327,8 +324,7 @@ describe("content release lifecycle ingress", () => {
     expect(activated.value).not.toHaveProperty("kind");
     await expect(
       t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toHaveLength(1);
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    ).resolves.toEqual([]);
 
     const recovered = await t.action((ctx) =>
       runLifecycle(
@@ -358,7 +354,6 @@ describe("content release lifecycle ingress", () => {
     expect(repeatedRecovery).toEqual(recovered);
     await expect(
       t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toHaveLength(2);
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    ).resolves.toEqual([]);
   });
 });

--- a/packages/backend/convex/contentRelease/ingress/lifecycle.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.ts
@@ -4,9 +4,13 @@ import { verifySignedContentRelease } from "@nakafa/aksara-contracts/release/ver
 import { validateRendererManifestHash } from "@nakafa/aksara-contracts/renderer/manifest";
 import type { PublicationRequest } from "@nakafa/aksara-contracts/transport/request";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
+import type { ActivationResult } from "@repo/backend/convex/contentRelease/activate";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
-import type { ReadModelStatus } from "@repo/backend/convex/contentRelease/models";
+import {
+  makeReadModelCoordinatorLive,
+  waitForReadModels,
+} from "@repo/backend/convex/contentRelease/ingress/readModels";
 import {
   decodeProofJson,
   decodeRendererJson,
@@ -14,13 +18,10 @@ import {
 import { contractFailure } from "@repo/backend/convex/contentRelease/proof/failure";
 import type { proofPollValidator } from "@repo/backend/convex/contentRelease/proof/spec";
 import { hasRendererIdentity } from "@repo/backend/convex/contentRelease/renderer";
-import type {
-  abortReceiptValidator,
-  publicationReceiptValidator,
-} from "@repo/backend/convex/contentRelease/spec";
+import type { abortReceiptValidator } from "@repo/backend/convex/contentRelease/spec";
 import { makeFunctionReference } from "convex/server";
 import type { Infer } from "convex/values";
-import { Duration, Effect } from "effect";
+import { Effect } from "effect";
 
 type LifecycleRequest = Extract<
   PublicationRequest,
@@ -44,7 +45,6 @@ interface StoredEnvelope {
 }
 type AbortReceipt = Infer<typeof abortReceiptValidator>;
 type ProofPoll = Infer<typeof proofPollValidator>;
-type PublicationReceipt = Infer<typeof publicationReceiptValidator>;
 const envelopeReference = makeFunctionReference<
   "query",
   { manifestHash: string; releaseId: string },
@@ -63,18 +63,13 @@ const abortReference = makeFunctionReference<
 const activateReference = makeFunctionReference<
   "mutation",
   { manifestHash: string; releaseId: string; rendererJson: string },
-  PublicationReceipt
+  ActivationResult
 >("contentRelease/activate:activate");
 const recoveryReference = makeFunctionReference<
   "mutation",
   { manifestHash: string; releaseId: string; rendererJson: string },
-  PublicationReceipt
+  ActivationResult
 >("contentRelease/activate:activateRecovery");
-const modelStatusReference = makeFunctionReference<
-  "query",
-  { releaseId: string },
-  ReadModelStatus
->("contentRelease/models:status");
 const proofPollReference = makeFunctionReference<
   "mutation",
   { manifestHash: string; releaseId: string },
@@ -111,27 +106,6 @@ const loadRenderer = Effect.fn("contentRelease.loadRenderer")(function* (
   }
   return envelope.rendererJson;
 });
-
-/** Waits until the single durable model lineage converges or fails visibly. */
-const waitForReadModels = Effect.fn("contentRelease.waitForReadModels")(
-  function* (ctx: ActionCtx, releaseId: string) {
-    while (true) {
-      const status = yield* callInternal(() =>
-        ctx.runQuery(modelStatusReference, { releaseId })
-      );
-      if (status.phase === "completed") {
-        return;
-      }
-      if (status.phase === "failed") {
-        return yield* releaseFail(
-          "CONTENT_RELEASE_INTEGRITY",
-          `Read-model sync ${releaseId} failed before completion.`
-        );
-      }
-      yield* Effect.sleep(Duration.millis(100));
-    }
-  }
-);
 
 /** Executes authenticated verification, activation, or recovery activation. */
 export const advancePublication = Effect.fn(
@@ -188,24 +162,31 @@ export const advancePublication = Effect.fn(
     };
   }
   const rendererJson = yield* loadRenderer(ctx, release);
+  const coordinator = makeReadModelCoordinatorLive(ctx);
   if (request.operation === "activate") {
-    const value = yield* callInternal(() =>
+    const result = yield* callInternal(() =>
       ctx.runMutation(activateReference, {
         manifestHash: release.manifestHash,
         releaseId,
         rendererJson,
       })
     );
-    yield* waitForReadModels(ctx, releaseId);
-    return { ok: true, operation: request.operation, value };
+    const policy =
+      result.kind === "completed" ? "restart-failed-once" : "observe";
+    yield* waitForReadModels(releaseId, policy).pipe(
+      Effect.provide(coordinator)
+    );
+    return { ok: true, operation: request.operation, value: result.receipt };
   }
-  const value = yield* callInternal(() =>
+  const result = yield* callInternal(() =>
     ctx.runMutation(recoveryReference, {
       manifestHash: release.manifestHash,
       releaseId,
       rendererJson,
     })
   );
-  yield* waitForReadModels(ctx, releaseId);
-  return { ok: true, operation: request.operation, value };
+  const policy =
+    result.kind === "completed" ? "restart-failed-once" : "observe";
+  yield* waitForReadModels(releaseId, policy).pipe(Effect.provide(coordinator));
+  return { ok: true, operation: request.operation, value: result.receipt };
 });

--- a/packages/backend/convex/contentRelease/ingress/readModels.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/readModels.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+
+import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
+import { internal } from "@repo/backend/convex/_generated/api";
+import {
+  ReadModelCoordinator,
+  type ReadModelCoordinatorService,
+  type ReadModelWaitPolicy,
+  waitForReadModels,
+} from "@repo/backend/convex/contentRelease/ingress/readModels";
+import type {
+  ReadModelRestartArgs,
+  ReadModelRestartResult,
+  ReadModelStatus,
+} from "@repo/backend/convex/contentRelease/models";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { convexTest } from "convex-test";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const releaseId = ReleaseIdSchema.make("release-read-model-waiter");
+
+/** Allocates valid scheduler identities without executing their test jobs. */
+function createScheduledJobIds() {
+  const t = convexTest(schema, convexModules);
+  return t.mutation((ctx) =>
+    Promise.all([
+      ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
+        generation: 1,
+        releaseId,
+      }),
+      ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
+        generation: 2,
+        releaseId,
+      }),
+    ])
+  );
+}
+
+/** Builds a deterministic coordinator for one waiter state-machine proof. */
+function makeReadModelCoordinator(
+  statuses: readonly ReadModelStatus[],
+  restartResults: readonly ReadModelRestartResult[] = []
+) {
+  const restarts: ReadModelRestartArgs[] = [];
+  let restartIndex = 0;
+  let statusIndex = 0;
+  const service: ReadModelCoordinatorService = {
+    restart: (args) => {
+      restarts.push(args);
+      const result = restartResults[restartIndex];
+      restartIndex += 1;
+      return result
+        ? Effect.succeed(result)
+        : Effect.die(new Error("Unexpected read-model restart."));
+    },
+    status: () => {
+      const status = statuses[statusIndex];
+      statusIndex += 1;
+      return status
+        ? Effect.succeed(status)
+        : Effect.die(new Error("Unexpected read-model status poll."));
+    },
+  };
+  return { restarts, service };
+}
+
+/** Runs one waiter policy at the explicit test boundary. */
+function runReadModelWait(
+  policy: ReadModelWaitPolicy,
+  service: ReadModelCoordinatorService
+) {
+  return Effect.runPromise(
+    waitForReadModels(releaseId, policy).pipe(
+      Effect.provideService(ReadModelCoordinator, service)
+    )
+  );
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("content release read-model waiter", () => {
+  it("observes an initial activation failure without restarting", async () => {
+    const [failedJobId] = await createScheduledJobIds();
+    const { restarts, service } = makeReadModelCoordinator([
+      {
+        phase: "failed",
+        releaseId,
+        syncGeneration: 1,
+        syncJobId: failedJobId,
+      },
+    ]);
+
+    await expect(runReadModelWait("observe", service)).rejects.toMatchObject({
+      _tag: "ReleaseError",
+      code: "CONTENT_RELEASE_INTEGRITY",
+    });
+    expect(restarts).toEqual([]);
+  });
+
+  it("restarts one explicitly retried failed activation", async () => {
+    const [failedJobId, successorJobId] = await createScheduledJobIds();
+    const { restarts, service } = makeReadModelCoordinator(
+      [
+        {
+          phase: "failed",
+          releaseId,
+          syncGeneration: 1,
+          syncJobId: failedJobId,
+        },
+        { phase: "completed", releaseId },
+      ],
+      [
+        {
+          status: "restarted",
+          syncGeneration: 2,
+          syncJobId: successorJobId,
+        },
+      ]
+    );
+
+    await expect(
+      runReadModelWait("restart-failed-once", service)
+    ).resolves.toBeUndefined();
+    expect(restarts).toEqual([
+      {
+        expectedGeneration: 1,
+        expectedJobId: failedJobId,
+        releaseId,
+      },
+    ]);
+  });
+
+  it("follows the winning lineage after a stale restart", async () => {
+    const [failedJobId] = await createScheduledJobIds();
+    const { restarts, service } = makeReadModelCoordinator(
+      [
+        {
+          phase: "failed",
+          releaseId,
+          syncGeneration: 1,
+          syncJobId: failedJobId,
+        },
+        { phase: "completed", releaseId },
+      ],
+      [{ status: "stale" }]
+    );
+
+    await expect(
+      runReadModelWait("restart-failed-once", service)
+    ).resolves.toBeUndefined();
+    expect(restarts).toHaveLength(1);
+  });
+
+  it("fails after the sole successor also reaches terminal failure", async () => {
+    const [failedJobId, successorJobId] = await createScheduledJobIds();
+    const { restarts, service } = makeReadModelCoordinator(
+      [
+        {
+          phase: "failed",
+          releaseId,
+          syncGeneration: 1,
+          syncJobId: failedJobId,
+        },
+        {
+          phase: "failed",
+          releaseId,
+          syncGeneration: 2,
+          syncJobId: successorJobId,
+        },
+      ],
+      [
+        {
+          status: "restarted",
+          syncGeneration: 2,
+          syncJobId: successorJobId,
+        },
+      ]
+    );
+
+    await expect(
+      runReadModelWait("restart-failed-once", service)
+    ).rejects.toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
+    expect(restarts).toHaveLength(1);
+  });
+
+  it("polls a running lineage until it completes", async () => {
+    vi.useFakeTimers();
+    const [runningJobId] = await createScheduledJobIds();
+    const { restarts, service } = makeReadModelCoordinator([
+      {
+        phase: "syncing",
+        releaseId,
+        syncGeneration: 1,
+        syncJobId: runningJobId,
+      },
+      { phase: "completed", releaseId },
+    ]);
+
+    const waiting = runReadModelWait("observe", service);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(waiting).resolves.toBeUndefined();
+    expect(restarts).toEqual([]);
+  });
+});

--- a/packages/backend/convex/contentRelease/ingress/readModels.ts
+++ b/packages/backend/convex/contentRelease/ingress/readModels.ts
@@ -1,0 +1,89 @@
+"use node";
+
+import type { ActionCtx } from "@repo/backend/convex/_generated/server";
+import type { ReleaseError } from "@repo/backend/convex/contentRelease/error";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
+import type {
+  ReadModelRestartArgs,
+  ReadModelRestartResult,
+  ReadModelStatus,
+} from "@repo/backend/convex/contentRelease/models";
+import { makeFunctionReference } from "convex/server";
+import { Context, Duration, Effect, Layer } from "effect";
+
+const modelStatusReference = makeFunctionReference<
+  "query",
+  { releaseId: string },
+  ReadModelStatus
+>("contentRelease/models:status");
+const modelRestartReference = makeFunctionReference<
+  "mutation",
+  ReadModelRestartArgs,
+  ReadModelRestartResult
+>("contentRelease/models:restart");
+
+export type ReadModelWaitPolicy = "observe" | "restart-failed-once";
+
+export interface ReadModelCoordinatorService {
+  /** Restarts only the exact generation and job observed as failed. */
+  readonly restart: (
+    args: ReadModelRestartArgs
+  ) => Effect.Effect<ReadModelRestartResult, ReleaseError>;
+  /** Reads the sole scheduler-owned status boundary for one active release. */
+  readonly status: (
+    releaseId: string
+  ) => Effect.Effect<ReadModelStatus, ReleaseError>;
+}
+
+/** Private coordinator dependency for publication ingress read models. */
+export class ReadModelCoordinator extends Context.Service<
+  ReadModelCoordinator,
+  ReadModelCoordinatorService
+>()("@repo/backend/contentRelease/ReadModelCoordinator") {}
+
+/** Binds one action context to the private read-model coordinator functions. */
+export function makeReadModelCoordinatorLive(ctx: ActionCtx) {
+  return Layer.succeed(ReadModelCoordinator, {
+    restart: (args) =>
+      callInternal(() => ctx.runMutation(modelRestartReference, args)),
+    status: (releaseId) =>
+      callInternal(() => ctx.runQuery(modelStatusReference, { releaseId })),
+  });
+}
+
+/** Waits for convergence with at most one explicitly authorized restart. */
+export const waitForReadModels: (
+  releaseId: string,
+  policy: ReadModelWaitPolicy
+) => Effect.Effect<void, ReleaseError, ReadModelCoordinator> = Effect.fn(
+  "contentRelease.waitForReadModels"
+)(function* (releaseId: string, policy: ReadModelWaitPolicy) {
+  const coordinator = yield* ReadModelCoordinator;
+  let canRestart = policy === "restart-failed-once";
+
+  while (true) {
+    const status = yield* coordinator.status(releaseId);
+    if (status.phase === "completed") {
+      return;
+    }
+    if (status.phase === "failed") {
+      if (!canRestart) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_INTEGRITY",
+          `Read-model sync ${releaseId} failed before completion.`
+        );
+      }
+
+      canRestart = false;
+      yield* coordinator.restart({
+        expectedGeneration: status.syncGeneration,
+        expectedJobId: status.syncJobId,
+        releaseId,
+      });
+      continue;
+    }
+
+    yield* Effect.sleep(Duration.millis(100));
+  }
+});

--- a/packages/backend/convex/contentRelease/models.test.ts
+++ b/packages/backend/convex/contentRelease/models.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@nakafa/aksara-contracts/release/snapshot/spec";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
-import { scheduleReadModels } from "@repo/backend/convex/contentRelease/models";
+import { startReadModels } from "@repo/backend/convex/contentRelease/models";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
@@ -54,7 +54,7 @@ describe("contentRelease/models", () => {
   afterEach(() => vi.useRealTimers());
 
   it.each(["page", "question"] as const)(
-    "claims unchanged models for %s content without scheduling empty scans",
+    "claims unchanged models for %s content under one activation lineage",
     async (family) => {
       const t = convexTest(schema, convexModules);
       await t.mutation((ctx) =>
@@ -68,7 +68,7 @@ describe("contentRelease/models", () => {
         )
       );
       await t.mutation((ctx) =>
-        runConvexProgram(scheduleReadModels(ctx, ACTIVE.releaseId))
+        runConvexProgram(startReadModels(ctx, ACTIVE.releaseId))
       );
 
       const claimed = await t.run(async (ctx) => ({
@@ -81,11 +81,15 @@ describe("contentRelease/models", () => {
           .unique(),
         state: await ctx.db.query("contentState").unique(),
       }));
-      expect(claimed.jobs).toHaveLength(0);
+      expect(claimed.jobs).toEqual([
+        expect.objectContaining({ state: { kind: "pending" } }),
+      ]);
       expect(claimed.release).toMatchObject({
         articleIndex: -1,
         materialIndex: -1,
         searchIndex: -1,
+        syncGeneration: 1,
+        syncJobId: expect.any(String),
       });
       expect(claimed.state).toMatchObject({
         articleReleaseId: ACTIVE.releaseId,
@@ -100,6 +104,17 @@ describe("contentRelease/models", () => {
         phase: "completed",
         releaseId: ACTIVE.releaseId,
       });
+      const [initialJob] = claimed.jobs;
+      if (!initialJob) {
+        expect.fail("Expected one generation-1 read-model job.");
+      }
+      await expect(
+        t.mutation(internal.contentRelease.models.restart, {
+          expectedGeneration: 1,
+          expectedJobId: initialJob._id,
+          releaseId: ACTIVE.releaseId,
+        })
+      ).resolves.toEqual({ status: "stale" });
     }
   );
 
@@ -118,7 +133,7 @@ describe("contentRelease/models", () => {
     const t = convexTest(schema, convexModules);
     await t.mutation((ctx) => seedActiveRelease(ctx, scope));
     await t.mutation((ctx) =>
-      runConvexProgram(scheduleReadModels(ctx, ACTIVE.releaseId))
+      runConvexProgram(startReadModels(ctx, ACTIVE.releaseId))
     );
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
@@ -139,8 +154,15 @@ describe("contentRelease/models", () => {
     const t = convexTest(schema, convexModules);
     await t.mutation((ctx) => seedActiveRelease(ctx));
     await t.mutation((ctx) =>
-      runConvexProgram(scheduleReadModels(ctx, ACTIVE.releaseId))
+      runConvexProgram(startReadModels(ctx, ACTIVE.releaseId))
     );
+
+    const [initialJob] = await t.run((ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect()
+    );
+    if (!initialJob) {
+      expect.fail("Expected one generation-1 read-model job.");
+    }
 
     await expect(
       t.query(internal.contentRelease.models.status, {
@@ -149,6 +171,8 @@ describe("contentRelease/models", () => {
     ).resolves.toEqual({
       phase: "syncing",
       releaseId: ACTIVE.releaseId,
+      syncGeneration: 1,
+      syncJobId: initialJob._id,
     });
 
     await t.mutation(internal.contentRelease.models.resume, {
@@ -185,27 +209,35 @@ describe("contentRelease/models", () => {
     ).resolves.toHaveLength(3);
   });
 
-  it("exposes a failed job and restarts it with a new generation", async () => {
+  it("fences concurrent restart attempts by generation and job identity", async () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(async (ctx) => {
       await seedActiveRelease(ctx);
       await insertReleaseItem(ctx, ACTIVE, "test:unexpected", 0);
-      await runConvexProgram(scheduleReadModels(ctx, ACTIVE.releaseId));
+      await runConvexProgram(startReadModels(ctx, ACTIVE.releaseId));
     });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    await expect(
-      t.query(internal.contentRelease.models.status, {
-        releaseId: ACTIVE.releaseId,
-      })
-    ).resolves.toEqual({
-      phase: "failed",
+    const failed = await t.query(internal.contentRelease.models.status, {
       releaseId: ACTIVE.releaseId,
     });
+    if (failed.phase !== "failed") {
+      expect.fail("Expected one terminal failed lineage.");
+    }
+    expect(failed).toMatchObject({
+      releaseId: ACTIVE.releaseId,
+      syncGeneration: 1,
+    });
 
-    await t.mutation((ctx) =>
-      runConvexProgram(scheduleReadModels(ctx, ACTIVE.releaseId))
-    );
+    const restartArgs = {
+      expectedGeneration: failed.syncGeneration,
+      expectedJobId: failed.syncJobId,
+      releaseId: ACTIVE.releaseId,
+    };
+    const attempts = await Promise.all([
+      t.mutation(internal.contentRelease.models.restart, restartArgs),
+      t.mutation(internal.contentRelease.models.restart, restartArgs),
+    ]);
     const restarted = await t.run(async (ctx) => ({
       jobs: await ctx.db.system.query("_scheduled_functions").collect(),
       release: await ctx.db
@@ -218,5 +250,27 @@ describe("contentRelease/models", () => {
     expect(restarted.jobs).toHaveLength(2);
     expect(restarted.jobs.at(-1)?.state).toEqual({ kind: "pending" });
     expect(restarted.release?.syncGeneration).toBe(2);
+    expect(attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "restarted", syncGeneration: 2 }),
+        { status: "stale" },
+      ])
+    );
+    await expect(
+      t.mutation(internal.contentRelease.models.restart, restartArgs)
+    ).resolves.toEqual({ status: "stale" });
+  });
+
+  it("fails closed when an incomplete release has no lineage identity", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation((ctx) => seedActiveRelease(ctx));
+
+    await expect(
+      t.query(internal.contentRelease.models.status, {
+        releaseId: ACTIVE.releaseId,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
   });
 });

--- a/packages/backend/convex/contentRelease/models.test.ts
+++ b/packages/backend/convex/contentRelease/models.test.ts
@@ -209,6 +209,50 @@ describe("contentRelease/models", () => {
     ).resolves.toHaveLength(3);
   });
 
+  it("does not restart a pending lineage", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedActiveRelease(ctx);
+      await insertReleaseItem(ctx, ACTIVE, "test:unexpected", 0);
+      await runConvexProgram(startReadModels(ctx, ACTIVE.releaseId));
+    });
+
+    const pending = await t.query(internal.contentRelease.models.status, {
+      releaseId: ACTIVE.releaseId,
+    });
+    if (pending.phase !== "syncing") {
+      expect.fail("Expected one pending read-model lineage.");
+    }
+
+    await expect(
+      t.mutation(internal.contentRelease.models.restart, {
+        expectedGeneration: pending.syncGeneration,
+        expectedJobId: pending.syncJobId,
+        releaseId: ACTIVE.releaseId,
+      })
+    ).resolves.toEqual({ status: "stale" });
+
+    const unchanged = await t.run(async (ctx) => ({
+      jobs: await ctx.db.system.query("_scheduled_functions").collect(),
+      release: await ctx.db
+        .query("contentReleases")
+        .withIndex("by_releaseId", (index) =>
+          index.eq("releaseId", ACTIVE.releaseId)
+        )
+        .unique(),
+    }));
+    expect(unchanged.jobs).toEqual([
+      expect.objectContaining({
+        _id: pending.syncJobId,
+        state: { kind: "pending" },
+      }),
+    ]);
+    expect(unchanged.release).toMatchObject({
+      syncGeneration: pending.syncGeneration,
+      syncJobId: pending.syncJobId,
+    });
+  });
+
   it("fences concurrent restart attempts by generation and job identity", async () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(async (ctx) => {

--- a/packages/backend/convex/contentRelease/models.test.ts
+++ b/packages/backend/convex/contentRelease/models.test.ts
@@ -54,7 +54,7 @@ describe("contentRelease/models", () => {
   afterEach(() => vi.useRealTimers());
 
   it.each(["page", "question"] as const)(
-    "claims unchanged models for %s content under one activation lineage",
+    "claims unchanged models for %s content without scheduling",
     async (family) => {
       const t = convexTest(schema, convexModules);
       await t.mutation((ctx) =>
@@ -67,9 +67,10 @@ describe("contentRelease/models", () => {
           })
         )
       );
-      await t.mutation((ctx) =>
+      const started = await t.mutation((ctx) =>
         runConvexProgram(startReadModels(ctx, ACTIVE.releaseId))
       );
+      expect(started).toBeNull();
 
       const claimed = await t.run(async (ctx) => ({
         jobs: await ctx.db.system.query("_scheduled_functions").collect(),
@@ -81,16 +82,14 @@ describe("contentRelease/models", () => {
           .unique(),
         state: await ctx.db.query("contentState").unique(),
       }));
-      expect(claimed.jobs).toEqual([
-        expect.objectContaining({ state: { kind: "pending" } }),
-      ]);
+      expect(claimed.jobs).toEqual([]);
       expect(claimed.release).toMatchObject({
         articleIndex: -1,
         materialIndex: -1,
         searchIndex: -1,
-        syncGeneration: 1,
-        syncJobId: expect.any(String),
       });
+      expect(claimed.release).not.toHaveProperty("syncGeneration");
+      expect(claimed.release).not.toHaveProperty("syncJobId");
       expect(claimed.state).toMatchObject({
         articleReleaseId: ACTIVE.releaseId,
         materialReleaseId: ACTIVE.releaseId,
@@ -104,17 +103,6 @@ describe("contentRelease/models", () => {
         phase: "completed",
         releaseId: ACTIVE.releaseId,
       });
-      const [initialJob] = claimed.jobs;
-      if (!initialJob) {
-        expect.fail("Expected one generation-1 read-model job.");
-      }
-      await expect(
-        t.mutation(internal.contentRelease.models.restart, {
-          expectedGeneration: 1,
-          expectedJobId: initialJob._id,
-          releaseId: ACTIVE.releaseId,
-        })
-      ).resolves.toEqual({ status: "stale" });
     }
   );
 

--- a/packages/backend/convex/contentRelease/models.ts
+++ b/packages/backend/convex/contentRelease/models.ts
@@ -22,15 +22,38 @@ import { Effect } from "effect";
 
 type ScheduledFunction = SystemDataModel["_scheduled_functions"]["document"];
 
-export const readModelStatusValidator = v.object({
-  phase: v.union(
-    v.literal("completed"),
-    v.literal("failed"),
-    v.literal("syncing")
-  ),
+export const readModelStatusValidator = v.union(
+  v.object({
+    phase: v.literal("completed"),
+    releaseId: v.string(),
+  }),
+  v.object({
+    phase: v.union(v.literal("failed"), v.literal("syncing")),
+    releaseId: v.string(),
+    syncGeneration: v.number(),
+    syncJobId: v.id("_scheduled_functions"),
+  })
+);
+export type ReadModelStatus = Infer<typeof readModelStatusValidator>;
+
+export const readModelRestartArgsValidator = v.object({
+  expectedGeneration: v.number(),
+  expectedJobId: v.id("_scheduled_functions"),
   releaseId: v.string(),
 });
-export type ReadModelStatus = Infer<typeof readModelStatusValidator>;
+export type ReadModelRestartArgs = Infer<typeof readModelRestartArgsValidator>;
+
+export const readModelRestartResultValidator = v.union(
+  v.object({
+    status: v.literal("restarted"),
+    syncGeneration: v.number(),
+    syncJobId: v.id("_scheduled_functions"),
+  }),
+  v.object({ status: v.literal("stale") })
+);
+export type ReadModelRestartResult = Infer<
+  typeof readModelRestartResultValidator
+>;
 
 const resumeReference = makeFunctionReference<
   "mutation",
@@ -138,14 +161,21 @@ const readModelStatus = Effect.fn("contentRelease.readModelStatus")(function* (
     } satisfies ReadModelStatus;
   }
   const syncJobId = release.syncJobId;
-  const job = syncJobId
-    ? yield* Effect.promise(() =>
-        ctx.db.system.get("_scheduled_functions", syncJobId)
-      )
-    : null;
+  const syncGeneration = release.syncGeneration;
+  if (syncGeneration === undefined || syncJobId === undefined) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Read-model sync ${releaseId} has no durable lineage identity.`
+    );
+  }
+  const job = yield* Effect.promise(() =>
+    ctx.db.system.get("_scheduled_functions", syncJobId)
+  );
   return {
     phase: isRunningJob(job) ? "syncing" : "failed",
     releaseId,
+    syncGeneration,
+    syncJobId,
   } satisfies ReadModelStatus;
 });
 
@@ -187,50 +217,77 @@ const resumeReadModels = Effect.fn("contentRelease.resumeReadModels")(
 );
 
 /**
- * Starts one serial read-model lineage or preserves its active generation.
+ * Starts exactly one generation-1 read-model lineage during activation.
  *
- * Scheduling occurs inside the activation transaction. A completed activation
- * retry reuses a pending lineage, restarts a failed lineage with a new
- * generation, and schedules nothing after all three model owners converge.
+ * Scheduling and persisted identity are part of the same activation
+ * transaction. Completed activation retries never call this program.
  */
-export const scheduleReadModels = Effect.fn(
-  "contentRelease.scheduleReadModels"
-)(function* (ctx: MutationCtx, releaseId: string) {
-  const { release, signed, state } = yield* loadSyncRelease(ctx, releaseId);
-  const claimedState = yield* claimUnchangedReadModels(
-    ctx,
-    release,
-    signed,
-    state
-  );
-  if (
-    hasCompletedReadModels(getReadModelOwnership(release, signed, claimedState))
-  ) {
-    return;
+export const startReadModels = Effect.fn("contentRelease.startReadModels")(
+  function* (ctx: MutationCtx, releaseId: string) {
+    const { release, signed, state } = yield* loadSyncRelease(ctx, releaseId);
+    yield* claimUnchangedReadModels(ctx, release, signed, state);
+    const syncGeneration = 1;
+    const syncJobId = yield* Effect.promise(() =>
+      ctx.scheduler.runAfter(0, resumeReference, {
+        generation: syncGeneration,
+        releaseId,
+      })
+    );
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", release._id, {
+        syncGeneration,
+        syncJobId,
+        updatedAt: Date.now(),
+      })
+    );
+    return { syncGeneration, syncJobId };
   }
-  const existingJobId = release.syncJobId;
-  const existingJob = existingJobId
-    ? yield* Effect.promise(() =>
-        ctx.db.system.get("_scheduled_functions", existingJobId)
-      )
-    : null;
-  if (isRunningJob(existingJob)) {
-    return;
-  }
-  const syncGeneration = (release.syncGeneration ?? 0) + 1;
-  const syncJobId = yield* Effect.promise(() =>
-    ctx.scheduler.runAfter(0, resumeReference, {
-      generation: syncGeneration,
-      releaseId,
-    })
-  );
-  yield* Effect.promise(() =>
-    ctx.db.patch("contentReleases", release._id, {
+);
+
+/** Restarts one failed lineage only while its persisted identity still wins. */
+const restartReadModels = Effect.fn("contentRelease.restartReadModels")(
+  function* (ctx: MutationCtx, args: ReadModelRestartArgs) {
+    const { release, signed, state } = yield* loadSyncRelease(
+      ctx,
+      args.releaseId
+    );
+    const ownership = getReadModelOwnership(release, signed, state);
+    if (hasCompletedReadModels(ownership)) {
+      return { status: "stale" } satisfies ReadModelRestartResult;
+    }
+    if (
+      release.syncGeneration !== args.expectedGeneration ||
+      release.syncJobId !== args.expectedJobId
+    ) {
+      return { status: "stale" } satisfies ReadModelRestartResult;
+    }
+    const syncGeneration = args.expectedGeneration + 1;
+    const syncJobId = yield* Effect.promise(() =>
+      ctx.scheduler.runAfter(0, resumeReference, {
+        generation: syncGeneration,
+        releaseId: args.releaseId,
+      })
+    );
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", release._id, {
+        syncGeneration,
+        syncJobId,
+        updatedAt: Date.now(),
+      })
+    );
+    return {
+      status: "restarted",
       syncGeneration,
       syncJobId,
-      updatedAt: Date.now(),
-    })
-  );
+    } satisfies ReadModelRestartResult;
+  }
+);
+
+/** Generation and job fenced recovery for one terminal failed lineage. */
+export const restart = internalMutation({
+  args: readModelRestartArgsValidator,
+  returns: readModelRestartResultValidator,
+  handler: (ctx, args) => runConvexProgram(restartReadModels(ctx, args)),
 });
 
 /** Internal read-only status used by the authenticated Node lifecycle action. */

--- a/packages/backend/convex/contentRelease/models.ts
+++ b/packages/backend/convex/contentRelease/models.ts
@@ -261,6 +261,12 @@ const restartReadModels = Effect.fn("contentRelease.restartReadModels")(
     ) {
       return { status: "stale" } satisfies ReadModelRestartResult;
     }
+    const job = yield* Effect.promise(() =>
+      ctx.db.system.get("_scheduled_functions", args.expectedJobId)
+    );
+    if (isRunningJob(job)) {
+      return { status: "stale" } satisfies ReadModelRestartResult;
+    }
     const syncGeneration = args.expectedGeneration + 1;
     const syncJobId = yield* Effect.promise(() =>
       ctx.scheduler.runAfter(0, resumeReference, {

--- a/packages/backend/convex/contentRelease/models.ts
+++ b/packages/backend/convex/contentRelease/models.ts
@@ -217,7 +217,7 @@ const resumeReadModels = Effect.fn("contentRelease.resumeReadModels")(
 );
 
 /**
- * Starts exactly one generation-1 read-model lineage during activation.
+ * Claims unchanged models and starts one generation-1 lineage when needed.
  *
  * Scheduling and persisted identity are part of the same activation
  * transaction. Completed activation retries never call this program.
@@ -225,7 +225,19 @@ const resumeReadModels = Effect.fn("contentRelease.resumeReadModels")(
 export const startReadModels = Effect.fn("contentRelease.startReadModels")(
   function* (ctx: MutationCtx, releaseId: string) {
     const { release, signed, state } = yield* loadSyncRelease(ctx, releaseId);
-    yield* claimUnchangedReadModels(ctx, release, signed, state);
+    const claimedState = yield* claimUnchangedReadModels(
+      ctx,
+      release,
+      signed,
+      state
+    );
+    if (
+      hasCompletedReadModels(
+        getReadModelOwnership(release, signed, claimedState)
+      )
+    ) {
+      return null;
+    }
     const syncGeneration = 1;
     const syncJobId = yield* Effect.promise(() =>
       ctx.scheduler.runAfter(0, resumeReference, {


### PR DESCRIPTION
## Summary

Remove activation scheduler contention while preserving the external publication receipt and serial read-model page chain. Prevent SSR-rendered Tafsir and contributor Drawer triggers from accepting a click before their Client Component controllers are hydrated.

## Why

Activation previously read scheduler state and could reschedule a completed release inside the activation transaction. A zero-impact activation could also claim every unchanged read model as complete while leaving a pending no-op job. The backend now follows Convex's documented [atomic scheduling](https://docs.convex.dev/scheduling/scheduled-functions), [system-table status](https://docs.convex.dev/database/advanced/system-tables), and [OCC](https://docs.convex.dev/database/advanced/occ) contracts.

Exact-head signed browser run 32898897169 proved that SSR-visible Tafsir and contributor triggers could be clicked before their nested controllers hydrated. Next.js documents that initial HTML is noninteractive until Client Components hydrate. The installed Mantine 9.5.2 [useMounted](https://mantine.dev/hooks/use-mounted/) hook now owns that readiness boundary.

## Scope

- New activations claim unchanged models, then schedule one generation-1 lineage only when work remains. Fully unchanged models complete with zero jobs and no lineage identity.
- Completed activation retries return the existing receipt without scheduling.
- Status owns scheduled-function reads and reports completed, syncing, or failed state with lineage identity.
- One generation and job fenced restart rejects active jobs and schedules one successor only for a terminal lineage.
- Only an explicit completed retry may restart one failed lineage once.
- The existing eight-item serial page chain remains. No Workflow journal, migration, facade, adapter, or compatibility route was added.
- One mounted-state owner per Tafsir controller and contributor gallery native-disables Drawer triggers until hydration. Tafsir keeps its direct React Compiler-owned handler and synchronous `pendingRequestId` duplicate fence.
- Styling, Drawer internals, E2E behavior, timeouts, retries, markup, workflow, and Gemini routing are unchanged.

## Verification at exact head

Exact head: `7c6608b3b678b6fa90db95e5adff0f452202a68f`, based on protected main `2629a4e3f6bef2c1a88ab079de0ce89983fc91cc`.

- Hydration correction: full WWW 207 files and 1,439 tests at 100% coverage, WWW typecheck, React Doctor 100/100, 55 Playwright cases discovered, and targeted Ultracite.
- Scheduler correction: 14 focused tests, full backend 323 files and 1,353 tests, backend typecheck, and isolated Convex preparation with no generated diff.
- Root lint checked 2,956 files; boundaries checked 2,890 files; Effect RC110 parity, diff integrity, alias-import, raw try/catch, and touched-LOC gates passed.
- Workflow and Gemini routing diffs are empty.
- Exact-head CI 32902648077 is green: Quality, Production, all 55 browser cases on the first execution in 7.3 minutes, AFDocs 23/23, final runtime fingerprint, cleanup, and Required passed.
- Exact-head Doctor 32902648092 is green at numeric 100/100 with no findings.

## Dependency or rollout state

This ready PR is the prerequisite for #347 because that PR reproduced the Tafsir hydration race on current main. No Vercel Preview or production write is used.

## Risks

Recovery remains bounded to one fenced restart after an explicit retry. Initial failures still fail closed. Production acceptance must prove scheduler behavior, first Tafsir interaction, Activity hide and restore, second interaction, dismissal, and detached contributor Drawer behavior. External HTTP, public Convex, receipt, schema, visual styling, Drawer, workflow, dependency, and Gemini contracts remain unchanged.