### PR TITLE
test(policy): ratchet Effect test runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "turbo run start",
     "test": "pnpm check:patches && pnpm check:tests && pnpm test:scripts && turbo run test",
     "test:coverage": "pnpm check:patches && pnpm check:tests && turbo run test:coverage",
-    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependency-policy.test.ts scripts/github-action-policy.test.ts scripts/effect-source.test.ts",
+    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependency-policy.test.ts scripts/effect-source.test.ts scripts/effect-test-policy.test.ts scripts/github-action-policy.test.ts",
     "test:ui": "turbo run test:ui",
     "test:watch": "turbo run test:watch",
     "translate": "turbo run translate",
@@ -62,6 +62,7 @@
     "turbo": "2.10.11",
     "typescript": "catalog:",
     "ultracite": "7.10.6",
+    "vitest": "^4.1.11",
     "yaml": "2.9.0"
   },
   "packageManager": "pnpm@11.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       ultracite:
         specifier: 7.10.6
         version: 7.10.6
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       yaml:
         specifier: 2.9.0
         version: 2.9.0

--- a/scripts/check-tests.ts
+++ b/scripts/check-tests.ts
@@ -1,5 +1,9 @@
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Effect, FileSystem, Path, Schema } from "effect";
+import {
+  EFFECT_TEST_ADAPTER,
+  inspectEffectTestRunnerPolicy,
+} from "./effect-test-policy.ts";
 import { writeError, writeOutput } from "./output.ts";
 
 const TEST_FILE_PATTERN = /\.test\.tsx?$/u;
@@ -83,12 +87,32 @@ const hasColocatedOwner = Effect.fn("RepositoryPolicy.hasColocatedOwner")(
   }
 );
 
+/** Reads one test module for Effect runner policy inspection. */
+const readTestSource = Effect.fn("RepositoryPolicy.readTestSource")(function* (
+  root: string,
+  testPath: string
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const source = yield* fileSystem.readFileString(testPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TestPolicyReadError({
+          cause,
+          message: `Unable to read ${testPath}.`,
+        })
+    )
+  );
+  return { path: path.relative(root, testPath), source };
+});
+
 /** Validates test ownership and final repository test layout. */
 export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
   function* (root: string) {
     const path = yield* Path.Path;
-    const files = yield* Effect.forEach(["apps", "packages"], (directory) =>
-      readFiles(path.join(root, directory))
+    const files = yield* Effect.forEach(
+      ["apps", "packages", "scripts"],
+      (directory) => readFiles(path.join(root, directory))
     ).pipe(Effect.map((groups) => groups.flat()));
     const tests = files.filter((file) => TEST_FILE_PATTERN.test(file));
     const ownership = yield* Effect.forEach(tests, (test) =>
@@ -96,6 +120,12 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
         Effect.map((hasOwner) => ({ hasOwner, test }))
       )
     );
+    const testSources = yield* Effect.forEach(
+      tests,
+      (test) => readTestSource(root, test),
+      { concurrency: 16 }
+    );
+    const effectRunnerProblems = inspectEffectTestRunnerPolicy(testSources);
     const orphanTests = ownership
       .filter(({ hasOwner }) => !hasOwner)
       .map(({ test }) => test);
@@ -109,9 +139,11 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
     if (
       orphanTests.length === 0 &&
       tsxTestFiles.length === 0 &&
-      nestedTestFiles.length === 0
+      nestedTestFiles.length === 0 &&
+      effectRunnerProblems.resolvedBaselineFiles.length === 0 &&
+      effectRunnerProblems.unexpectedRunnerFiles.length === 0
     ) {
-      yield* writeOutput("Test ownership checks passed.\n");
+      yield* writeOutput("Test ownership and Effect runner checks passed.\n");
       return 0;
     }
 
@@ -133,6 +165,20 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
       yield* writeError(
         `Tests must not use __test__ or __tests__ folders:\n${nestedTestFiles
           .map((file) => `  - ${path.relative(root, file)}`)
+          .join("\n")}\n`
+      );
+    }
+    if (effectRunnerProblems.unexpectedRunnerFiles.length > 0) {
+      yield* writeError(
+        `Tests importing ${EFFECT_TEST_ADAPTER} must use its Effect test methods instead of direct Effect runners:\n${effectRunnerProblems.unexpectedRunnerFiles
+          .map((file) => `  - ${file}`)
+          .join("\n")}\n`
+      );
+    }
+    if (effectRunnerProblems.resolvedBaselineFiles.length > 0) {
+      yield* writeError(
+        `Remove resolved Effect runner migration baseline entries in the same checkpoint:\n${effectRunnerProblems.resolvedBaselineFiles
+          .map((file) => `  - ${file}`)
           .join("\n")}\n`
       );
     }

--- a/scripts/effect-test-policy.test.ts
+++ b/scripts/effect-test-policy.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  inspectEffectTestRunnerPolicy,
+  type TestSource,
+} from "./effect-test-policy.ts";
+
+const effectProgram = "program";
+
+/** Creates one synthetic repository test module. */
+function testSource(path: string, source: string): TestSource {
+  return { path, source };
+}
+
+describe("Effect test runner policy", () => {
+  it("rejects direct runners hidden behind the Effect test adapter", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/program.test.ts",
+          `import { it } from "@repo/testing/effect";
+import { Effect as Program } from "effect";
+
+it("runs", async () => Program.runPromise(${effectProgram}));`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: ["packages/example/program.test.ts"],
+    });
+  });
+
+  it("accepts Effect programs returned through it.effect", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/program.test.ts",
+          `import { it } from "@repo/testing/effect";
+import { Effect } from "effect";
+
+it.effect("runs", () => ${effectProgram});`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("keeps ordinary Vitest runner boundaries outside the adapter policy", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/schema.test.ts",
+          `import { Effect } from "effect";
+import { it } from "vitest";
+
+it("encodes", async () => Effect.runPromise(${effectProgram}));`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("recognizes namespace, contextual, and direct Effect runners", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/namespace.test.ts",
+          `import { it } from "@repo/testing/effect";
+import * as Runtime from "effect/Effect";
+
+it("runs", () => Runtime.runSync(${effectProgram}));`
+        ),
+        testSource(
+          "packages/example/contextual.test.ts",
+          `import { it } from "@repo/testing/effect";
+import { Effect } from "effect";
+
+it("runs", () => Effect.runCallbackWith(context)(${effectProgram}));`
+        ),
+        testSource(
+          "packages/example/direct.test.ts",
+          `import { it } from "@repo/testing/effect";
+import { runPromiseExit as run } from "effect/Effect";
+
+it("runs", () => run(${effectProgram}));`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems.unexpectedRunnerFiles).toEqual([
+      "packages/example/contextual.test.ts",
+      "packages/example/direct.test.ts",
+      "packages/example/namespace.test.ts",
+    ]);
+  });
+
+  it("does not match runner names inside comments or strings", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/text.test.ts",
+          `import { it } from "@repo/testing/effect";
+import { Effect } from "effect";
+
+// Effect.runPromise(${effectProgram})
+it("documents", () => "Effect.runSync(program)");`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("forces resolved migration baseline entries to be removed", () => {
+    const path = "packages/example/migrated.test.ts";
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          path,
+          `import { it } from "@repo/testing/effect";
+import { Effect } from "effect";
+
+it.effect("runs", () => ${effectProgram});`
+        ),
+      ],
+      new Set([path])
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [path],
+      unexpectedRunnerFiles: [],
+    });
+  });
+});

--- a/scripts/effect-test-policy.ts
+++ b/scripts/effect-test-policy.ts
@@ -1,0 +1,181 @@
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isNamedImports,
+  isNamespaceImport,
+  isPropertyAccessExpression,
+  isStringLiteral,
+  type Node,
+  ScriptKind,
+  ScriptTarget,
+  type SourceFile,
+} from "typescript";
+
+export const EFFECT_TEST_ADAPTER = "@repo/testing/effect";
+
+const EFFECT_MODULES = new Set(["effect", "effect/Effect"]);
+const DIRECT_EFFECT_RUNNERS = new Set([
+  "runCallback",
+  "runCallbackWith",
+  "runFork",
+  "runForkWith",
+  "runPromise",
+  "runPromiseExit",
+  "runPromiseExitWith",
+  "runPromiseWith",
+  "runSync",
+  "runSyncExit",
+  "runSyncExitWith",
+  "runSyncWith",
+]);
+const EFFECT_TEST_RUNNER_MIGRATION_BASELINE = new Set([
+  "apps/www/components/shared/open-content/copy.test.ts",
+  "packages/backend/convex/contentRelease/program/context.test.ts",
+  "packages/backend/convex/contentRelease/program/route.test.ts",
+  "packages/backend/convex/contentRelease/runtime/public/dispatch.test.ts",
+  "packages/design-system/lib/theme/contract.test.ts",
+]);
+
+export interface TestSource {
+  readonly path: string;
+  readonly source: string;
+}
+
+export interface EffectTestRunnerPolicyProblems {
+  readonly resolvedBaselineFiles: readonly string[];
+  readonly unexpectedRunnerFiles: readonly string[];
+}
+
+/** Returns the string module specifier for one static import. */
+function importSource(statement: SourceFile["statements"][number]) {
+  if (
+    !(
+      isImportDeclaration(statement) &&
+      isStringLiteral(statement.moduleSpecifier)
+    )
+  ) {
+    return;
+  }
+  return statement.moduleSpecifier.text;
+}
+
+/** Detects the shared Effect Vitest adapter in one parsed test module. */
+function importsEffectTestAdapter(sourceFile: SourceFile) {
+  return sourceFile.statements.some(
+    (statement) => importSource(statement) === EFFECT_TEST_ADAPTER
+  );
+}
+
+/** Collects local names that can invoke an Effect runtime directly. */
+function readEffectRunnerBindings(sourceFile: SourceFile) {
+  const directRunners = new Set<string>();
+  const effectNamespaces = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    const moduleName = importSource(statement);
+    if (!(moduleName && EFFECT_MODULES.has(moduleName))) {
+      continue;
+    }
+    if (!isImportDeclaration(statement)) {
+      continue;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings) {
+      continue;
+    }
+    if (isNamespaceImport(bindings)) {
+      effectNamespaces.add(bindings.name.text);
+      continue;
+    }
+    if (!isNamedImports(bindings)) {
+      continue;
+    }
+
+    for (const binding of bindings.elements) {
+      const importedName = binding.propertyName?.text ?? binding.name.text;
+      if (moduleName === "effect" && importedName === "Effect") {
+        effectNamespaces.add(binding.name.text);
+      }
+      if (
+        moduleName === "effect/Effect" &&
+        DIRECT_EFFECT_RUNNERS.has(importedName)
+      ) {
+        directRunners.add(binding.name.text);
+      }
+    }
+  }
+
+  return { directRunners, effectNamespaces };
+}
+
+/** Detects a direct Effect runner call without matching comments or strings. */
+function callsDirectEffectRunner(sourceFile: SourceFile) {
+  const { directRunners, effectNamespaces } =
+    readEffectRunnerBindings(sourceFile);
+  let found = false;
+
+  const visit = (node: Node) => {
+    if (found) {
+      return;
+    }
+    if (isCallExpression(node)) {
+      const expression = node.expression;
+      if (isIdentifier(expression) && directRunners.has(expression.text)) {
+        found = true;
+        return;
+      }
+      if (
+        isPropertyAccessExpression(expression) &&
+        isIdentifier(expression.expression) &&
+        effectNamespaces.has(expression.expression.text) &&
+        DIRECT_EFFECT_RUNNERS.has(expression.name.text)
+      ) {
+        found = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+
+  forEachChild(sourceFile, visit);
+  return found;
+}
+
+/** Finds adapter imports that still hide direct Effect test runners. */
+export function inspectEffectTestRunnerPolicy(
+  tests: readonly TestSource[],
+  migrationBaseline: ReadonlySet<string> = EFFECT_TEST_RUNNER_MIGRATION_BASELINE
+): EffectTestRunnerPolicyProblems {
+  const runnerFiles = new Set(
+    tests.flatMap((test) => {
+      const sourceFile = createSourceFile(
+        test.path,
+        test.source,
+        ScriptTarget.Latest,
+        true,
+        ScriptKind.TS
+      );
+      if (
+        !(
+          importsEffectTestAdapter(sourceFile) &&
+          callsDirectEffectRunner(sourceFile)
+        )
+      ) {
+        return [];
+      }
+      return [test.path];
+    })
+  );
+
+  return {
+    resolvedBaselineFiles: [...migrationBaseline]
+      .filter((file) => !runnerFiles.has(file))
+      .sort(),
+    unexpectedRunnerFiles: [...runnerFiles]
+      .filter((file) => !migrationBaseline.has(file))
+      .sort(),
+  };
+}


### PR DESCRIPTION
## Summary

- add a TypeScript AST policy that rejects direct Effect runtime calls in tests importing @repo/testing/effect
- cover all 12 Effect runtime entry points exported by the pinned Effect v4 rc.110 source
- carry an exact shrinking five-file migration baseline and fail when a resolved entry is not removed
- keep this pure policy suite on ordinary Vitest with a direct root development dependency

## Proof

- pnpm --filter @repo/testing exec vitest run --root ../.. scripts/effect-test-policy.test.ts --coverage.enabled=false: 6 passed
- pnpm typecheck:scripts: passed
- pnpm check:tests: passed
- pnpm test:scripts: 15 passed
- pnpm lint: passed, including Effect source identity rc.110 at 66114151c2b4640bf773f2b3456ce70d679422f6
- pnpm security:audit: no known vulnerabilities
- git diff --check: passed

## Coordination

- exact base: b23c92461346c97d09a1a3634f185502ed4cd67a
- exact head: aa81eadf3b8d28ab6eb44f3dd928242a6df33536
- zero path overlap with PR #348 or PR #350
- no Vercel Preview requested or created