### PR TITLE
build(vercel): restrict production builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,17 @@ Favor readable, skimmable, well-verified code over speed or cleverness.
 - Run the smallest useful verification set after changes, then expand if risk is high.
 - Prefer `pnpm start` over `pnpm dev` when you only need to run the built app. Use `pnpm dev` when the task needs devtools, hot reload, development-mode diagnostics, or Convex live debugging.
 
+## Vercel Cost And Deployment Policy
+
+- Vercel Preview deployments are prohibited for every Nakafa project.
+- Never call the Vercel deploy connector, `vercel`, or `vercel deploy` for a feature branch or pull request.
+- Never require a Vercel Preview URL as a pull request gate.
+- Verify feature work with local production-mode builds and starts, exact-head GitHub CI, Browser or Playwright, and isolated Convex Agent Mode deployments where needed.
+- Vercel Production deployment is allowed only after a protected merge to `main`, through the existing `main` Git integration.
+- Keep every app Vercel config restricted to `main`; all other branch patterns remain disabled.
+- Do not enable external Turborepo Remote Cache for the signed `www` production build until every server-side environment input and signed-content generation is included in its task hash.
+- If an accidental Preview deployment starts, cancel it immediately, identify the owner, and remove every task-owned Preview artifact during cleanup.
+
 ## Module Size And Decomposition
 
 - Hand-written `.ts` and `.tsx` Modules should target 300 LOC or less.

--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -1,6 +1,8 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
+  ignoreCommand:
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/cas/vercel.ts
+++ b/apps/cas/vercel.ts
@@ -3,6 +3,8 @@ import type { VercelConfig } from "@vercel/config/v1";
 export const config: VercelConfig = {
   framework: "fastapi",
   buildCommand: "turbo run build && uv sync --no-dev --frozen",
+  ignoreCommand:
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages cas --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/mcp/vercel.ts
+++ b/apps/mcp/vercel.ts
@@ -1,6 +1,8 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
+  ignoreCommand:
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -3,6 +3,17 @@ import packageJson from "@/package.json";
 import { config } from "@/vercel";
 
 describe("www Vercel configuration", () => {
+  it("builds only affected production commits", () => {
+    expect(config.ignoreCommand).toBe(
+      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1'
+    );
+    expect(config.git?.deploymentEnabled).toEqual({
+      "**": false,
+      "changeset-release/main": false,
+      main: true,
+    });
+  });
+
   it("deploys the matching Convex backend with the production web build", () => {
     const buildCommand = config.buildCommand ?? "";
     const deploymentCommand = packageJson.scripts["build:vercel"];

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -2,6 +2,8 @@ import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
   buildCommand: "pnpm run build:vercel",
+  ignoreCommand:
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,


### PR DESCRIPTION
## Outcome

Nakafa now encodes a production-only Vercel deployment policy and skips unaffected projects after protected merges to `main`.

## Changes

- Prohibit Vercel Preview deployments in the repository agent guide.
- Keep Git deployments restricted to `main` for `www`, `api`, `mcp`, and `cas`.
- Short-circuit every non-production Vercel environment before a build runs.
- Use Vercel's documented `turbo query affected` command with `VERCEL_GIT_PREVIOUS_SHA` to skip unaffected Production projects.
- Fail open to a Production build if the affected query cannot complete.
- Record why external Turborepo Remote Cache is not yet safe for the signed `www` build.

## Verification

Exact head: `8f73089fb016b6b4346255de18704a3badb35665`

- Frozen install passed.
- Formatting made no changes.
- Vercel config test passed: 2 tests, 100% coverage.
- `www`, `api`, and `mcp` typechecks passed.
- Lint, boundaries, dependency audit, changeset status, and Effect source identity passed.
- Gemini routing diff is empty.
- Config import proof confirms all four apps use the same main-only policy and non-production short-circuit.
- Docs-only commit `ffdf1a180b` skips all four projects.
- Design-system commit `637fcd908c` rebuilds `www`, `api`, and `mcp`, while skipping independent `cas`.
- Backend-only commit `14f7043cdd` rebuilds `www`, `api`, and `mcp`, while skipping independent `cas`.
- This policy commit marks all four projects affected, so the first protected merge applies the configuration everywhere.

No Vercel Preview deployment was created or used.