### PR TITLE
fix(design-system): restore bacterial growth animation

### DIFF
--- a/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
@@ -100,12 +100,13 @@ export function BacterialGrowth({
   });
 
   const isInView = entry?.isIntersecting ?? false;
+  const activeGeneration = Math.min(generation, maxGenerations);
   // Viewport visibility gates work without overriding the user's Play/Pause intent.
-  const isEffectivelyPlaying = isPlaying && generation < maxGenerations;
+  const isEffectivelyPlaying = isPlaying && activeGeneration < maxGenerations;
   const isAnimating = isEffectivelyPlaying && isInView;
   const frameInput = Schema.decodeSync(BacterialGrowthFrameInputSchema)({
     formulaType,
-    generation,
+    generation: activeGeneration,
     initialCount,
     maxGenerations,
     ratio,
@@ -135,7 +136,7 @@ export function BacterialGrowth({
   }
 
   function togglePlayPause() {
-    if (!isEffectivelyPlaying && generation >= maxGenerations) {
+    if (!isEffectivelyPlaying && activeGeneration >= maxGenerations) {
       // If at max generation and trying to play, restart from beginning
       setGeneration(0);
       setIsPlaying(true);
@@ -212,7 +213,7 @@ export function BacterialGrowth({
       </CardContent>
 
       <BacterialControls
-        generation={generation}
+        generation={activeGeneration}
         isPlaying={isEffectivelyPlaying}
         maxGenerations={maxGenerations}
         onGenerationChange={selectGeneration}

--- a/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
@@ -4,6 +4,7 @@ import { useIntersection } from "@mantine/hooks";
 import { BacterialControls } from "@repo/design-system/components/contents/mathematics/bacterial-controls";
 import {
   type BacterialFormulaType,
+  BacterialFormulaTypeSchema,
   getBacterialGrowthFrame,
 } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
 import {
@@ -13,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@repo/design-system/components/ui/card";
+import { Schema } from "effect";
 import {
   AnimatePresence,
   domMax,
@@ -101,8 +103,11 @@ export function BacterialGrowth({
   // Viewport visibility gates work without overriding the user's Play/Pause intent.
   const isEffectivelyPlaying = isPlaying && generation < maxGenerations;
   const isAnimating = isEffectivelyPlaying && isInView;
+  const validatedFormulaType = Schema.decodeSync(BacterialFormulaTypeSchema)(
+    formulaType
+  );
   const frame = getBacterialGrowthFrame({
-    formulaType,
+    formulaType: validatedFormulaType,
     generation,
     initialCount,
     maxGenerations,

--- a/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
@@ -3,6 +3,10 @@
 import { useIntersection } from "@mantine/hooks";
 import { BacterialControls } from "@repo/design-system/components/contents/mathematics/bacterial-controls";
 import {
+  type BacterialFormulaType,
+  getBacterialGrowthFrame,
+} from "@repo/design-system/components/contents/mathematics/bacterial-growth";
+import {
   Card,
   CardContent,
   CardDescription,
@@ -17,21 +21,18 @@ import {
   MotionConfig,
 } from "motion/react";
 import * as m from "motion/react-m";
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-const MAX_BACTERIA_COUNT = 100;
 const SPEED_INTERVAL = 1000;
 const STAGGER_DELAY = 0.01;
 const SCALE_INCREASE = 1.1;
-
-type FormulaType = "geometric" | "exponential";
 
 interface BacterialGrowthProps {
   /**
    * The type of formula to use.
    * @default "geometric"
    */
-  formulaType?: FormulaType;
+  formulaType?: BacterialFormulaType;
   /**
    * The initial count of bacteria.
    * @default 1
@@ -43,7 +44,6 @@ interface BacterialGrowthProps {
   labels?: {
     title?: string;
     bacterial?: string;
-    initialBacteria?: string;
   };
   /**
    * The maximum number of generations to display.
@@ -87,7 +87,6 @@ export function BacterialGrowth({
   labels = {
     title: "Bacterial Growth",
     bacterial: "Bacterial",
-    initialBacteria: "Initial bacteria",
   },
 }: BacterialGrowthProps) {
   const [generation, setGeneration] = useState(0);
@@ -102,47 +101,16 @@ export function BacterialGrowth({
   // Viewport visibility gates work without overriding the user's Play/Pause intent.
   const isEffectivelyPlaying = isPlaying && generation < maxGenerations;
   const isAnimating = isEffectivelyPlaying && isInView;
-  const deferredAnimating = useDeferredValue(isAnimating);
-  const deferredGeneration = useDeferredValue(generation);
-  const pulseRepeat = deferredAnimating ? Number.POSITIVE_INFINITY : 0;
-
-  // Calculate current bacteria count based on the selected formula type
-  const bacteriaCount = useMemo(() => {
-    if (formulaType === "geometric") {
-      // U_n = a·r^(n-1) (standard geometric sequence formula)
-      // For bacterial growth: bacteria after n generations = initial × ratio^(generation)
-      // We always start index from 0, so we don't need to subtract 1 from the generation
-      return initialCount * ratio ** deferredGeneration;
-    }
-
-    // B(t) = B₀ × e^(kt) where k = ln(ratio)
-    return initialCount * Math.exp(Math.log(ratio) * deferredGeneration);
-  }, [initialCount, deferredGeneration, ratio, formulaType]);
-
-  // Create an array of bacteria to display
-  const bacteria = useMemo(
-    () =>
-      Array.from(
-        { length: Math.min(Math.round(bacteriaCount), MAX_BACTERIA_COUNT) },
-        (_, i) => i
-      ),
-    [bacteriaCount]
-  );
-
-  // Calculate how many bacteria to actually show (cap at 100 for performance)
-  const displayCount = useMemo(
-    () => Math.min(Math.round(bacteriaCount), MAX_BACTERIA_COUNT),
-    [bacteriaCount]
-  );
-
-  // Calculate grid dimensions based on bacteria count
-  const gridCols = useMemo(
-    () => Math.min(Math.ceil(Math.sqrt(displayCount)), 10),
-    [displayCount]
-  );
+  const frame = getBacterialGrowthFrame({
+    formulaType,
+    generation,
+    initialCount,
+    maxGenerations,
+    ratio,
+  });
 
   useEffect(() => {
-    if (!deferredAnimating || deferredGeneration >= maxGenerations) {
+    if (!isAnimating) {
       return;
     }
 
@@ -156,7 +124,7 @@ export function BacterialGrowth({
     }, SPEED_INTERVAL / speed);
 
     return () => clearInterval(interval);
-  }, [deferredAnimating, deferredGeneration, maxGenerations, speed]);
+  }, [isAnimating, maxGenerations, speed]);
 
   function resetAnimation() {
     setGeneration(0);
@@ -183,56 +151,52 @@ export function BacterialGrowth({
     <Card className="content-auto-card" ref={ref}>
       <CardHeader>
         <CardTitle>{labels.title}</CardTitle>
-        <CardDescription>
-          {Math.round(bacteriaCount)} {labels.bacterial}
+        <CardDescription aria-live="polite">
+          {frame.bacteriaCount} {labels.bacterial}
         </CardDescription>
       </CardHeader>
 
       <CardContent>
-        <div className="relative aspect-square w-full overflow-hidden rounded-lg border bg-card sm:aspect-video">
+        <div
+          aria-label={`${frame.bacteriaCount} ${labels.bacterial}`}
+          className="relative aspect-square w-full overflow-hidden rounded-lg border bg-card sm:aspect-video"
+          data-bacteria-count={frame.bacteriaCount}
+          data-visible-bacteria-count={frame.bacteriaIds.length}
+          role="img"
+        >
           <div
             className="relative grid h-full w-full gap-0.5 p-2 sm:px-0"
             style={{
-              gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
+              gridTemplateColumns: `repeat(${frame.gridColumns}, minmax(0, 1fr))`,
             }}
           >
             <MotionConfig reducedMotion="user">
               <LazyMotion features={domMax} strict>
                 <LayoutGroup>
                   <AnimatePresence mode="popLayout">
-                    {bacteria.map((id) => (
+                    {frame.bacteriaIds.map((id, index) => (
                       <m.div
                         animate={{
-                          scale: 1,
                           opacity: 1,
+                          scale: 1,
+                          x: 0,
                         }}
                         className="relative flex items-center justify-center"
-                        exit={{ scale: 0.95, opacity: 0 }}
-                        initial={{ scale: 0.95, opacity: 0 }}
+                        exit={{ opacity: 0, scale: 0.35, x: -10 }}
+                        initial={{ opacity: 0, scale: 0.35, x: -10 }}
                         key={id}
                         layout
                         transition={{
                           type: "spring",
                           stiffness: 500,
                           damping: 30,
-                          delay: id * STAGGER_DELAY, // Stagger effect
+                          delay: index * STAGGER_DELAY,
                         }}
+                        whileHover={{ scale: SCALE_INCREASE }}
                       >
-                        <m.div
-                          animate={{
-                            scale: deferredAnimating
-                              ? [1, SCALE_INCREASE, 1]
-                              : 1,
-                          }}
+                        <div
                           className="aspect-square h-full max-h-5 w-full max-w-5 rounded-full bg-chart-1 sm:max-h-8 sm:max-w-8"
-                          transition={{
-                            duration: 1,
-                            repeat: pulseRepeat,
-                            repeatType: "reverse",
-                          }}
-                          whileHover={{
-                            scale: SCALE_INCREASE,
-                          }}
+                          data-bacterium=""
                         />
                       </m.div>
                     ))}

--- a/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
+++ b/packages/design-system/components/contents/mathematics/animation-bacterial.tsx
@@ -4,7 +4,7 @@ import { useIntersection } from "@mantine/hooks";
 import { BacterialControls } from "@repo/design-system/components/contents/mathematics/bacterial-controls";
 import {
   type BacterialFormulaType,
-  BacterialFormulaTypeSchema,
+  BacterialGrowthFrameInputSchema,
   getBacterialGrowthFrame,
 } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
 import {
@@ -103,16 +103,14 @@ export function BacterialGrowth({
   // Viewport visibility gates work without overriding the user's Play/Pause intent.
   const isEffectivelyPlaying = isPlaying && generation < maxGenerations;
   const isAnimating = isEffectivelyPlaying && isInView;
-  const validatedFormulaType = Schema.decodeSync(BacterialFormulaTypeSchema)(
-    formulaType
-  );
-  const frame = getBacterialGrowthFrame({
-    formulaType: validatedFormulaType,
+  const frameInput = Schema.decodeSync(BacterialGrowthFrameInputSchema)({
+    formulaType,
     generation,
     initialCount,
     maxGenerations,
     ratio,
   });
+  const frame = getBacterialGrowthFrame(frameInput);
 
   useEffect(() => {
     if (!isAnimating) {

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import {
-  BacterialFormulaTypeSchema,
+  BacterialGrowthFrameInputSchema,
   getBacterialGrowthFrame,
 } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
 import { Schema } from "effect";
@@ -117,6 +117,22 @@ describe("bacterial growth frames", () => {
     expect(frame.bacteriaIds).toEqual([0, 2, 3, 1, 4]);
   });
 
+  it("seeds visible lineages when an unvalidated caller grows from rounded zero", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 1,
+      initialCount: 0.4,
+      maxGenerations: 1,
+      ratio: 10,
+    });
+
+    expect(frame).toEqual({
+      bacteriaCount: 4,
+      bacteriaIds: [0, 1, 2, 3],
+      gridColumns: 2,
+    });
+  });
+
   it("never exceeds the visual DOM budget", () => {
     const frame = getBacterialGrowthFrame({
       formulaType: "exponential",
@@ -130,9 +146,32 @@ describe("bacterial growth frames", () => {
     expect(frame.gridColumns).toBe(10);
   });
 
-  it("rejects unsupported formula types at the renderer boundary", () => {
+  it("rejects invalid growth inputs at the renderer boundary", () => {
+    const validInput = {
+      formulaType: "geometric",
+      generation: 1,
+      initialCount: 1,
+      maxGenerations: 2,
+      ratio: 2,
+    };
+
     expect(() =>
-      Schema.decodeUnknownSync(BacterialFormulaTypeSchema)("linear")
+      Schema.decodeUnknownSync(BacterialGrowthFrameInputSchema)({
+        ...validInput,
+        formulaType: "linear",
+      })
+    ).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(BacterialGrowthFrameInputSchema)({
+        ...validInput,
+        initialCount: 0.4,
+      })
+    ).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(BacterialGrowthFrameInputSchema)({
+        ...validInput,
+        generation: 3,
+      })
     ).toThrow();
   });
 });

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
@@ -1,5 +1,9 @@
 // @vitest-environment node
-import { getBacterialGrowthFrame } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
+import {
+  BacterialFormulaTypeSchema,
+  getBacterialGrowthFrame,
+} from "@repo/design-system/components/contents/mathematics/bacterial-growth";
+import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
 describe("bacterial growth frames", () => {
@@ -21,10 +25,21 @@ describe("bacterial growth frames", () => {
       1, 2, 4, 8, 16,
     ]);
     expect(frames[2]?.bacteriaIds).toEqual([0, 2, 1, 3]);
-    expect(frames[4]).toMatchObject({
-      bacteriaPerDot: 100,
-      gridColumns: 4,
-    });
+    expect(frames[4]).toMatchObject({ gridColumns: 4 });
+  });
+
+  it("keeps every bounded generation visually distinct", () => {
+    const visibleCounts = Array.from({ length: 11 }, (_, generation) =>
+      getBacterialGrowthFrame({
+        formulaType: "exponential",
+        generation,
+        initialCount: 1,
+        maxGenerations: 10,
+        ratio: 2,
+      })
+    ).map((frame) => frame.bacteriaIds.length);
+
+    expect(visibleCounts).toEqual([1, 2, 4, 8, 16, 32, 64, 97, 98, 99, 100]);
   });
 
   it("renders one dot per bacterium while the complete culture stays bounded", () => {
@@ -38,7 +53,6 @@ describe("bacterial growth frames", () => {
 
     expect(frame).toMatchObject({
       bacteriaCount: 54,
-      bacteriaPerDot: 1,
       gridColumns: 8,
     });
     expect(frame.bacteriaIds).toHaveLength(54);
@@ -57,9 +71,38 @@ describe("bacterial growth frames", () => {
     expect(frame).toMatchObject({
       bacteriaCount: 1,
       bacteriaIds: [0],
-      bacteriaPerDot: 1,
       gridColumns: 1,
     });
+  });
+
+  it("renders an empty culture after its population reaches zero", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 2,
+      initialCount: 1,
+      maxGenerations: 2,
+      ratio: 0.5,
+    });
+
+    expect(frame).toEqual({
+      bacteriaCount: 0,
+      bacteriaIds: [],
+      gridColumns: 1,
+    });
+  });
+
+  it("keeps a large decreasing culture visually distinct through zero", () => {
+    const visibleCounts = Array.from({ length: 12 }, (_, generation) =>
+      getBacterialGrowthFrame({
+        formulaType: "geometric",
+        generation,
+        initialCount: 1000,
+        maxGenerations: 11,
+        ratio: 0.5,
+      })
+    ).map((frame) => frame.bacteriaIds.length);
+
+    expect(visibleCounts).toEqual([100, 50, 25, 13, 7, 6, 5, 4, 3, 2, 1, 0]);
   });
 
   it("distributes an uneven number of daughters across existing parents", () => {
@@ -85,5 +128,11 @@ describe("bacterial growth frames", () => {
 
     expect(frame.bacteriaIds).toHaveLength(100);
     expect(frame.gridColumns).toBe(10);
+  });
+
+  it("rejects unsupported formula types at the renderer boundary", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(BacterialFormulaTypeSchema)("linear")
+    ).toThrow();
   });
 });

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { getBacterialGrowthFrame } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
+import { describe, expect, it } from "vitest";
+
+describe("bacterial growth frames", () => {
+  it("keeps every exponential division visible for a large initial culture", () => {
+    const frames = Array.from({ length: 5 }, (_, generation) =>
+      getBacterialGrowthFrame({
+        formulaType: "exponential",
+        generation,
+        initialCount: 100,
+        maxGenerations: 4,
+        ratio: 2,
+      })
+    );
+
+    expect(frames.map((frame) => frame.bacteriaCount)).toEqual([
+      100, 200, 400, 800, 1600,
+    ]);
+    expect(frames.map((frame) => frame.bacteriaIds.length)).toEqual([
+      1, 2, 4, 8, 16,
+    ]);
+    expect(frames[2]?.bacteriaIds).toEqual([0, 2, 1, 3]);
+    expect(frames[4]).toMatchObject({
+      bacteriaPerDot: 100,
+      gridColumns: 4,
+    });
+  });
+
+  it("renders one dot per bacterium while the complete culture stays bounded", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 3,
+      initialCount: 2,
+      maxGenerations: 3,
+      ratio: 3,
+    });
+
+    expect(frame).toMatchObject({
+      bacteriaCount: 54,
+      bacteriaPerDot: 1,
+      gridColumns: 8,
+    });
+    expect(frame.bacteriaIds).toHaveLength(54);
+    expect(new Set(frame.bacteriaIds)).toHaveProperty("size", 54);
+  });
+
+  it("removes lineages when a bounded culture decreases", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 3,
+      initialCount: 8,
+      maxGenerations: 3,
+      ratio: 0.5,
+    });
+
+    expect(frame).toMatchObject({
+      bacteriaCount: 1,
+      bacteriaIds: [0],
+      bacteriaPerDot: 1,
+      gridColumns: 1,
+    });
+  });
+
+  it("distributes an uneven number of daughters across existing parents", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 1,
+      initialCount: 2,
+      maxGenerations: 1,
+      ratio: 2.5,
+    });
+
+    expect(frame.bacteriaIds).toEqual([0, 2, 3, 1, 4]);
+  });
+
+  it("never exceeds the visual DOM budget", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "exponential",
+      generation: 8,
+      initialCount: 1,
+      maxGenerations: 8,
+      ratio: 10,
+    });
+
+    expect(frame.bacteriaIds).toHaveLength(100);
+    expect(frame.gridColumns).toBe(10);
+  });
+});

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
@@ -105,6 +105,27 @@ describe("bacterial growth frames", () => {
     expect(visibleCounts).toEqual([100, 50, 25, 13, 7, 6, 5, 4, 3, 2, 1, 0]);
   });
 
+  it("preserves every distinct decay generation within the visual budget", () => {
+    const frames = Array.from({ length: 21 }, (_, generation) =>
+      getBacterialGrowthFrame({
+        formulaType: "geometric",
+        generation,
+        initialCount: 104,
+        maxGenerations: 20,
+        ratio: 0.9,
+      })
+    );
+
+    expect(frames.map((frame) => frame.bacteriaCount)).toEqual([
+      104, 94, 84, 76, 68, 61, 55, 50, 45, 40, 36, 33, 29, 26, 24, 21, 19, 17,
+      16, 14, 13,
+    ]);
+    expect(frames.map((frame) => frame.bacteriaIds.length)).toEqual([
+      100, 90, 81, 73, 65, 59, 53, 48, 43, 38, 35, 32, 28, 25, 23, 20, 18, 16,
+      15, 14, 13,
+    ]);
+  });
+
   it("distributes an uneven number of daughters across existing parents", () => {
     const frame = getBacterialGrowthFrame({
       formulaType: "geometric",
@@ -144,6 +165,19 @@ describe("bacterial growth frames", () => {
 
     expect(frame.bacteriaIds).toHaveLength(100);
     expect(frame.gridColumns).toBe(10);
+  });
+
+  it("bounds more than 100 distinct generations to the visual budget", () => {
+    const frame = getBacterialGrowthFrame({
+      formulaType: "geometric",
+      generation: 200,
+      initialCount: 1000,
+      maxGenerations: 200,
+      ratio: 1.0005,
+    });
+
+    expect(frame.bacteriaCount).toBe(1105);
+    expect(frame.bacteriaIds).toHaveLength(1);
   });
 
   it("rejects invalid growth inputs at the renderer boundary", () => {

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.ts
@@ -1,6 +1,13 @@
 import { Schema } from "effect";
 
 const MAX_VISIBLE_BACTERIA = 100;
+const NonNegativeIntegerSchema = Schema.Finite.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isGreaterThanOrEqualTo(0))
+);
+const PositiveNumberSchema = Schema.Finite.pipe(
+  Schema.check(Schema.isGreaterThan(0))
+);
 
 export const BacterialFormulaTypeSchema = Schema.Literals([
   "geometric",
@@ -10,13 +17,22 @@ export type BacterialFormulaType = Schema.Schema.Type<
   typeof BacterialFormulaTypeSchema
 >;
 
-interface BacterialGrowthFrameInput {
-  formulaType: BacterialFormulaType;
-  generation: number;
-  initialCount: number;
-  maxGenerations: number;
-  ratio: number;
-}
+export const BacterialGrowthFrameInputSchema = Schema.Struct({
+  formulaType: BacterialFormulaTypeSchema,
+  generation: NonNegativeIntegerSchema,
+  initialCount: NonNegativeIntegerSchema,
+  maxGenerations: NonNegativeIntegerSchema,
+  ratio: PositiveNumberSchema,
+}).pipe(
+  Schema.check(
+    Schema.makeFilter((input) => input.generation <= input.maxGenerations, {
+      expected: "generation no greater than maxGenerations",
+    })
+  )
+);
+type BacterialGrowthFrameInput = Schema.Schema.Type<
+  typeof BacterialGrowthFrameInputSchema
+>;
 
 /**
  * Calculates the population represented by one generation.
@@ -47,6 +63,18 @@ function createNextGeneration(
     return {
       bacteriaIds: bacteriaIds.slice(0, nextVisibleCount),
       nextLineageId,
+    };
+  }
+
+  if (bacteriaIds.length === 0) {
+    const seededBacteriaIds = Array.from(
+      { length: nextVisibleCount },
+      (_, index) => nextLineageId + index
+    );
+
+    return {
+      bacteriaIds: seededBacteriaIds,
+      nextLineageId: nextLineageId + seededBacteriaIds.length,
     };
   }
 

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.ts
@@ -1,0 +1,129 @@
+const MAX_VISIBLE_BACTERIA = 100;
+
+export type BacterialFormulaType = "geometric" | "exponential";
+
+interface BacterialGrowthFrameInput {
+  formulaType: BacterialFormulaType;
+  generation: number;
+  initialCount: number;
+  maxGenerations: number;
+  ratio: number;
+}
+
+/**
+ * Calculates the population represented by one generation.
+ */
+function calculateBacteriaCount(
+  input: BacterialGrowthFrameInput,
+  generation: number
+) {
+  if (input.formulaType === "exponential") {
+    return Math.round(
+      input.initialCount * Math.exp(Math.log(input.ratio) * generation)
+    );
+  }
+
+  return Math.round(input.initialCount * input.ratio ** generation);
+}
+
+/**
+ * Adds each new daughter immediately after its parent while preserving every
+ * existing lineage identifier for Motion layout transitions.
+ */
+function createNextGeneration(
+  bacteriaIds: readonly number[],
+  nextVisibleCount: number,
+  nextLineageId: number
+) {
+  if (nextVisibleCount <= bacteriaIds.length) {
+    return {
+      bacteriaIds: bacteriaIds.slice(0, nextVisibleCount),
+      nextLineageId,
+    };
+  }
+
+  const daughterCount = nextVisibleCount - bacteriaIds.length;
+  const daughtersPerParent = Math.floor(daughterCount / bacteriaIds.length);
+  const parentsWithExtraDaughter = daughterCount % bacteriaIds.length;
+  const nextBacteriaIds: number[] = [];
+  let availableLineageId = nextLineageId;
+
+  for (const [parentIndex, parentId] of bacteriaIds.entries()) {
+    nextBacteriaIds.push(parentId);
+
+    const extraDaughter = parentIndex < parentsWithExtraDaughter ? 1 : 0;
+    const parentDaughterCount = daughtersPerParent + extraDaughter;
+
+    for (let index = 0; index < parentDaughterCount; index += 1) {
+      nextBacteriaIds.push(availableLineageId);
+      availableLineageId += 1;
+    }
+  }
+
+  return {
+    bacteriaIds: nextBacteriaIds,
+    nextLineageId: availableLineageId,
+  };
+}
+
+function getVisibleCount(bacteriaCount: number, bacteriaPerDot: number) {
+  return Math.min(
+    MAX_VISIBLE_BACTERIA,
+    Math.max(1, Math.ceil(bacteriaCount / bacteriaPerDot))
+  );
+}
+
+/**
+ * Builds one truthful bacterial-growth frame.
+ *
+ * Small cultures render one dot per bacterium. Large cultures use one fixed
+ * cohort scale across every frame, so division stays visible without creating
+ * an unbounded number of DOM nodes.
+ */
+export function getBacterialGrowthFrame(input: BacterialGrowthFrameInput) {
+  const bacteriaCounts = Array.from(
+    { length: input.maxGenerations + 1 },
+    (_, generation) => calculateBacteriaCount(input, generation)
+  );
+  const largestBacteriaCount = Math.max(...bacteriaCounts);
+  const bacteriaPerDot =
+    largestBacteriaCount > MAX_VISIBLE_BACTERIA
+      ? Math.max(
+          1,
+          Math.round(input.initialCount),
+          Math.ceil(largestBacteriaCount / MAX_VISIBLE_BACTERIA)
+        )
+      : 1;
+
+  const initialVisibleCount = getVisibleCount(
+    calculateBacteriaCount(input, 0),
+    bacteriaPerDot
+  );
+  let bacteriaIds = Array.from(
+    { length: initialVisibleCount },
+    (_, index) => index
+  );
+  let nextLineageId = bacteriaIds.length;
+
+  for (let generation = 1; generation <= input.generation; generation += 1) {
+    const nextVisibleCount = getVisibleCount(
+      calculateBacteriaCount(input, generation),
+      bacteriaPerDot
+    );
+    const nextGeneration = createNextGeneration(
+      bacteriaIds,
+      nextVisibleCount,
+      nextLineageId
+    );
+
+    bacteriaIds = nextGeneration.bacteriaIds;
+    nextLineageId = nextGeneration.nextLineageId;
+  }
+
+  return {
+    bacteriaCount: calculateBacteriaCount(input, input.generation),
+    bacteriaIds,
+    bacteriaPerDot,
+    gridColumns: Math.min(Math.ceil(Math.sqrt(bacteriaIds.length)), 10),
+  };
+}

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.ts
@@ -1,6 +1,14 @@
+import { Schema } from "effect";
+
 const MAX_VISIBLE_BACTERIA = 100;
 
-export type BacterialFormulaType = "geometric" | "exponential";
+export const BacterialFormulaTypeSchema = Schema.Literals([
+  "geometric",
+  "exponential",
+]);
+export type BacterialFormulaType = Schema.Schema.Type<
+  typeof BacterialFormulaTypeSchema
+>;
 
 interface BacterialGrowthFrameInput {
   formulaType: BacterialFormulaType;
@@ -66,39 +74,69 @@ function createNextGeneration(
   };
 }
 
-function getVisibleCount(bacteriaCount: number, bacteriaPerDot: number) {
-  return Math.min(
-    MAX_VISIBLE_BACTERIA,
-    Math.max(1, Math.ceil(bacteriaCount / bacteriaPerDot))
-  );
+function getVisibleBacteriaCounts(
+  bacteriaCounts: readonly number[],
+  isGrowing: boolean
+) {
+  const largestBacteriaCount = Math.max(...bacteriaCounts);
+  if (largestBacteriaCount <= MAX_VISIBLE_BACTERIA) {
+    return [...bacteriaCounts];
+  }
+
+  const positiveBacteriaCounts = [
+    ...new Set(bacteriaCounts.filter((count) => count > 0)),
+  ].sort((left, right) => left - right);
+  const smallestPositiveCount = positiveBacteriaCounts[0];
+  const scale = isGrowing
+    ? smallestPositiveCount
+    : largestBacteriaCount / MAX_VISIBLE_BACTERIA;
+
+  return bacteriaCounts.map((bacteriaCount) => {
+    if (bacteriaCount === 0) {
+      return 0;
+    }
+
+    const rank = positiveBacteriaCounts.indexOf(bacteriaCount) + 1;
+    const remainingDistinctCounts = positiveBacteriaCounts.length - rank;
+    const minimumVisibleCount = Math.min(rank, MAX_VISIBLE_BACTERIA);
+    const maximumVisibleCount = Math.max(
+      1,
+      MAX_VISIBLE_BACTERIA - remainingDistinctCounts
+    );
+    const scaledCount = Math.max(1, Math.round(bacteriaCount / scale));
+    const lowerVisibleCount = Math.min(
+      minimumVisibleCount,
+      maximumVisibleCount
+    );
+    const upperVisibleCount = Math.max(
+      minimumVisibleCount,
+      maximumVisibleCount
+    );
+
+    return Math.min(
+      upperVisibleCount,
+      Math.max(lowerVisibleCount, scaledCount)
+    );
+  });
 }
 
 /**
  * Builds one truthful bacterial-growth frame.
  *
- * Small cultures render one dot per bacterium. Large cultures use one fixed
- * cohort scale across every frame, so division stays visible without creating
- * an unbounded number of DOM nodes.
+ * Small cultures render one dot per bacterium. Large cultures use bounded
+ * representative counts that preserve every distinct generation whenever the
+ * visual budget can do so.
  */
 export function getBacterialGrowthFrame(input: BacterialGrowthFrameInput) {
   const bacteriaCounts = Array.from(
     { length: input.maxGenerations + 1 },
     (_, generation) => calculateBacteriaCount(input, generation)
   );
-  const largestBacteriaCount = Math.max(...bacteriaCounts);
-  const bacteriaPerDot =
-    largestBacteriaCount > MAX_VISIBLE_BACTERIA
-      ? Math.max(
-          1,
-          Math.round(input.initialCount),
-          Math.ceil(largestBacteriaCount / MAX_VISIBLE_BACTERIA)
-        )
-      : 1;
-
-  const initialVisibleCount = getVisibleCount(
-    calculateBacteriaCount(input, 0),
-    bacteriaPerDot
+  const visibleBacteriaCounts = getVisibleBacteriaCounts(
+    bacteriaCounts,
+    input.ratio >= 1
   );
+  const initialVisibleCount = visibleBacteriaCounts[0];
   let bacteriaIds = Array.from(
     { length: initialVisibleCount },
     (_, index) => index
@@ -106,10 +144,7 @@ export function getBacterialGrowthFrame(input: BacterialGrowthFrameInput) {
   let nextLineageId = bacteriaIds.length;
 
   for (let generation = 1; generation <= input.generation; generation += 1) {
-    const nextVisibleCount = getVisibleCount(
-      calculateBacteriaCount(input, generation),
-      bacteriaPerDot
-    );
+    const nextVisibleCount = visibleBacteriaCounts[generation];
     const nextGeneration = createNextGeneration(
       bacteriaIds,
       nextVisibleCount,
@@ -123,7 +158,9 @@ export function getBacterialGrowthFrame(input: BacterialGrowthFrameInput) {
   return {
     bacteriaCount: calculateBacteriaCount(input, input.generation),
     bacteriaIds,
-    bacteriaPerDot,
-    gridColumns: Math.min(Math.ceil(Math.sqrt(bacteriaIds.length)), 10),
+    gridColumns: Math.max(
+      1,
+      Math.min(Math.ceil(Math.sqrt(bacteriaIds.length)), 10)
+    ),
   };
 }

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.ts
@@ -33,6 +33,13 @@ export const BacterialGrowthFrameInputSchema = Schema.Struct({
 type BacterialGrowthFrameInput = Schema.Schema.Type<
   typeof BacterialGrowthFrameInputSchema
 >;
+interface BacteriaCountGroup {
+  bacteriaCount: number;
+  generationCount: number;
+}
+interface VisibleBacteriaCountGroup extends BacteriaCountGroup {
+  visibleCount: number;
+}
 
 /**
  * Calculates the population represented by one generation.
@@ -102,6 +109,23 @@ function createNextGeneration(
   };
 }
 
+function groupBacteriaCounts(bacteriaCounts: readonly number[]) {
+  const groups: BacteriaCountGroup[] = [];
+
+  for (const bacteriaCount of bacteriaCounts) {
+    const previousGroup = groups.at(-1);
+
+    if (previousGroup?.bacteriaCount === bacteriaCount) {
+      previousGroup.generationCount += 1;
+      continue;
+    }
+
+    groups.push({ bacteriaCount, generationCount: 1 });
+  }
+
+  return groups;
+}
+
 function getVisibleBacteriaCounts(
   bacteriaCounts: readonly number[],
   isGrowing: boolean
@@ -111,41 +135,74 @@ function getVisibleBacteriaCounts(
     return [...bacteriaCounts];
   }
 
-  const positiveBacteriaCounts = [
-    ...new Set(bacteriaCounts.filter((count) => count > 0)),
-  ].sort((left, right) => left - right);
-  const smallestPositiveCount = positiveBacteriaCounts[0];
+  const positiveGenerationGroups: BacteriaCountGroup[] = [];
+  let smallestPositiveCount = largestBacteriaCount;
+  let zeroGenerationCount = 0;
+
+  for (const group of groupBacteriaCounts(bacteriaCounts)) {
+    if (group.bacteriaCount === 0) {
+      zeroGenerationCount += group.generationCount;
+      continue;
+    }
+
+    positiveGenerationGroups.push(group);
+    smallestPositiveCount = Math.min(
+      smallestPositiveCount,
+      group.bacteriaCount
+    );
+  }
+
+  const ascendingGenerationGroups = isGrowing
+    ? positiveGenerationGroups
+    : [...positiveGenerationGroups].reverse();
   const scale = isGrowing
     ? smallestPositiveCount
     : largestBacteriaCount / MAX_VISIBLE_BACTERIA;
 
-  return bacteriaCounts.map((bacteriaCount) => {
-    if (bacteriaCount === 0) {
-      return 0;
+  const canPreserveEveryDistinctCount =
+    ascendingGenerationGroups.length <= MAX_VISIBLE_BACTERIA;
+  const ascendingVisibleGroups: VisibleBacteriaCountGroup[] = [];
+  let previousVisibleCount = 0;
+
+  for (const [index, group] of ascendingGenerationGroups.entries()) {
+    const scaledCount = Math.min(
+      MAX_VISIBLE_BACTERIA,
+      Math.max(1, Math.round(group.bacteriaCount / scale))
+    );
+
+    if (!canPreserveEveryDistinctCount) {
+      ascendingVisibleGroups.push({ ...group, visibleCount: scaledCount });
+      continue;
     }
 
-    const rank = positiveBacteriaCounts.indexOf(bacteriaCount) + 1;
-    const remainingDistinctCounts = positiveBacteriaCounts.length - rank;
-    const minimumVisibleCount = Math.min(rank, MAX_VISIBLE_BACTERIA);
-    const maximumVisibleCount = Math.max(
-      1,
-      MAX_VISIBLE_BACTERIA - remainingDistinctCounts
-    );
-    const scaledCount = Math.max(1, Math.round(bacteriaCount / scale));
-    const lowerVisibleCount = Math.min(
-      minimumVisibleCount,
-      maximumVisibleCount
-    );
-    const upperVisibleCount = Math.max(
-      minimumVisibleCount,
-      maximumVisibleCount
+    const remainingDistinctCounts =
+      ascendingGenerationGroups.length - index - 1;
+    const minimumVisibleCount = previousVisibleCount + 1;
+    const maximumVisibleCount = MAX_VISIBLE_BACTERIA - remainingDistinctCounts;
+    const visibleCount = Math.min(
+      maximumVisibleCount,
+      Math.max(minimumVisibleCount, scaledCount)
     );
 
-    return Math.min(
-      upperVisibleCount,
-      Math.max(lowerVisibleCount, scaledCount)
-    );
-  });
+    ascendingVisibleGroups.push({ ...group, visibleCount });
+    previousVisibleCount = visibleCount;
+  }
+
+  const generationOrderedVisibleGroups = isGrowing
+    ? ascendingVisibleGroups
+    : [...ascendingVisibleGroups].reverse();
+  const positiveVisibleCounts = generationOrderedVisibleGroups.flatMap(
+    (group) =>
+      Array.from({ length: group.generationCount }, () => group.visibleCount)
+  );
+  const zeroVisibleCounts = Array.from(
+    { length: zeroGenerationCount },
+    () => 0
+  );
+
+  return isGrowing
+    ? [...zeroVisibleCounts, ...positiveVisibleCounts]
+    : [...positiveVisibleCounts, ...zeroVisibleCounts];
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace the static 100-dot plateau with a bounded cohort model that keeps every division visible
- preserve stable lineage IDs so parents move and new daughters appear beside them
- keep the 100-node DOM budget and add accessible population state
- cover large exponential growth, bounded geometric growth, decay, uneven ratios, and the DOM cap

## Root cause

The authored lesson changed from an initial population of 1 to 100 bacteria. The renderer already capped every frame at 100 dots, so 100, 200, 400, 800, and 1,600 all produced the same visual even though the timer and counter continued to update.

Companion content layout: nakafaai/aksara#129

## Verification

- `pnpm --filter @repo/design-system test`
- `pnpm --filter @repo/design-system typecheck`
- `NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud POSTHOG_PROXY_HOST=https://t.nakafa.com pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`
- real Aksara renderer preview in Chromium and WebKit
- manual time controls and autoplay both verified at 100, 200, 400, 800, and 1,600 bacteria

No Vercel Preview is required or permitted for this branch.