### PR TITLE
test(backend): use Effect Vitest for score results

### DIFF
--- a/apps/www/e2e/coordinate-system.browser.ts
+++ b/apps/www/e2e/coordinate-system.browser.ts
@@ -8,7 +8,7 @@ import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
 
 const LINEAR_SYSTEM_ROUTE =
   "/id/materi/matematika/sistem-persamaan-dan-pertidaksamaan-linear/sistem-persamaan-linear";
-const MANY_SOLUTIONS_SCENE_INDEX = 2;
+const MANY_SOLUTIONS_TITLE = "Sistem Persamaan Linear dengan Banyak Solusi";
 const VISUAL_ASSERTION_TIMEOUT = 5000;
 const REQUIRED_STABLE_SAMPLES = 2;
 
@@ -131,15 +131,21 @@ const expectStableCoordinateSystem = Effect.fn(
   );
   yield* Effect.sync(() => expect(response?.ok()).toBe(true));
 
-  const scene = page
-    .locator('[data-slot="line-scene"]')
-    .nth(MANY_SOLUTIONS_SCENE_INDEX);
+  const card = page.locator('[data-slot="card"]').filter({
+    hasText: MANY_SOLUTIONS_TITLE,
+  });
+  const scene = card.locator('[data-slot="line-scene"]');
   const canvas = scene.locator("canvas");
   const playButton = scene.getByRole("button", { name: "Toggle Play" });
 
-  yield* Effect.promise(() => expect(scene).toBeAttached());
-  yield* Effect.promise(() => scene.scrollIntoViewIfNeeded());
-  yield* Effect.promise(() => expect(canvas).toBeVisible({ timeout: 30_000 }));
+  yield* Effect.promise(() =>
+    expect(async () => {
+      await expect(card).toHaveCount(1);
+      await expect(scene).toBeAttached();
+      await scene.scrollIntoViewIfNeeded();
+      expect(await canvas.isVisible()).toBe(true);
+    }).toPass({ timeout: 30_000 })
+  );
   yield* observeDrawingBufferSize(canvas);
   yield* waitForStableCanvas(canvas);
 

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -226,11 +226,17 @@ const nextConfig = {
     },
     // Anonymous Convex shares this runner. Split the export across two isolated
     // worker heaps, but let each worker process only one page at a time so the
-    // backend sees at most two concurrent static-generation requests.
+    // backend sees at most two concurrent static-generation requests. Retry one
+    // complete page after an intermittent local-backend response; repeated or
+    // deterministic page failures still fail the build.
     // Production keeps Next.js' default static-generation concurrency.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(configEnv.CONVEX_AGENT_MODE === "anonymous"
-      ? { cpus: 2, staticGenerationMaxConcurrency: 1 }
+      ? {
+          cpus: 2,
+          staticGenerationMaxConcurrency: 1,
+          staticGenerationRetryCount: 2,
+        }
       : {}),
   },
 } satisfies NextConfig;

--- a/packages/backend/convex/tryouts/score/result.test.ts
+++ b/packages/backend/convex/tryouts/score/result.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
@@ -8,7 +9,6 @@ import {
   TryoutScoreReadError,
 } from "@repo/backend/convex/tryouts/score/result";
 import { TEST_RELEASE_ID } from "@repo/backend/test/content-release";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 const NOW = Date.UTC(2026, 7, 8, 12, 0, 0);

--- a/packages/backend/convex/tryouts/score/result.test.ts
+++ b/packages/backend/convex/tryouts/score/result.test.ts
@@ -1,3 +1,4 @@
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
@@ -7,72 +8,96 @@ import {
   TryoutScoreReadError,
 } from "@repo/backend/convex/tryouts/score/result";
 import { TEST_RELEASE_ID } from "@repo/backend/test/content-release";
+import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 8, 12, 0, 0);
 
 describe("tryouts/score/result", () => {
-  it("returns a typed integrity failure for a terminal attempt without a score", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const identity = await t.mutation((ctx) =>
-      seedAuthenticatedUser(ctx, {
-        now: NOW,
-        suffix: "missing-tryout-score",
+  it.effect(
+    "returns a typed integrity failure for a terminal attempt without a score",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const identity = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.promise(() =>
+                seedAuthenticatedUser(ctx, {
+                  now: NOW,
+                  suffix: "missing-tryout-score",
+                })
+              )
+            )
+          )
+        );
+
+        const failure = yield* Effect.promise(() =>
+          t.run((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attemptId = yield* Effect.promise(() =>
+                  ctx.db.insert("tryoutAttempts", {
+                    accessEndsAt: NOW + 3_600_000,
+                    accessSourceKind: "free",
+                    attemptNumber: 1,
+                    completedAt: NOW,
+                    completedSectionKeys: [],
+                    countsForCompetition: false,
+                    countryKey: "indonesia",
+                    endReason: "submitted",
+                    examKey: "snbt",
+                    expiresAt: NOW + 3_600_000,
+                    lastActivityAt: NOW,
+                    appLocale: "id",
+                    scoreStatus: "official",
+                    scoringStrategy: "raw",
+                    sectionSnapshots: [],
+                    setIdentity: "set:indonesia:snbt:2027:set-1",
+                    setKey: "set-1",
+                    setPublicPath: "try-out/indonesia/snbt/2027/set-1",
+                    snapshotReleaseId: TEST_RELEASE_ID,
+                    startedAt: NOW - 1000,
+                    status: "completed",
+                    totalCorrect: 0,
+                    totalQuestions: 0,
+                    trackKey: "2027",
+                    tryoutSnapshotId: `sha256:${"a".repeat(64)}`,
+                    userId: identity.userId,
+                  })
+                );
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get(attemptId)
+                );
+                if (!attempt) {
+                  return yield* Effect.die(
+                    "Expected the terminal attempt fixture."
+                  );
+                }
+                return yield* loadAttemptScoreResult(ctx, attempt).pipe(
+                  Effect.match({
+                    onFailure: (error) => ({
+                      _tag: error._tag,
+                      code: error.code,
+                      message: error.message,
+                    }),
+                    onSuccess: () => null,
+                  })
+                );
+              })
+            )
+          )
+        );
+
+        const expected = new TryoutScoreReadError({
+          code: "TRYOUT_SCORE_NOT_FOUND",
+          message: "Terminal try-out attempt is missing its score snapshot.",
+        });
+        expect(failure).toEqual({
+          _tag: expected._tag,
+          code: expected.code,
+          message: expected.message,
+        });
       })
-    );
-
-    const failure = await t.run(async (ctx) => {
-      const attemptId = await ctx.db.insert("tryoutAttempts", {
-        accessEndsAt: NOW + 3_600_000,
-        accessSourceKind: "free",
-        attemptNumber: 1,
-        completedAt: NOW,
-        completedSectionKeys: [],
-        countsForCompetition: false,
-        countryKey: "indonesia",
-        endReason: "submitted",
-        examKey: "snbt",
-        expiresAt: NOW + 3_600_000,
-        lastActivityAt: NOW,
-        appLocale: "id",
-        scoreStatus: "official",
-        scoringStrategy: "raw",
-        sectionSnapshots: [],
-        setIdentity: "set:indonesia:snbt:2027:set-1",
-        setKey: "set-1",
-        setPublicPath: "try-out/indonesia/snbt/2027/set-1",
-        snapshotReleaseId: TEST_RELEASE_ID,
-        startedAt: NOW - 1000,
-        status: "completed",
-        totalCorrect: 0,
-        totalQuestions: 0,
-        trackKey: "2027",
-        tryoutSnapshotId: `sha256:${"a".repeat(64)}`,
-        userId: identity.userId,
-      });
-      const attempt = await ctx.db.get(attemptId);
-      if (!attempt) {
-        throw new Error("Expected the terminal attempt fixture.");
-      }
-      const error = await Effect.runPromise(
-        loadAttemptScoreResult(ctx, attempt).pipe(Effect.flip)
-      );
-      return {
-        _tag: error._tag,
-        code: error.code,
-        message: error.message,
-      };
-    });
-
-    const expected = new TryoutScoreReadError({
-      code: "TRYOUT_SCORE_NOT_FOUND",
-      message: "Terminal try-out attempt is missing its score snapshot.",
-    });
-    expect(failure).toEqual({
-      _tag: expected._tag,
-      code: expected.code,
-      message: expected.message,
-    });
-  });
+  );
 });


### PR DESCRIPTION
## Scope

Migrates the score-result integrity test as an Effect v4 checkpoint, repairs a production-browser hydration race exposed by the first exact-head run, and makes the anonymous Convex exporter tolerate one intermittent local-backend response without weakening deterministic build failures. Production application behavior and Vercel production concurrency are unchanged.

## Backend architecture

- Runs the effectful case through `it.effect` directly from `@effect/vitest`.
- Lifts `convex-test` Promises with `Effect.promise`.
- Reuses the production `runConvexProgram` boundary only inside the Convex test callback.
- Uses `Effect.match` to inspect the typed internal failure without corrupting the runner error contract.
- Keeps an impossible fixture absence in the Effect defect channel.
- Adds no dependency, helper, wrapper, cast, fallback, mock, or production module.

## Browser root cause and repair

Exact-head run [33000469402](https://github.com/nakafaai/nakafa.com/actions/runs/33000469402) passed Quality, the production build, 56 of 57 browser cases, and the original #357 projectile recovery scenario. The coordinate-system case alone failed because it selected the third server-rendered scene by ordinal and performed one scroll before Next.js selective hydration had committed that scene. The first attempt never activated a canvas; the retry caught the selected server node detaching during the scroll.

The repaired test:

- identifies the intended card by its authored `Sistem Persamaan Linear dengan Banyak Solusi` title instead of a positional index;
- retries the complete card count, scene attachment, scroll, and canvas visibility interaction through Playwright `toPass`;
- re-resolves the locator and re-scrolls if a streamed server node is replaced during hydration;
- keeps all interaction and drawing-buffer assertions unchanged.

This follows the installed Next.js 16.3.2 streaming contract and Playwright 1.62.1 `toPass` contract.

## Anonymous build root cause and repair

The later exact-head run [33004375143](https://github.com/nakafaai/nakafa.com/actions/runs/33004375143) passed Quality and Doctor, imported and verified the signed snapshot, then received an unmarked JSON 500 from the anonymous local Convex HTTP-action boundary while prerendering page 304 of 1,927. The content transport already exhausted its three safe read attempts before reporting `ContentTransportError { reason: "response-unmarked" }`.

This is not a deterministic bad row or locale contract:

- an unrelated #370 head failed with the same unmarked response at page 0 on a different English material route;
- the final #370 head and protected `main` completed all 1,927 pages with the same content lineage;
- #362 then failed on another material route without touching production content code;
- the classifier observed a private local-backend HTTP action and no request identifier, which means the Convex platform returned before Nakafa produced its marked response.

The repair uses the installed Next.js 16.3.2 `staticGenerationRetryCount` contract only in anonymous Agent Mode. Two isolated worker heaps and one page per worker remain unchanged. A page receives one fresh full-generation attempt with Next's built-in jitter; a repeated or deterministic page failure still fails the build. Vercel production keeps the Next.js defaults. There is no workflow rerun loop, fixed sleep, Preview, or branch-protection bypass.

## Exact revision

- Base: `6339cfd2d501734aec33c3a8e4fed3f03b013986`
- Head: `63d74bae409ad38e56005ca1856b0ffccf88c7ef`
- Tree: `73dd0e353fc5dea7787ad2d1b0b28cbd982e70c8`
- Patch SHA-256: `78906a24f8144e6c53ae68b78397c3fdfe9bb0ea6b7daaaf14afdc7fe9ef6428`
- Exact diff: three files, 107 insertions and 70 deletions.

## Local evidence

- Focused backend test: 1 file, 1 test passed.
- Repaired coordinate-system browser test against the live production route: 3 consecutive runs passed with one worker and no retry, both before and after the final rebase.
- Anonymous Next config loading and route type generation passed with Next.js 16.3.2.
- Backend and web TypeScript 7 typechecks passed. The web typecheck used the workflow-equivalent safe loopback Convex URL and public PostHog proxy URL.
- `pnpm lint` passed, including Effect source parity at RC110 commit `66114151c2b4640bf773f2b3456ce70d679422f6`.
- `pnpm boundaries` passed across 2,938 files in 18 packages.
- React Doctor changed-scope result: 100/100 with no findings.
- `pnpm test:scripts` passed: 3 files, 9 tests.
- `pnpm security:audit` found no known vulnerabilities before this dependency-free final change.
- Formatting and diff checks passed.

## Release

No Vercel Preview is requested or permitted. Merge only after this exact head remains current with protected `main`, every review thread is resolved, and required `Required` plus `Doctor` checks pass.
