### PR TITLE
fix(three): stabilize coordinate-system interaction

### DIFF
--- a/apps/www/e2e/coordinate-system.browser.ts
+++ b/apps/www/e2e/coordinate-system.browser.ts
@@ -9,19 +9,58 @@ import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
 const LINEAR_SYSTEM_ROUTE =
   "/id/materi/matematika/sistem-persamaan-dan-pertidaksamaan-linear/sistem-persamaan-linear";
 const MANY_SOLUTIONS_SCENE_INDEX = 2;
+const VISUAL_ASSERTION_TIMEOUT = 5000;
+const REQUIRED_STABLE_SAMPLES = 2;
 
-const waitForRenderedFrames = Effect.fn("NakafaE2E.waitForRenderedFrames")(
-  function* (page: Page) {
+const waitForStableCanvas = Effect.fn("NakafaE2E.waitForStableCanvas")(
+  function* (canvas: Locator) {
+    let previousFrame = yield* Effect.promise(() => canvas.screenshot());
+    let stableSamples = 0;
+
     yield* Effect.promise(() =>
-      page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-          })
-      )
+      expect
+        .poll(
+          async () => {
+            const currentFrame = await canvas.screenshot();
+
+            if (currentFrame.equals(previousFrame)) {
+              stableSamples += 1;
+            } else {
+              stableSamples = 0;
+            }
+
+            previousFrame = currentFrame;
+            return stableSamples;
+          },
+          {
+            intervals: [100, 200, 300],
+            timeout: VISUAL_ASSERTION_TIMEOUT,
+          }
+        )
+        .toBeGreaterThanOrEqual(REQUIRED_STABLE_SAMPLES)
     );
   }
 );
+
+const expectCanvasToMove = Effect.fn("NakafaE2E.expectCanvasToMove")(function* (
+  canvas: Locator,
+  baseline: Uint8Array
+) {
+  yield* Effect.promise(() =>
+    expect
+      .poll(
+        async () => {
+          const currentFrame = await canvas.screenshot();
+          return currentFrame.equals(baseline);
+        },
+        {
+          intervals: [50, 100, 200],
+          timeout: VISUAL_ASSERTION_TIMEOUT,
+        }
+      )
+      .toBe(false)
+  );
+});
 
 const observeDrawingBufferSize = Effect.fn(
   "NakafaE2E.observeDrawingBufferSize"
@@ -81,7 +120,6 @@ const orbitScene = Effect.fn("NakafaE2E.orbitScene")(function* (
     })
   );
   yield* Effect.promise(() => page.mouse.up());
-  yield* waitForRenderedFrames(page);
 });
 
 const expectStableCoordinateSystem = Effect.fn(
@@ -103,18 +141,17 @@ const expectStableCoordinateSystem = Effect.fn(
   yield* Effect.promise(() => scene.scrollIntoViewIfNeeded());
   yield* Effect.promise(() => expect(canvas).toBeVisible({ timeout: 30_000 }));
   yield* observeDrawingBufferSize(canvas);
-
-  const beforeDrag = yield* Effect.promise(() => canvas.screenshot());
-  yield* orbitScene(page, canvas);
-  const afterDrag = yield* Effect.promise(() => canvas.screenshot());
-  yield* Effect.sync(() => expect(afterDrag.equals(beforeDrag)).toBe(false));
+  yield* waitForStableCanvas(canvas);
 
   const beforePlay = yield* Effect.promise(() => canvas.screenshot());
   yield* Effect.promise(() => playButton.click());
-  yield* waitForRenderedFrames(page);
-  const duringPlay = yield* Effect.promise(() => canvas.screenshot());
+  yield* expectCanvasToMove(canvas, beforePlay);
   yield* Effect.promise(() => playButton.click());
-  yield* Effect.sync(() => expect(duringPlay.equals(beforePlay)).toBe(false));
+  yield* waitForStableCanvas(canvas);
+
+  const beforeDrag = yield* Effect.promise(() => canvas.screenshot());
+  yield* orbitScene(page, canvas);
+  yield* expectCanvasToMove(canvas, beforeDrag);
   yield* Effect.promise(() =>
     expect(canvas).toHaveAttribute("data-drawing-buffer-changed", "false")
   );

--- a/apps/www/e2e/coordinate-system.browser.ts
+++ b/apps/www/e2e/coordinate-system.browser.ts
@@ -1,0 +1,146 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { Effect } from "effect";
+import {
+  withBrowserContext,
+  withObservedPageErrors,
+} from "@/e2e/support/browser-context";
+import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
+
+const LINEAR_SYSTEM_ROUTE =
+  "/id/materi/matematika/sistem-persamaan-dan-pertidaksamaan-linear/sistem-persamaan-linear";
+const MANY_SOLUTIONS_SCENE_INDEX = 2;
+
+const waitForRenderedFrames = Effect.fn("NakafaE2E.waitForRenderedFrames")(
+  function* (page: Page) {
+    yield* Effect.promise(() =>
+      page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          })
+      )
+    );
+  }
+);
+
+const observeDrawingBufferSize = Effect.fn(
+  "NakafaE2E.observeDrawingBufferSize"
+)(function* (canvas: Locator) {
+  const started = yield* Effect.promise(() =>
+    canvas.evaluate((element) => {
+      if (!(element instanceof HTMLCanvasElement)) {
+        return false;
+      }
+
+      const initialHeight = element.height;
+      const initialWidth = element.width;
+      element.dataset.drawingBufferChanged = "false";
+
+      const observer = new MutationObserver(() => {
+        if (
+          element.height === initialHeight &&
+          element.width === initialWidth
+        ) {
+          return;
+        }
+
+        element.dataset.drawingBufferChanged = "true";
+        observer.disconnect();
+      });
+      observer.observe(element, {
+        attributeFilter: ["height", "width"],
+        attributes: true,
+      });
+      return true;
+    })
+  );
+
+  yield* Effect.sync(() => expect(started).toBe(true));
+});
+
+const orbitScene = Effect.fn("NakafaE2E.orbitScene")(function* (
+  page: Page,
+  canvas: Locator
+) {
+  const bounds = yield* Effect.promise(() => canvas.boundingBox());
+  yield* Effect.sync(() => expect(bounds).not.toBeNull());
+  if (!bounds) {
+    return;
+  }
+
+  const startX = bounds.x + bounds.width * 0.4;
+  const startY = bounds.y + bounds.height * 0.55;
+  const endX = bounds.x + bounds.width * 0.7;
+  const endY = bounds.y + bounds.height * 0.4;
+
+  yield* Effect.promise(() => page.mouse.move(startX, startY));
+  yield* Effect.promise(() => page.mouse.down());
+  yield* Effect.promise(() =>
+    page.mouse.move(endX, endY, {
+      steps: 6,
+    })
+  );
+  yield* Effect.promise(() => page.mouse.up());
+  yield* waitForRenderedFrames(page);
+});
+
+const expectStableCoordinateSystem = Effect.fn(
+  "NakafaE2E.expectStableCoordinateSystem"
+)(function* (page: Page) {
+  yield* seedDeniedAnalyticsConsent(page);
+  const response = yield* Effect.promise(() =>
+    page.goto(LINEAR_SYSTEM_ROUTE, { waitUntil: "domcontentloaded" })
+  );
+  yield* Effect.sync(() => expect(response?.ok()).toBe(true));
+
+  const scene = page
+    .locator('[data-slot="line-scene"]')
+    .nth(MANY_SOLUTIONS_SCENE_INDEX);
+  const canvas = scene.locator("canvas");
+  const playButton = scene.getByRole("button", { name: "Toggle Play" });
+
+  yield* Effect.promise(() => expect(scene).toBeAttached());
+  yield* Effect.promise(() => scene.scrollIntoViewIfNeeded());
+  yield* Effect.promise(() => expect(canvas).toBeVisible({ timeout: 30_000 }));
+  yield* observeDrawingBufferSize(canvas);
+
+  const beforeDrag = yield* Effect.promise(() => canvas.screenshot());
+  yield* orbitScene(page, canvas);
+  const afterDrag = yield* Effect.promise(() => canvas.screenshot());
+  yield* Effect.sync(() => expect(afterDrag.equals(beforeDrag)).toBe(false));
+
+  const beforePlay = yield* Effect.promise(() => canvas.screenshot());
+  yield* Effect.promise(() => playButton.click());
+  yield* waitForRenderedFrames(page);
+  const duringPlay = yield* Effect.promise(() => canvas.screenshot());
+  yield* Effect.promise(() => playButton.click());
+  yield* Effect.sync(() => expect(duringPlay.equals(beforePlay)).toBe(false));
+  yield* Effect.promise(() =>
+    expect(canvas).toHaveAttribute("data-drawing-buffer-changed", "false")
+  );
+});
+
+test("coordinate-system interaction keeps its drawing buffer stable", async ({
+  baseURL,
+  browser,
+}) => {
+  expect(baseURL).toBeTruthy();
+  await Effect.runPromise(
+    withBrowserContext(
+      browser,
+      {
+        baseURL: baseURL ?? "",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1200 },
+      },
+      (context) =>
+        Effect.gen(function* () {
+          const page = yield* Effect.promise(() => context.newPage());
+          yield* withObservedPageErrors(
+            page,
+            expectStableCoordinateSystem(page)
+          );
+        })
+    )
+  );
+});

--- a/packages/design-system/components/three/camera-controls.tsx
+++ b/packages/design-system/components/three/camera-controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
-import { useFrame, useThree } from "@react-three/fiber";
+import { useThree } from "@react-three/fiber";
 import { type ComponentRef, useCallback, useEffect, useRef } from "react";
 
 const DEFAULT_CAMERA_X = 12;
@@ -36,6 +36,10 @@ const DEFAULT_CAMERA_TARGET = [
  * systems, Three.js requires OrbitControls.update() after manual camera
  * transform changes, and demand-rendered R3F canvases need invalidate() after
  * imperative mutations.
+ *
+ * Drei owns OrbitControls frame updates and demand-mode invalidation. Keeping a
+ * second update or performance-regression loop here would resize AdaptiveDpr's
+ * drawing buffer while camera damping settles.
  *
  * @see https://react.dev/learn/synchronizing-with-effects
  * @see https://threejs.org/docs/#examples/en/controls/OrbitControls
@@ -77,7 +81,6 @@ export function CameraControls(props: CameraControlsProps) {
   const controlsRef = useRef<ComponentRef<typeof OrbitControls>>(null);
   const domElement = useThree((state) => state.gl.domElement);
   const invalidate = useThree((state) => state.invalidate);
-  const regress = useThree((state) => state.performance.regress);
   const [cameraPositionX, cameraPositionY, cameraPositionZ] = cameraPosition;
   const [cameraTargetX, cameraTargetY, cameraTargetZ] = cameraTarget;
 
@@ -114,28 +117,6 @@ export function CameraControls(props: CameraControlsProps) {
     };
   }, [domElement]);
 
-  useFrame(() => {
-    if (!autoRotate) {
-      return;
-    }
-
-    if (!controlsRef.current) {
-      return;
-    }
-
-    regress();
-    controlsRef.current.update();
-    invalidate();
-  });
-
-  /**
-   * Re-renders demand-driven canvases when the user interacts with controls.
-   */
-  const invalidateCameraControls = useCallback(() => {
-    regress();
-    invalidate();
-  }, [invalidate, regress]);
-
   /**
    * Mirrors OrbitControls interaction state into the canvas cursor.
    */
@@ -168,7 +149,6 @@ export function CameraControls(props: CameraControlsProps) {
         minAzimuthAngle={minAzimuthAngle}
         minDistance={minDistance}
         minPolarAngle={minPolarAngle}
-        onChange={invalidateCameraControls}
         onEnd={handleEnd}
         onStart={handleStart}
         ref={controlsRef}


### PR DESCRIPTION
## Summary

- let Drei own OrbitControls frame updates and demand-mode invalidation
- stop interaction and auto-rotation from repeatedly regressing AdaptiveDpr
- add production browser coverage for real orbit dragging, Play motion, and drawing-buffer stability

## Root cause

CameraControls called `performance.regress()`, `controls.update()`, and `invalidate()` during every controls change and auto-rotation frame. AdaptiveDpr converted each regression into a drawing-buffer resize. Its 100 ms recovery raced OrbitControls damping, so the production canvas oscillated between `1344x939` and `1075x751` after interaction.

Drei already updates OrbitControls and invalidates demand-rendered canvases. Removing the duplicate loop preserves camera motion while keeping the drawing buffer stable.

## Verification

- `pnpm lint`
- `pnpm --filter @repo/design-system typecheck`
- `NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud POSTHOG_PROXY_HOST=https://us.i.posthog.com pnpm --filter www typecheck`
- `pnpm --filter @repo/design-system test` with 323 tests and 100% enforced coverage
- React Doctor changed-scope audit: 100/100
- exact Aksara Indonesian lesson in local Chrome: drag and Play visibly move the scene while the buffer remains fixed at `1344x939`
- focused Playwright acceptance: 1 passed

## Release scope

- no Vercel Preview was created or required
- no Convex schema, function, environment, or deployment contract changed
- protected-main CI remains the production build and browser acceptance gate