### PR TITLE
fix(www): expand Convex before production build

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",
-    "build:vercel": "pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
+    "build:vercel": "pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "next dev -p 3000 --turbopack",
     "doctor": "pnpm dlx react-doctor@0.9.12",

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -1,6 +1,62 @@
-import { describe, expect, it } from "vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
+  PUBLIC_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
+import { api } from "@repo/backend/convex/_generated/api";
+import { describe, expect, it } from "@repo/testing/effect";
+import { getFunctionName } from "convex/server";
+import { Effect, FileSystem, Path } from "effect";
 import packageJson from "@/package.json";
-import { config } from "@/vercel";
+import { config, staticBuildRoutes } from "@/vercel";
+
+/** Finds every Page or Layout that contributes static params to Next build. */
+const findStaticBuildRoutes = Effect.fn("www.vercel.findStaticBuildRoutes")(
+  function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const modulePath = yield* path.fromFileUrl(new URL(import.meta.url));
+    const moduleRoot = path.dirname(modulePath);
+    const appRoot = path.resolve(moduleRoot, "app");
+    const entries = yield* fileSystem.readDirectory(appRoot, {
+      recursive: true,
+    });
+    const routes = yield* Effect.forEach(entries, (entry) =>
+      Effect.gen(function* () {
+        const fileName = path.basename(entry);
+        if (!(fileName === "layout.tsx" || fileName === "page.tsx")) {
+          return;
+        }
+        const sourcePath = path.resolve(appRoot, entry);
+        const source = yield* fileSystem.readFileString(sourcePath);
+        if (!source.includes("function generateStaticParams")) {
+          return;
+        }
+        return path.relative(moduleRoot, sourcePath);
+      })
+    );
+
+    return routes
+      .flatMap((source) => (source === undefined ? [] : [source]))
+      .sort();
+  }
+);
+
+/** Reads the installed Convex deploy implementation through typed IO. */
+const readConvexDeploySource = Effect.fn("www.vercel.readConvexDeploySource")(
+  function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const serverModule = yield* path.fromFileUrl(
+      new URL(import.meta.resolve("convex/server"))
+    );
+    const packageRoot = path.resolve(path.dirname(serverModule), "../../..");
+
+    return yield* fileSystem.readFileString(
+      path.resolve(packageRoot, "src/cli/lib/deploy2.ts")
+    );
+  }
+);
 
 describe("www Vercel configuration", () => {
   it("builds only affected production commits", () => {
@@ -14,12 +70,19 @@ describe("www Vercel configuration", () => {
     });
   });
 
-  it("deploys the matching Convex backend with the production web build", () => {
+  it("expands Convex before any production route build can use successors", () => {
     const buildCommand = config.buildCommand ?? "";
     const deploymentCommand = packageJson.scripts["build:vercel"];
     const backendTypecheck = "pnpm --dir ../../packages/backend typecheck";
     const convexDeploy = "pnpm --dir ../../packages/backend exec convex deploy";
     const webBuild = "pnpm --dir ../../apps/www build";
+    const stages = deploymentCommand.split(" && ");
+    const firstDeploy = deploymentCommand.indexOf(convexDeploy);
+    const secondDeploy = deploymentCommand.indexOf(
+      convexDeploy,
+      firstDeploy + convexDeploy.length
+    );
+    const webBuildIndex = deploymentCommand.indexOf(webBuild);
 
     expect(buildCommand).toBe("pnpm run build:vercel");
     expect(buildCommand.length).toBeLessThanOrEqual(256);
@@ -33,11 +96,68 @@ describe("www Vercel configuration", () => {
       "--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL"
     );
     expect(deploymentCommand.indexOf(backendTypecheck)).toBe(0);
-    expect(deploymentCommand.indexOf(convexDeploy)).toBeGreaterThan(
+    expect(stages).toHaveLength(3);
+    expect(stages[0]).toBe(backendTypecheck);
+    expect(stages[1]).toContain(convexDeploy);
+    expect(stages[2]).toContain(convexDeploy);
+    expect(deploymentCommand).not.toContain(";");
+    expect(deploymentCommand).not.toContain("--preview");
+    expect(firstDeploy).toBeGreaterThan(
       deploymentCommand.indexOf(backendTypecheck)
     );
-    expect(deploymentCommand.indexOf(webBuild)).toBeGreaterThan(
-      deploymentCommand.indexOf(convexDeploy)
+    expect(secondDeploy).toBeGreaterThan(firstDeploy);
+    expect(webBuildIndex).toBeGreaterThan(secondDeploy);
+    expect(deploymentCommand.slice(firstDeploy, secondDeploy)).not.toContain(
+      "--cmd"
     );
+    expect(deploymentCommand.slice(secondDeploy, webBuildIndex)).toContain(
+      "--cmd"
+    );
+    expect(deploymentCommand.indexOf(convexDeploy, secondDeploy + 1)).toBe(-1);
   });
+
+  it.effect("proves the installed Convex command runs before its push", () =>
+    Effect.gen(function* () {
+      const source = yield* readConvexDeploySource();
+      const commandIndex = source.indexOf("await runCommand(ctx");
+      const pushIndex = source.indexOf("await runPush(ctx");
+
+      expect(commandIndex).toBeGreaterThan(-1);
+      expect(pushIndex).toBeGreaterThan(commandIndex);
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+
+  it.effect("inventories every production static-param route", () =>
+    Effect.gen(function* () {
+      const sources = staticBuildRoutes.map(({ source }) => source).sort();
+      const contracts = new Set(
+        staticBuildRoutes.flatMap((route) => route.contracts)
+      );
+      const requiredBridgeContracts = [
+        getFunctionName(api.contentRelease.article.publications),
+        getFunctionName(api.contentRelease.article.route),
+        getFunctionName(api.contentRelease.material.publications),
+        getFunctionName(api.contentRelease.material.publication),
+        PUBLIC_CONTENT_RUNTIME_PATH,
+      ];
+
+      expect(yield* findStaticBuildRoutes()).toEqual(sources);
+      expect(PUBLIC_CONTENT_RUNTIME_BATCH_PATH).toBe(
+        `${PUBLIC_CONTENT_RUNTIME_PATH}/batch`
+      );
+      for (const contract of requiredBridgeContracts) {
+        expect(contracts).toContain(contract);
+      }
+      expect(staticBuildRoutes).toContainEqual(
+        expect.objectContaining({
+          contracts: expect.arrayContaining([
+            "contentRelease/article:route",
+            "/internal/content/runtime/v2",
+          ]),
+          source:
+            "app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/[slug]/page.tsx",
+        })
+      );
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
 });

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -1,5 +1,61 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
+/**
+ * Every Next static-param owner and each remote contract its generated routes
+ * can read while metadata and page output are built.
+ */
+export const staticBuildRoutes = [
+  {
+    contracts: [],
+    source: "app/[locale]/layout.tsx",
+  },
+  {
+    contracts: ["contentRelease/page:catalog", "/internal/content/runtime/v2"],
+    source: "app/[locale]/(app)/(shared)/(site)/(legal)/[...page]/page.tsx",
+  },
+  {
+    contracts: ["contentRelease/program:page", "contentRelease/program:route"],
+    source:
+      "app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx",
+  },
+  {
+    contracts: ["contentRelease/quran:surahs", "contentRelease/quran:view"],
+    source: "app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx",
+  },
+  {
+    contracts: [
+      "contentRelease/article:categories",
+      "contentRelease/article:publications",
+    ],
+    source:
+      "app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/page.tsx",
+  },
+  {
+    contracts: [
+      "contentRelease/article:categories",
+      "contentRelease/article:publications",
+      "contentRelease/article:route",
+      "/internal/content/runtime/v2",
+    ],
+    source:
+      "app/[locale]/(app)/(shared)/(main)/(learn)/articles/[category]/[slug]/page.tsx",
+  },
+  {
+    contracts: [
+      "contentRelease/material:publications",
+      "contentRelease/material:publication",
+      "/internal/content/runtime/v2",
+    ],
+    source:
+      "app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/page.tsx",
+  },
+] as const;
+
+/**
+ * The production script temporarily pushes the additive content bridge before
+ * Next builds these routes. The switch change removes that first push only
+ * after its exact deploymentId and successor function spec are verified.
+ */
 export const config: VercelConfig = {
   buildCommand: "pnpm run build:vercel",
   ignoreCommand:


### PR DESCRIPTION
## Summary

Restores the protected-main production deployment sequence by pushing the additive Convex SEO bridge before Next.js builds routes that consume its successor functions and current runtime endpoints.

## Why

The merged bridge retained predecessor contracts, but the installed Convex CLI runs `--cmd` before bundling and pushing functions. The production Next build therefore called successor article and material contracts that were not yet deployed, failed static collection, and prevented the later Convex push.

## Scope

- Run backend typecheck, one additive Convex push without `--cmd`, then the existing command-bearing production build and idempotent push.
- Inventory all seven `generateStaticParams` owners and their build-time remote contracts, including article detail metadata and body reads.
- Verify shell ordering and installed Convex CLI ordering through Effect-native FileSystem and Path tests.
- Keep all predecessor adapters, successor functions, current runtime routes, consumers, and publication data unchanged.

## Exact-head Verification

Exact head `e39817bd4b07d14b3722ea41cd13b66ced4da9be`. Focused WWW Vercel tests pass 4/4, WWW typecheck passes, Effect source identity matches rc.110 commit `66114151`, Ultracite formatting and `git diff --check` pass. Turbo affected proof selects WWW only and skips API and MCP. Required and Doctor are pending on this exact head.

## Dependency or rollout state

This is the additive expand recovery only. No Preview, manual Vercel action, manual Convex production deploy, migration, or production data write is permitted. After protected merge, exact-main WWW must be READY and the production Convex function spec must expose every successor. A separate switch change then removes this temporary first push after deployment evidence is recorded as `deploymentId`.

## Material Risks

The first push may succeed before a later build failure, but it is additive and remains compatible with predecessor readers. The second same-source push is intentionally idempotent. A failed Vercel build is not promoted, so the prior live WWW remains available. Merge remains blocked until exact-head Required, Doctor, and one independently classified fresh review are green.