### PR TITLE
fix(content): retry interrupted Convex responses

### DIFF
--- a/packages/backend/client/runtime.test.ts
+++ b/packages/backend/client/runtime.test.ts
@@ -82,7 +82,7 @@ function queryThroughFetch(result: unknown = null) {
 }
 
 /** Creates the nested rejection shape produced by Node fetch. */
-function createFetchFailure(code?: string) {
+function createNetworkFailure(code?: string) {
   const cause = code
     ? Object.assign(new Error("private network detail"), { code })
     : new Error("private network detail");
@@ -100,8 +100,8 @@ describe("Convex runtime query", () => {
   it.effect("retries Effect callers through the typed network channel", () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockRejectedValueOnce(createFetchFailure("ECONNRESET"))
-      .mockRejectedValueOnce(createFetchFailure("UND_ERR_SOCKET"))
+      .mockRejectedValueOnce(createNetworkFailure("ECONNRESET"))
+      .mockRejectedValueOnce(createNetworkFailure("UND_ERR_SOCKET"))
       .mockResolvedValueOnce(new Response("ok"));
     vi.stubGlobal("fetch", fetchMock);
     queryThroughFetch(42);
@@ -133,6 +133,22 @@ describe("Convex runtime query", () => {
     });
   });
 
+  it.effect("retries allowlisted response-stream network failures", () => {
+    clientState.query
+      .mockRejectedValueOnce(createNetworkFailure("UND_ERR_SOCKET"))
+      .mockResolvedValueOnce(42);
+
+    return Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(
+        readConvexRuntimeQuery(runtimeUrl, query, args)
+      );
+      yield* TestClock.adjust(Duration.millis(500));
+
+      expect(yield* Fiber.join(fiber)).toBe(42);
+      expect(clientState.query).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it.live("does not retry Convex function failures", () =>
     Effect.gen(function* () {
       clientState.query.mockRejectedValueOnce(
@@ -155,7 +171,7 @@ describe("Convex runtime query", () => {
   it.effect("preserves sanitized codes after retry exhaustion", () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockRejectedValue(createFetchFailure("EPIPE"));
+      .mockRejectedValue(createNetworkFailure("EPIPE"));
     vi.stubGlobal("fetch", fetchMock);
     queryThroughFetch();
     return Effect.gen(function* () {
@@ -181,7 +197,7 @@ describe("Convex runtime query", () => {
     Effect.gen(function* () {
       const fetchMock = vi
         .fn<typeof fetch>()
-        .mockRejectedValue(createFetchFailure("UND_ERR_CONNECT_TIMEOUT"));
+        .mockRejectedValue(createNetworkFailure("UND_ERR_CONNECT_TIMEOUT"));
       vi.stubGlobal("fetch", fetchMock);
       queryThroughFetch();
 

--- a/packages/backend/client/runtime.ts
+++ b/packages/backend/client/runtime.ts
@@ -62,6 +62,16 @@ function mapQueryFailure(query: string, cause: unknown) {
   if (cause instanceof NetworkRequestError) {
     return createRuntimeQueryError(query, "transport", cause.networkCodes);
   }
+
+  const responseNetworkError = createNetworkRequestError(cause);
+  if (responseNetworkError.networkCodes.length > 0) {
+    return createRuntimeQueryError(
+      query,
+      "transport",
+      responseNetworkError.networkCodes
+    );
+  }
+
   return createRuntimeQueryError(query, "query");
 }
 
@@ -72,12 +82,13 @@ function isRetryableQueryError(error: ConvexRuntimeQueryError) {
 /**
  * Reads one public Convex query through the Effect error channel.
  *
- * Only allowlisted pre-response network failures receive the shared bounded
- * retry schedule. Convex function, HTTP, protocol, timeout, and unknown
- * failures remain terminal.
+ * Only allowlisted network failures receive the shared bounded retry schedule,
+ * including response-stream failures surfaced by the official client. Convex
+ * function, HTTP, protocol, timeout, and unknown failures remain terminal.
  *
  * @see https://docs.convex.dev/functions/error-handling/
  * @see https://effect.website/docs/error-management/retrying/
+ * @see https://github.com/nodejs/undici/blob/v7.29.0/lib/web/fetch/index.js#L2130-L2135
  */
 export const readConvexRuntimeQuery = Effect.fn("ConvexRuntime.query")(
   function* <Query extends FunctionReference<"query">>(


### PR DESCRIPTION
## What changed

- Classify allowlisted network failures that surface after the official Convex client has received response headers.
- Reuse the existing Effect retry schedule: at most two read retries after 500 ms and 1,000 ms.
- Add a regression for the exact Node and Undici `TypeError: terminated` shape with nested `UND_ERR_SOCKET`.
- Keep Convex function, HTTP, protocol, timeout, abort, TLS, and unknown failures terminal.

## Why

The exact main www Production deployment `dpl_2bm6vDMiUSNoUWZMcaCtxUGDjven` compiled and typechecked, then failed during static generation while reading `contentRelease/material:route`. Production Convex logs show the function completed successfully at that time without an application error.

The installed Convex 1.45.0 `ConvexHttpClient` awaits `response.json()` after `fetch()` resolves. The pinned Undici 7.29.0 implementation reports an interrupted response stream as `TypeError: terminated` with the socket failure as its cause. A Node 24 reproduction confirmed the response was received before parsing failed and the nested code was `UND_ERR_SOCKET`.

The existing Nakafa boundary sanitized and retried only rejections from the custom fetch hook. A response-stream rejection occurred later inside `client.query()`, so the same allowlisted socket code was incorrectly mapped to a terminal query error. This PR closes only that classification gap. It does not retry an unclassified error or any received HTTP or Convex function failure.

References:

- https://github.com/get-convex/convex-js/blob/main/src/browser/http_client.ts
- https://github.com/nodejs/undici/blob/v7.29.0/lib/web/fetch/index.js#L2130-L2135
- https://github.com/nodejs/undici/blob/v7.29.0/lib/handler/retry-handler.js
- https://docs.convex.dev/functions/error-handling/
- https://effect.website/docs/error-management/retrying/

## Verification

- Base: `bd69cc95f504a1a1a76da4818a205ff00e5a4749`
- Exact head: `5552c83188f86a65c223343e2628c1c135c12bd0`
- `pnpm test`: 14 of 14 tasks
- Backend: 314 files, 1,275 tests
- www: 203 files, 1,349 tests, 100% coverage
- API: 9 files, 51 tests, 100% coverage
- MCP: 7 files, 19 tests, 100% coverage
- Every workspace typecheck passed
- `pnpm lint`
- `pnpm boundaries`
- `pnpm security:audit`
- `pnpm effect:source:check`
- `pnpm format:doctor`
- React Doctor changed scope: no changed www source files
- Gemini routing diff: empty
- Touched modules: 130 and 262 lines
- Vercel Preview is disabled. No manual Vercel deployment is used.
