### PR TITLE
perf(www): overlap material static generation safely

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
@@ -12,7 +12,11 @@ import {
   type MaterialParams,
   readMaterialRequest,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/data";
-import { getMaterialPublication } from "@/lib/content/material/publication";
+import { normalizeMaterialMetadata } from "@/lib/content/material/decode";
+import {
+  getMaterialCatalogRoute,
+  getMaterialPublication,
+} from "@/lib/content/material/publication";
 import { hasPreviewConfig } from "@/lib/content/preview/config";
 import {
   type MaterialPreviewContent,
@@ -35,12 +39,15 @@ interface PublishedOwner {
 
 type MaterialOwner = PreviewOwner | PublishedOwner;
 
-interface MaterialFields {
+interface MaterialRouteFields {
   readonly alternates: readonly MaterialLessonProjection[];
   readonly appLocale: Locale;
   readonly metadata: MaterialMetadata;
-  readonly rendererDomain: RendererDomain;
   readonly route: MaterialLessonProjection;
+}
+
+interface MaterialFields extends MaterialRouteFields {
+  readonly rendererDomain: RendererDomain;
 }
 
 interface PreviewContent extends MaterialFields {
@@ -66,7 +73,7 @@ interface PublishedContent extends MaterialFields {
 export type MaterialPageContent = PreviewContent | PublishedContent;
 
 /** Metadata selected from the same exclusive owner as the page body. */
-export interface MaterialMetadataContent extends MaterialFields {
+export interface MaterialMetadataContent extends MaterialRouteFields {
   readonly kind: MaterialOwner["kind"];
 }
 
@@ -117,26 +124,20 @@ export async function readMaterialMetadata(
       kind: owner.kind,
       appLocale: owner.appLocale,
       metadata: owner.preview.metadata,
-      rendererDomain: owner.preview.rendererDomain,
       route: owner.preview.projection,
     };
   }
 
-  const publication = await getMaterialPublication(
-    owner.locale,
-    owner.publicPath
-  );
-  if (!publication) {
+  const model = await getMaterialCatalogRoute(owner.locale, owner.publicPath);
+  if (!model.projection) {
     notFound();
   }
-  const { model, published } = publication;
 
   return {
     alternates: model.alternates,
     kind: owner.kind,
     appLocale: owner.locale,
-    metadata: published.metadata,
-    rendererDomain: published.rendererDomain,
+    metadata: normalizeMaterialMetadata(model.projection.metadata),
     route: model.projection,
   };
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
@@ -12,9 +12,7 @@ import {
   type MaterialParams,
   readMaterialRequest,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/data";
-import { normalizeMaterialMetadata } from "@/lib/content/material/decode";
 import { getMaterialPublication } from "@/lib/content/material/publication";
-import { getPublishedMaterialRoute } from "@/lib/content/material/route";
 import { hasPreviewConfig } from "@/lib/content/preview/config";
 import {
   type MaterialPreviewContent,
@@ -124,17 +122,21 @@ export async function readMaterialMetadata(
     };
   }
 
-  const model = await getPublishedMaterialRoute(owner.locale, owner.publicPath);
-  if (!model.projection) {
+  const publication = await getMaterialPublication(
+    owner.locale,
+    owner.publicPath
+  );
+  if (!publication) {
     notFound();
   }
+  const { model, published } = publication;
 
   return {
     alternates: model.alternates,
     kind: owner.kind,
     appLocale: owner.locale,
-    metadata: normalizeMaterialMetadata(model.projection.metadata),
-    rendererDomain: model.rendererDomain,
+    metadata: published.metadata,
+    rendererDomain: published.rendererDomain,
     route: model.projection,
   };
 }
@@ -183,7 +185,7 @@ export async function readMaterialPage(
     kind: owner.kind,
     appLocale: owner.locale,
     metadata: published.metadata,
-    rendererDomain: model.rendererDomain,
+    rendererDomain: published.rendererDomain,
     route: model.projection,
     siblings: model.siblings,
     sourceUrl: published.sourceRevision

--- a/apps/www/e2e/features.browser.ts
+++ b/apps/www/e2e/features.browser.ts
@@ -9,7 +9,9 @@ import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
 const NINA_ANSWER_TEXT = "Subtract the first equation";
 const NINA_HEADING_PATTERN = /Nina already knows/;
 const NINA_REASONING_TEXT = "Compare the two known equations";
-const NEXT_CHUNK_PATH = /\/_next\/static\/chunks\/.*\.js(?:\?.*)?$/;
+// Match local Next and Vercel-promoted production chunk paths.
+const NEXT_CHUNK_PATH =
+  /\/_next\/static\/(?:immutable\/)?chunks\/.*\.js(?:\?.*)?$/;
 
 // Normal motion remains covered at three widths. Wide layouts use the product's
 // reduced-motion path so continuous WebGL frames cannot starve pointer checks.
@@ -216,6 +218,21 @@ const expectProjectileDeferred = Effect.fn(
   );
 });
 
+const expectProjectileHydratedWhileDeferred = Effect.fn(
+  "NakafaE2E.expectProjectileHydratedWhileDeferred"
+)(function* (page: Page) {
+  const highArc = page.getByRole("button", { name: "High Arc" });
+  yield* Effect.promise(() =>
+    expect
+      .poll(async () => {
+        await highArc.dispatchEvent("click");
+        return await highArc.getAttribute("aria-pressed");
+      })
+      .toBe("true")
+  );
+  yield* expectProjectileDeferred(page);
+});
+
 for (const viewport of targetViewports) {
   test(`homepage features preserve UX at ${viewport.name}`, async ({
     baseURL,
@@ -273,6 +290,7 @@ test("homepage projectile recovers from a terminal scene load failure", async ({
             Effect.gen(function* () {
               yield* prepareFeaturesPage(page);
               yield* expectProjectileDeferred(page);
+              yield* expectProjectileHydratedWhileDeferred(page);
               yield* expectProjectileRecovery(page);
             })
           );

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -5,8 +5,9 @@ import {
   type MaterialLessonProjection,
 } from "@nakafa/aksara-contracts/projection/material";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
+import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedMaterialRoutes,
   readPublishedMaterialPage,
@@ -34,11 +35,13 @@ vi.mock("@/lib/content/runtime/query", async () => {
 function materialPage({
   done = true,
   managed = true,
+  revision = sourceRevision,
   routes = [previewProjection],
   stale = false,
 }: {
   readonly done?: boolean;
   readonly managed?: boolean;
+  readonly revision?: null | string;
   readonly routes?: readonly MaterialLessonProjection[];
   readonly stale?: boolean;
 } = {}) {
@@ -51,7 +54,7 @@ function materialPage({
       isDone: done,
       page: routes.map((route) => canonicalizeMaterialProjection(route)),
     },
-    sourceRevision: managed ? sourceRevision : null,
+    sourceRevision: managed ? revision : null,
     stale,
   };
 }
@@ -62,35 +65,35 @@ beforeEach(() => {
 });
 
 describe("published material catalog", () => {
-  it("decodes one bounded release page", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(materialPage({ done: false }));
+  it.effect("decodes one bounded release page", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(materialPage({ done: false }));
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialPage({
+      expect(
+        yield* readPublishedMaterialPage({
           cursor: null,
           expectedManifestHash: null,
           expectedReleaseId: null,
           locale: "en",
         })
-      )
-    ).resolves.toMatchObject({
-      activeManifestHash: manifestHash,
-      activeReleaseId: releaseId,
-      done: false,
-      managed: true,
-      nextCursor: "next",
-      routes: [previewProjection],
-      sourceRevision,
-      stale: false,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "en",
-      expectedManifestHash: null,
-      expectedReleaseId: null,
-      paginationOpts: { cursor: null, numItems: PROJECTION_PAGE_LIMIT },
-    });
-  });
+      ).toMatchObject({
+        activeManifestHash: manifestHash,
+        activeReleaseId: releaseId,
+        done: false,
+        managed: true,
+        nextCursor: "next",
+        routes: [previewProjection],
+        sourceRevision,
+        stale: false,
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "en",
+        expectedManifestHash: null,
+        expectedReleaseId: null,
+        paginationOpts: { cursor: null, numItems: PROJECTION_PAGE_LIMIT },
+      });
+    })
+  );
 
   it("reads all pages through one stable release cursor", async () => {
     runtimeQueryMock
@@ -113,43 +116,62 @@ describe("published material catalog", () => {
     expect(cacheMock).toHaveBeenCalledOnce();
   });
 
-  it("rejects unmanaged and stale ownership states", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce(materialPage({ managed: false, routes: [] }))
-      .mockResolvedValueOnce(materialPage({ routes: [], stale: true }));
+  it.effect("rejects unmanaged and stale ownership states", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce(materialPage({ managed: false, routes: [] }))
+        .mockResolvedValueOnce(materialPage({ routes: [], stale: true }));
 
-    await expect(
-      Effect.runPromise(readPublishedMaterialRoutes("en").pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(readPublishedMaterialRoutes("en").pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      expect(
+        yield* readPublishedMaterialRoutes("en").pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+      expect(
+        yield* readPublishedMaterialRoutes("en").pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-  it("rejects missing, malformed, and changing catalog identities", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        ...materialPage(),
-        activeReleaseId: null,
-      })
-      .mockResolvedValueOnce({
-        ...materialPage(),
-        activeManifestHash: "invalid",
-      })
-      .mockResolvedValueOnce(materialPage({ done: false }))
-      .mockResolvedValueOnce({
-        ...materialPage(),
-        activeReleaseId: "release-other",
-      });
+  it.effect("rejects missing, malformed, and changing release identities", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          ...materialPage(),
+          activeReleaseId: null,
+        })
+        .mockResolvedValueOnce({
+          ...materialPage(),
+          activeManifestHash: "invalid",
+        })
+        .mockResolvedValueOnce(materialPage({ done: false }))
+        .mockResolvedValueOnce({
+          ...materialPage(),
+          activeReleaseId: "release-other",
+        });
 
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      await expect(
-        Effect.runPromise(readPublishedMaterialRoutes("en").pipe(Effect.flip))
-      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    }
-  });
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        expect(
+          yield* readPublishedMaterialRoutes("en").pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
 
-  it.each([
+  it.effect("rejects malformed and changing source revisions", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce(materialPage({ revision: "main" }))
+        .mockResolvedValueOnce(materialPage({ done: false }))
+        .mockResolvedValueOnce(materialPage({ revision: "b".repeat(40) }));
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        expect(
+          yield* readPublishedMaterialRoutes("en").pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
+
+  it.effect.each([
     ["foreign locale", materialPage({ routes: [previewIdProjection] })],
     [
       "missing continuation identity",
@@ -158,18 +180,18 @@ describe("published material catalog", () => {
         activeManifestHash: null,
       },
     ],
-  ])("rejects %s", async (_label, result) => {
-    runtimeQueryMock.mockResolvedValueOnce(result);
+  ])("rejects %s", ([_label, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(result);
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialPage({
+      expect(
+        yield* readPublishedMaterialPage({
           cursor: null,
           expectedManifestHash: null,
           expectedReleaseId: null,
           locale: "en",
         }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -98,6 +98,9 @@ describe("published material catalog", () => {
       .mockResolvedValueOnce(materialPage());
 
     await expect(getPublishedMaterialRoutes("en")).resolves.toMatchObject({
+      activeManifestHash: manifestHash,
+      activeReleaseId: releaseId,
+      appLocale: "en",
       routes: [previewProjection, previewProjection],
       sourceRevision,
     });
@@ -121,6 +124,29 @@ describe("published material catalog", () => {
     await expect(
       Effect.runPromise(readPublishedMaterialRoutes("en").pipe(Effect.flip))
     ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
+  });
+
+  it("rejects missing, malformed, and changing catalog identities", async () => {
+    runtimeQueryMock
+      .mockResolvedValueOnce({
+        ...materialPage(),
+        activeReleaseId: null,
+      })
+      .mockResolvedValueOnce({
+        ...materialPage(),
+        activeManifestHash: "invalid",
+      })
+      .mockResolvedValueOnce(materialPage({ done: false }))
+      .mockResolvedValueOnce({
+        ...materialPage(),
+        activeReleaseId: "release-other",
+      });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(
+        Effect.runPromise(readPublishedMaterialRoutes("en").pipe(Effect.flip))
+      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
+    }
   });
 
   it.each([

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -9,8 +9,10 @@ import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
+  getPublishedMaterialRelease,
   getPublishedMaterialRoutes,
   readPublishedMaterialPage,
+  readPublishedMaterialRelease,
   readPublishedMaterialRoutes,
 } from "@/lib/content/material/catalog";
 import { previewIdProjection, previewProjection } from "@/test/content-preview";
@@ -56,6 +58,26 @@ function materialPage({
     },
     sourceRevision: managed ? revision : null,
     stale,
+  };
+}
+
+/** Builds the signed material release identity returned by Convex. */
+function materialRelease({
+  activeAppLocales = ["en", "id", "de"],
+  manifest = manifestHash,
+  release = releaseId,
+  revision = sourceRevision,
+}: {
+  readonly activeAppLocales?: readonly string[];
+  readonly manifest?: null | string;
+  readonly release?: null | string;
+  readonly revision?: null | string;
+} = {}) {
+  return {
+    activeAppLocales,
+    activeManifestHash: manifest,
+    activeReleaseId: release,
+    sourceRevision: revision,
   };
 }
 
@@ -115,6 +137,38 @@ describe("published material catalog", () => {
     });
     expect(cacheMock).toHaveBeenCalledOnce();
   });
+
+  it("reads and caches signed release locale membership", async () => {
+    runtimeQueryMock.mockResolvedValueOnce(materialRelease());
+
+    await expect(getPublishedMaterialRelease()).resolves.toMatchObject({
+      activeAppLocales: ["en", "id", "de"],
+      activeManifestHash: manifestHash,
+      activeReleaseId: releaseId,
+      sourceRevision,
+    });
+    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+      appLocale: "en",
+      publicPath: "materials",
+    });
+    expect(cacheMock).toHaveBeenCalledOnce();
+  });
+
+  it.effect("rejects malformed signed release identity", () =>
+    Effect.gen(function* () {
+      for (const result of [
+        materialRelease({ activeAppLocales: ["id", "en"] }),
+        materialRelease({ manifest: null }),
+        materialRelease({ release: null }),
+        materialRelease({ revision: "main" }),
+      ]) {
+        runtimeQueryMock.mockResolvedValueOnce(result);
+        expect(
+          yield* readPublishedMaterialRelease().pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
 
   it.effect("rejects unmanaged and stale ownership states", () =>
     Effect.gen(function* () {

--- a/apps/www/lib/content/material/catalog.ts
+++ b/apps/www/lib/content/material/catalog.ts
@@ -145,9 +145,8 @@ export const readPublishedMaterialRoutes = Effect.fn(
   };
   let catalogIdentity: null | Pick<
     PublishedMaterialCatalog,
-    "activeManifestHash" | "activeReleaseId"
+    "activeManifestHash" | "activeReleaseId" | "sourceRevision"
   > = null;
-  let sourceRevision: null | typeof GitCommitShaSchema.Type = null;
   while (true) {
     const page: PublishedMaterialPage = yield* readPublishedMaterialPage({
       ...cursor,
@@ -169,22 +168,26 @@ export const readPublishedMaterialRoutes = Effect.fn(
       Schema.decodeEffect(Sha256HashSchema)(page.activeManifestHash),
       Schema.decodeEffect(ReleaseIdSchema)(page.activeReleaseId),
     ]).pipe(Effect.mapError(() => new PublishedProjectionError(identity)));
+    const pageIdentity = {
+      activeManifestHash,
+      activeReleaseId,
+      sourceRevision: page.sourceRevision,
+    };
     if (
       catalogIdentity !== null &&
-      (catalogIdentity.activeManifestHash !== activeManifestHash ||
-        catalogIdentity.activeReleaseId !== activeReleaseId)
+      (catalogIdentity.activeManifestHash !== pageIdentity.activeManifestHash ||
+        catalogIdentity.activeReleaseId !== pageIdentity.activeReleaseId ||
+        catalogIdentity.sourceRevision !== pageIdentity.sourceRevision)
     ) {
       return yield* new PublishedProjectionError(identity);
     }
-    catalogIdentity ??= { activeManifestHash, activeReleaseId };
+    catalogIdentity ??= pageIdentity;
     routes.push(...page.routes);
-    sourceRevision = page.sourceRevision;
     if (page.done) {
       return {
         ...catalogIdentity,
         appLocale,
         routes,
-        sourceRevision,
       } satisfies PublishedMaterialCatalog;
     }
     cursor = {

--- a/apps/www/lib/content/material/catalog.ts
+++ b/apps/www/lib/content/material/catalog.ts
@@ -5,7 +5,10 @@ import {
   ReleaseIdSchema,
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
-import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import {
+  ActiveAppLocaleListSchema,
+  AppLocaleSchema,
+} from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { api } from "@repo/backend/convex/_generated/api";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
@@ -60,6 +63,14 @@ export interface PublishedMaterialCatalog {
   readonly activeReleaseId: typeof ReleaseIdSchema.Type;
   readonly appLocale: typeof AppLocaleSchema.Type;
   readonly routes: readonly MaterialLessonProjection[];
+  readonly sourceRevision: null | typeof GitCommitShaSchema.Type;
+}
+
+/** Signed release identity shared by every localized material catalog. */
+export interface PublishedMaterialRelease {
+  readonly activeAppLocales: typeof ActiveAppLocaleListSchema.Type;
+  readonly activeManifestHash: typeof Sha256HashSchema.Type;
+  readonly activeReleaseId: typeof ReleaseIdSchema.Type;
   readonly sourceRevision: null | typeof GitCommitShaSchema.Type;
 }
 
@@ -198,11 +209,54 @@ export const readPublishedMaterialRoutes = Effect.fn(
   }
 });
 
+/** Reads signed locale membership from one guaranteed material tombstone. */
+export const readPublishedMaterialRelease = Effect.fn(
+  "NakafaMaterial.readPublishedRelease"
+)(function* () {
+  const appLocale = AppLocaleSchema.make("en");
+  const identity = { appLocale, publicPath: "materials" };
+  const result = yield* readRuntimeQuery(
+    api.contentRelease.material.publication,
+    identity
+  );
+  if (result.activeManifestHash === null || result.activeReleaseId === null) {
+    return yield* new PublishedProjectionError(identity);
+  }
+  const [
+    activeAppLocales,
+    activeManifestHash,
+    activeReleaseId,
+    sourceRevision,
+  ] = yield* Effect.all([
+    Schema.decodeUnknownEffect(ActiveAppLocaleListSchema)(
+      result.activeAppLocales
+    ),
+    Schema.decodeEffect(Sha256HashSchema)(result.activeManifestHash),
+    Schema.decodeEffect(ReleaseIdSchema)(result.activeReleaseId),
+    decodeSourceRevision(result.sourceRevision, identity),
+  ]).pipe(Effect.mapError(() => new PublishedProjectionError(identity)));
+  return {
+    activeAppLocales,
+    activeManifestHash,
+    activeReleaseId,
+    sourceRevision,
+  } satisfies PublishedMaterialRelease;
+});
+
 /** Caches all localized material routes under release invalidation. */
 export async function getPublishedMaterialRoutes(locale: Locale) {
   "use cache";
 
   const result = await Effect.runPromise(readPublishedMaterialRoutes(locale));
+  applyContentRuntimeCache();
+  return result;
+}
+
+/** Caches signed material release membership under release invalidation. */
+export async function getPublishedMaterialRelease() {
+  "use cache";
+
+  const result = await Effect.runPromise(readPublishedMaterialRelease());
   applyContentRuntimeCache();
   return result;
 }

--- a/apps/www/lib/content/material/catalog.ts
+++ b/apps/www/lib/content/material/catalog.ts
@@ -1,12 +1,16 @@
 import "server-only";
 
-import type { GitCommitShaSchema } from "@nakafa/aksara-contracts/ids";
+import {
+  type GitCommitShaSchema,
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { api } from "@repo/backend/convex/_generated/api";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
 import type { FunctionArgs } from "convex/server";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import type { Locale } from "next-intl";
 import { applyContentRuntimeCache } from "@/lib/content/cache";
 import { decodeMaterialJson } from "@/lib/content/material/decode";
@@ -49,6 +53,15 @@ export type PublishedMaterialPage = PublishedMaterialPageBase &
         readonly nextCursor: string;
       }
   );
+
+/** One complete localized catalog pinned to an authenticated release. */
+export interface PublishedMaterialCatalog {
+  readonly activeManifestHash: typeof Sha256HashSchema.Type;
+  readonly activeReleaseId: typeof ReleaseIdSchema.Type;
+  readonly appLocale: typeof AppLocaleSchema.Type;
+  readonly routes: readonly MaterialLessonProjection[];
+  readonly sourceRevision: null | typeof GitCommitShaSchema.Type;
+}
 
 /** Reads and decodes one release-bound page of material routes. */
 export const readPublishedMaterialPage = Effect.fn(
@@ -123,12 +136,17 @@ export const readPublishedMaterialRoutes = Effect.fn(
   "NakafaMaterial.readPublishedRoutes"
 )(function* (locale: Locale) {
   const appLocale = AppLocaleSchema.make(locale);
+  const identity = { appLocale, publicPath: "materials" };
   const routes: MaterialLessonProjection[] = [];
   let cursor: MaterialPageCursor = {
     cursor: null,
     expectedManifestHash: null,
     expectedReleaseId: null,
   };
+  let catalogIdentity: null | Pick<
+    PublishedMaterialCatalog,
+    "activeManifestHash" | "activeReleaseId"
+  > = null;
   let sourceRevision: null | typeof GitCommitShaSchema.Type = null;
   while (true) {
     const page: PublishedMaterialPage = yield* readPublishedMaterialPage({
@@ -142,15 +160,32 @@ export const readPublishedMaterialRoutes = Effect.fn(
       });
     }
     if (!page.managed) {
-      return yield* new PublishedProjectionError({
-        appLocale,
-        publicPath: "materials",
-      });
+      return yield* new PublishedProjectionError(identity);
     }
+    if (page.activeManifestHash === null || page.activeReleaseId === null) {
+      return yield* new PublishedProjectionError(identity);
+    }
+    const [activeManifestHash, activeReleaseId] = yield* Effect.all([
+      Schema.decodeEffect(Sha256HashSchema)(page.activeManifestHash),
+      Schema.decodeEffect(ReleaseIdSchema)(page.activeReleaseId),
+    ]).pipe(Effect.mapError(() => new PublishedProjectionError(identity)));
+    if (
+      catalogIdentity !== null &&
+      (catalogIdentity.activeManifestHash !== activeManifestHash ||
+        catalogIdentity.activeReleaseId !== activeReleaseId)
+    ) {
+      return yield* new PublishedProjectionError(identity);
+    }
+    catalogIdentity ??= { activeManifestHash, activeReleaseId };
     routes.push(...page.routes);
     sourceRevision = page.sourceRevision;
     if (page.done) {
-      return { routes, sourceRevision };
+      return {
+        ...catalogIdentity,
+        appLocale,
+        routes,
+        sourceRevision,
+      } satisfies PublishedMaterialCatalog;
     }
     cursor = {
       cursor: page.nextCursor,

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -187,6 +187,7 @@ describe("material publication", () => {
 
     await expect(getMaterialPublication("en", publicPath)).resolves.toBeNull();
     expect(catalogMock).toHaveBeenCalledTimes(3);
+    expect(catalogCacheMock).toHaveBeenCalledOnce();
     expect(catalogCacheMock).toHaveBeenCalledWith("material");
     expect(contentCacheMock).not.toHaveBeenCalled();
   });
@@ -248,7 +249,8 @@ describe("material publication", () => {
       },
       published,
     });
-    expect(catalogCacheMock).not.toHaveBeenCalled();
+    expect(catalogCacheMock).toHaveBeenCalledOnce();
+    expect(catalogCacheMock).toHaveBeenCalledWith("material");
     expect(contentCacheMock).toHaveBeenCalledWith(
       "material",
       previewArtifactHash

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -1,22 +1,36 @@
 // @vitest-environment node
 
 import {
+  ContentKeySchema,
   GitCommitShaSchema,
   PublicPathSchema,
   ReleaseIdSchema,
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
-import type { AppLocale } from "@nakafa/aksara-contracts/locale";
+import {
+  ACTIVE_APP_LOCALES,
+  type ActiveAppLocaleList,
+  type AppLocale,
+  AppLocaleSchema,
+} from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
+import { MATERIAL_GROUP_LIMIT } from "@repo/backend/convex/contentRelease/material/limits";
+import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { beforeEach, describe, expect, it } from "@repo/testing/effect";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
+import type { Locale } from "next-intl";
 import { vi } from "vitest";
-import type { PublishedMaterialCatalog } from "@/lib/content/material/catalog";
+import type {
+  PublishedMaterialCatalog,
+  PublishedMaterialRelease,
+} from "@/lib/content/material/catalog";
 import {
+  getMaterialCatalogRoute,
   getMaterialPublication,
   readMaterialCatalogRoute,
 } from "@/lib/content/material/publication";
+import { PublishedProjectionError } from "@/lib/content/published/errors";
 import {
   previewArtifactHash,
   previewDeProjection,
@@ -28,20 +42,28 @@ import {
 const catalogCacheMock = vi.hoisted(() => vi.fn());
 const catalogMock = vi.hoisted(() => vi.fn());
 const contentCacheMock = vi.hoisted(() => vi.fn());
+const releaseMock = vi.hoisted(() => vi.fn());
 const renderMock = vi.hoisted(() => vi.fn());
 const activeManifestHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
 const activeReleaseId = ReleaseIdSchema.make("release-material");
 const sourceRevision = GitCommitShaSchema.make("a".repeat(40));
+const published = {
+  activeReleaseId,
+  artifactHash: previewArtifactHash,
+  projection: previewProjection,
+  rendererDomain: "mathematics",
+};
 
 vi.mock("@/lib/content/cache", () => ({
   applyPublishedCatalogCache: catalogCacheMock,
   applyPublishedContentCache: contentCacheMock,
 }));
 vi.mock("@/lib/content/material/catalog", () => ({
+  getPublishedMaterialRelease: releaseMock,
   getPublishedMaterialRoutes: catalogMock,
 }));
 vi.mock("@/lib/content/published/material", () => ({
-  renderPublishedMaterial: renderMock,
+  readRenderedMaterial: renderMock,
 }));
 
 /** Builds one decoded locale catalog under the selected release identity. */
@@ -57,6 +79,18 @@ function materialCatalog(
     appLocale,
     routes,
     sourceRevision: revision,
+  };
+}
+
+/** Builds the signed release identity shared by every locale catalog. */
+function materialRelease(
+  activeAppLocales: ActiveAppLocaleList = ACTIVE_APP_LOCALES
+): PublishedMaterialRelease {
+  return {
+    activeAppLocales,
+    activeManifestHash,
+    activeReleaseId,
+    sourceRevision,
   };
 }
 
@@ -76,11 +110,23 @@ function mockCatalogReads(source = catalogs) {
   );
 }
 
+/** Reads the standard fixture route with optional release and locale overrides. */
+function readCatalogRoute(
+  source: readonly PublishedMaterialCatalog[],
+  release = materialRelease(),
+  locale: Locale = "en",
+  publicPath = previewProjection.publicPath
+) {
+  return readMaterialCatalogRoute(release, source, locale, publicPath);
+}
+
 beforeEach(() => {
   catalogCacheMock.mockReset();
   catalogMock.mockReset();
   contentCacheMock.mockReset();
+  releaseMock.mockReset();
   renderMock.mockReset();
+  releaseMock.mockResolvedValue(materialRelease());
   mockCatalogReads();
 });
 
@@ -96,17 +142,14 @@ describe("material publication", () => {
           catalogReleases.push(() => resolve(catalog));
         })
     );
-    const published = {
-      activeReleaseId,
-      artifactHash: previewArtifactHash,
-      projection: previewProjection,
-      rendererDomain: "mathematics",
-    };
     let releasePublished: () => void = () => undefined;
     renderMock.mockReturnValue(
-      new Promise((resolve) => {
-        releasePublished = () => resolve(published);
-      })
+      Effect.promise(
+        () =>
+          new Promise((resolve) => {
+            releasePublished = () => resolve(published);
+          })
+      )
     );
 
     const publication = getMaterialPublication(
@@ -115,6 +158,7 @@ describe("material publication", () => {
     );
     await vi.waitFor(() => {
       expect(catalogMock).toHaveBeenCalledTimes(3);
+      expect(releaseMock).toHaveBeenCalledOnce();
       expect(renderMock).toHaveBeenCalledOnce();
     });
     for (const releaseCatalog of catalogReleases) {
@@ -129,14 +173,16 @@ describe("material publication", () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    renderMock.mockRejectedValueOnce(
-      new ContentRuntimeMissingError({
-        request: {
-          appLocale: previewProjection.appLocale,
-          delivery: "public",
-          publicPath,
-        },
-      })
+    renderMock.mockReturnValueOnce(
+      Effect.fail(
+        new ContentRuntimeMissingError({
+          request: {
+            appLocale: previewProjection.appLocale,
+            delivery: "public",
+            publicPath,
+          },
+        })
+      )
     );
 
     await expect(getMaterialPublication("en", publicPath)).resolves.toBeNull();
@@ -146,14 +192,16 @@ describe("material publication", () => {
   });
 
   it("rejects a missing body when the signed catalog route still exists", async () => {
-    renderMock.mockRejectedValueOnce(
-      new ContentRuntimeMissingError({
-        request: {
-          appLocale: previewProjection.appLocale,
-          delivery: "public",
-          publicPath: previewProjection.publicPath,
-        },
-      })
+    renderMock.mockReturnValueOnce(
+      Effect.fail(
+        new ContentRuntimeMissingError({
+          request: {
+            appLocale: previewProjection.appLocale,
+            delivery: "public",
+            publicPath: previewProjection.publicPath,
+          },
+        })
+      )
     );
 
     await expect(
@@ -169,12 +217,7 @@ describe("material publication", () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    renderMock.mockResolvedValueOnce({
-      activeReleaseId,
-      artifactHash: previewArtifactHash,
-      projection: previewProjection,
-      rendererDomain: "mathematics",
-    });
+    renderMock.mockReturnValueOnce(Effect.succeed(published));
 
     await expect(
       getMaterialPublication("en", publicPath)
@@ -186,13 +229,7 @@ describe("material publication", () => {
   });
 
   it("verifies and caches one coherent material publication", async () => {
-    const published = {
-      activeReleaseId,
-      artifactHash: previewArtifactHash,
-      projection: previewProjection,
-      rendererDomain: "mathematics",
-    };
-    renderMock.mockResolvedValueOnce(published);
+    renderMock.mockReturnValueOnce(Effect.succeed(published));
 
     await expect(
       getMaterialPublication("en", previewProjection.publicPath)
@@ -218,6 +255,128 @@ describe("material publication", () => {
     );
   });
 
+  it("reads metadata from catalogs without evaluating the signed body", async () => {
+    await expect(
+      getMaterialCatalogRoute("en", previewProjection.publicPath)
+    ).resolves.toMatchObject({ projection: previewProjection });
+
+    expect(renderMock).not.toHaveBeenCalled();
+    expect(catalogCacheMock).toHaveBeenCalledWith("material");
+    expect(contentCacheMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new NakafaAgentDataReadError({ message: "Catalog unavailable." }),
+    new PublishedProjectionError({
+      appLocale: previewProjection.appLocale,
+      publicPath: previewProjection.publicPath,
+    }),
+  ])(
+    "preserves typed failures across cached Promise boundaries",
+    async (failure) => {
+      releaseMock.mockRejectedValueOnce(failure);
+
+      await expect(
+        getMaterialCatalogRoute("en", previewProjection.publicPath)
+      ).rejects.toBe(failure);
+    }
+  );
+
+  it("maps unknown cached Promise failures explicitly", async () => {
+    releaseMock.mockRejectedValueOnce("unexpected");
+
+    await expect(
+      getMaterialCatalogRoute("en", previewProjection.publicPath)
+    ).rejects.toSatisfy(Cause.isUnknownError);
+  });
+
+  it.effect("uses only signed active locale membership", () =>
+    Effect.gen(function* () {
+      const release = materialRelease([
+        AppLocaleSchema.make("en"),
+        AppLocaleSchema.make("id"),
+      ]);
+      const subsetCatalogs = [
+        catalogs[0],
+        catalogs[1],
+        materialCatalog(previewDeProjection.appLocale, []),
+      ];
+      const route = yield* readCatalogRoute(subsetCatalogs, release);
+      expect(route.alternates).toEqual([
+        previewProjection,
+        previewIdProjection,
+      ]);
+      expect(
+        yield* readCatalogRoute(
+          subsetCatalogs,
+          release,
+          "de",
+          previewDeProjection.publicPath
+        )
+      ).toMatchObject({ projection: null });
+
+      const invalidInactiveCatalog = [
+        subsetCatalogs[0],
+        subsetCatalogs[1],
+        catalogs[2],
+      ];
+      expect(
+        yield* readCatalogRoute(invalidInactiveCatalog, release).pipe(
+          Effect.flip
+        )
+      ).toBeInstanceOf(PublishedProjectionError);
+    })
+  );
+
+  it.effect("preserves bounded coherent sibling ordering", () =>
+    Effect.gen(function* () {
+      const sameOrderNext = {
+        ...previewNextProjection,
+        order: previewProjection.order,
+      };
+      const reversedCatalogs = [
+        materialCatalog(previewProjection.appLocale, [
+          sameOrderNext,
+          previewProjection,
+        ]),
+        catalogs[1],
+        catalogs[2],
+      ];
+      const route = yield* readCatalogRoute(reversedCatalogs);
+      expect(route.siblings).toEqual([previewProjection, sameOrderNext]);
+
+      const splitSibling = {
+        ...previewNextProjection,
+        contentKey: ContentKeySchema.make("test:split-sibling"),
+        parentPath: PublicPathSchema.make("subjects/mathematics/other-topic"),
+      };
+      const oversizedGroup = Array.from(
+        { length: MATERIAL_GROUP_LIMIT },
+        (_, index) => ({
+          ...previewNextProjection,
+          contentKey: ContentKeySchema.make(`test:oversized-${index}`),
+          order: index + 6,
+          publicPath: PublicPathSchema.make(
+            `${previewProjection.parentPath}/oversized-${index}`
+          ),
+        })
+      );
+      for (const routes of [
+        [previewProjection, splitSibling],
+        [previewProjection, ...oversizedGroup],
+      ]) {
+        const malformed = [
+          materialCatalog(previewProjection.appLocale, routes),
+          catalogs[1],
+          catalogs[2],
+        ];
+        expect(
+          yield* readCatalogRoute(malformed).pipe(Effect.flip)
+        ).toBeInstanceOf(PublishedProjectionError);
+      }
+    })
+  );
+
   it.effect("rejects catalogs from different active releases", () =>
     Effect.gen(function* () {
       const mismatched = [
@@ -231,11 +390,7 @@ describe("material publication", () => {
       ];
 
       expect(
-        yield* readMaterialCatalogRoute(
-          mismatched,
-          "en",
-          previewProjection.publicPath
-        ).pipe(Effect.flip)
+        yield* readCatalogRoute(mismatched).pipe(Effect.flip)
       ).toMatchObject({ _tag: "PublishedReleaseMismatchError" });
     })
   );
@@ -254,11 +409,7 @@ describe("material publication", () => {
           catalogs[2],
         ];
         expect(
-          yield* readMaterialCatalogRoute(
-            mismatched,
-            "en",
-            previewProjection.publicPath
-          ).pipe(Effect.flip)
+          yield* readCatalogRoute(mismatched).pipe(Effect.flip)
         ).toMatchObject({ _tag: "PublishedProjectionError" });
       }
     })
@@ -291,13 +442,9 @@ describe("material publication", () => {
       ];
 
       for (const source of malformedCatalogs) {
-        expect(
-          yield* readMaterialCatalogRoute(
-            source,
-            "en",
-            previewProjection.publicPath
-          ).pipe(Effect.flip)
-        ).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(yield* readCatalogRoute(source).pipe(Effect.flip)).toMatchObject(
+          { _tag: "PublishedProjectionError" }
+        );
       }
     })
   );
@@ -332,18 +479,15 @@ describe("material publication", () => {
         missingCounterpart,
         ambiguousCounterpart,
       ]) {
-        expect(
-          yield* readMaterialCatalogRoute(
-            source,
-            "en",
-            previewProjection.publicPath
-          ).pipe(Effect.flip)
-        ).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(yield* readCatalogRoute(source).pipe(Effect.flip)).toMatchObject(
+          { _tag: "PublishedProjectionError" }
+        );
       }
 
       expect(
-        yield* readMaterialCatalogRoute(
+        yield* readCatalogRoute(
           missingLocale,
+          materialRelease(),
           "de",
           previewDeProjection.publicPath
         ).pipe(Effect.flip)

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -9,8 +9,9 @@ import {
 import type { AppLocale } from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
+import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import type { PublishedMaterialCatalog } from "@/lib/content/material/catalog";
 import {
   getMaterialPublication,
@@ -47,14 +48,15 @@ vi.mock("@/lib/content/published/material", () => ({
 function materialCatalog(
   appLocale: AppLocale,
   routes: readonly MaterialLessonProjection[],
-  releaseId = activeReleaseId
+  releaseId = activeReleaseId,
+  revision: PublishedMaterialCatalog["sourceRevision"] = sourceRevision
 ): PublishedMaterialCatalog {
   return {
     activeManifestHash,
     activeReleaseId: releaseId,
     appLocale,
     routes,
-    sourceRevision,
+    sourceRevision: revision,
   };
 }
 
@@ -83,6 +85,46 @@ beforeEach(() => {
 });
 
 describe("material publication", () => {
+  it("starts every catalog and the signed body before either owner settles", async () => {
+    const catalogReleases: Array<() => void> = [];
+    catalogMock.mockImplementation(
+      (locale: AppLocale) =>
+        new Promise((resolve) => {
+          const catalog = catalogs.find(
+            (candidate) => candidate.appLocale === locale
+          );
+          catalogReleases.push(() => resolve(catalog));
+        })
+    );
+    const published = {
+      activeReleaseId,
+      artifactHash: previewArtifactHash,
+      projection: previewProjection,
+      rendererDomain: "mathematics",
+    };
+    let releasePublished: () => void = () => undefined;
+    renderMock.mockReturnValue(
+      new Promise((resolve) => {
+        releasePublished = () => resolve(published);
+      })
+    );
+
+    const publication = getMaterialPublication(
+      "en",
+      previewProjection.publicPath
+    );
+    await vi.waitFor(() => {
+      expect(catalogMock).toHaveBeenCalledTimes(3);
+      expect(renderMock).toHaveBeenCalledOnce();
+    });
+    for (const releaseCatalog of catalogReleases) {
+      releaseCatalog();
+    }
+    releasePublished();
+
+    await expect(publication).resolves.toMatchObject({ published });
+  });
+
   it("returns a release-bound missing route without rendering an application error", async () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
@@ -165,6 +207,7 @@ describe("material publication", () => {
         ],
         projection: previewProjection,
         siblings: [previewProjection, previewNextProjection],
+        sourceRevision,
       },
       published,
     });
@@ -175,112 +218,136 @@ describe("material publication", () => {
     );
   });
 
-  it("rejects catalogs from different active releases", async () => {
-    const mismatched = [
-      catalogs[0],
-      materialCatalog(
-        previewIdProjection.appLocale,
-        [previewIdProjection],
-        ReleaseIdSchema.make("release-other")
-      ),
-      catalogs[2],
-    ];
+  it.effect("rejects catalogs from different active releases", () =>
+    Effect.gen(function* () {
+      const mismatched = [
+        catalogs[0],
+        materialCatalog(
+          previewIdProjection.appLocale,
+          [previewIdProjection],
+          ReleaseIdSchema.make("release-other")
+        ),
+        catalogs[2],
+      ];
 
-    await expect(
-      Effect.runPromise(
-        readMaterialCatalogRoute(
+      expect(
+        yield* readMaterialCatalogRoute(
           mismatched,
           "en",
           previewProjection.publicPath
         ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedReleaseMismatchError" });
-  });
+      ).toMatchObject({ _tag: "PublishedReleaseMismatchError" });
+    })
+  );
 
-  it("rejects malformed catalog ownership", async () => {
-    const otherManifestHash = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
-    const malformedCatalogs = [
-      [
+  it.effect("rejects catalogs from different source revisions", () =>
+    Effect.gen(function* () {
+      for (const revision of [GitCommitShaSchema.make("b".repeat(40)), null]) {
+        const mismatched = [
+          catalogs[0],
+          materialCatalog(
+            previewIdProjection.appLocale,
+            [previewIdProjection],
+            activeReleaseId,
+            revision
+          ),
+          catalogs[2],
+        ];
+        expect(
+          yield* readMaterialCatalogRoute(
+            mismatched,
+            "en",
+            previewProjection.publicPath
+          ).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
+
+  it.effect("rejects malformed catalog ownership", () =>
+    Effect.gen(function* () {
+      const otherManifestHash = Sha256HashSchema.make(
+        `sha256:${"b".repeat(64)}`
+      );
+      const malformedCatalogs = [
+        [
+          catalogs[0],
+          { ...catalogs[1], activeManifestHash: otherManifestHash },
+          catalogs[2],
+        ],
+        [
+          materialCatalog(previewProjection.appLocale, [
+            previewProjection,
+            previewProjection,
+          ]),
+          catalogs[1],
+          catalogs[2],
+        ],
+        [
+          materialCatalog(previewProjection.appLocale, [previewIdProjection]),
+          catalogs[1],
+          catalogs[2],
+        ],
+      ];
+
+      for (const source of malformedCatalogs) {
+        expect(
+          yield* readMaterialCatalogRoute(
+            source,
+            "en",
+            previewProjection.publicPath
+          ).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
+
+  it.effect("rejects incomplete locale and counterpart ownership", () =>
+    Effect.gen(function* () {
+      const missingLocale = catalogs.slice(0, 2);
+      const duplicateLocale = [catalogs[0], catalogs[0], catalogs[2]];
+      const duplicateCounterpart = {
+        ...previewIdProjection,
+        publicPath: PublicPathSchema.make(
+          `${previewIdProjection.parentPath}/duplicate-counterpart`
+        ),
+      };
+      const missingCounterpart = [
         catalogs[0],
-        { ...catalogs[1], activeManifestHash: otherManifestHash },
+        materialCatalog(previewIdProjection.appLocale, []),
         catalogs[2],
-      ],
-      [
-        materialCatalog(previewProjection.appLocale, [
-          previewProjection,
-          previewProjection,
+      ];
+      const ambiguousCounterpart = [
+        catalogs[0],
+        materialCatalog(previewIdProjection.appLocale, [
+          previewIdProjection,
+          duplicateCounterpart,
         ]),
-        catalogs[1],
         catalogs[2],
-      ],
-      [
-        materialCatalog(previewProjection.appLocale, [previewIdProjection]),
-        catalogs[1],
-        catalogs[2],
-      ],
-    ];
+      ];
 
-    for (const source of malformedCatalogs) {
-      await expect(
-        Effect.runPromise(
-          readMaterialCatalogRoute(
+      for (const source of [
+        missingLocale,
+        duplicateLocale,
+        missingCounterpart,
+        ambiguousCounterpart,
+      ]) {
+        expect(
+          yield* readMaterialCatalogRoute(
             source,
             "en",
             previewProjection.publicPath
           ).pipe(Effect.flip)
-        )
-      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    }
-  });
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
 
-  it("rejects incomplete locale and counterpart ownership", async () => {
-    const missingLocale = catalogs.slice(0, 2);
-    const duplicateLocale = [catalogs[0], catalogs[0], catalogs[2]];
-    const duplicateCounterpart = {
-      ...previewIdProjection,
-      publicPath: PublicPathSchema.make(
-        `${previewIdProjection.parentPath}/duplicate-counterpart`
-      ),
-    };
-    const missingCounterpart = [
-      catalogs[0],
-      materialCatalog(previewIdProjection.appLocale, []),
-      catalogs[2],
-    ];
-    const ambiguousCounterpart = [
-      catalogs[0],
-      materialCatalog(previewIdProjection.appLocale, [
-        previewIdProjection,
-        duplicateCounterpart,
-      ]),
-      catalogs[2],
-    ];
-
-    for (const source of [
-      missingLocale,
-      duplicateLocale,
-      missingCounterpart,
-      ambiguousCounterpart,
-    ]) {
-      await expect(
-        Effect.runPromise(
-          readMaterialCatalogRoute(
-            source,
-            "en",
-            previewProjection.publicPath
-          ).pipe(Effect.flip)
-        )
-      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    }
-
-    await expect(
-      Effect.runPromise(
-        readMaterialCatalogRoute(
+      expect(
+        yield* readMaterialCatalogRoute(
           missingLocale,
           "de",
           previewDeProjection.publicPath
         ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -1,60 +1,109 @@
 // @vitest-environment node
 
-import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
+import {
+  GitCommitShaSchema,
+  PublicPathSchema,
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";
+import type { AppLocale } from "@nakafa/aksara-contracts/locale";
+import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
+import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMaterialPublication } from "@/lib/content/material/publication";
-import { previewArtifactHash, previewProjection } from "@/test/content-preview";
+import type { PublishedMaterialCatalog } from "@/lib/content/material/catalog";
+import {
+  getMaterialPublication,
+  readMaterialCatalogRoute,
+} from "@/lib/content/material/publication";
+import {
+  previewArtifactHash,
+  previewDeProjection,
+  previewIdProjection,
+  previewNextProjection,
+  previewProjection,
+} from "@/test/content-preview";
 
 const catalogCacheMock = vi.hoisted(() => vi.fn());
+const catalogMock = vi.hoisted(() => vi.fn());
 const contentCacheMock = vi.hoisted(() => vi.fn());
 const renderMock = vi.hoisted(() => vi.fn());
-const routeMock = vi.hoisted(() => vi.fn());
+const activeManifestHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
 const activeReleaseId = ReleaseIdSchema.make("release-material");
+const sourceRevision = GitCommitShaSchema.make("a".repeat(40));
 
 vi.mock("@/lib/content/cache", () => ({
   applyPublishedCatalogCache: catalogCacheMock,
   applyPublishedContentCache: contentCacheMock,
 }));
-vi.mock("@/lib/content/material/route", () => ({
-  getPublishedMaterialRoute: routeMock,
+vi.mock("@/lib/content/material/catalog", () => ({
+  getPublishedMaterialRoutes: catalogMock,
 }));
 vi.mock("@/lib/content/published/material", () => ({
   renderPublishedMaterial: renderMock,
 }));
 
+/** Builds one decoded locale catalog under the selected release identity. */
+function materialCatalog(
+  appLocale: AppLocale,
+  routes: readonly MaterialLessonProjection[],
+  releaseId = activeReleaseId
+): PublishedMaterialCatalog {
+  return {
+    activeManifestHash,
+    activeReleaseId: releaseId,
+    appLocale,
+    routes,
+    sourceRevision,
+  };
+}
+
+const catalogs = [
+  materialCatalog(previewProjection.appLocale, [
+    previewProjection,
+    previewNextProjection,
+  ]),
+  materialCatalog(previewIdProjection.appLocale, [previewIdProjection]),
+  materialCatalog(previewDeProjection.appLocale, [previewDeProjection]),
+];
+
+/** Resolves the matching low-cardinality catalog for every locale read. */
+function mockCatalogReads(source = catalogs) {
+  catalogMock.mockImplementation((locale: AppLocale) =>
+    Promise.resolve(source.find((catalog) => catalog.appLocale === locale))
+  );
+}
+
 beforeEach(() => {
   catalogCacheMock.mockReset();
+  catalogMock.mockReset();
   contentCacheMock.mockReset();
   renderMock.mockReset();
-  routeMock.mockReset();
+  mockCatalogReads();
 });
 
 describe("material publication", () => {
-  it("returns a signed missing route without rendering an application error", async () => {
-    routeMock.mockResolvedValueOnce({ activeReleaseId, projection: null });
+  it("returns a release-bound missing route without rendering an application error", async () => {
+    const publicPath = PublicPathSchema.make(
+      `${previewProjection.publicPath}-missing`
+    );
     renderMock.mockRejectedValueOnce(
       new ContentRuntimeMissingError({
         request: {
           appLocale: previewProjection.appLocale,
           delivery: "public",
-          publicPath: previewProjection.publicPath,
+          publicPath,
         },
       })
     );
 
-    await expect(
-      getMaterialPublication("en", previewProjection.publicPath)
-    ).resolves.toBeNull();
+    await expect(getMaterialPublication("en", publicPath)).resolves.toBeNull();
+    expect(catalogMock).toHaveBeenCalledTimes(3);
     expect(catalogCacheMock).toHaveBeenCalledWith("material");
     expect(contentCacheMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a missing body when the signed route still exists", async () => {
-    routeMock.mockResolvedValueOnce({
-      activeReleaseId,
-      projection: previewProjection,
-    });
+  it("rejects a missing body when the signed catalog route still exists", async () => {
     renderMock.mockRejectedValueOnce(
       new ContentRuntimeMissingError({
         request: {
@@ -74,26 +123,164 @@ describe("material publication", () => {
     });
   });
 
-  it("verifies and caches one coherent material publication", async () => {
-    const model = {
+  it("rejects a signed body that has no matching catalog route", async () => {
+    const publicPath = PublicPathSchema.make(
+      `${previewProjection.publicPath}-missing`
+    );
+    renderMock.mockResolvedValueOnce({
       activeReleaseId,
+      artifactHash: previewArtifactHash,
       projection: previewProjection,
-    };
+      rendererDomain: "mathematics",
+    });
+
+    await expect(
+      getMaterialPublication("en", publicPath)
+    ).rejects.toMatchObject({
+      _tag: "PublishedProjectionError",
+      appLocale: previewProjection.appLocale,
+      publicPath,
+    });
+  });
+
+  it("verifies and caches one coherent material publication", async () => {
     const published = {
       activeReleaseId,
       artifactHash: previewArtifactHash,
       projection: previewProjection,
+      rendererDomain: "mathematics",
     };
-    routeMock.mockResolvedValueOnce(model);
     renderMock.mockResolvedValueOnce(published);
 
     await expect(
       getMaterialPublication("en", previewProjection.publicPath)
-    ).resolves.toEqual({ model, published });
+    ).resolves.toEqual({
+      model: {
+        activeManifestHash,
+        activeReleaseId,
+        alternates: [
+          previewProjection,
+          previewIdProjection,
+          previewDeProjection,
+        ],
+        projection: previewProjection,
+        siblings: [previewProjection, previewNextProjection],
+      },
+      published,
+    });
     expect(catalogCacheMock).not.toHaveBeenCalled();
     expect(contentCacheMock).toHaveBeenCalledWith(
       "material",
       previewArtifactHash
     );
+  });
+
+  it("rejects catalogs from different active releases", async () => {
+    const mismatched = [
+      catalogs[0],
+      materialCatalog(
+        previewIdProjection.appLocale,
+        [previewIdProjection],
+        ReleaseIdSchema.make("release-other")
+      ),
+      catalogs[2],
+    ];
+
+    await expect(
+      Effect.runPromise(
+        readMaterialCatalogRoute(
+          mismatched,
+          "en",
+          previewProjection.publicPath
+        ).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({ _tag: "PublishedReleaseMismatchError" });
+  });
+
+  it("rejects malformed catalog ownership", async () => {
+    const otherManifestHash = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
+    const malformedCatalogs = [
+      [
+        catalogs[0],
+        { ...catalogs[1], activeManifestHash: otherManifestHash },
+        catalogs[2],
+      ],
+      [
+        materialCatalog(previewProjection.appLocale, [
+          previewProjection,
+          previewProjection,
+        ]),
+        catalogs[1],
+        catalogs[2],
+      ],
+      [
+        materialCatalog(previewProjection.appLocale, [previewIdProjection]),
+        catalogs[1],
+        catalogs[2],
+      ],
+    ];
+
+    for (const source of malformedCatalogs) {
+      await expect(
+        Effect.runPromise(
+          readMaterialCatalogRoute(
+            source,
+            "en",
+            previewProjection.publicPath
+          ).pipe(Effect.flip)
+        )
+      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
+    }
+  });
+
+  it("rejects incomplete locale and counterpart ownership", async () => {
+    const missingLocale = catalogs.slice(0, 2);
+    const duplicateLocale = [catalogs[0], catalogs[0], catalogs[2]];
+    const duplicateCounterpart = {
+      ...previewIdProjection,
+      publicPath: PublicPathSchema.make(
+        `${previewIdProjection.parentPath}/duplicate-counterpart`
+      ),
+    };
+    const missingCounterpart = [
+      catalogs[0],
+      materialCatalog(previewIdProjection.appLocale, []),
+      catalogs[2],
+    ];
+    const ambiguousCounterpart = [
+      catalogs[0],
+      materialCatalog(previewIdProjection.appLocale, [
+        previewIdProjection,
+        duplicateCounterpart,
+      ]),
+      catalogs[2],
+    ];
+
+    for (const source of [
+      missingLocale,
+      duplicateLocale,
+      missingCounterpart,
+      ambiguousCounterpart,
+    ]) {
+      await expect(
+        Effect.runPromise(
+          readMaterialCatalogRoute(
+            source,
+            "en",
+            previewProjection.publicPath
+          ).pipe(Effect.flip)
+        )
+      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
+    }
+
+    await expect(
+      Effect.runPromise(
+        readMaterialCatalogRoute(
+          missingLocale,
+          "de",
+          previewDeProjection.publicPath
+        ).pipe(Effect.flip)
+      )
+    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
   });
 });

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -30,7 +30,10 @@ import {
   getMaterialPublication,
   readMaterialCatalogRoute,
 } from "@/lib/content/material/publication";
-import { PublishedProjectionError } from "@/lib/content/published/errors";
+import {
+  PublishedProjectionError,
+  PublishedReleaseMismatchError,
+} from "@/lib/content/published/errors";
 import {
   previewArtifactHash,
   previewDeProjection,
@@ -66,7 +69,6 @@ vi.mock("@/lib/content/published/material", () => ({
   readRenderedMaterial: renderMock,
 }));
 
-/** Builds one decoded locale catalog under the selected release identity. */
 function materialCatalog(
   appLocale: AppLocale,
   routes: readonly MaterialLessonProjection[],
@@ -81,8 +83,6 @@ function materialCatalog(
     sourceRevision: revision,
   };
 }
-
-/** Builds the signed release identity shared by every locale catalog. */
 function materialRelease(
   activeAppLocales: ActiveAppLocaleList = ACTIVE_APP_LOCALES
 ): PublishedMaterialRelease {
@@ -93,7 +93,6 @@ function materialRelease(
     sourceRevision,
   };
 }
-
 const catalogs = [
   materialCatalog(previewProjection.appLocale, [
     previewProjection,
@@ -102,15 +101,12 @@ const catalogs = [
   materialCatalog(previewIdProjection.appLocale, [previewIdProjection]),
   materialCatalog(previewDeProjection.appLocale, [previewDeProjection]),
 ];
-
-/** Resolves the matching low-cardinality catalog for every locale read. */
 function mockCatalogReads(source = catalogs) {
   catalogMock.mockImplementation((locale: AppLocale) =>
     Promise.resolve(source.find((catalog) => catalog.appLocale === locale))
   );
 }
 
-/** Reads the standard fixture route with optional release and locale overrides. */
 function readCatalogRoute(
   source: readonly PublishedMaterialCatalog[],
   release = materialRelease(),
@@ -272,6 +268,10 @@ describe("material publication", () => {
     new PublishedProjectionError({
       appLocale: previewProjection.appLocale,
       publicPath: previewProjection.publicPath,
+    }),
+    new PublishedReleaseMismatchError({
+      actualReleaseId: ReleaseIdSchema.make("release-other"),
+      expectedReleaseId: activeReleaseId,
     }),
   ])(
     "preserves typed failures across cached Promise boundaries",

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -236,6 +236,16 @@ export async function getMaterialCatalogRoute(
   return result;
 }
 
+/** Reuses the metadata-safe route cache inside the full publication program. */
+const readCachedMaterialCatalogRoute = Effect.fn(
+  "NakafaMaterial.readCachedCatalogRoute"
+)((locale: Locale, publicPath: string) =>
+  Effect.tryPromise({
+    catch: preserveCatalogFailure,
+    try: () => getMaterialCatalogRoute(locale, publicPath),
+  })
+);
+
 /** Reads and verifies one coherent material shell and body concurrently. */
 const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
   function* (locale: Locale, publicPath: string) {
@@ -244,11 +254,10 @@ const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
       Effect.catchTag("ContentRuntimeMissingError", () => Effect.succeed(null))
     );
     const [model, published] = yield* Effect.all(
-      [readMaterialCatalogModel(locale, publicPath), readPublished],
+      [readCachedMaterialCatalogRoute(locale, publicPath), readPublished],
       { concurrency: "unbounded" }
     );
     if (!model.projection) {
-      yield* Effect.sync(() => applyPublishedCatalogCache("material"));
       if (published) {
         return yield* makeMaterialProjectionError({ appLocale, publicPath });
       }

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -1,20 +1,23 @@
 import "server-only";
 
 import {
-  ACTIVE_APP_LOCALES,
+  APP_LOCALE_CODES,
   AppLocaleSchema,
 } from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
-import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
-import { Effect } from "effect";
+import { MATERIAL_GROUP_LIMIT } from "@repo/backend/convex/contentRelease/material/limits";
+import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
+import { Cause, Effect } from "effect";
 import type { Locale } from "next-intl";
 import {
   applyPublishedCatalogCache,
   applyPublishedContentCache,
 } from "@/lib/content/cache";
 import {
+  getPublishedMaterialRelease,
   getPublishedMaterialRoutes,
   type PublishedMaterialCatalog,
+  type PublishedMaterialRelease,
 } from "@/lib/content/material/catalog";
 import {
   isMaterialCounterpart,
@@ -22,8 +25,11 @@ import {
   makeMaterialProjectionError,
   verifyMaterialPublication,
 } from "@/lib/content/material/decode";
-import { PublishedReleaseMismatchError } from "@/lib/content/published/errors";
-import { renderPublishedMaterial } from "@/lib/content/published/material";
+import {
+  PublishedProjectionError,
+  PublishedReleaseMismatchError,
+} from "@/lib/content/published/errors";
+import { readRenderedMaterial } from "@/lib/content/published/material";
 
 interface MaterialCatalogIdentity {
   readonly activeManifestHash: PublishedMaterialCatalog["activeManifestHash"];
@@ -53,10 +59,54 @@ function hasUniquePublicPaths(routes: readonly MaterialLessonProjection[]) {
   );
 }
 
+/** Preserves typed catalog failures rejected by an Effect framework runner. */
+function preserveCatalogFailure(cause: unknown) {
+  if (
+    cause instanceof NakafaAgentDataReadError ||
+    cause instanceof PublishedProjectionError
+  ) {
+    return cause;
+  }
+  return new Cause.UnknownError(
+    cause,
+    "Unable to read the cached material catalog."
+  );
+}
+
+/** Lifts one cached locale catalog back into the publication program. */
+const readCachedMaterialCatalog = Effect.fn("NakafaMaterial.readCachedCatalog")(
+  (locale: Locale) =>
+    Effect.tryPromise({
+      catch: preserveCatalogFailure,
+      try: () => getPublishedMaterialRoutes(locale),
+    })
+);
+
+/** Lifts the signed release identity back into the publication program. */
+const readCachedMaterialRelease = Effect.fn("NakafaMaterial.readCachedRelease")(
+  () =>
+    Effect.tryPromise({
+      catch: preserveCatalogFailure,
+      try: () => getPublishedMaterialRelease(),
+    })
+);
+
+/** Orders one localized lesson group exactly like the backend index. */
+function compareMaterialSiblings(
+  left: MaterialLessonProjection,
+  right: MaterialLessonProjection
+) {
+  if (left.order !== right.order) {
+    return left.order - right.order;
+  }
+  return left.publicPath.localeCompare(right.publicPath);
+}
+
 /** Selects one complete shell from low-cardinality release-bound catalogs. */
 export const readMaterialCatalogRoute = Effect.fn(
   "NakafaMaterial.readCatalogRoute"
 )(function* (
+  release: PublishedMaterialRelease,
   catalogs: readonly PublishedMaterialCatalog[],
   locale: Locale,
   publicPath: string
@@ -71,44 +121,51 @@ export const readMaterialCatalogRoute = Effect.fn(
     return yield* makeMaterialProjectionError(projectionIdentity);
   }
   if (
-    catalogs.length !== ACTIVE_APP_LOCALES.length ||
-    catalogsByLocale.size !== ACTIVE_APP_LOCALES.length
+    catalogs.length !== APP_LOCALE_CODES.length ||
+    catalogsByLocale.size !== APP_LOCALE_CODES.length
   ) {
     return yield* makeMaterialProjectionError(projectionIdentity);
   }
+  const activeLocaleSet = new Set(release.activeAppLocales);
   for (const catalog of catalogs) {
-    if (catalog.activeReleaseId !== currentCatalog.activeReleaseId) {
+    if (catalog.activeReleaseId !== release.activeReleaseId) {
       return yield* new PublishedReleaseMismatchError({
         actualReleaseId: catalog.activeReleaseId,
-        expectedReleaseId: currentCatalog.activeReleaseId,
+        expectedReleaseId: release.activeReleaseId,
       });
     }
     if (
-      catalog.activeManifestHash !== currentCatalog.activeManifestHash ||
-      catalog.sourceRevision !== currentCatalog.sourceRevision ||
+      catalog.activeManifestHash !== release.activeManifestHash ||
+      catalog.sourceRevision !== release.sourceRevision ||
       !hasUniquePublicPaths(catalog.routes) ||
-      catalog.routes.some((route) => route.appLocale !== catalog.appLocale)
+      catalog.routes.some((route) => route.appLocale !== catalog.appLocale) ||
+      (!activeLocaleSet.has(catalog.appLocale) && catalog.routes.length > 0)
     ) {
       return yield* makeMaterialProjectionError(projectionIdentity);
     }
+  }
+
+  const missingRoute = {
+    activeManifestHash: release.activeManifestHash,
+    activeReleaseId: release.activeReleaseId,
+    alternates: [],
+    projection: null,
+    siblings: [],
+    sourceRevision: release.sourceRevision,
+  } satisfies MaterialCatalogRoute;
+  if (!activeLocaleSet.has(appLocale)) {
+    return missingRoute;
   }
 
   const projection = currentCatalog.routes.find(
     (route) => route.publicPath === publicPath
   );
   if (!projection) {
-    return {
-      activeManifestHash: currentCatalog.activeManifestHash,
-      activeReleaseId: currentCatalog.activeReleaseId,
-      alternates: [],
-      projection: null,
-      siblings: [],
-      sourceRevision: currentCatalog.sourceRevision,
-    } satisfies MaterialCatalogRoute;
+    return missingRoute;
   }
 
   const alternates: MaterialLessonProjection[] = [];
-  for (const activeLocale of ACTIVE_APP_LOCALES) {
+  for (const activeLocale of release.activeAppLocales) {
     const counterparts = catalogs.flatMap((catalog) =>
       catalog.appLocale === activeLocale
         ? catalog.routes.filter((candidate) =>
@@ -123,43 +180,73 @@ export const readMaterialCatalogRoute = Effect.fn(
     alternates.push(counterpart);
   }
 
-  const siblings = currentCatalog.routes.filter((candidate) =>
-    isMaterialSibling(projection, candidate)
+  const siblingGroup = currentCatalog.routes.filter(
+    (candidate) => candidate.materialKey === projection.materialKey
   );
+  if (
+    siblingGroup.length > MATERIAL_GROUP_LIMIT ||
+    siblingGroup.some((candidate) => !isMaterialSibling(projection, candidate))
+  ) {
+    return yield* makeMaterialProjectionError(projectionIdentity);
+  }
+  const siblings = [...siblingGroup].sort(compareMaterialSiblings);
 
   return {
-    activeManifestHash: currentCatalog.activeManifestHash,
-    activeReleaseId: currentCatalog.activeReleaseId,
+    activeManifestHash: release.activeManifestHash,
+    activeReleaseId: release.activeReleaseId,
     alternates,
     projection,
     siblings,
-    sourceRevision: currentCatalog.sourceRevision,
+    sourceRevision: release.sourceRevision,
   } satisfies MaterialCatalogRoute;
 });
+
+/** Reads one release-bound route model from all authenticated catalogs. */
+const readMaterialCatalogModel = Effect.fn("NakafaMaterial.readCatalogModel")(
+  function* (locale: Locale, publicPath: string) {
+    const [release, catalogs] = yield* Effect.all(
+      [
+        readCachedMaterialRelease(),
+        Effect.forEach(APP_LOCALE_CODES, readCachedMaterialCatalog, {
+          concurrency: "unbounded",
+        }),
+      ],
+      { concurrency: "unbounded" }
+    );
+    return yield* readMaterialCatalogRoute(
+      release,
+      catalogs,
+      locale,
+      publicPath
+    );
+  }
+);
+
+/** Caches one metadata-safe shell without evaluating its MDX artifact. */
+export async function getMaterialCatalogRoute(
+  locale: Locale,
+  publicPath: string
+) {
+  "use cache";
+
+  const result = await Effect.runPromise(
+    readMaterialCatalogModel(locale, publicPath)
+  );
+  applyPublishedCatalogCache("material");
+  return result;
+}
 
 /** Reads and verifies one coherent material shell and body concurrently. */
 const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
   function* (locale: Locale, publicPath: string) {
     const appLocale = AppLocaleSchema.make(locale);
-    const readCatalogs = Effect.forEach(
-      ACTIVE_APP_LOCALES,
-      (activeLocale) =>
-        Effect.tryPromise(() => getPublishedMaterialRoutes(activeLocale)),
+    const readPublished = readRenderedMaterial({ appLocale, publicPath }).pipe(
+      Effect.catchTag("ContentRuntimeMissingError", () => Effect.succeed(null))
+    );
+    const [model, published] = yield* Effect.all(
+      [readMaterialCatalogModel(locale, publicPath), readPublished],
       { concurrency: "unbounded" }
     );
-    const readPublished = Effect.tryPromise(() =>
-      renderPublishedMaterial({ appLocale, publicPath })
-    ).pipe(
-      Effect.catchIf(
-        (failure) => failure.cause instanceof ContentRuntimeMissingError,
-        () => Effect.succeed(null)
-      )
-    );
-    const [catalogs, published] = yield* Effect.all(
-      [readCatalogs, readPublished],
-      { concurrency: "unbounded" }
-    );
-    const model = yield* readMaterialCatalogRoute(catalogs, locale, publicPath);
     if (!model.projection) {
       yield* Effect.sync(() => applyPublishedCatalogCache("material"));
       if (published) {

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import {
+  ACTIVE_APP_LOCALES,
+  AppLocaleSchema,
+} from "@nakafa/aksara-contracts/locale";
+import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
@@ -9,11 +13,125 @@ import {
   applyPublishedContentCache,
 } from "@/lib/content/cache";
 import {
+  getPublishedMaterialRoutes,
+  type PublishedMaterialCatalog,
+} from "@/lib/content/material/catalog";
+import {
+  isMaterialCounterpart,
+  isMaterialSibling,
   makeMaterialProjectionError,
   verifyMaterialPublication,
 } from "@/lib/content/material/decode";
-import { getPublishedMaterialRoute } from "@/lib/content/material/route";
+import { PublishedReleaseMismatchError } from "@/lib/content/published/errors";
 import { renderPublishedMaterial } from "@/lib/content/published/material";
+
+interface MaterialCatalogIdentity {
+  readonly activeManifestHash: PublishedMaterialCatalog["activeManifestHash"];
+  readonly activeReleaseId: PublishedMaterialCatalog["activeReleaseId"];
+}
+
+/** Route shell selected exclusively from authenticated release catalogs. */
+export type MaterialCatalogRoute = MaterialCatalogIdentity &
+  (
+    | {
+        readonly alternates: readonly [];
+        readonly projection: null;
+        readonly siblings: readonly [];
+      }
+    | {
+        readonly alternates: readonly MaterialLessonProjection[];
+        readonly projection: MaterialLessonProjection;
+        readonly siblings: readonly MaterialLessonProjection[];
+      }
+  );
+
+/** Checks a decoded route set for one unambiguous public identity. */
+function hasUniquePublicPaths(routes: readonly MaterialLessonProjection[]) {
+  return (
+    new Set(routes.map(({ publicPath }) => publicPath)).size === routes.length
+  );
+}
+
+/** Selects one complete shell from low-cardinality release-bound catalogs. */
+export const readMaterialCatalogRoute = Effect.fn(
+  "NakafaMaterial.readCatalogRoute"
+)(function* (
+  catalogs: readonly PublishedMaterialCatalog[],
+  locale: Locale,
+  publicPath: string
+) {
+  const appLocale = AppLocaleSchema.make(locale);
+  const projectionIdentity = { appLocale, publicPath };
+  const catalogsByLocale = new Map(
+    catalogs.map((catalog) => [catalog.appLocale, catalog])
+  );
+  const currentCatalog = catalogsByLocale.get(appLocale);
+  if (!currentCatalog) {
+    return yield* makeMaterialProjectionError(projectionIdentity);
+  }
+  if (
+    catalogs.length !== ACTIVE_APP_LOCALES.length ||
+    catalogsByLocale.size !== ACTIVE_APP_LOCALES.length
+  ) {
+    return yield* makeMaterialProjectionError(projectionIdentity);
+  }
+  for (const catalog of catalogs) {
+    if (catalog.activeReleaseId !== currentCatalog.activeReleaseId) {
+      return yield* new PublishedReleaseMismatchError({
+        actualReleaseId: catalog.activeReleaseId,
+        expectedReleaseId: currentCatalog.activeReleaseId,
+      });
+    }
+    if (
+      catalog.activeManifestHash !== currentCatalog.activeManifestHash ||
+      !hasUniquePublicPaths(catalog.routes) ||
+      catalog.routes.some((route) => route.appLocale !== catalog.appLocale)
+    ) {
+      return yield* makeMaterialProjectionError(projectionIdentity);
+    }
+  }
+
+  const projection = currentCatalog.routes.find(
+    (route) => route.publicPath === publicPath
+  );
+  if (!projection) {
+    return {
+      activeManifestHash: currentCatalog.activeManifestHash,
+      activeReleaseId: currentCatalog.activeReleaseId,
+      alternates: [],
+      projection: null,
+      siblings: [],
+    } satisfies MaterialCatalogRoute;
+  }
+
+  const alternates: MaterialLessonProjection[] = [];
+  for (const activeLocale of ACTIVE_APP_LOCALES) {
+    const counterparts = catalogs.flatMap((catalog) =>
+      catalog.appLocale === activeLocale
+        ? catalog.routes.filter((candidate) =>
+            isMaterialCounterpart(projection, candidate)
+          )
+        : []
+    );
+    const counterpart = counterparts[0];
+    if (!counterpart || counterparts.length !== 1) {
+      return yield* makeMaterialProjectionError(projectionIdentity);
+    }
+    alternates.push(counterpart);
+  }
+
+  const siblings = currentCatalog.routes.filter((candidate) =>
+    isMaterialSibling(projection, candidate)
+  );
+
+  return {
+    activeManifestHash: currentCatalog.activeManifestHash,
+    activeReleaseId: currentCatalog.activeReleaseId,
+    alternates,
+    projection,
+    siblings,
+  } satisfies MaterialCatalogRoute;
+});
 
 /** Reads one coherent material shell and body without a sequential network waterfall. */
 export async function getMaterialPublication(
@@ -31,12 +149,24 @@ export async function getMaterialPublication(
       () => Effect.succeed(null)
     )
   );
-  const [model, published] = await Promise.all([
-    getPublishedMaterialRoute(locale, publicPath),
+  const [catalogs, published] = await Promise.all([
+    Promise.all(
+      ACTIVE_APP_LOCALES.map((activeLocale) =>
+        getPublishedMaterialRoutes(activeLocale)
+      )
+    ),
     Effect.runPromise(readPublished),
   ]);
+  const model = await Effect.runPromise(
+    readMaterialCatalogRoute(catalogs, locale, publicPath)
+  );
   if (!model.projection) {
     applyPublishedCatalogCache("material");
+    if (published) {
+      return await Effect.runPromise(
+        Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
+      );
+    }
     return null;
   }
   if (!published) {

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -28,6 +28,7 @@ import { renderPublishedMaterial } from "@/lib/content/published/material";
 interface MaterialCatalogIdentity {
   readonly activeManifestHash: PublishedMaterialCatalog["activeManifestHash"];
   readonly activeReleaseId: PublishedMaterialCatalog["activeReleaseId"];
+  readonly sourceRevision: PublishedMaterialCatalog["sourceRevision"];
 }
 
 /** Route shell selected exclusively from authenticated release catalogs. */
@@ -84,6 +85,7 @@ export const readMaterialCatalogRoute = Effect.fn(
     }
     if (
       catalog.activeManifestHash !== currentCatalog.activeManifestHash ||
+      catalog.sourceRevision !== currentCatalog.sourceRevision ||
       !hasUniquePublicPaths(catalog.routes) ||
       catalog.routes.some((route) => route.appLocale !== catalog.appLocale)
     ) {
@@ -101,6 +103,7 @@ export const readMaterialCatalogRoute = Effect.fn(
       alternates: [],
       projection: null,
       siblings: [],
+      sourceRevision: currentCatalog.sourceRevision,
     } satisfies MaterialCatalogRoute;
   }
 
@@ -130,61 +133,65 @@ export const readMaterialCatalogRoute = Effect.fn(
     alternates,
     projection,
     siblings,
+    sourceRevision: currentCatalog.sourceRevision,
   } satisfies MaterialCatalogRoute;
 });
 
-/** Reads one coherent material shell and body without a sequential network waterfall. */
+/** Reads and verifies one coherent material shell and body concurrently. */
+const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
+  function* (locale: Locale, publicPath: string) {
+    const appLocale = AppLocaleSchema.make(locale);
+    const readCatalogs = Effect.forEach(
+      ACTIVE_APP_LOCALES,
+      (activeLocale) =>
+        Effect.tryPromise(() => getPublishedMaterialRoutes(activeLocale)),
+      { concurrency: "unbounded" }
+    );
+    const readPublished = Effect.tryPromise(() =>
+      renderPublishedMaterial({ appLocale, publicPath })
+    ).pipe(
+      Effect.catchIf(
+        (failure) => failure.cause instanceof ContentRuntimeMissingError,
+        () => Effect.succeed(null)
+      )
+    );
+    const [catalogs, published] = yield* Effect.all(
+      [readCatalogs, readPublished],
+      { concurrency: "unbounded" }
+    );
+    const model = yield* readMaterialCatalogRoute(catalogs, locale, publicPath);
+    if (!model.projection) {
+      yield* Effect.sync(() => applyPublishedCatalogCache("material"));
+      if (published) {
+        return yield* makeMaterialProjectionError({ appLocale, publicPath });
+      }
+      return null;
+    }
+    if (!published) {
+      return yield* makeMaterialProjectionError({ appLocale, publicPath });
+    }
+
+    yield* verifyMaterialPublication(
+      {
+        activeReleaseId: model.activeReleaseId,
+        projection: model.projection,
+      },
+      published
+    );
+    yield* Effect.sync(() =>
+      applyPublishedContentCache("material", published.artifactHash)
+    );
+
+    return { model, published };
+  }
+);
+
+/** Caches one coherent material publication at the Next.js framework boundary. */
 export async function getMaterialPublication(
   locale: Locale,
   publicPath: string
 ) {
   "use cache";
 
-  const appLocale = AppLocaleSchema.make(locale);
-  const readPublished = Effect.tryPromise(() =>
-    renderPublishedMaterial({ appLocale, publicPath })
-  ).pipe(
-    Effect.catchIf(
-      (failure) => failure.cause instanceof ContentRuntimeMissingError,
-      () => Effect.succeed(null)
-    )
-  );
-  const [catalogs, published] = await Promise.all([
-    Promise.all(
-      ACTIVE_APP_LOCALES.map((activeLocale) =>
-        getPublishedMaterialRoutes(activeLocale)
-      )
-    ),
-    Effect.runPromise(readPublished),
-  ]);
-  const model = await Effect.runPromise(
-    readMaterialCatalogRoute(catalogs, locale, publicPath)
-  );
-  if (!model.projection) {
-    applyPublishedCatalogCache("material");
-    if (published) {
-      return await Effect.runPromise(
-        Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
-      );
-    }
-    return null;
-  }
-  if (!published) {
-    return await Effect.runPromise(
-      Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
-    );
-  }
-
-  await Effect.runPromise(
-    verifyMaterialPublication(
-      {
-        activeReleaseId: model.activeReleaseId,
-        projection: model.projection,
-      },
-      published
-    )
-  );
-  applyPublishedContentCache("material", published.artifactHash);
-
-  return { model, published };
+  return await Effect.runPromise(readMaterialPublication(locale, publicPath));
 }

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -63,7 +63,8 @@ function hasUniquePublicPaths(routes: readonly MaterialLessonProjection[]) {
 function preserveCatalogFailure(cause: unknown) {
   if (
     cause instanceof NakafaAgentDataReadError ||
-    cause instanceof PublishedProjectionError
+    cause instanceof PublishedProjectionError ||
+    cause instanceof PublishedReleaseMismatchError
   ) {
     return cause;
   }

--- a/apps/www/lib/content/published/material.tsx
+++ b/apps/www/lib/content/published/material.tsx
@@ -83,12 +83,19 @@ const renderMaterialArtifact = Effect.fn(
   } satisfies PublishedMaterialContent;
 });
 
+/** Reads and renders one material through one signed publication program. */
+const readRenderedMaterial = Effect.fn("NakafaContent.readRenderedMaterial")(
+  function* (input: PublishedMaterialInput) {
+    const data = yield* readPublishedMaterial(input);
+    return yield* renderMaterialArtifact(data);
+  }
+);
+
 /** Caches JSX rendered from one reviewed, signed Aksara material artifact. */
 export async function renderPublishedMaterial(input: PublishedMaterialInput) {
   "use cache";
 
-  const data = await Effect.runPromise(readPublishedMaterial(input));
-  const rendered = await Effect.runPromise(renderMaterialArtifact(data));
-  applyPublishedContentCache("material", data.artifact.artifactHash);
+  const rendered = await Effect.runPromise(readRenderedMaterial(input));
+  applyPublishedContentCache("material", rendered.artifactHash);
   return rendered;
 }

--- a/apps/www/lib/content/published/material.tsx
+++ b/apps/www/lib/content/published/material.tsx
@@ -8,6 +8,7 @@ import type {
   MaterialLessonProjection,
   MaterialMetadata,
 } from "@nakafa/aksara-contracts/projection/material";
+import type { RendererDomain } from "@nakafa/aksara-contracts/renderer/domain";
 import { Effect } from "effect";
 import type { ReactNode } from "react";
 import { applyPublishedContentCache } from "@/lib/content/cache";
@@ -33,6 +34,7 @@ export interface PublishedMaterialContent {
   readonly metadata: MaterialMetadata;
   readonly projection: MaterialLessonProjection;
   readonly rawMdx: string;
+  readonly rendererDomain: RendererDomain;
   readonly sourcePath: CorpusSourcePath;
   readonly sourceRevision: GitCommitSha | null;
 }
@@ -75,6 +77,7 @@ const renderMaterialArtifact = Effect.fn(
     metadata: data.metadata,
     projection: data.projection,
     rawMdx: rendered.artifact.payload.rawMdx,
+    rendererDomain: rendered.artifact.payload.rendererDomain,
     sourcePath: data.sourcePath,
     sourceRevision: data.sourceRevision,
   } satisfies PublishedMaterialContent;

--- a/apps/www/lib/content/published/material.tsx
+++ b/apps/www/lib/content/published/material.tsx
@@ -11,7 +11,6 @@ import type {
 import type { RendererDomain } from "@nakafa/aksara-contracts/renderer/domain";
 import { Effect } from "effect";
 import type { ReactNode } from "react";
-import { applyPublishedContentCache } from "@/lib/content/cache";
 import {
   decodeMaterialProjection,
   normalizeMaterialMetadata,
@@ -84,18 +83,9 @@ const renderMaterialArtifact = Effect.fn(
 });
 
 /** Reads and renders one material through one signed publication program. */
-const readRenderedMaterial = Effect.fn("NakafaContent.readRenderedMaterial")(
-  function* (input: PublishedMaterialInput) {
-    const data = yield* readPublishedMaterial(input);
-    return yield* renderMaterialArtifact(data);
-  }
-);
-
-/** Caches JSX rendered from one reviewed, signed Aksara material artifact. */
-export async function renderPublishedMaterial(input: PublishedMaterialInput) {
-  "use cache";
-
-  const rendered = await Effect.runPromise(readRenderedMaterial(input));
-  applyPublishedContentCache("material", rendered.artifactHash);
-  return rendered;
-}
+export const readRenderedMaterial = Effect.fn(
+  "NakafaContent.readRenderedMaterial"
+)(function* (input: PublishedMaterialInput) {
+  const data = yield* readPublishedMaterial(input);
+  return yield* renderMaterialArtifact(data);
+});

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -224,12 +224,13 @@ const nextConfig = {
     instantInsights: {
       validationLevel: "warning",
     },
-    // Anonymous Convex shares this runner, so keep one worker process while
-    // allowing two static pages to overlap their bounded catalog reads.
+    // Anonymous Convex shares this runner. Split the export across two isolated
+    // worker heaps, but let each worker process only one page at a time so the
+    // backend sees at most two concurrent static-generation requests.
     // Production keeps Next.js' default static-generation concurrency.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(configEnv.CONVEX_AGENT_MODE === "anonymous"
-      ? { cpus: 1, staticGenerationMaxConcurrency: 2 }
+      ? { cpus: 2, staticGenerationMaxConcurrency: 1 }
       : {}),
   },
 } satisfies NextConfig;

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -216,11 +216,12 @@ const nextConfig = {
     instantInsights: {
       validationLevel: "warning",
     },
-    // Anonymous Convex shares this runner, so use one worker with one page.
+    // Anonymous Convex shares this runner, so keep one worker process while
+    // allowing two static pages to overlap their bounded catalog reads.
     // Production keeps Next.js' default static-generation concurrency.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(configEnv.CONVEX_AGENT_MODE === "anonymous"
-      ? { cpus: 1, staticGenerationMaxConcurrency: 1 }
+      ? { cpus: 1, staticGenerationMaxConcurrency: 2 }
       : {}),
   },
 } satisfies NextConfig;

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -172,6 +172,14 @@ const nextConfig = {
   ...config,
   cacheComponents: true,
   partialPrefetching: true,
+  // Cache Components enables prerender source maps by default. The anonymous
+  // CI build does not publish those artifacts, and retaining them exhausted
+  // the static worker's isolated 4 GiB heap with two pages in flight.
+  // Production keeps source maps enabled. Docs:
+  // https://nextjs.org/docs/app/guides/memory-usage#disable-source-maps
+  ...(configEnv.CONVEX_AGENT_MODE === "anonymous"
+    ? { enablePrerenderSourceMaps: false }
+    : {}),
   env: {
     NEXT_PUBLIC_AKSARA_PREVIEW_CHILD: `${isAksaraPreviewChild}`,
   },

--- a/packages/backend/convex/contentRelease/material/page.test.ts
+++ b/packages/backend/convex/contentRelease/material/page.test.ts
@@ -2,10 +2,13 @@ import { readMaterialPage } from "@repo/backend/convex/contentRelease/material/p
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeMaterialProjection } from "@repo/backend/test/content-material";
 import {
   activateMaterialCatalog,
+  advanceMaterialCatalog,
   MATERIAL_IDENTITY,
 } from "@repo/backend/test/material-catalog";
+import { insertRuntimeBinding } from "@repo/backend/test/runtime-head";
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 
@@ -113,6 +116,38 @@ describe("contentRelease/material/page", () => {
       managed: true,
       result: { isDone: true, page: [] },
       stale: true,
+    });
+  });
+
+  it("rejects catalog rows removed from the effective publication", async () => {
+    const t = convexTest(schema, convexModules);
+    const removed = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(t);
+    await t.mutation((ctx) =>
+      insertRuntimeBinding(ctx, null, {
+        appLocale: removed.appLocale,
+        bindingReleaseId: "release-next",
+        bindingSequence: 2,
+        publicPath: removed.publicPath,
+      })
+    );
+    await advanceMaterialCatalog(t);
+
+    await expect(
+      t.query((ctx) =>
+        runConvexProgram(
+          readMaterialPage(
+            ctx,
+            removed.appLocale,
+            null,
+            null,
+            { cursor: null, numItems: 2 },
+            "publication"
+          )
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_ROUTE" },
     });
   });
 

--- a/packages/backend/convex/contentRelease/material/page.ts
+++ b/packages/backend/convex/contentRelease/material/page.ts
@@ -10,7 +10,7 @@ import {
   encodePredecessorProjection,
   type MaterialProjectionContract,
 } from "@repo/backend/convex/contentRelease/material/predecessor";
-import { verifyMaterial } from "@repo/backend/convex/contentRelease/material/verify";
+import { verifyEffectiveMaterial } from "@repo/backend/convex/contentRelease/material/verify";
 import { validateProjectionPage } from "@repo/backend/convex/contentRelease/paging";
 import { readSourceRevision } from "@repo/backend/convex/contentRelease/runtime/origin";
 import { Effect } from "effect";
@@ -78,6 +78,7 @@ export const readMaterialPage = Effect.fn("contentRelease.readMaterialPage")(
         stale: false,
       };
     }
+    const activePublication = owner.active;
     const stored = yield* Effect.promise(() =>
       ctx.db
         .query("materialCatalog")
@@ -86,25 +87,26 @@ export const readMaterialPage = Effect.fn("contentRelease.readMaterialPage")(
         )
         .paginate(options)
     );
-    const verified = yield* Effect.forEach(stored.page, verifyMaterial);
-    const page = yield* Effect.forEach(
-      verified,
-      ({ projection, projectionJson }) => {
-        if (contract === "publication") {
-          return Effect.succeed(projectionJson);
-        }
-        return encodePredecessorProjection(projection);
-      }
+    const verified = yield* Effect.forEach(
+      stored.page,
+      (row) => verifyEffectiveMaterial(ctx, row, activePublication.sequence),
+      { concurrency: "unbounded" }
     );
+    const page = yield* Effect.forEach(verified, ({ projection, resolved }) => {
+      if (contract === "publication") {
+        return Effect.succeed(resolved.projectionJson);
+      }
+      return encodePredecessorProjection(projection);
+    });
     return {
-      activeManifestHash: owner.active.manifestHash,
-      activeReleaseId: owner.active.releaseId,
+      activeManifestHash: activePublication.manifestHash,
+      activeReleaseId: activePublication.releaseId,
       managed: true,
       result: {
         ...stored,
         page,
       },
-      sourceRevision: readSourceRevision(owner.active),
+      sourceRevision: readSourceRevision(activePublication),
       stale: false,
     };
   }


### PR DESCRIPTION
## Summary

Reduce signed WWW build time by loading each authenticated material catalog once per locale, deriving route shells from those catalogs, keeping metadata body-free, and splitting anonymous Agent Mode static export across two bounded Next workers.

## Root cause

The signed Production job is about 20 to 25 minutes because it serially owns snapshot preparation, a cold 1,927-page Next build, production Browser acceptance, AFDocs, fingerprint verification, and cleanup. The previous single Next worker serialized static export. Increasing page concurrency inside that one worker exhausted its approximately 4.1 GB JavaScript heap. Two workers with one page each isolate the heaps and repeatedly complete the export. This is a GitHub acceptance-runner constraint, not a Vercel production or Convex deployment limit. The controls follow the official [Next static-generation documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration).

## Scope

Ten files change. Effect-native publication programs load release identity and three locale catalogs concurrently, select one route, derive siblings and alternates, and evaluate exactly one signed body. Metadata does not evaluate MDX. Convex catalog pages authenticate every row against the effective active publication and reject removed routes. Only anonymous Agent Mode uses two Next workers, one static page per worker, and no unpublished prerender source maps. Normal Vercel production retains Next defaults. No workflow, package script, timeout, retry, Browser coverage, Preview, or production deployment configuration changes.

## Preserved contracts

The signed artifact exchange, cache tags, authenticated renderer domain, active release and projection equality, release-bound source revision and manifest identity, effective-route membership, sibling order and bound, tombstones, and typed failures remain fail-closed. Cached Promise boundaries preserve known domain failures and map only unknown failures. Convex keeps the existing indexed bounded cursor page and verifies every returned row. References: [Convex pagination](https://docs.convex.dev/database/pagination), [Convex limits](https://docs.convex.dev/production/state/limits), and [Next use cache](https://nextjs.org/docs/app/api-reference/directives/use-cache).

## Exact-head proof

- Head: `9283cdfa9a37e1d315b646baa74e515ee898c6e9`
- Tree: `a6d3ac8045977c3b8bb74dfc56e392e8fe100b94`
- Protected base: `c1dceeed4bdae49254fe428e92340d55760d6c70`
- Ten cohesive commits
- Stable cumulative patch ID: `ee7c48331e4633b095e27005ea1e8313d7e4439b`
- Rebase range-diff: all ten commits patch-equivalent, no conflict or delta
- Prior local proof: WWW 209 files and 1,518 tests at configured 100 percent coverage; backend 326 files and 1,370 tests; WWW/backend typechecks; lint; boundaries; Effect source parity; test ownership; formatting; diff checks; Doctor 100
- Final strict-protection rebase preserved all ten patches and the cumulative patch ID
- The prior PR-head red run `32961138519` failed on inherited signed Quran source identity. It did not reach material static generation, and protected main later passed after the signed source pointer settled.
- Exact-head CI and Doctor: pending

## Release

Accept only after exact-head Quality, signed Production, full Browser coverage first-pass with two workers and no retry or flake, AFDocs 23/23, fingerprints, cleanup, Required, Doctor 100, one fresh exact-head independent review, mergeability, and zero unresolved threads. Merge through protected main, then verify exact-main CI and the Git-integrated Vercel production deployment. No Preview.