### PR TITLE
fix(design-system): distinguish coincident lines

### DIFF
--- a/packages/design-system/components/contents/mathematics/line/scene.tsx
+++ b/packages/design-system/components/contents/mathematics/line/scene.tsx
@@ -16,9 +16,10 @@ export function LineScene({
       showGizmo={showZAxis}
       showZAxis={showZAxis}
     >
-      {lines.map((line) => (
+      {lines.map((line, index) => (
         <LineEquation
-          key={`line-${line.points.map((point) => `${point.x},${point.y},${point.z}`).join(";")}`}
+          // biome-ignore lint/suspicious/noArrayIndexKey: Authored order is stable, and coincident lines intentionally share every point.
+          key={`line-${index}-${line.points.map((point) => `${point.x},${point.y},${point.z}`).join(";")}`}
           {...line}
         />
       ))}


### PR DESCRIPTION
## Summary

- make coincident LineEquation segments keep distinct React keys
- preserve authored draw order so layered line styles remain visible

## Why

The lesson has two equations, but the second is exactly twice the first, so both equations correctly occupy one geometric line. Aksara now uses layered widths and clearer explanation. This renderer change prevents duplicate keys when the two authored segments have identical endpoints.

Companion content PR: https://github.com/nakafaai/aksara/pull/131

## Exact head

`fd59e93a804dc377b9fcbb0080cca4cb49dadee6`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm lint`
- `pnpm --filter @repo/design-system typecheck`
- `pnpm --filter @repo/design-system test`: 323 tests, 100% coverage
- `NEXT_PUBLIC_CONVEX_URL=https://dapper-antelope-269.convex.cloud POSTHOG_PROXY_HOST=https://t.nakafa.com pnpm --filter www typecheck`
- `pnpm security:audit`
- production build compilation and TypeScript passed; final page collection requires the protected `INTERNAL_CONTENT_API_KEY` supplied by CI
- local production browser acceptance with the companion Aksara content passed

No Vercel Preview was created.