### PR TITLE
refactor(backend): make learning preferences Effect native

### DIFF
--- a/packages/backend/convex/learningPreferences/impl.ts
+++ b/packages/backend/convex/learningPreferences/impl.ts
@@ -8,7 +8,6 @@ import type {
   QueryCtx,
 } from "@repo/backend/convex/_generated/server";
 import { loadTryoutOwner } from "@repo/backend/convex/contentRelease/tryout/owner";
-import { getUnknownErrorMessage } from "@repo/backend/convex/lib/effect";
 import type { Locale } from "@repo/backend/convex/lib/validators/contents";
 import { readTryoutCatalogRowByIdentity } from "@repo/backend/convex/tryouts/catalog/row";
 import type { LearningInterest } from "@repo/contents/_types/learner/preferences";
@@ -18,21 +17,23 @@ type PreferenceCtx = MutationCtx | QueryCtx;
 type LearningProgramKind = typeof LearningProgramKindSchema.Type;
 const learningPreferencePersistenceFailedCode =
   "LEARNING_PREFERENCE_PERSISTENCE_FAILED";
+const learningPreferencePersistenceFailedMessage =
+  "Unable to read or persist learning preferences.";
 
 /** Expected database failure while reading or writing learner preferences. */
 export class LearningPreferencePersistenceError extends Schema.TaggedError<LearningPreferencePersistenceError>()(
   "LearningPreferencePersistenceError",
   {
     code: Schema.Literal(learningPreferencePersistenceFailedCode),
-    message: Schema.String,
+    message: Schema.Literal(learningPreferencePersistenceFailedMessage),
   }
 ) {}
 
 /** Maps unknown database failures into the preference persistence contract. */
-function toLearningPreferencePersistenceError(error: unknown) {
+function toLearningPreferencePersistenceError() {
   return new LearningPreferencePersistenceError({
     code: learningPreferencePersistenceFailedCode,
-    message: getUnknownErrorMessage(error),
+    message: learningPreferencePersistenceFailedMessage,
   });
 }
 

--- a/packages/backend/convex/learningPreferences/impl.ts
+++ b/packages/backend/convex/learningPreferences/impl.ts
@@ -36,6 +36,14 @@ function toLearningPreferencePersistenceError(error: unknown) {
   });
 }
 
+/** Runs one preference database operation through its typed error channel. */
+function tryLearningPreferencePersistence<A>(operation: () => Promise<A>) {
+  return Effect.tryPromise({
+    catch: toLearningPreferencePersistenceError,
+    try: operation,
+  });
+}
+
 /** Converts a try-out country row into the compact option used by navigation. */
 export function toTryoutCountryOption(country: TryoutCountry) {
   return {
@@ -46,25 +54,16 @@ export function toTryoutCountryOption(country: TryoutCountry) {
   };
 }
 
-/** Loads the saved preference row for one app user. */
-export async function getLearningPreferenceByUserId(
-  ctx: PreferenceCtx,
-  userId: Id<"users">
-) {
-  return await ctx.db
-    .query("learningPreferences")
-    .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .unique();
-}
-
 /** Loads one preference row through the typed persistence error channel. */
 export const readLearningPreferenceByUserId = Effect.fn(
   "learningPreferences.readLearningPreferenceByUserId"
 )(function* (ctx: PreferenceCtx, userId: Id<"users">) {
-  return yield* Effect.tryPromise({
-    catch: toLearningPreferencePersistenceError,
-    try: () => getLearningPreferenceByUserId(ctx, userId),
-  });
+  return yield* tryLearningPreferencePersistence(() =>
+    ctx.db
+      .query("learningPreferences")
+      .withIndex("by_userId", (query) => query.eq("userId", userId))
+      .unique()
+  );
 });
 
 /** Loads one active try-out country from the signed catalog. */
@@ -117,7 +116,9 @@ export const readCurrentTryoutCountry = Effect.fn(
 });
 
 /** Creates or updates the current user's preferred curriculum program key. */
-export async function upsertPreferredCurriculumProgram({
+export const upsertPreferredCurriculumProgram = Effect.fn(
+  "learningPreferences.upsertPreferredCurriculumProgram"
+)(function* ({
   ctx,
   now,
   programKey,
@@ -128,27 +129,31 @@ export async function upsertPreferredCurriculumProgram({
   programKey: string;
   userId: Id<"users">;
 }) {
-  const current = await getLearningPreferenceByUserId(ctx, userId);
+  const current = yield* readLearningPreferenceByUserId(ctx, userId);
 
   if (!current) {
-    return await ctx.db.insert("learningPreferences", {
-      preferredCurriculumProgramKey: programKey,
-      updatedAt: now,
-      userId,
-    });
+    return yield* tryLearningPreferencePersistence(() =>
+      ctx.db.insert("learningPreferences", {
+        preferredCurriculumProgramKey: programKey,
+        updatedAt: now,
+        userId,
+      })
+    );
   }
 
   if (current.preferredCurriculumProgramKey === programKey) {
     return current._id;
   }
 
-  await ctx.db.patch(current._id, {
-    preferredCurriculumProgramKey: programKey,
-    updatedAt: now,
-  });
+  yield* tryLearningPreferencePersistence(() =>
+    ctx.db.patch(current._id, {
+      preferredCurriculumProgramKey: programKey,
+      updatedAt: now,
+    })
+  );
 
   return current._id;
-}
+});
 
 /** Creates or updates the current user's canonical learning selection. */
 export const saveLearningSelection = Effect.fn(
@@ -182,18 +187,16 @@ export const saveLearningSelection = Effect.fn(
     : {};
 
   if (!current) {
-    return yield* Effect.tryPromise({
-      catch: toLearningPreferencePersistenceError,
-      try: () =>
-        ctx.db.insert("learningPreferences", {
-          learningInterest: interest,
-          primaryProgramKey: programKey,
-          ...curriculumPreference,
-          selectionUpdatedAt,
-          updatedAt: now,
-          userId,
-        }),
-    });
+    return yield* tryLearningPreferencePersistence(() =>
+      ctx.db.insert("learningPreferences", {
+        learningInterest: interest,
+        primaryProgramKey: programKey,
+        ...curriculumPreference,
+        selectionUpdatedAt,
+        updatedAt: now,
+        userId,
+      })
+    );
   }
 
   if (
@@ -209,35 +212,33 @@ export const saveLearningSelection = Effect.fn(
       return current._id;
     }
 
-    yield* Effect.tryPromise({
-      catch: toLearningPreferencePersistenceError,
-      try: () =>
-        ctx.db.patch(current._id, {
-          selectionUpdatedAt,
-          updatedAt: now,
-        }),
-    });
+    yield* tryLearningPreferencePersistence(() =>
+      ctx.db.patch(current._id, {
+        selectionUpdatedAt,
+        updatedAt: now,
+      })
+    );
 
     return current._id;
   }
 
-  yield* Effect.tryPromise({
-    catch: toLearningPreferencePersistenceError,
-    try: () =>
-      ctx.db.patch(current._id, {
-        learningInterest: interest,
-        primaryProgramKey: programKey,
-        ...curriculumPreference,
-        selectionUpdatedAt,
-        updatedAt: now,
-      }),
-  });
+  yield* tryLearningPreferencePersistence(() =>
+    ctx.db.patch(current._id, {
+      learningInterest: interest,
+      primaryProgramKey: programKey,
+      ...curriculumPreference,
+      selectionUpdatedAt,
+      updatedAt: now,
+    })
+  );
 
   return current._id;
 });
 
 /** Creates or updates the current user's preferred try-out country key. */
-export async function upsertPreferredTryoutCountry({
+export const upsertPreferredTryoutCountry = Effect.fn(
+  "learningPreferences.upsertPreferredTryoutCountry"
+)(function* ({
   countryKey,
   ctx,
   now,
@@ -248,24 +249,28 @@ export async function upsertPreferredTryoutCountry({
   now: number;
   userId: Id<"users">;
 }) {
-  const current = await getLearningPreferenceByUserId(ctx, userId);
+  const current = yield* readLearningPreferenceByUserId(ctx, userId);
 
   if (!current) {
-    return await ctx.db.insert("learningPreferences", {
-      preferredTryoutCountryKey: countryKey,
-      updatedAt: now,
-      userId,
-    });
+    return yield* tryLearningPreferencePersistence(() =>
+      ctx.db.insert("learningPreferences", {
+        preferredTryoutCountryKey: countryKey,
+        updatedAt: now,
+        userId,
+      })
+    );
   }
 
   if (current.preferredTryoutCountryKey === countryKey) {
     return current._id;
   }
 
-  await ctx.db.patch(current._id, {
-    preferredTryoutCountryKey: countryKey,
-    updatedAt: now,
-  });
+  yield* tryLearningPreferencePersistence(() =>
+    ctx.db.patch(current._id, {
+      preferredTryoutCountryKey: countryKey,
+      updatedAt: now,
+    })
+  );
 
   return current._id;
-}
+});

--- a/packages/backend/convex/learningPreferences/mutations.test.ts
+++ b/packages/backend/convex/learningPreferences/mutations.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ActiveAppLocaleListSchema,
   ActiveAppLocaleSchema,
@@ -20,7 +21,6 @@ import {
   makeTechnicalProgram,
 } from "@repo/backend/test/program-snapshot";
 import { activateTryoutStartSource } from "@repo/backend/test/tryout-source";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
 import { vi } from "vitest";
 

--- a/packages/backend/convex/learningPreferences/mutations.test.ts
+++ b/packages/backend/convex/learningPreferences/mutations.test.ts
@@ -8,6 +8,7 @@ import {
   LearningProgramSchema,
 } from "@nakafa/aksara-contracts/program/spec";
 import { api } from "@repo/backend/convex/_generated/api";
+import { readLearningPreferenceByUserId } from "@repo/backend/convex/learningPreferences/impl";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
@@ -21,6 +22,7 @@ import {
 import { activateTryoutStartSource } from "@repo/backend/test/tryout-source";
 import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
+import { vi } from "vitest";
 
 const NOW = 1_798_752_000_000;
 const PREFERENCE_APP_LOCALES = Schema.decodeSync(ActiveAppLocaleListSchema)([
@@ -234,6 +236,101 @@ describe("learningPreferences", () => {
           },
         })
       );
+    })
+  );
+
+  it.effect("preserves the shared authentication contracts", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+
+      yield* Effect.promise(() =>
+        expect(
+          t.mutation(
+            api.learningPreferences.mutations.setPreferredTryoutCountry,
+            {
+              locale: "id",
+              preferredTryoutCountryKey: "indonesia",
+            }
+          )
+        ).rejects.toMatchObject({
+          data: {
+            code: "UNAUTHENTICATED",
+            message: "Unauthenticated",
+          },
+        })
+      );
+
+      const identity = yield* seedPreferenceUser(t);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.patch("users", identity.userId, {
+                deletionPreparedAt: NOW,
+              })
+            )
+          )
+        )
+      );
+      const authed = t.withIdentity({
+        sessionId: identity.sessionId,
+        subject: identity.authUserId,
+      });
+
+      yield* Effect.promise(() =>
+        expect(
+          authed.mutation(
+            api.learningPreferences.mutations.setPreferredTryoutCountry,
+            {
+              locale: "id",
+              preferredTryoutCountryKey: "indonesia",
+            }
+          )
+        ).rejects.toMatchObject({
+          data: {
+            code: "UNAUTHORIZED",
+            message: "User not found.",
+          },
+        })
+      );
+    })
+  );
+
+  it.effect("redacts preference persistence failures", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const identity = yield* seedPreferenceUser(t);
+      const failure = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.acquireUseRelease(
+              Effect.sync(() =>
+                vi.spyOn(ctx.db, "query").mockImplementationOnce(() => {
+                  throw new Error("private database details");
+                })
+              ),
+              () =>
+                readLearningPreferenceByUserId(ctx, identity.userId).pipe(
+                  Effect.match({
+                    onFailure: (error) => ({
+                      _tag: error._tag,
+                      code: error.code,
+                      message: error.message,
+                    }),
+                    onSuccess: () => null,
+                  })
+                ),
+              (querySpy) => Effect.sync(() => querySpy.mockRestore())
+            )
+          )
+        )
+      );
+
+      expect(failure).toMatchObject({
+        _tag: "LearningPreferencePersistenceError",
+        code: "LEARNING_PREFERENCE_PERSISTENCE_FAILED",
+        message: "Unable to read or persist learning preferences.",
+      });
     })
   );
 

--- a/packages/backend/convex/learningPreferences/mutations.test.ts
+++ b/packages/backend/convex/learningPreferences/mutations.test.ts
@@ -8,6 +8,7 @@ import {
   LearningProgramSchema,
 } from "@nakafa/aksara-contracts/program/spec";
 import { api } from "@repo/backend/convex/_generated/api";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
@@ -18,8 +19,8 @@ import {
   makeTechnicalProgram,
 } from "@repo/backend/test/program-snapshot";
 import { activateTryoutStartSource } from "@repo/backend/test/tryout-source";
+import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const NOW = 1_798_752_000_000;
 const PREFERENCE_APP_LOCALES = Schema.decodeSync(ActiveAppLocaleListSchema)([
@@ -47,149 +48,236 @@ const PREFERENCE_PROGRAMS = [
   makePreferenceProgram(5, "snbt", "ID", "snbt", "SNBT", "admission-exam"),
 ];
 
-describe("learningPreferences", () => {
-  it("lists school curriculum preferences in catalog display order", async () => {
-    const t = createConvexTestWithBetterAuth();
+type PreferenceTest = ReturnType<typeof createConvexTestWithBetterAuth>;
 
-    await syncPrograms(t);
-
-    const programs = await t.query(
-      api.learningPreferences.queries.listCurriculumPrograms,
-      { locale: "id" }
-    );
-
-    expect(programs.map((program) => program.key)).toEqual([
-      "merdeka",
-      "cambridge-international",
-      "singapore-moe",
-      "united-states",
-    ]);
-    expect(programs.at(-1)).toMatchObject({
-      countryCode: "US",
-      publicSlug: "amerika-serikat",
-      title: "United States Standards-Aligned Pathway",
-    });
-  });
-
-  it("saves and reads the authenticated user's preferred curriculum", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const identity = await t.mutation((ctx) =>
-      seedAuthenticatedUser(ctx, { now: NOW })
-    );
-
-    await syncPrograms(t);
-
-    await expect(
-      t.query(api.learningPreferences.queries.getCurrent, { locale: "id" })
-    ).resolves.toBeNull();
-
-    const authed = t.withIdentity({
-      sessionId: identity.sessionId,
-      subject: identity.authUserId,
-    });
-    const saved = await authed.mutation(
-      api.learningPreferences.mutations.setPreferredCurriculum,
-      {
-        locale: "id",
-        preferredCurriculumProgramKey: "united-states",
-      }
-    );
-
-    expect(saved).toMatchObject({
-      preferredCurriculumProgramKey: "united-states",
-      program: {
-        countryCode: "US",
-        key: "united-states",
-        publicSlug: "amerika-serikat",
-        title: "United States Standards-Aligned Pathway",
-      },
-    });
-    await expect(
-      authed.query(api.learningPreferences.queries.getCurrent, {
-        locale: "id",
-      })
-    ).resolves.toMatchObject(saved);
-  });
-
-  it("saves and reads the authenticated user's preferred try-out country", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const identity = await t.mutation(async (ctx) => {
-      const user = await seedAuthenticatedUser(ctx, { now: NOW });
-      await activateTryoutStartSource(ctx, "visible");
-      return user;
-    });
-
-    await expect(
-      t.query(api.learningPreferences.queries.getCurrentTryout, {
-        locale: "id",
-      })
-    ).resolves.toBeNull();
-
-    const authed = t.withIdentity({
-      sessionId: identity.sessionId,
-      subject: identity.authUserId,
-    });
-    const saved = await authed.mutation(
-      api.learningPreferences.mutations.setPreferredTryoutCountry,
-      {
-        locale: "id",
-        preferredTryoutCountryKey: "indonesia",
-      }
-    );
-
-    expect(saved).toMatchObject({
-      country: {
-        countryCode: "ID",
-        key: "indonesia",
-        publicPath: "try-out/indonesia",
-        title: "Indonesia",
-      },
-      preferredTryoutCountryKey: "indonesia",
-    });
-    await expect(
-      authed.query(api.learningPreferences.queries.getCurrentTryout, {
-        locale: "id",
-      })
-    ).resolves.toMatchObject(saved);
-    await expect(
-      authed.query(api.learningPreferences.queries.getCurrent, { locale: "id" })
-    ).resolves.toBeNull();
-  });
-
-  it("rejects non-curriculum program keys", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const identity = await t.mutation((ctx) =>
-      seedAuthenticatedUser(ctx, { now: NOW })
-    );
-
-    await syncPrograms(t);
-
-    const authed = t.withIdentity({
-      sessionId: identity.sessionId,
-      subject: identity.authUserId,
-    });
-
-    await expect(
-      authed.mutation(
-        api.learningPreferences.mutations.setPreferredCurriculum,
-        {
-          locale: "id",
-          preferredCurriculumProgramKey: "snbt",
-        }
+/** Creates one authenticated preference-test user. */
+const seedPreferenceUser = Effect.fn("test.learningPreferences.seedUser")(
+  function* (t: PreferenceTest) {
+    return yield* Effect.promise(() =>
+      t.mutation((ctx) =>
+        runConvexProgram(
+          Effect.promise(() => seedAuthenticatedUser(ctx, { now: NOW }))
+        )
       )
-    ).rejects.toThrow("CURRICULUM_PROGRAM_NOT_FOUND");
-  });
+    );
+  }
+);
+
+/** Creates one authenticated user and activates the signed try-out source. */
+const seedTryoutPreferenceUser = Effect.fn(
+  "test.learningPreferences.seedTryoutUser"
+)(function* (t: PreferenceTest) {
+  return yield* Effect.promise(() =>
+    t.mutation((ctx) =>
+      runConvexProgram(
+        Effect.gen(function* () {
+          const user = yield* Effect.promise(() =>
+            seedAuthenticatedUser(ctx, { now: NOW })
+          );
+          yield* Effect.promise(() =>
+            activateTryoutStartSource(ctx, "visible")
+          );
+          return user;
+        })
+      )
+    )
+  );
+});
+
+describe("learningPreferences", () => {
+  it.effect(
+    "lists school curriculum preferences in catalog display order",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        yield* syncPrograms(t);
+
+        const programs = yield* Effect.promise(() =>
+          t.query(api.learningPreferences.queries.listCurriculumPrograms, {
+            locale: "id",
+          })
+        );
+
+        expect(programs.map((program) => program.key)).toEqual([
+          "merdeka",
+          "cambridge-international",
+          "singapore-moe",
+          "united-states",
+        ]);
+        expect(programs.at(-1)).toMatchObject({
+          countryCode: "US",
+          publicSlug: "amerika-serikat",
+          title: "United States Standards-Aligned Pathway",
+        });
+      })
+  );
+
+  it.effect(
+    "saves and reads the authenticated user's preferred curriculum",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const identity = yield* seedPreferenceUser(t);
+        yield* syncPrograms(t);
+
+        const guestPreference = yield* Effect.promise(() =>
+          t.query(api.learningPreferences.queries.getCurrent, { locale: "id" })
+        );
+        expect(guestPreference).toBeNull();
+
+        const authed = t.withIdentity({
+          sessionId: identity.sessionId,
+          subject: identity.authUserId,
+        });
+        const saved = yield* Effect.promise(() =>
+          authed.mutation(
+            api.learningPreferences.mutations.setPreferredCurriculum,
+            {
+              locale: "id",
+              preferredCurriculumProgramKey: "united-states",
+            }
+          )
+        );
+
+        expect(saved).toMatchObject({
+          preferredCurriculumProgramKey: "united-states",
+          program: {
+            countryCode: "US",
+            key: "united-states",
+            publicSlug: "amerika-serikat",
+            title: "United States Standards-Aligned Pathway",
+          },
+        });
+        const current = yield* Effect.promise(() =>
+          authed.query(api.learningPreferences.queries.getCurrent, {
+            locale: "id",
+          })
+        );
+        expect(current).toMatchObject(saved);
+      })
+  );
+
+  it.effect(
+    "saves and reads the authenticated user's preferred try-out country",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const identity = yield* seedTryoutPreferenceUser(t);
+
+        const guestPreference = yield* Effect.promise(() =>
+          t.query(api.learningPreferences.queries.getCurrentTryout, {
+            locale: "id",
+          })
+        );
+        expect(guestPreference).toBeNull();
+
+        const authed = t.withIdentity({
+          sessionId: identity.sessionId,
+          subject: identity.authUserId,
+        });
+        const saved = yield* Effect.promise(() =>
+          authed.mutation(
+            api.learningPreferences.mutations.setPreferredTryoutCountry,
+            {
+              locale: "id",
+              preferredTryoutCountryKey: "indonesia",
+            }
+          )
+        );
+
+        expect(saved).toMatchObject({
+          country: {
+            countryCode: "ID",
+            key: "indonesia",
+            publicPath: "try-out/indonesia",
+            title: "Indonesia",
+          },
+          preferredTryoutCountryKey: "indonesia",
+        });
+        const currentTryout = yield* Effect.promise(() =>
+          authed.query(api.learningPreferences.queries.getCurrentTryout, {
+            locale: "id",
+          })
+        );
+        expect(currentTryout).toMatchObject(saved);
+        const currentCurriculum = yield* Effect.promise(() =>
+          authed.query(api.learningPreferences.queries.getCurrent, {
+            locale: "id",
+          })
+        );
+        expect(currentCurriculum).toBeNull();
+      })
+  );
+
+  it.effect("rejects a try-out country missing from the signed catalog", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const identity = yield* seedTryoutPreferenceUser(t);
+      const authed = t.withIdentity({
+        sessionId: identity.sessionId,
+        subject: identity.authUserId,
+      });
+
+      yield* Effect.promise(() =>
+        expect(
+          authed.mutation(
+            api.learningPreferences.mutations.setPreferredTryoutCountry,
+            {
+              locale: "id",
+              preferredTryoutCountryKey: "missing-country",
+            }
+          )
+        ).rejects.toMatchObject({
+          data: {
+            code: "TRYOUT_COUNTRY_NOT_FOUND",
+            message: "Try-out country not found.",
+          },
+        })
+      );
+    })
+  );
+
+  it.effect("rejects non-curriculum program keys", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const identity = yield* seedPreferenceUser(t);
+      yield* syncPrograms(t);
+
+      const authed = t.withIdentity({
+        sessionId: identity.sessionId,
+        subject: identity.authUserId,
+      });
+
+      yield* Effect.promise(() =>
+        expect(
+          authed.mutation(
+            api.learningPreferences.mutations.setPreferredCurriculum,
+            {
+              locale: "id",
+              preferredCurriculumProgramKey: "snbt",
+            }
+          )
+        ).rejects.toMatchObject({
+          data: {
+            code: "CURRICULUM_PROGRAM_NOT_FOUND",
+            message: "Curriculum program not found.",
+          },
+        })
+      );
+    })
+  );
 });
 
 /** Activates the reviewed program copy as one signed snapshot. */
-async function syncPrograms(
-  t: ReturnType<typeof createConvexTestWithBetterAuth>
-) {
-  const data = await Effect.runPromise(
-    makeProgramSnapshotData(PREFERENCE_PROGRAMS, PREFERENCE_APP_LOCALES)
-  );
-  await activateProgramSnapshot(t, data);
-}
+const syncPrograms = Effect.fn("test.learningPreferences.syncPrograms")(
+  function* (t: PreferenceTest) {
+    const data = yield* makeProgramSnapshotData(
+      PREFERENCE_PROGRAMS,
+      PREFERENCE_APP_LOCALES
+    );
+    yield* Effect.promise(() => activateProgramSnapshot(t, data));
+  }
+);
 
 /** Builds one explicit signed current program used by preference tests. */
 function makePreferenceProgram(

--- a/packages/backend/convex/learningPreferences/mutations.ts
+++ b/packages/backend/convex/learningPreferences/mutations.ts
@@ -11,7 +11,7 @@ import {
   currentTryoutPreferenceValidator,
 } from "@repo/backend/convex/learningPreferences/schema";
 import {
-  getUnknownErrorMessage,
+  readConvexErrorData,
   runConvexProgram,
 } from "@repo/backend/convex/lib/effect";
 import { requireAuth } from "@repo/backend/convex/lib/helpers/auth";
@@ -20,19 +20,26 @@ import {
   localeValidator,
 } from "@repo/backend/convex/lib/validators/contents";
 import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { Clock, Effect, Schema } from "effect";
 
 const curriculumPreferenceAuthFailedCode = "CURRICULUM_PREFERENCE_AUTH_FAILED";
+const curriculumPreferenceAuthFailedMessage =
+  "Unable to authenticate the curriculum preference request.";
 const tryoutPreferenceAuthFailedCode = "TRYOUT_PREFERENCE_AUTH_FAILED";
+const tryoutPreferenceAuthFailedMessage =
+  "Unable to authenticate the try-out preference request.";
 const tryoutCountryNotFoundCode = "TRYOUT_COUNTRY_NOT_FOUND";
+const unauthenticatedCode = "UNAUTHENTICATED";
+const unauthenticatedMessage = "Unauthenticated";
+const unauthorizedCode = "UNAUTHORIZED";
 
 /** Raised when curriculum preference authentication fails unexpectedly. */
 class CurriculumPreferenceAuthError extends Schema.TaggedError<CurriculumPreferenceAuthError>()(
   "CurriculumPreferenceAuthError",
   {
     code: Schema.Literal(curriculumPreferenceAuthFailedCode),
-    message: Schema.String,
+    message: Schema.Literal(curriculumPreferenceAuthFailedMessage),
   }
 ) {}
 
@@ -43,10 +50,44 @@ class TryoutPreferenceError extends Schema.TaggedError<TryoutPreferenceError>()(
     code: Schema.Literals([
       tryoutPreferenceAuthFailedCode,
       tryoutCountryNotFoundCode,
+      unauthenticatedCode,
+      unauthorizedCode,
     ]),
     message: Schema.String,
   }
 ) {}
+
+/** Maps unknown curriculum auth failures into a stable public contract. */
+function toCurriculumPreferenceAuthError() {
+  return new CurriculumPreferenceAuthError({
+    code: curriculumPreferenceAuthFailedCode,
+    message: curriculumPreferenceAuthFailedMessage,
+  });
+}
+
+/** Preserves known shared auth failures and tags unknown boundary failures. */
+function toTryoutPreferenceAuthError(error: unknown) {
+  const known = readConvexErrorData(error);
+
+  if (known?.code === unauthenticatedCode || known?.code === unauthorizedCode) {
+    return new TryoutPreferenceError({
+      code: known.code,
+      message: known.message,
+    });
+  }
+
+  if (error instanceof ConvexError && error.data === unauthenticatedMessage) {
+    return new TryoutPreferenceError({
+      code: unauthenticatedCode,
+      message: unauthenticatedMessage,
+    });
+  }
+
+  return new TryoutPreferenceError({
+    code: tryoutPreferenceAuthFailedCode,
+    message: tryoutPreferenceAuthFailedMessage,
+  });
+}
 
 /** Saves one authenticated curriculum preference from the signed catalog. */
 const setPreferredCurriculumProgram = Effect.fn(
@@ -59,11 +100,7 @@ const setPreferredCurriculumProgram = Effect.fn(
   }
 ) {
   const user = yield* Effect.tryPromise({
-    catch: (error) =>
-      new CurriculumPreferenceAuthError({
-        code: curriculumPreferenceAuthFailedCode,
-        message: getUnknownErrorMessage(error),
-      }),
+    catch: toCurriculumPreferenceAuthError,
     try: () => requireAuth(ctx),
   });
 
@@ -86,11 +123,7 @@ const setPreferredTryoutCountryProgram = Effect.fn(
   }
 ) {
   const user = yield* Effect.tryPromise({
-    catch: (error) =>
-      new TryoutPreferenceError({
-        code: tryoutPreferenceAuthFailedCode,
-        message: getUnknownErrorMessage(error),
-      }),
+    catch: toTryoutPreferenceAuthError,
     try: () => requireAuth(ctx),
   });
   const country = yield* readActiveTryoutCountry(ctx, {

--- a/packages/backend/convex/learningPreferences/mutations.ts
+++ b/packages/backend/convex/learningPreferences/mutations.ts
@@ -1,3 +1,4 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { mutation } from "@repo/backend/convex/functions";
 import {
   readActiveTryoutCountry,
@@ -14,12 +15,17 @@ import {
   runConvexProgram,
 } from "@repo/backend/convex/lib/effect";
 import { requireAuth } from "@repo/backend/convex/lib/helpers/auth";
-import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
+import {
+  type Locale,
+  localeValidator,
+} from "@repo/backend/convex/lib/validators/contents";
 import { tryoutRouteKeyValidator } from "@repo/backend/convex/tryouts/route";
-import { ConvexError, v } from "convex/values";
-import { Effect, Schema } from "effect";
+import { v } from "convex/values";
+import { Clock, Effect, Schema } from "effect";
 
 const curriculumPreferenceAuthFailedCode = "CURRICULUM_PREFERENCE_AUTH_FAILED";
+const tryoutPreferenceAuthFailedCode = "TRYOUT_PREFERENCE_AUTH_FAILED";
+const tryoutCountryNotFoundCode = "TRYOUT_COUNTRY_NOT_FOUND";
 
 /** Raised when curriculum preference authentication fails unexpectedly. */
 class CurriculumPreferenceAuthError extends Schema.TaggedError<CurriculumPreferenceAuthError>()(
@@ -30,6 +36,89 @@ class CurriculumPreferenceAuthError extends Schema.TaggedError<CurriculumPrefere
   }
 ) {}
 
+/** Raised when a try-out preference mutation cannot be completed safely. */
+class TryoutPreferenceError extends Schema.TaggedError<TryoutPreferenceError>()(
+  "TryoutPreferenceError",
+  {
+    code: Schema.Literals([
+      tryoutPreferenceAuthFailedCode,
+      tryoutCountryNotFoundCode,
+    ]),
+    message: Schema.String,
+  }
+) {}
+
+/** Saves one authenticated curriculum preference from the signed catalog. */
+const setPreferredCurriculumProgram = Effect.fn(
+  "learningPreferences.setPreferredCurriculum"
+)(function* (
+  ctx: MutationCtx,
+  args: {
+    readonly locale: Locale;
+    readonly preferredCurriculumProgramKey: string;
+  }
+) {
+  const user = yield* Effect.tryPromise({
+    catch: (error) =>
+      new CurriculumPreferenceAuthError({
+        code: curriculumPreferenceAuthFailedCode,
+        message: getUnknownErrorMessage(error),
+      }),
+    try: () => requireAuth(ctx),
+  });
+
+  return yield* saveCurriculumProgram(
+    ctx,
+    args.locale,
+    args.preferredCurriculumProgramKey,
+    user.appUser._id
+  );
+});
+
+/** Saves one authenticated try-out country from the signed catalog. */
+const setPreferredTryoutCountryProgram = Effect.fn(
+  "learningPreferences.setPreferredTryoutCountry"
+)(function* (
+  ctx: MutationCtx,
+  args: {
+    readonly locale: Locale;
+    readonly preferredTryoutCountryKey: string;
+  }
+) {
+  const user = yield* Effect.tryPromise({
+    catch: (error) =>
+      new TryoutPreferenceError({
+        code: tryoutPreferenceAuthFailedCode,
+        message: getUnknownErrorMessage(error),
+      }),
+    try: () => requireAuth(ctx),
+  });
+  const country = yield* readActiveTryoutCountry(ctx, {
+    countryKey: args.preferredTryoutCountryKey,
+    locale: args.locale,
+  });
+
+  if (!country) {
+    return yield* new TryoutPreferenceError({
+      code: tryoutCountryNotFoundCode,
+      message: "Try-out country not found.",
+    });
+  }
+
+  const now = yield* Clock.currentTimeMillis;
+  yield* upsertPreferredTryoutCountry({
+    countryKey: country.countryKey,
+    ctx,
+    now,
+    userId: user.appUser._id,
+  });
+
+  return {
+    country: toTryoutCountryOption(country),
+    preferredTryoutCountryKey: country.countryKey,
+  };
+});
+
 /** Saves the authenticated user's preferred school curriculum program. */
 export const setPreferredCurriculum = mutation({
   args: {
@@ -38,24 +127,7 @@ export const setPreferredCurriculum = mutation({
   },
   returns: currentLearningPreferenceValidator,
   handler: (ctx, args) =>
-    runConvexProgram(
-      Effect.gen(function* () {
-        const user = yield* Effect.tryPromise({
-          catch: (error) =>
-            new CurriculumPreferenceAuthError({
-              code: curriculumPreferenceAuthFailedCode,
-              message: getUnknownErrorMessage(error),
-            }),
-          try: () => requireAuth(ctx),
-        });
-        return yield* saveCurriculumProgram(
-          ctx,
-          args.locale,
-          args.preferredCurriculumProgramKey,
-          user.appUser._id
-        );
-      })
-    ),
+    runConvexProgram(setPreferredCurriculumProgram(ctx, args)),
 });
 
 /** Saves the authenticated user's preferred try-out country. */
@@ -65,32 +137,6 @@ export const setPreferredTryoutCountry = mutation({
     preferredTryoutCountryKey: tryoutRouteKeyValidator,
   },
   returns: currentTryoutPreferenceValidator,
-  handler: async (ctx, args) => {
-    const user = await requireAuth(ctx);
-    const country = await runConvexProgram(
-      readActiveTryoutCountry(ctx, {
-        countryKey: args.preferredTryoutCountryKey,
-        locale: args.locale,
-      })
-    );
-
-    if (!country) {
-      throw new ConvexError({
-        code: "TRYOUT_COUNTRY_NOT_FOUND",
-        message: "Try-out country not found.",
-      });
-    }
-
-    await upsertPreferredTryoutCountry({
-      countryKey: country.countryKey,
-      ctx,
-      now: Date.now(),
-      userId: user.appUser._id,
-    });
-
-    return {
-      country: toTryoutCountryOption(country),
-      preferredTryoutCountryKey: country.countryKey,
-    };
-  },
+  handler: (ctx, args) =>
+    runConvexProgram(setPreferredTryoutCountryProgram(ctx, args)),
 });

--- a/packages/backend/convex/learningPreferences/program.ts
+++ b/packages/backend/convex/learningPreferences/program.ts
@@ -12,12 +12,13 @@ import {
   listSignedPrograms,
   readSignedProgram,
 } from "@repo/backend/convex/learningPrograms/selection";
-import { getUnknownErrorMessage } from "@repo/backend/convex/lib/effect";
 import type { Locale } from "@repo/backend/convex/lib/validators/contents";
 import { Clock, Effect, Schema } from "effect";
 
 const CURRICULUM_PROGRAM_LIMIT = 50;
 const curriculumPreferenceIoFailedCode = "CURRICULUM_PREFERENCE_IO_FAILED";
+const curriculumPreferenceIoFailedMessage =
+  "Unable to read or persist curriculum preferences.";
 const curriculumProgramNotFoundCode = "CURRICULUM_PROGRAM_NOT_FOUND";
 /** Expected curriculum preference failure exposed through Convex errors. */
 export class CurriculumPreferenceError extends Schema.TaggedError<CurriculumPreferenceError>()(
@@ -38,10 +39,10 @@ export interface CurriculumProgramOption {
   readonly title: string;
 }
 /** Maps unknown database failures into the curriculum preference error channel. */
-function toPreferenceIoError(error: unknown) {
+function toPreferenceIoError() {
   return new CurriculumPreferenceError({
     code: curriculumPreferenceIoFailedCode,
-    message: getUnknownErrorMessage(error),
+    message: curriculumPreferenceIoFailedMessage,
   });
 }
 /** Converts one verified Aksara program into a localized selector option. */

--- a/packages/backend/convex/learningPreferences/program.ts
+++ b/packages/backend/convex/learningPreferences/program.ts
@@ -5,7 +5,7 @@ import type {
   QueryCtx,
 } from "@repo/backend/convex/_generated/server";
 import {
-  getLearningPreferenceByUserId,
+  readLearningPreferenceByUserId,
   upsertPreferredCurriculumProgram,
 } from "@repo/backend/convex/learningPreferences/impl";
 import {
@@ -98,10 +98,9 @@ export const listCurriculumPrograms = Effect.fn(
 export const readCurrentCurriculumProgram = Effect.fn(
   "learningPreferences.readCurrentCurriculumProgram"
 )(function* (ctx: QueryCtx, locale: Locale, userId: Id<"users">) {
-  const preference = yield* Effect.tryPromise({
-    catch: toPreferenceIoError,
-    try: () => getLearningPreferenceByUserId(ctx, userId),
-  });
+  const preference = yield* readLearningPreferenceByUserId(ctx, userId).pipe(
+    Effect.mapError(toPreferenceIoError)
+  );
   if (!preference?.preferredCurriculumProgramKey) {
     return null;
   }
@@ -135,16 +134,12 @@ export const saveCurriculumProgram = Effect.fn(
     });
   }
   const now = yield* Clock.currentTimeMillis;
-  yield* Effect.tryPromise({
-    catch: toPreferenceIoError,
-    try: () =>
-      upsertPreferredCurriculumProgram({
-        ctx,
-        now,
-        programKey: program.key,
-        userId,
-      }),
-  });
+  yield* upsertPreferredCurriculumProgram({
+    ctx,
+    now,
+    programKey: program.key,
+    userId,
+  }).pipe(Effect.mapError(toPreferenceIoError));
   return {
     preferredCurriculumProgramKey: program.key,
     program,

--- a/packages/backend/convex/learningPreferences/queries.ts
+++ b/packages/backend/convex/learningPreferences/queries.ts
@@ -12,31 +12,30 @@ import {
   currentTryoutPreferenceValidator,
   curriculumProgramOptionValidator,
 } from "@repo/backend/convex/learningPreferences/schema";
-import {
-  getUnknownErrorMessage,
-  runConvexProgram,
-} from "@repo/backend/convex/lib/effect";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { getOptionalAppUserForRead } from "@repo/backend/convex/lib/helpers/auth";
 import { localeValidator } from "@repo/backend/convex/lib/validators/contents";
 import { v } from "convex/values";
 import { Effect, Schema } from "effect";
 
 const learningPreferenceIoFailedCode = "LEARNING_PREFERENCE_IO_FAILED";
+const learningPreferenceIoFailedMessage =
+  "Unable to read learning preferences.";
 
 /** Raised when an authenticated preference query cannot read its user. */
 class LearningPreferenceIoError extends Schema.TaggedError<LearningPreferenceIoError>()(
   "LearningPreferenceIoError",
   {
     code: Schema.Literal(learningPreferenceIoFailedCode),
-    message: Schema.String,
+    message: Schema.Literal(learningPreferenceIoFailedMessage),
   }
 ) {}
 
 /** Maps unknown authentication reads into the preference error channel. */
-function toLearningPreferenceIoError(error: unknown) {
+function toLearningPreferenceIoError() {
   return new LearningPreferenceIoError({
     code: learningPreferenceIoFailedCode,
-    message: getUnknownErrorMessage(error),
+    message: learningPreferenceIoFailedMessage,
   });
 }
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",
+    "@effect/vitest": "catalog:",
     "@nakafa/aksara-v150": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz",
     "@repo/testing": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,9 @@ importers:
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@nakafa/aksara-v150':
         specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz
         version: '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz(effect@4.0.0-rc.110)'


### PR DESCRIPTION
## Scope

Migrates the learning-preference persistence and mutation capability as one production-owned Effect v4 checkpoint, together with its real colocated mutation test.

## Production architecture

- Replaces three exported raw Promise persistence functions with named `Effect.fn` programs.
- Centralizes database rejection mapping in the typed `LearningPreferencePersistenceError` channel with a stable redacted public message.
- Composes both mutation handlers through named Effect programs and the existing `runConvexProgram` framework boundary.
- Replaces `Date.now()` with `Clock.currentTimeMillis`.
- Replaces the thrown try-out `ConvexError` with `TryoutPreferenceError` in the typed error channel.
- Preserves the shared `UNAUTHENTICATED` and `UNAUTHORIZED` contracts while mapping only unknown auth failures to `TRYOUT_PREFERENCE_AUTH_FAILED`.

## Test architecture

- Uses `it.effect` directly from `@effect/vitest` for every effectful case.
- Lifts `convex-test` Promises into Effect without adding nested runners.
- Removes the direct `Effect.runPromise` test helper and every raw async test body.
- Adds regression coverage for missing try-out countries, both shared auth codes, and persistence-error redaction.

## Maintainability

The exact diff passed the architecture and Effect boundary scans. No touched module exceeds 500 lines. No new service, cache, allowlist, cast, fallback, global mock, or wrapper chain is introduced. The only raw thrown error in touched files is an intentional private test defect used to prove public redaction.

## Exact revision

- Base: `2c3efc5306de20443353e6c88b1f15d5e15e4803`
- Head: `d7b3249be5f5e3edb98ff55f6c4b3daea492f5bf`
- Tree: `75fe4c1599bd22c5c00d2ef4d3dedde80d7e1de6`
- Patch SHA-256: `c286809715dcd75fc5920d881e85e01eaa245d5aeae5baac104434d41a0c01f2`

## Local evidence

- Affected tests: 3 files, 17 tests passed.
- Backend typecheck passed.
- `pnpm lint` passed, including Effect source parity at RC110 commit `66114151c2b4640bf773f2b3456ce70d679422f6`.
- `pnpm boundaries` passed across 2,915 files in 18 packages.
- `pnpm test:scripts` passed: 3 files, 9 tests.
- `pnpm security:audit` found no known vulnerabilities.
- The optional whole-backend run completed 1,368 tests and hit five five-second timeouts in four unrelated files. An immediate isolated rerun of those four files passed all 20 tests in 5.66 seconds. Exact serialized CI remains the release gate.

## Release

No Vercel Preview is requested or permitted. Merge only after the exact pushed head is current with protected `main`, all review threads are resolved, and required `Required` plus `Doctor` checks pass.