### PR TITLE
perf(ci): parallelize Playwright browser acceptance

### DIFF
--- a/apps/www/e2e/navigation.browser.ts
+++ b/apps/www/e2e/navigation.browser.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { Effect } from "effect";
-import { withBrowserContext } from "./support/browser-context";
-import { seedDeniedAnalyticsConsent } from "./support/consent";
+import { withBrowserContext } from "@/e2e/support/browser-context";
+import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
 import {
   navigationCases,
   verifyHardAndClientNavigation,
-} from "./support/navigation/cases";
+} from "@/e2e/support/navigation/cases";
 
 const targetViewports = [
   { height: 800, name: "compact", width: 320 },
@@ -14,6 +14,8 @@ const targetViewports = [
   { height: 768, name: "tablet-landscape", width: 1024 },
   { height: 900, name: "desktop", width: 1440 },
 ] as const;
+
+test.describe.configure({ mode: "parallel" });
 
 for (const viewport of targetViewports) {
   for (const navigationCase of navigationCases) {

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -22,5 +22,5 @@ export default defineConfig({
     trace: "retain-on-failure",
     video: "retain-on-failure",
   },
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
 });


### PR DESCRIPTION
## Summary

Pins Playwright CI to two workers and opts only the independent navigation matrix into per-test parallel execution.

## Type

Performance improvement to signed browser acceptance. No product behavior or test expectation changes.

## Scope and invariants

- Changes only `apps/www/playwright.config.ts` and `apps/www/e2e/navigation.browser.ts`.
- Preserves all 55 cases across 7 files, every route and viewport, isolated BrowserContexts, timeouts, retries, and `failOnFlakyTests`.
- Does not change workflows, package scripts, Next build concurrency, Convex, Vercel, Gemini, or deployment ordering.
- PR #333 protected-merged as `f1ce615544b99b7156e8df3e2e29012ec35d9dc5`; native gh-stack auto-restacked #347 onto `main` at exact immutable head `271021f4bdf715a76f1ec023b3d493b418850986`.

## Local verification

- `CI=1 pnpm --filter www test:browser --list`: 55 tests in 7 files.
- `NEXT_PUBLIC_CONVEX_URL=https://ci-proof.convex.cloud POSTHOG_PROXY_HOST=https://ci-proof.example pnpm --filter www typecheck`: passed.
- `pnpm lint`: passed.
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`: 100/100.
- Focused Biome and `git diff --check`: passed.
- Auto-restack proof: exact parent `f1ce615544b99b7156e8df3e2e29012ec35d9dc5`, equal range-diff, stable patch ID `94cf404be4dca54084d00d85bd4ab4ac7e47105d`, and the same two-file patch.

## Signed acceptance

Two consecutive signed cycles passed at exact immutable head `271021f4bdf715a76f1ec023b3d493b418850986`. [CI 32905270485 attempt 1](https://github.com/nakafaai/nakafa.com/actions/runs/32905270485/attempts/1) passed Quality in 6m16s and Production in 23m37s, with all 55 browser cases first attempt using 2 workers in 5.8m. [Attempt 2](https://github.com/nakafaai/nakafa.com/actions/runs/32905270485/attempts/2) passed Quality in 6m13s and Production in 20m53s, with all 55 browser cases first attempt using 2 workers in 5.0m. Both cycles had no retry, flake, failure, or timeout marker; AFDocs passed 23/23; final runtime verification, cleanup, and Required passed. React Doctor [32905270494](https://github.com/nakafaai/nakafa.com/actions/runs/32905270494) scored 100/100 at the same head.

## Sources

The design follows the official [Playwright parallelism guidance](https://playwright.dev/docs/test-parallel), [BrowserContext isolation guidance](https://playwright.dev/docs/browser-contexts), and [GitHub stacked pull request guidance](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests), verified against installed Playwright 1.62.1 source and gh-stack v0.1.0 help.
