### PR TITLE
test(backend): use Effect Vitest for welcome email

### DIFF
--- a/packages/backend/convex/emails/welcome.test.ts
+++ b/packages/backend/convex/emails/welcome.test.ts
@@ -1,7 +1,9 @@
 import { canonicalizePublicPageProjection } from "@nakafa/aksara-contracts/projection/page";
 import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { resend } from "@repo/backend/convex/emails/client";
 import { resolveWelcomeEmailLinks } from "@repo/backend/convex/emails/welcome";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -9,9 +11,10 @@ import {
   TEST_PAGE_PROJECTION_JSON,
 } from "@repo/backend/test/content-page";
 import { TEST_ARTICLE_PROJECTION_JSON } from "@repo/backend/test/content-runtime";
+import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const SITE_URL = new URL("https://nakafa.com");
 
@@ -21,11 +24,31 @@ function pageJson(pageKey: string, publicPath: string) {
   );
 }
 
+/** Inserts one welcome-email recipient fixture. */
+function insertWelcomeUser(
+  ctx: MutationCtx,
+  suffix: string,
+  deletionPreparedAt?: number
+) {
+  return Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: `${suffix}-welcome-owner`,
+      credits: 0,
+      creditsResetAt: 0,
+      deletionPreparedAt,
+      email: `${suffix}@example.com`,
+      name: `${suffix} Welcome Owner`,
+      plan: "free",
+    })
+  );
+}
+
 describe("emails/welcome", () => {
-  it("resolves legal URLs from the signed English Page projections", async () => {
-    await expect(
-      Effect.runPromise(
-        resolveWelcomeEmailLinks(
+  it.effect(
+    "resolves legal URLs from the signed English Page projections",
+    () =>
+      Effect.gen(function* () {
+        const links = yield* resolveWelcomeEmailLinks(
           {
             managed: true,
             projectionJson: [
@@ -34,16 +57,17 @@ describe("emails/welcome", () => {
             ],
           },
           SITE_URL
-        )
-      )
-    ).resolves.toEqual({
-      privacyPolicyUrl: "https://nakafa.com/en/privacy-current",
-      startLearningUrl: "https://nakafa.com/en",
-      termsOfServiceUrl: "https://nakafa.com/en/terms-current",
-    });
-  });
+        );
 
-  it.each([
+        expect(links).toEqual({
+          privacyPolicyUrl: "https://nakafa.com/en/privacy-current",
+          startLearningUrl: "https://nakafa.com/en",
+          termsOfServiceUrl: "https://nakafa.com/en/terms-current",
+        });
+      })
+  );
+
+  it.effect.each([
     ["an unmanaged catalog", { managed: false, projectionJson: [] }],
     ["a malformed projection", { managed: true, projectionJson: ["not-json"] }],
     [
@@ -54,78 +78,83 @@ describe("emails/welcome", () => {
       "a missing legal Page",
       { managed: true, projectionJson: [TEST_PAGE_PROJECTION_JSON] },
     ],
-  ])("rejects %s", async (_label, catalog) => {
-    await expect(
-      Effect.runPromise(resolveWelcomeEmailLinks(catalog, SITE_URL))
-    ).rejects.toMatchObject({
-      _tag: "ReleaseError",
-      code: "CONTENT_RELEASE_INTEGRITY",
-    });
-  });
+  ] as const)("rejects %s", ([, catalog]) =>
+    Effect.gen(function* () {
+      const error = yield* resolveWelcomeEmailLinks(catalog, SITE_URL).pipe(
+        Effect.flip
+      );
 
-  it("skips enqueue when the recipient disappeared or entered deletion", async () => {
-    const t = convexTest(schema, convexModules);
-    const deletedUserId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "deleted-welcome-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "deleted@example.com",
-        name: "Deleted Welcome Owner",
-        plan: "free",
-      })
-    );
-    const pendingUserId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "pending-welcome-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        deletionPreparedAt: 1,
-        email: "pending@example.com",
-        name: "Pending Welcome Owner",
-        plan: "free",
-      })
-    );
-    await t.mutation((ctx) => ctx.db.delete("users", deletedUserId));
+      expect(error).toMatchObject({
+        _tag: "ReleaseError",
+        code: "CONTENT_RELEASE_INTEGRITY",
+      });
+    })
+  );
 
-    for (const userId of [deletedUserId, pendingUserId]) {
-      await expect(
-        t.mutation(internal.emails.welcome.enqueueWelcomeEmail, {
-          html: "<p>Welcome</p>",
-          text: "Welcome",
-          userId,
-        })
-      ).resolves.toBeNull();
-    }
-  });
+  it.effect(
+    "skips enqueue when the recipient disappeared or entered deletion",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const deletedUserId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertWelcomeUser(ctx, "deleted"))
+          )
+        );
+        const pendingUserId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertWelcomeUser(ctx, "pending", 1))
+          )
+        );
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.promise(() => ctx.db.delete("users", deletedUserId))
+            )
+          )
+        );
 
-  it("translates a component enqueue failure into a typed Convex error", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "failed-welcome-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "failed@example.com",
-        name: "Failed Welcome Owner",
-        plan: "free",
+        for (const userId of [deletedUserId, pendingUserId]) {
+          const result = yield* Effect.promise(() =>
+            t.mutation(internal.emails.welcome.enqueueWelcomeEmail, {
+              html: "<p>Welcome</p>",
+              text: "Welcome",
+              userId,
+            })
+          );
+          expect(result).toBeNull();
+        }
       })
-    );
-    vi.spyOn(resend, "sendEmail").mockRejectedValueOnce(
-      new Error("component unavailable")
-    );
+  );
 
-    await expect(
-      t.mutation(internal.emails.welcome.enqueueWelcomeEmail, {
-        html: "<p>Welcome</p>",
-        text: "Welcome",
-        userId,
+  it.effect(
+    "translates a component enqueue failure into a typed Convex error",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertWelcomeUser(ctx, "failed"))
+          )
+        );
+        vi.spyOn(resend, "sendEmail").mockRejectedValueOnce(
+          new Error("component unavailable")
+        );
+
+        yield* Effect.promise(() =>
+          expect(
+            t.mutation(internal.emails.welcome.enqueueWelcomeEmail, {
+              html: "<p>Welcome</p>",
+              text: "Welcome",
+              userId,
+            })
+          ).rejects.toMatchObject({
+            data: {
+              code: "WELCOME_EMAIL_DELIVERY_FAILED",
+              message: "Unable to enqueue the welcome email.",
+            },
+          })
+        );
       })
-    ).rejects.toMatchObject({
-      data: {
-        code: "WELCOME_EMAIL_DELIVERY_FAILED",
-        message: "Unable to enqueue the welcome email.",
-      },
-    });
-  });
+  );
 });


### PR DESCRIPTION
## Scope

Migrates the single mixed welcome-email backend test module as one package-owned Effect v4 checkpoint. Neighboring pure deterministic email tests remain ordinary Vitest.

## Architecture

- Effect programs run through `it.effect` from `@repo/testing/effect`, which is backed by pinned `@effect/vitest@4.0.0-rc.110`.
- Expected release failures stay in the typed Effect error channel and are asserted after `Effect.flip`.
- Convex test Promises are lifted with `Effect.promise`.
- Direct fixture database programs use the repository's existing `runConvexProgram` Convex boundary.
- The direct Vitest import is limited to the local `vi` transform API. No global mock surface or new wrapper was added.

## Legacy removed

- No direct `Effect.runPromise`, `Effect.runPromiseExit`, or `Effect.runSync` remains in this test module.
- No raw async Vitest test body remains.
- The PR changes exactly `packages/backend/convex/emails/welcome.test.ts`.

## Local proof

- Focused test: 1 file, 7 cases passed.
- Backend typecheck passed.
- Full backend suite: 326 files and 1,369 tests passed.
- Full repository suite: 14 of 14 tasks passed, including 209 web files and 1,501 web tests at 100% coverage.
- Lint, test policy, patch policy, Effect source parity, security audit, and Doctor passed.
- Two unrelated 5-second timeout cases from one loaded run were reproduced green together, then the complete repository suite passed.

## Exact head

- Commit: `b570d2f24caf94f514ea015eaca08f3ebacda8f5`
- Base: `1ba7c3728b254e42231779726709c0f85889d07a`
- File checksum: `302104555aac70069a8a617be4ca21e5dd442fc22ed490ac1646943e66c32e1a`

## Release

No Vercel Preview is requested or permitted. Merge through protected `main` only after exact-head required checks and final review-state verification are green.