### PR TITLE
test(backend): migrate tryout content runtime to Effect

### DIFF
--- a/packages/backend/convex/tryouts/runtime/access.test.ts
+++ b/packages/backend/convex/tryouts/runtime/access.test.ts
@@ -1,3 +1,4 @@
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { readOwnedTryoutSectionContent } from "@repo/backend/convex/tryouts/runtime/access";
 import { seedTryoutContentAccessState } from "@repo/backend/test/tryout-runtime";
@@ -5,123 +6,172 @@ import {
   TRYOUT_SECTION_KEY,
   TRYOUT_TEST_NOW,
 } from "@repo/backend/test/tryouts";
+import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 beforeEach(() => {
   vi.setSystemTime(new Date(TRYOUT_TEST_NOW));
 });
 
 describe("tryouts/runtime/access", () => {
-  it("returns signed questions for the active section", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation((ctx) =>
-      seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-active",
-      })
-    );
-
-    const content = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get(seeded.attemptId);
-      if (!attempt) {
-        throw new Error("Expected an attempt fixture.");
-      }
-      return Effect.runPromise(
-        readOwnedTryoutSectionContent(ctx, {
-          attempt,
-          appLocale: "id",
-          sectionKey: TRYOUT_SECTION_KEY,
-        })
-      );
-    });
-
-    expect(content).toEqual({
-      answers: [],
-      kind: "signed",
-      questions: [seeded.signedContent.question],
-      runtime: "current",
-    });
-  });
-
-  it("returns signed answers for a resolved terminal attempt", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation((ctx) =>
-      seedTryoutContentAccessState(ctx, {
-        attemptStatus: "completed",
-        sectionStatus: "completed",
-        suffix: "content-terminal",
-      })
-    );
-
-    const content = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get(seeded.attemptId);
-      if (!attempt) {
-        throw new Error("Expected an attempt fixture.");
-      }
-      return Effect.runPromise(
-        readOwnedTryoutSectionContent(ctx, {
-          attempt,
-          appLocale: "id",
-          sectionKey: TRYOUT_SECTION_KEY,
-        })
-      );
-    });
-
-    expect(content).toEqual({
-      answers: [seeded.signedContent.answer],
-      kind: "signed",
-      questions: [seeded.signedContent.question],
-      runtime: "current",
-    });
-  });
-
-  it("maps duplicate section state into a typed read failure", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation(async (ctx) => {
-      const fixture = await seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-duplicate-section",
-      });
-      const section = await ctx.db.get(fixture.sectionAttemptId);
-      if (!section) {
-        throw new Error("Expected a section attempt fixture.");
-      }
-      await ctx.db.insert("tryoutSectionAttempts", {
-        answeredCount: section.answeredCount,
-        completedAt: section.completedAt,
-        correctAnswers: section.correctAnswers,
-        endReason: section.endReason,
-        expiresAt: section.expiresAt,
-        lastActivityAt: section.lastActivityAt,
-        score: section.score,
-        sectionIdentity: section.sectionIdentity,
-        sectionKey: section.sectionKey,
-        sectionOrder: section.sectionOrder,
-        startedAt: section.startedAt,
-        status: section.status,
-        totalQuestions: section.totalQuestions,
-        tryoutAttemptId: section.tryoutAttemptId,
-      });
-      return fixture;
-    });
-
-    await expect(
-      t.query(async (ctx) => {
-        const attempt = await ctx.db.get(seeded.attemptId);
-        if (!attempt) {
-          throw new Error("Expected an attempt fixture.");
-        }
-        return Effect.runPromise(
-          readOwnedTryoutSectionContent(ctx, {
-            attempt,
-            appLocale: "id",
-            sectionKey: TRYOUT_SECTION_KEY,
+  it.effect("returns signed questions for the active section", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          seedTryoutContentAccessState(ctx, {
+            attemptStatus: "in-progress",
+            sectionStatus: "in-progress",
+            suffix: "content-active",
           })
-        );
-      })
-    ).rejects.toThrow("Unable to read try-out content access.");
-  });
+        )
+      );
+
+      const content = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const attempt = yield* Effect.promise(() =>
+                ctx.db.get(seeded.attemptId)
+              );
+              if (!attempt) {
+                return yield* Effect.die(
+                  new Error("Expected an attempt fixture.")
+                );
+              }
+              return yield* readOwnedTryoutSectionContent(ctx, {
+                attempt,
+                appLocale: "id",
+                sectionKey: TRYOUT_SECTION_KEY,
+              });
+            })
+          )
+        )
+      );
+
+      expect(content).toEqual({
+        answers: [],
+        kind: "signed",
+        questions: [seeded.signedContent.question],
+        runtime: "current",
+      });
+    })
+  );
+
+  it.effect("returns signed answers for a resolved terminal attempt", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          seedTryoutContentAccessState(ctx, {
+            attemptStatus: "completed",
+            sectionStatus: "completed",
+            suffix: "content-terminal",
+          })
+        )
+      );
+
+      const content = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const attempt = yield* Effect.promise(() =>
+                ctx.db.get(seeded.attemptId)
+              );
+              if (!attempt) {
+                return yield* Effect.die(
+                  new Error("Expected an attempt fixture.")
+                );
+              }
+              return yield* readOwnedTryoutSectionContent(ctx, {
+                attempt,
+                appLocale: "id",
+                sectionKey: TRYOUT_SECTION_KEY,
+              });
+            })
+          )
+        )
+      );
+
+      expect(content).toEqual({
+        answers: [seeded.signedContent.answer],
+        kind: "signed",
+        questions: [seeded.signedContent.question],
+        runtime: "current",
+      });
+    })
+  );
+
+  it.effect("maps duplicate section state into a typed read failure", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const fixture = yield* Effect.promise(() =>
+                seedTryoutContentAccessState(ctx, {
+                  attemptStatus: "in-progress",
+                  sectionStatus: "in-progress",
+                  suffix: "content-duplicate-section",
+                })
+              );
+              const section = yield* Effect.promise(() =>
+                ctx.db.get(fixture.sectionAttemptId)
+              );
+              if (!section) {
+                return yield* Effect.die(
+                  new Error("Expected a section attempt fixture.")
+                );
+              }
+              yield* Effect.promise(() =>
+                ctx.db.insert("tryoutSectionAttempts", {
+                  answeredCount: section.answeredCount,
+                  completedAt: section.completedAt,
+                  correctAnswers: section.correctAnswers,
+                  endReason: section.endReason,
+                  expiresAt: section.expiresAt,
+                  lastActivityAt: section.lastActivityAt,
+                  score: section.score,
+                  sectionIdentity: section.sectionIdentity,
+                  sectionKey: section.sectionKey,
+                  sectionOrder: section.sectionOrder,
+                  startedAt: section.startedAt,
+                  status: section.status,
+                  totalQuestions: section.totalQuestions,
+                  tryoutAttemptId: section.tryoutAttemptId,
+                })
+              );
+              return fixture;
+            })
+          )
+        )
+      );
+
+      yield* Effect.promise(() =>
+        expect(
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get(seeded.attemptId)
+                );
+                if (!attempt) {
+                  return yield* Effect.die(
+                    new Error("Expected an attempt fixture.")
+                  );
+                }
+                return yield* readOwnedTryoutSectionContent(ctx, {
+                  attempt,
+                  appLocale: "id",
+                  sectionKey: TRYOUT_SECTION_KEY,
+                });
+              })
+            )
+          )
+        ).rejects.toThrow("Unable to read try-out content access.")
+      );
+    })
+  );
 });

--- a/packages/backend/convex/tryouts/runtime/selectors.test.ts
+++ b/packages/backend/convex/tryouts/runtime/selectors.test.ts
@@ -1,3 +1,4 @@
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { loadTryoutSignedContent } from "@repo/backend/convex/tryouts/runtime/selectors";
 import {
@@ -10,283 +11,397 @@ import {
   TRYOUT_SECTION_KEY,
   TRYOUT_TEST_NOW,
 } from "@repo/backend/test/tryouts";
-import { Cause, Effect, Exit, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { Effect } from "effect";
+import { vi } from "vitest";
 
 beforeEach(() => {
   vi.setSystemTime(new Date(TRYOUT_TEST_NOW));
 });
+
 describe("tryouts/runtime/selectors", () => {
-  it("returns signed selectors for the active attempt", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation((ctx) =>
-      seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-signed-active",
-      })
-    );
-    const content = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get(seeded.attemptId);
-      if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
-        throw new Error("Expected a signed attempt fixture.");
-      }
-      return Effect.runPromise(
-        loadTryoutSignedContent({
-          answers: false,
-          attempt,
-          ctx,
-          appLocale: "id",
-          sectionKey: TRYOUT_SECTION_KEY,
-          snapshotId: attempt.tryoutSnapshotId,
-          snapshotReleaseId: attempt.snapshotReleaseId,
-          totalQuestions: 1,
-        })
-      );
-    });
-    expect(content).toEqual({
-      answers: [],
-      kind: "signed",
-      questions: [seeded.signedContent.question],
-      runtime: "current",
-    });
-  });
-  it("returns entitled answer selectors only after terminal review", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation((ctx) =>
-      seedTryoutContentAccessState(ctx, {
-        attemptStatus: "completed",
-        sectionStatus: "completed",
-        suffix: "content-signed-review",
-      })
-    );
-    const content = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get(seeded.attemptId);
-      if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
-        throw new Error("Expected a signed attempt fixture.");
-      }
-      return Effect.runPromise(
-        loadTryoutSignedContent({
-          answers: true,
-          attempt,
-          ctx,
-          appLocale: "id",
-          sectionKey: TRYOUT_SECTION_KEY,
-          snapshotId: attempt.tryoutSnapshotId,
-          snapshotReleaseId: attempt.snapshotReleaseId,
-          totalQuestions: 1,
-        })
-      );
-    });
-    expect(content).toEqual({
-      answers: [seeded.signedContent.answer],
-      kind: "signed",
-      questions: [seeded.signedContent.question],
-      runtime: "current",
-    });
-  });
-  it("selects authenticated history only through an attempt marker", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation(async (ctx) => {
-      const fixture = await seedTryoutContentAccessState(ctx, {
-        attemptStatus: "completed",
-        sectionStatus: "completed",
-        suffix: "content-stored-review",
-      });
-      if (!fixture.placementId) {
-        throw new Error("Expected one frozen placement fixture.");
-      }
-      const historical = TEST_STORED_TRYOUT_PLACEMENT.record.row;
-      await ctx.db.patch(fixture.attemptId, {
-        appLocale: "id",
-        snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
-        tryoutSnapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
-      });
-      await ctx.db.patch(fixture.placementId, {
-        answerArtifactHash: historical.answerArtifactHash,
-        answerContentKey: historical.answerContentKey,
-        choiceSnapshots: [...historical.choices],
-        contentHash: historical.contentHash,
-        placementRowHash: TEST_STORED_TRYOUT_PLACEMENT.record.rowHash,
-        questionArtifactHash: historical.questionArtifactHash,
-        questionContentKey: historical.questionContentKey,
-        questionOrder: historical.questionOrder,
-        rendererDomain: historical.rendererDomain,
-        sectionKey: historical.sectionKey,
-        sourcePath: historical.questionSourcePath,
-        sourceRevision: historical.sourceRevision,
-      });
-      await ctx.db.insert("tryoutHistoryRows", {
-        answerArtifactHash: historical.answerArtifactHash,
-        index: 0,
-        questionArtifactHash: historical.questionArtifactHash,
-        rowHash: TEST_STORED_TRYOUT_PLACEMENT.record.rowHash,
-        rowJson: JSON.stringify(TEST_STORED_TRYOUT_PLACEMENT),
-        rowKind: "placement",
-        snapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
-      });
-      await ctx.db.insert("tryoutAttemptHistory", {
-        snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
-        tryoutAttemptId: fixture.attemptId,
-        tryoutSnapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
-      });
-      return fixture;
-    });
-    const content = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get("tryoutAttempts", seeded.attemptId);
-      if (!attempt) {
-        throw new Error("Expected one retained attempt fixture.");
-      }
-      return Effect.runPromise(
-        loadTryoutSignedContent({
-          answers: true,
-          appLocale: "id",
-          attempt,
-          ctx,
-          sectionKey: TEST_STORED_TRYOUT_PLACEMENT.record.row.sectionKey,
-          snapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
-          snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
-          totalQuestions: 1,
-        })
-      );
-    });
-    expect(content).toMatchObject({
-      answers: [
-        {
-          appLocale: "id",
-          artifactLocale: "en",
-          delivery: "entitled",
-        },
-      ],
-      attemptId: seeded.attemptId,
-      kind: "signed",
-      questions: [
-        {
-          appLocale: "id",
-          artifactLocale: "en",
-          delivery: "authenticated",
-        },
-      ],
-      runtime: "history",
-    });
-  });
-  it("fails closed when signed attempt locale identity drifts", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation(async (ctx) => {
-      const fixture = await seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-signed-locale",
-      });
-      await ctx.db.patch(fixture.attemptId, { appLocale: "en" });
-      return fixture;
-    });
-    await expect(
-      t.query(async (ctx) => {
-        const attempt = await ctx.db.get(seeded.attemptId);
-        if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
-          throw new Error("Expected a signed attempt fixture.");
-        }
-        return Effect.runPromise(
-          loadTryoutSignedContent({
-            answers: false,
-            attempt,
-            ctx,
-            appLocale: "id",
-            sectionKey: TRYOUT_SECTION_KEY,
-            snapshotId: attempt.tryoutSnapshotId,
-            snapshotReleaseId: attempt.snapshotReleaseId,
-            totalQuestions: 1,
+  it.effect("returns signed selectors for the active attempt", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          seedTryoutContentAccessState(ctx, {
+            attemptStatus: "in-progress",
+            sectionStatus: "in-progress",
+            suffix: "content-signed-active",
           })
-        );
-      })
-    ).rejects.toThrow(
-      "Signed try-out attempt lost its locale or snapshot identity."
-    );
-  });
-  it("fails closed when one signed placement is missing", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation(async (ctx) => {
-      const fixture = await seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-signed-placement",
-      });
-      if (!fixture.placementId) {
-        throw new Error("Expected a signed placement fixture.");
-      }
-      await ctx.db.delete(fixture.placementId);
-      return fixture;
-    });
-    await expect(
-      t.query(async (ctx) => {
-        const attempt = await ctx.db.get(seeded.attemptId);
-        if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
-          throw new Error("Expected a signed attempt fixture.");
-        }
-        return Effect.runPromise(
-          loadTryoutSignedContent({
-            answers: false,
-            attempt,
-            ctx,
-            appLocale: "id",
-            sectionKey: TRYOUT_SECTION_KEY,
-            snapshotId: attempt.tryoutSnapshotId,
-            snapshotReleaseId: attempt.snapshotReleaseId,
-            totalQuestions: 1,
-          })
-        );
-      })
-    ).rejects.toThrow(
-      "Signed try-out section lost one or more frozen placements."
-    );
-  });
-  it("maps placement read failures into the typed selector error", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const seeded = await t.mutation((ctx) =>
-      seedTryoutContentAccessState(ctx, {
-        attemptStatus: "in-progress",
-        sectionStatus: "in-progress",
-        suffix: "content-selector-read-failure",
-      })
-    );
-    const failure = await t.query(async (ctx) => {
-      const attempt = await ctx.db.get(seeded.attemptId);
-      if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
-        throw new Error("Expected a signed attempt fixture.");
-      }
-      vi.spyOn(ctx.db, "query").mockImplementationOnce(() => {
-        throw new Error("Injected selector read failure.");
-      });
-      const exit = await Effect.runPromiseExit(
-        loadTryoutSignedContent({
-          answers: false,
-          attempt,
-          ctx,
-          appLocale: "id",
-          sectionKey: TRYOUT_SECTION_KEY,
-          snapshotId: attempt.tryoutSnapshotId,
-          snapshotReleaseId: attempt.snapshotReleaseId,
-          totalQuestions: 1,
-        })
+        )
       );
-      if (Exit.isSuccess(exit)) {
-        throw new Error("Expected selector resolution to fail.");
-      }
-      const error = Cause.findErrorOption(exit.cause);
-      if (Option.isNone(error)) {
-        throw new Error("Expected a typed selector failure.");
-      }
-      return {
-        code: error.value.code,
-        message: error.value.message,
-        tag: error.value._tag,
-      };
-    });
-    expect(failure).toMatchObject({
-      code: "TRYOUT_SELECTOR_INTEGRITY",
-      message: "Unable to read signed try-out selectors.",
-      tag: "TryoutSelectorReadError",
-    });
-  });
+      const content = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const attempt = yield* Effect.promise(() =>
+                ctx.db.get(seeded.attemptId)
+              );
+              if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
+                return yield* Effect.die(
+                  new Error("Expected a signed attempt fixture.")
+                );
+              }
+              return yield* loadTryoutSignedContent({
+                answers: false,
+                attempt,
+                ctx,
+                appLocale: "id",
+                sectionKey: TRYOUT_SECTION_KEY,
+                snapshotId: attempt.tryoutSnapshotId,
+                snapshotReleaseId: attempt.snapshotReleaseId,
+                totalQuestions: 1,
+              });
+            })
+          )
+        )
+      );
+      expect(content).toEqual({
+        answers: [],
+        kind: "signed",
+        questions: [seeded.signedContent.question],
+        runtime: "current",
+      });
+    })
+  );
+
+  it.effect(
+    "returns entitled answer selectors only after terminal review",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const seeded = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            seedTryoutContentAccessState(ctx, {
+              attemptStatus: "completed",
+              sectionStatus: "completed",
+              suffix: "content-signed-review",
+            })
+          )
+        );
+        const content = yield* Effect.promise(() =>
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get(seeded.attemptId)
+                );
+                if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
+                  return yield* Effect.die(
+                    new Error("Expected a signed attempt fixture.")
+                  );
+                }
+                return yield* loadTryoutSignedContent({
+                  answers: true,
+                  attempt,
+                  ctx,
+                  appLocale: "id",
+                  sectionKey: TRYOUT_SECTION_KEY,
+                  snapshotId: attempt.tryoutSnapshotId,
+                  snapshotReleaseId: attempt.snapshotReleaseId,
+                  totalQuestions: 1,
+                });
+              })
+            )
+          )
+        );
+        expect(content).toEqual({
+          answers: [seeded.signedContent.answer],
+          kind: "signed",
+          questions: [seeded.signedContent.question],
+          runtime: "current",
+        });
+      })
+  );
+
+  it.effect(
+    "selects authenticated history only through an attempt marker",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const seeded = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const fixture = yield* Effect.promise(() =>
+                  seedTryoutContentAccessState(ctx, {
+                    attemptStatus: "completed",
+                    sectionStatus: "completed",
+                    suffix: "content-stored-review",
+                  })
+                );
+                if (!fixture.placementId) {
+                  return yield* Effect.die(
+                    new Error("Expected one frozen placement fixture.")
+                  );
+                }
+                const historical = TEST_STORED_TRYOUT_PLACEMENT.record.row;
+                yield* Effect.promise(() =>
+                  ctx.db.patch(fixture.attemptId, {
+                    appLocale: "id",
+                    snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
+                    tryoutSnapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.patch(fixture.placementId, {
+                    answerArtifactHash: historical.answerArtifactHash,
+                    answerContentKey: historical.answerContentKey,
+                    choiceSnapshots: [...historical.choices],
+                    contentHash: historical.contentHash,
+                    placementRowHash:
+                      TEST_STORED_TRYOUT_PLACEMENT.record.rowHash,
+                    questionArtifactHash: historical.questionArtifactHash,
+                    questionContentKey: historical.questionContentKey,
+                    questionOrder: historical.questionOrder,
+                    rendererDomain: historical.rendererDomain,
+                    sectionKey: historical.sectionKey,
+                    sourcePath: historical.questionSourcePath,
+                    sourceRevision: historical.sourceRevision,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("tryoutHistoryRows", {
+                    answerArtifactHash: historical.answerArtifactHash,
+                    index: 0,
+                    questionArtifactHash: historical.questionArtifactHash,
+                    rowHash: TEST_STORED_TRYOUT_PLACEMENT.record.rowHash,
+                    rowJson: JSON.stringify(TEST_STORED_TRYOUT_PLACEMENT),
+                    rowKind: "placement",
+                    snapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("tryoutAttemptHistory", {
+                    snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
+                    tryoutAttemptId: fixture.attemptId,
+                    tryoutSnapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
+                  })
+                );
+                return fixture;
+              })
+            )
+          )
+        );
+        const content = yield* Effect.promise(() =>
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get("tryoutAttempts", seeded.attemptId)
+                );
+                if (!attempt) {
+                  return yield* Effect.die(
+                    new Error("Expected one retained attempt fixture.")
+                  );
+                }
+                return yield* loadTryoutSignedContent({
+                  answers: true,
+                  appLocale: "id",
+                  attempt,
+                  ctx,
+                  sectionKey:
+                    TEST_STORED_TRYOUT_PLACEMENT.record.row.sectionKey,
+                  snapshotId: TEST_STORED_TRYOUT_SNAPSHOT_ID,
+                  snapshotReleaseId: TEST_STORED_TRYOUT_RELEASE_ID,
+                  totalQuestions: 1,
+                });
+              })
+            )
+          )
+        );
+        expect(content).toMatchObject({
+          answers: [
+            {
+              appLocale: "id",
+              artifactLocale: "en",
+              delivery: "entitled",
+            },
+          ],
+          attemptId: seeded.attemptId,
+          kind: "signed",
+          questions: [
+            {
+              appLocale: "id",
+              artifactLocale: "en",
+              delivery: "authenticated",
+            },
+          ],
+          runtime: "history",
+        });
+      })
+  );
+
+  it.effect("fails closed when signed attempt locale identity drifts", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const fixture = yield* Effect.promise(() =>
+                seedTryoutContentAccessState(ctx, {
+                  attemptStatus: "in-progress",
+                  sectionStatus: "in-progress",
+                  suffix: "content-signed-locale",
+                })
+              );
+              yield* Effect.promise(() =>
+                ctx.db.patch(fixture.attemptId, { appLocale: "en" })
+              );
+              return fixture;
+            })
+          )
+        )
+      );
+      yield* Effect.promise(() =>
+        expect(
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get(seeded.attemptId)
+                );
+                if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
+                  return yield* Effect.die(
+                    new Error("Expected a signed attempt fixture.")
+                  );
+                }
+                return yield* loadTryoutSignedContent({
+                  answers: false,
+                  attempt,
+                  ctx,
+                  appLocale: "id",
+                  sectionKey: TRYOUT_SECTION_KEY,
+                  snapshotId: attempt.tryoutSnapshotId,
+                  snapshotReleaseId: attempt.snapshotReleaseId,
+                  totalQuestions: 1,
+                });
+              })
+            )
+          )
+        ).rejects.toThrow(
+          "Signed try-out attempt lost its locale or snapshot identity."
+        )
+      );
+    })
+  );
+
+  it.effect("fails closed when one signed placement is missing", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const fixture = yield* Effect.promise(() =>
+                seedTryoutContentAccessState(ctx, {
+                  attemptStatus: "in-progress",
+                  sectionStatus: "in-progress",
+                  suffix: "content-signed-placement",
+                })
+              );
+              if (!fixture.placementId) {
+                return yield* Effect.die(
+                  new Error("Expected a signed placement fixture.")
+                );
+              }
+              yield* Effect.promise(() => ctx.db.delete(fixture.placementId));
+              return fixture;
+            })
+          )
+        )
+      );
+      yield* Effect.promise(() =>
+        expect(
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const attempt = yield* Effect.promise(() =>
+                  ctx.db.get(seeded.attemptId)
+                );
+                if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
+                  return yield* Effect.die(
+                    new Error("Expected a signed attempt fixture.")
+                  );
+                }
+                return yield* loadTryoutSignedContent({
+                  answers: false,
+                  attempt,
+                  ctx,
+                  appLocale: "id",
+                  sectionKey: TRYOUT_SECTION_KEY,
+                  snapshotId: attempt.tryoutSnapshotId,
+                  snapshotReleaseId: attempt.snapshotReleaseId,
+                  totalQuestions: 1,
+                });
+              })
+            )
+          )
+        ).rejects.toThrow(
+          "Signed try-out section lost one or more frozen placements."
+        )
+      );
+    })
+  );
+
+  it.effect("maps placement read failures into the typed selector error", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          seedTryoutContentAccessState(ctx, {
+            attemptStatus: "in-progress",
+            sectionStatus: "in-progress",
+            suffix: "content-selector-read-failure",
+          })
+        )
+      );
+      const failure = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const attempt = yield* Effect.promise(() =>
+                ctx.db.get(seeded.attemptId)
+              );
+              if (!(attempt?.snapshotReleaseId && attempt.tryoutSnapshotId)) {
+                return yield* Effect.die(
+                  new Error("Expected a signed attempt fixture.")
+                );
+              }
+              vi.spyOn(ctx.db, "query").mockImplementationOnce(() => {
+                throw new Error("Injected selector read failure.");
+              });
+              return yield* loadTryoutSignedContent({
+                answers: false,
+                attempt,
+                ctx,
+                appLocale: "id",
+                sectionKey: TRYOUT_SECTION_KEY,
+                snapshotId: attempt.tryoutSnapshotId,
+                snapshotReleaseId: attempt.snapshotReleaseId,
+                totalQuestions: 1,
+              }).pipe(
+                Effect.match({
+                  onFailure: (error) => ({
+                    code: error.code,
+                    message: error.message,
+                    tag: error._tag,
+                  }),
+                  onSuccess: () => null,
+                })
+              );
+            })
+          )
+        )
+      );
+      expect(failure).toMatchObject({
+        code: "TRYOUT_SELECTOR_INTEGRITY",
+        message: "Unable to read signed try-out selectors.",
+        tag: "TryoutSelectorReadError",
+      });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

Migrates the two tryout runtime access and selector test modules to the repository-owned Effect v4 Vitest adapter.

## Effect v4 architecture

- All nine effectful cases return their programs through `it.effect`.
- Convex test harness promises are lifted into Effect.
- The existing `runConvexProgram` boundary remains the only Effect runtime boundary inside Convex handlers.
- Direct Vitest imports are limited to `vi` for system time and one deliberately injected database failure.
- The changed files contain no direct `Effect.run*` or `Runtime.run*` calls, raw async test bodies, global `vi`, `.only`, or `.skip`.

## Preserved behavior

The same nine behavior cases and nine assertions remain, including signed active and terminal content, authenticated history, locale drift, missing placement, duplicate section state, and typed selector read failure.

## Source evidence

The implementation matches `effect@4.0.0-rc.110`, `@effect/vitest@4.0.0-rc.110`, vendored Effect commit `66114151c2b4640bf773f2b3456ce70d679422f6`, installed source, and the official v4 Vitest API: https://effect.website/docs/v4/api/vitest

## Exact revision

- Head: `7ca8f7fc0f7d945e4f2332ba992ca22289239901`
- Base: `0b7914a378a43a175b2f361d87aa7976683142d4`
- Tree: `a6efe0be035013ce06d34cb76a797e68d08c2d44`
- Patch checksum: `6804c35e34eaad9c962276ae77f30d73f671205454104ef12823e10a6fc4f0db`
- Stable patch ID: `17b3f890de27444b0e8582ab63509cbe054ab0bc`
- Scope: exactly two backend test modules

## Verification

- Focused tests: 2 files, 9 tests passed
- Backend: 326 files, 1,369 tests passed
- Full repository: 14 of 14 tasks passed
- WWW: 209 files, 1,501 tests, 100 percent statements, branches, functions, and lines
- Backend typecheck, root lint, test ownership, patch policy, vendored Effect identity, formatting, diff check, and dependency audit passed
- Changed-scope React Doctor correctly skipped because no React source changed

## Deployment

No production code, dependency, schema, or deployment configuration changes. No Vercel Preview or Convex production mutation was created. Production verification follows only after a protected merge to `main`.