### PR TITLE
chore(ci): simplify check names

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -1,4 +1,4 @@
-name: Agent-Friendly Docs
+name: CI
 
 on:
   pull_request:
@@ -45,7 +45,7 @@ jobs:
         run: pnpm test
 
   production:
-    name: Production acceptance
+    name: Production
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih')
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -399,6 +399,7 @@ jobs:
             -exec rm -rf -- {} +
 
   agent-docs:
+    name: Required
     if: always()
     needs: [quality, production]
     runs-on: ubuntu-latest

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Agent-Friendly Docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,4 +1,4 @@
-name: React Doctor
+name: React
 
 on:
   pull_request:
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   react-doctor:
+    name: Doctor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Packages
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Give GitHub checks short hierarchical names:

- `CI / Quality`
- `CI / Production`
- `CI / Required`
- `React / Doctor`
- `Packages / Release`

## Why

GitHub displays every Actions check as `workflow / job (event)`. The previous workflow and job names repeated the same concept, which made the merge panel harder to scan.

## Scope

Workflow and job display names change. The renamed CI and package-release workflows now use stable literal concurrency keys that preserve their pre-rename namespaces. Commands, permissions, triggers, timeouts, protected acceptance behavior, Gemini routing, application code, and deployment behavior are unchanged.

## Exact-head verification

Head: `efcb028d9ea19883b08d2a7da5243110cac39000`

- Actionlint passed for all three workflows.
- Script typecheck and 9 workflow, dependency, and Effect source policy tests passed.
- Diff integrity and prohibited punctuation scans passed.
- Exact-head GitHub checks are running.

## Dependency and rollout state

Branch protection still requires `agent-docs` and `react-doctor`; it has not been changed. After the new `Required` and `Doctor` checks pass at this exact head, their actual check contexts will be verified before any atomic protection migration.

No Vercel Preview or production write is involved.

## Material risks

Renaming a required job without coordinating branch protection would block merges. Renaming a workflow-derived concurrency group could also allow old and new runs to overlap. Stable concurrency keys and the explicit context transition prevent both gaps.
