### PR TITLE
fix(release): respect Vercel command limit

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",
+    "build:vercel": "pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "next dev -p 3000 --turbopack",
     "doctor": "pnpm dlx react-doctor@0.9.12",

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -1,28 +1,32 @@
 import { describe, expect, it } from "vitest";
+import packageJson from "@/package.json";
 import { config } from "@/vercel";
 
 describe("www Vercel configuration", () => {
   it("deploys the matching Convex backend with the production web build", () => {
     const buildCommand = config.buildCommand ?? "";
+    const deploymentCommand = packageJson.scripts["build:vercel"];
     const backendTypecheck = "pnpm --dir ../../packages/backend typecheck";
     const convexDeploy = "pnpm --dir ../../packages/backend exec convex deploy";
     const webBuild = "pnpm --dir ../../apps/www build";
 
-    expect(buildCommand).toContain("--yes");
-    expect(buildCommand).toContain("--typecheck disable");
-    expect(buildCommand).toContain("--typecheck-components");
-    expect(buildCommand).toContain(
+    expect(buildCommand).toBe("pnpm run build:vercel");
+    expect(buildCommand.length).toBeLessThanOrEqual(256);
+    expect(deploymentCommand).toContain("--yes");
+    expect(deploymentCommand).toContain("--typecheck disable");
+    expect(deploymentCommand).toContain("--typecheck-components");
+    expect(deploymentCommand).toContain(
       'NEXT_PUBLIC_CONVEX_SITE_URL="$VITE_CONVEX_SITE_URL"'
     );
-    expect(buildCommand).toContain(
+    expect(deploymentCommand).toContain(
       "--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL"
     );
-    expect(buildCommand.indexOf(backendTypecheck)).toBe(0);
-    expect(buildCommand.indexOf(convexDeploy)).toBeGreaterThan(
-      buildCommand.indexOf(backendTypecheck)
+    expect(deploymentCommand.indexOf(backendTypecheck)).toBe(0);
+    expect(deploymentCommand.indexOf(convexDeploy)).toBeGreaterThan(
+      deploymentCommand.indexOf(backendTypecheck)
     );
-    expect(buildCommand.indexOf(webBuild)).toBeGreaterThan(
-      buildCommand.indexOf(convexDeploy)
+    expect(deploymentCommand.indexOf(webBuild)).toBeGreaterThan(
+      deploymentCommand.indexOf(convexDeploy)
     );
   });
 });

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -1,8 +1,7 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
-  buildCommand:
-    "pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
+  buildCommand: "pnpm run build:vercel",
   git: {
     deploymentEnabled: {
       "**": false,


### PR DESCRIPTION
## Outcome

Keep the production website and Convex deployment coordinated without exceeding the Vercel project configuration schema.

## Root cause

The merged production deployment for commit 4893964900836dd09ae60fb74eebbd4153755699 was rejected before any build ran because the inline buildCommand exceeded Vercel’s 256-character limit. The previous production deployment remained active and Convex was not changed.

## Change

- Move the full backend typecheck, Convex deploy, and nested website build command into the WWW package script.
- Keep vercel.ts at the short command pnpm run build:vercel.
- Assert the Vercel length limit and the complete deployment sequence in the configuration test.

Temporary Convex compatibility remains governed by expand, switch, observe, contract. This hotfix does not add a compatibility layer or change any public function.

## Verification

- Focused Vercel configuration test passed with 100% coverage.
- WWW TypeScript check passed.
- Full repository lint passed across 2,825 files.
- Gemini routing diff is empty.