### PR TITLE
test(policy): ratchet Effect test runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "turbo run start",
     "test": "pnpm check:patches && pnpm check:tests && pnpm test:scripts && turbo run test",
     "test:coverage": "pnpm check:patches && pnpm check:tests && turbo run test:coverage",
-    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependency-policy.test.ts scripts/github-action-policy.test.ts scripts/effect-source.test.ts",
+    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. packages/testing/effect-test-policy.test.ts scripts/dependency-policy.test.ts scripts/effect-source.test.ts scripts/github-action-policy.test.ts",
     "test:ui": "turbo run test:ui",
     "test:watch": "turbo run test:watch",
     "translate": "turbo run translate",

--- a/packages/testing/effect-test-policy.test.ts
+++ b/packages/testing/effect-test-policy.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  inspectEffectTestRunnerPolicy,
+  type TestSource,
+} from "#testing/effect-test-policy";
+
+const effectProgram = "program";
+
+/** Creates one synthetic repository test module. */
+function testSource(path: string, source: string): TestSource {
+  return { path, source };
+}
+
+describe("Effect test runner policy", () => {
+  it("rejects direct runners behind ordinary Vitest", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/program.test.ts",
+          `import { Effect as Program } from "effect";
+import { it } from "vitest";
+
+it("runs", async () => Program.runPromise(${effectProgram}));`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: ["packages/example/program.test.ts"],
+    });
+  });
+
+  it("accepts Effect programs returned through it.effect", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/program.test.ts",
+          `import { it } from "@repo/testing/effect";
+
+it.effect("runs", () => ${effectProgram});`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("accepts pure Effect values in ordinary Vitest", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/exit.test.ts",
+          `import { Exit } from "effect";
+import { expect, it } from "vitest";
+
+it("constructs an exit", () => {
+  expect(Exit.succeed("ok")._tag).toBe("Success");
+});`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("recognizes namespace, contextual, and direct Effect runners", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/namespace.test.ts",
+          `import * as Runtime from "effect/Effect";
+import { it } from "vitest";
+
+it("runs", () => Runtime.runSync(${effectProgram}));`
+        ),
+        testSource(
+          "packages/example/contextual.test.ts",
+          `import { Effect } from "effect";
+import { it } from "vitest";
+
+it("runs", () => Effect.runCallbackWith(context)(${effectProgram}));`
+        ),
+        testSource(
+          "packages/example/direct.test.ts",
+          `import { runPromiseExit as run } from "effect/Effect";
+import { it } from "vitest";
+
+it("runs", () => run(${effectProgram}));`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems.unexpectedRunnerFiles).toEqual([
+      "packages/example/contextual.test.ts",
+      "packages/example/direct.test.ts",
+      "packages/example/namespace.test.ts",
+    ]);
+  });
+
+  it("does not match runner names inside comments or strings", () => {
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          "packages/example/text.test.ts",
+          `import { Effect } from "effect";
+import { it } from "vitest";
+
+// Effect.runPromise(${effectProgram})
+it("documents", () => "Effect.runSync(program)");`
+        ),
+      ],
+      new Set()
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [],
+      unexpectedRunnerFiles: [],
+    });
+  });
+
+  it("forces resolved migration baseline entries to be removed", () => {
+    const path = "packages/example/migrated.test.ts";
+    const problems = inspectEffectTestRunnerPolicy(
+      [
+        testSource(
+          path,
+          `import { it } from "@repo/testing/effect";
+
+it.effect("runs", () => ${effectProgram});`
+        ),
+      ],
+      new Set([path])
+    );
+
+    expect(problems).toEqual({
+      resolvedBaselineFiles: [path],
+      unexpectedRunnerFiles: [],
+    });
+  });
+});

--- a/packages/testing/effect-test-policy.ts
+++ b/packages/testing/effect-test-policy.ts
@@ -1,0 +1,262 @@
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isNamedImports,
+  isNamespaceImport,
+  isPropertyAccessExpression,
+  isStringLiteral,
+  type Node,
+  ScriptKind,
+  ScriptTarget,
+  type SourceFile,
+} from "typescript";
+
+export const EFFECT_TEST_ADAPTER = "@repo/testing/effect";
+
+const EFFECT_MODULES = new Set(["effect", "effect/Effect"]);
+const DIRECT_EFFECT_RUNNERS = new Set([
+  "runCallback",
+  "runCallbackWith",
+  "runFork",
+  "runForkWith",
+  "runPromise",
+  "runPromiseExit",
+  "runPromiseExitWith",
+  "runPromiseWith",
+  "runSync",
+  "runSyncExit",
+  "runSyncExitWith",
+  "runSyncWith",
+]);
+const EFFECT_TEST_RUNNER_MIGRATION_BASELINE = new Set([
+  "apps/www/app/api/chat/context.test.ts",
+  "apps/www/app/api/chat/persistence.test.ts",
+  "apps/www/app/api/chat/published.test.ts",
+  "apps/www/app/api/chat/utils.test.ts",
+  "apps/www/app/api/internal/content/renderer/route.test.ts",
+  "apps/www/components/shared/open-content/copy.test.ts",
+  "apps/www/lib/analytics/consent/storage.test.ts",
+  "apps/www/lib/content/article/catalog.test.ts",
+  "apps/www/lib/content/article/category.test.ts",
+  "apps/www/lib/content/article/decode.test.ts",
+  "apps/www/lib/content/article/discovery.test.ts",
+  "apps/www/lib/content/article/navigation.test.ts",
+  "apps/www/lib/content/article/route.test.ts",
+  "apps/www/lib/content/article/sitemap.test.ts",
+  "apps/www/lib/content/cache.test.ts",
+  "apps/www/lib/content/material/catalog.test.ts",
+  "apps/www/lib/content/material/context.test.ts",
+  "apps/www/lib/content/material/decode.test.ts",
+  "apps/www/lib/content/material/discovery.test.ts",
+  "apps/www/lib/content/material/route.test.ts",
+  "apps/www/lib/content/material/sitemap.test.ts",
+  "apps/www/lib/content/material/trust.test.ts",
+  "apps/www/lib/content/page/catalog.test.ts",
+  "apps/www/lib/content/page/navigation.test.ts",
+  "apps/www/lib/content/preview/config.test.ts",
+  "apps/www/lib/content/preview/events.test.ts",
+  "apps/www/lib/content/preview/material.test.ts",
+  "apps/www/lib/content/preview/question.test.ts",
+  "apps/www/lib/content/preview/request.test.ts",
+  "apps/www/lib/content/preview/route.test.ts",
+  "apps/www/lib/content/program/cards.test.ts",
+  "apps/www/lib/content/program/catalog.test.ts",
+  "apps/www/lib/content/program/decode.test.ts",
+  "apps/www/lib/content/program/route.test.ts",
+  "apps/www/lib/content/published/active.test.ts",
+  "apps/www/lib/content/published/exchange.test.ts",
+  "apps/www/lib/content/published/origin.test.ts",
+  "apps/www/lib/content/published/projection.test.ts",
+  "apps/www/lib/content/published/release.test.ts",
+  "apps/www/lib/content/published/route.test.ts",
+  "apps/www/lib/content/quran/publication.test.ts",
+  "apps/www/lib/content/quran/recovery.test.ts",
+  "apps/www/lib/content/renderer/components.test.ts",
+  "apps/www/lib/content/renderer/manifest.test.ts",
+  "apps/www/lib/content/runtime/query.test.ts",
+  "apps/www/lib/content/tryout/sitemap.test.ts",
+  "apps/www/lib/llms/content-entries.test.ts",
+  "apps/www/lib/llms/content-listing.test.ts",
+  "apps/www/lib/llms/content.test.ts",
+  "apps/www/lib/llms/indexes.test.ts",
+  "apps/www/lib/llms/material-pages.test.ts",
+  "apps/www/lib/llms/published.test.ts",
+  "apps/www/lib/llms/quran.test.ts",
+  "apps/www/lib/llms/section.test.ts",
+  "apps/www/lib/llms/site.test.ts",
+  "apps/www/lib/routing/locale/published.test.ts",
+  "apps/www/lib/routing/locale/resolve.test.ts",
+  "apps/www/lib/routing/public/migration.test.ts",
+  "apps/www/lib/routing/public/projected.test.ts",
+  "apps/www/lib/routing/public/source.test.ts",
+  "apps/www/lib/sitemap/catalog.test.ts",
+  "apps/www/lib/sitemap/entries.test.ts",
+  "apps/www/lib/sitemap/routes.test.ts",
+  "apps/www/lib/utils/seo/quran.test.ts",
+  "apps/www/lib/utils/seo/translations.test.ts",
+  "apps/www/scripts/indexing/manifest.test.ts",
+  "packages/analytics/consent.test.ts",
+  "packages/analytics/posthog/browser.test.ts",
+  "packages/analytics/posthog/server.test.ts",
+  "packages/backend/convex/contentRelease/article/dates.test.ts",
+  "packages/backend/convex/contentRelease/article/order.test.ts",
+  "packages/backend/convex/contentRelease/article/predecessor.test.ts",
+  "packages/backend/convex/contentRelease/ingress/group.test.ts",
+  "packages/backend/convex/contentRelease/ingress/lifecycle.test.ts",
+  "packages/backend/convex/contentRelease/ingress/readModels.test.ts",
+  "packages/backend/convex/contentRelease/ingress/rollback.test.ts",
+  "packages/backend/convex/contentRelease/ingress/stage.test.ts",
+  "packages/backend/convex/contentRelease/material/predecessor.test.ts",
+  "packages/backend/convex/contentRelease/program/context.test.ts",
+  "packages/backend/convex/contentRelease/program/route.test.ts",
+  "packages/backend/convex/contentRelease/proof/verify.test.ts",
+  "packages/backend/convex/contentRelease/runtime/public/batch.test.ts",
+  "packages/backend/convex/contentRelease/runtime/public/dispatch.test.ts",
+  "packages/backend/convex/contents/views/context.test.ts",
+  "packages/backend/convex/customers/polar/target.test.ts",
+  "packages/backend/convex/customers/polar/webhook.test.ts",
+  "packages/backend/convex/emails/welcome.test.ts",
+  "packages/backend/convex/learningPreferences/mutations.test.ts",
+  "packages/backend/convex/tryouts/progress/write.test.ts",
+  "packages/backend/convex/tryouts/runtime/access.test.ts",
+  "packages/backend/convex/tryouts/runtime/score.test.ts",
+  "packages/backend/convex/tryouts/runtime/selectors.test.ts",
+  "packages/backend/convex/tryouts/score/result.test.ts",
+  "packages/backend/convex/tryouts/sets/page.test.ts",
+  "packages/design-system/lib/theme/compatibility.test.ts",
+  "packages/design-system/lib/theme/contract.test.ts",
+  "packages/design-system/lib/theme/contrast.test.ts",
+  "packages/design-system/lib/theme/registry.test.ts",
+]);
+
+export interface TestSource {
+  readonly path: string;
+  readonly source: string;
+}
+
+export interface EffectTestRunnerPolicyProblems {
+  readonly resolvedBaselineFiles: readonly string[];
+  readonly unexpectedRunnerFiles: readonly string[];
+}
+
+/** Returns the string module specifier for one static import. */
+function importSource(statement: SourceFile["statements"][number]) {
+  if (
+    !(
+      isImportDeclaration(statement) &&
+      isStringLiteral(statement.moduleSpecifier)
+    )
+  ) {
+    return;
+  }
+  return statement.moduleSpecifier.text;
+}
+
+/** Collects local names that can invoke an Effect runtime directly. */
+function readEffectRunnerBindings(sourceFile: SourceFile) {
+  const directRunners = new Set<string>();
+  const effectNamespaces = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    const moduleName = importSource(statement);
+    if (!(moduleName && EFFECT_MODULES.has(moduleName))) {
+      continue;
+    }
+    if (!isImportDeclaration(statement)) {
+      continue;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings) {
+      continue;
+    }
+    if (isNamespaceImport(bindings)) {
+      effectNamespaces.add(bindings.name.text);
+      continue;
+    }
+    if (!isNamedImports(bindings)) {
+      continue;
+    }
+
+    for (const binding of bindings.elements) {
+      const importedName = binding.propertyName?.text ?? binding.name.text;
+      if (moduleName === "effect" && importedName === "Effect") {
+        effectNamespaces.add(binding.name.text);
+      }
+      if (
+        moduleName === "effect/Effect" &&
+        DIRECT_EFFECT_RUNNERS.has(importedName)
+      ) {
+        directRunners.add(binding.name.text);
+      }
+    }
+  }
+
+  return { directRunners, effectNamespaces };
+}
+
+/** Detects a direct Effect runner call without matching comments or strings. */
+function callsDirectEffectRunner(sourceFile: SourceFile) {
+  const { directRunners, effectNamespaces } =
+    readEffectRunnerBindings(sourceFile);
+  let found = false;
+
+  const visit = (node: Node) => {
+    if (found) {
+      return;
+    }
+    if (isCallExpression(node)) {
+      const expression = node.expression;
+      if (isIdentifier(expression) && directRunners.has(expression.text)) {
+        found = true;
+        return;
+      }
+      if (
+        isPropertyAccessExpression(expression) &&
+        isIdentifier(expression.expression) &&
+        effectNamespaces.has(expression.expression.text) &&
+        DIRECT_EFFECT_RUNNERS.has(expression.name.text)
+      ) {
+        found = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+
+  forEachChild(sourceFile, visit);
+  return found;
+}
+
+/** Finds authored tests that invoke an Effect runtime directly. */
+export function inspectEffectTestRunnerPolicy(
+  tests: readonly TestSource[],
+  migrationBaseline: ReadonlySet<string> = EFFECT_TEST_RUNNER_MIGRATION_BASELINE
+): EffectTestRunnerPolicyProblems {
+  const runnerFiles = new Set(
+    tests.flatMap((test) => {
+      const sourceFile = createSourceFile(
+        test.path,
+        test.source,
+        ScriptTarget.Latest,
+        true,
+        ScriptKind.TS
+      );
+      if (!callsDirectEffectRunner(sourceFile)) {
+        return [];
+      }
+      return [test.path];
+    })
+  );
+
+  return {
+    resolvedBaselineFiles: [...migrationBaseline]
+      .filter((file) => !runnerFiles.has(file))
+      .sort(),
+    unexpectedRunnerFiles: [...runnerFiles]
+      .filter((file) => !migrationBaseline.has(file))
+      .sort(),
+  };
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     "./effect": "./effect.ts",
+    "./effect-test-policy": "./effect-test-policy.ts",
     "./node": "./node.ts",
     "./react": "./react.ts"
   },
@@ -23,6 +24,7 @@
     "@repo/typescript-config": "workspace:*",
     "@vitejs/plugin-react": "^6.1.0",
     "@vitest/coverage-istanbul": "^4.1.11",
+    "typescript": "catalog:",
     "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,6 +1108,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^4.1.11
         version: 4.1.11(supports-color@7.2.0)(vitest@4.1.11)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@edge-runtime/vm@5.0.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))

--- a/scripts/check-tests.ts
+++ b/scripts/check-tests.ts
@@ -1,4 +1,8 @@
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import {
+  EFFECT_TEST_ADAPTER,
+  inspectEffectTestRunnerPolicy,
+} from "@repo/testing/effect-test-policy";
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { writeError, writeOutput } from "./output.ts";
 
@@ -83,12 +87,32 @@ const hasColocatedOwner = Effect.fn("RepositoryPolicy.hasColocatedOwner")(
   }
 );
 
+/** Reads one test module for Effect runner policy inspection. */
+const readTestSource = Effect.fn("RepositoryPolicy.readTestSource")(function* (
+  root: string,
+  testPath: string
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const source = yield* fileSystem.readFileString(testPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TestPolicyReadError({
+          cause,
+          message: `Unable to read ${testPath}.`,
+        })
+    )
+  );
+  return { path: path.relative(root, testPath), source };
+});
+
 /** Validates test ownership and final repository test layout. */
 export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
   function* (root: string) {
     const path = yield* Path.Path;
-    const files = yield* Effect.forEach(["apps", "packages"], (directory) =>
-      readFiles(path.join(root, directory))
+    const files = yield* Effect.forEach(
+      ["apps", "packages", "scripts"],
+      (directory) => readFiles(path.join(root, directory))
     ).pipe(Effect.map((groups) => groups.flat()));
     const tests = files.filter((file) => TEST_FILE_PATTERN.test(file));
     const ownership = yield* Effect.forEach(tests, (test) =>
@@ -96,6 +120,12 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
         Effect.map((hasOwner) => ({ hasOwner, test }))
       )
     );
+    const testSources = yield* Effect.forEach(
+      tests,
+      (test) => readTestSource(root, test),
+      { concurrency: 16 }
+    );
+    const effectRunnerProblems = inspectEffectTestRunnerPolicy(testSources);
     const orphanTests = ownership
       .filter(({ hasOwner }) => !hasOwner)
       .map(({ test }) => test);
@@ -109,9 +139,11 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
     if (
       orphanTests.length === 0 &&
       tsxTestFiles.length === 0 &&
-      nestedTestFiles.length === 0
+      nestedTestFiles.length === 0 &&
+      effectRunnerProblems.resolvedBaselineFiles.length === 0 &&
+      effectRunnerProblems.unexpectedRunnerFiles.length === 0
     ) {
-      yield* writeOutput("Test ownership checks passed.\n");
+      yield* writeOutput("Test ownership and Effect runner checks passed.\n");
       return 0;
     }
 
@@ -133,6 +165,20 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
       yield* writeError(
         `Tests must not use __test__ or __tests__ folders:\n${nestedTestFiles
           .map((file) => `  - ${path.relative(root, file)}`)
+          .join("\n")}\n`
+      );
+    }
+    if (effectRunnerProblems.unexpectedRunnerFiles.length > 0) {
+      yield* writeError(
+        `Effectful tests must use ${EFFECT_TEST_ADAPTER} methods instead of direct Effect runtime calls:\n${effectRunnerProblems.unexpectedRunnerFiles
+          .map((file) => `  - ${file}`)
+          .join("\n")}\n`
+      );
+    }
+    if (effectRunnerProblems.resolvedBaselineFiles.length > 0) {
+      yield* writeError(
+        `Remove resolved Effect runner migration baseline entries in the same checkpoint:\n${effectRunnerProblems.resolvedBaselineFiles
+          .map((file) => `  - ${file}`)
           .join("\n")}\n`
       );
     }


### PR DESCRIPTION
## 1. Outcome

Adds a repository-wide shrinking ratchet for direct Effect runtime calls in authored tests. Closed PR #353 and its old reviewed commit aa81eadf3b8d28ab6eb44f3dd928242a6df33536 are superseded by corrected head 7c7b598c3acb76d2862886cbd0bbbedc5358dc42.

## 2. Exact scope

- package.json
- packages/testing/package.json
- packages/testing/effect-test-policy.ts
- packages/testing/effect-test-policy.test.ts
- pnpm-lock.yaml
- scripts/check-tests.ts

## 3. Ratchet contract

The TypeScript AST scan covers every authored test under apps, packages, and scripts, independent of which Vitest adapter it imports. It recognizes all 12 Effect v4 rc.110 runtime entry points. The exact current 98-file baseline may only shrink: a new runner file fails, and a resolved baseline entry also fails until removed. Pure deterministic tests remain ordinary Vitest when they do not directly run an Effect.

## 4. Ownership

packages/testing owns the pure policy test, Vitest runtime, and its direct catalog TypeScript compiler API dependency. The root has no Vitest dependency. The lockfile change only records TypeScript under the testing package importer.

## 5. Proof

- focused policy: 6 passed
- packages/testing typecheck: passed
- scripts typecheck: passed
- live check:tests: passed against exactly 98 baseline paths
- test:scripts: 15 passed
- lint, boundaries, security audit, and diff check: passed
- baseline SHA-256: 660fbc75776bc60623a14953c868ae8bf6fe1652be49c4bf676e1fd21c7e7521
- binary diff SHA-256: 87afe81a75c390fc95581471c4f077df769d0dbffc2ccd5d52de295c041d8d97

## 6. Merge order and release guard

This replacement PR must not merge before PR #348 protected-merges. Let exact-head Quality, signed Production, Required, and numeric Doctor complete first. Do not request final Codex review until those exact-head gates are green. No Vercel Preview is requested or permitted.