### PR TITLE
fix(ui): align Safari content rendering

### DIFF
--- a/apps/www/lib/theme/viewport.test.ts
+++ b/apps/www/lib/theme/viewport.test.ts
@@ -15,4 +15,8 @@ describe("appViewport", () => {
       },
     ]);
   });
+
+  it("keeps the default interactive widget mode implicit", () => {
+    expect(appViewport).not.toHaveProperty("interactiveWidget");
+  });
 });

--- a/apps/www/lib/theme/viewport.ts
+++ b/apps/www/lib/theme/viewport.ts
@@ -16,5 +16,4 @@ export const appViewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  interactiveWidget: "resizes-visual",
 } satisfies Viewport;

--- a/packages/design-system/components/markdown/mdx.tsx
+++ b/packages/design-system/components/markdown/mdx.tsx
@@ -121,7 +121,10 @@ export function MdxUnorderedList(props: ListProps) {
 /** Renders one MDX list item with consistent prose spacing. */
 export function MdxListItem(props: ListItemProps) {
   return (
-    <li className="space-y-4 text-pretty pl-1 leading-relaxed" {...props} />
+    <li
+      className="text-pretty pl-1 leading-relaxed [&>*+*]:mt-4 [&>p:first-child]:inline"
+      {...props}
+    />
   );
 }
 

--- a/packages/design-system/components/markdown/react-text.tsx
+++ b/packages/design-system/components/markdown/react-text.tsx
@@ -115,7 +115,7 @@ export const reactTextComponents: ReactMarkdownComponents = {
   li: memo(
     ({ ...props }) => (
       <li
-        className="space-y-4 text-pretty pl-1 leading-relaxed"
+        className="text-pretty pl-1 leading-relaxed [&>*+*]:mt-4 [&>p:first-child]:inline"
         data-nakafa="list-item"
         {...props}
       />


### PR DESCRIPTION
## Outcome

Safari list markers now align with their first paragraph like Chromium and Firefox, list block spacing remains intact, and Nakafa no longer emits the redundant WebKit viewport warning.

## Root cause

- Markdown list items rendered their first paragraph as a block. Safari positions the marker differently around that block formatting context.
- Making the first paragraph inline requires sibling-owned spacing because block-axis margins on that inline paragraph no longer create reliable separation.
- The viewport explicitly emitted `interactive-widget=resizes-visual`, even though that is the standard default and WebKit does not recognize the token.

## Changes

- Render the first paragraph in both authored MDX and React Markdown list items inline with the marker.
- Preserve spacing between later list-item children through an adjacent-sibling selector.
- Remove the redundant explicit interactive-widget token.
- Add a focused viewport contract test.

## Verification

Exact head: `c46c33766cc196aae4d0fa84f029713578b806b8`

- www: 203 files, 1,349 tests, 100% coverage.
- design system: 31 files, 314 tests, 100% coverage.
- www and design-system typechecks passed.
- Lint, boundaries, dependency audit, and Effect source identity passed.
- React Doctor passed at 100/100.
- Touched TypeScript and TSX modules are all below 300 lines.
- No raw try or catch exists in the touched app modules.
- Gemini routing diff is empty.
- The exact affected-project query rebuilds `www`, `api`, and `mcp`, while skipping independent `cas`.
- No Vercel Preview deployment was created or used.
