### PR TITLE
test(backend): migrate tryout progress to Effect

### DIFF
--- a/packages/backend/convex/tryouts/progress/write.test.ts
+++ b/packages/backend/convex/tryouts/progress/write.test.ts
@@ -1,5 +1,6 @@
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { tryoutCatalogNodeIdentity } from "@nakafa/aksara-contracts/tryout/identity";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
@@ -7,8 +8,8 @@ import {
 import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
 import { insertTryoutAttempt } from "@repo/backend/test/tryout-runtime";
 import { makeTryoutSet, TRYOUT_TEST_NOW } from "@repo/backend/test/tryouts";
+import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 
 const SIGNED_SET_IDENTITY = tryoutCatalogNodeIdentity({
   appLocale: AppLocaleSchema.make("id"),
@@ -23,145 +24,179 @@ type ProgressScoreMismatch = Pick<
   ProgressInput,
   "publishedScore" | "status"
 > & {
+  readonly code: string;
   readonly message: string;
 };
 
 /** Verifies that one invalid progress score pair fails through the typed seam. */
-async function expectProgressScoreMismatch(scenario: ProgressScoreMismatch) {
+const expectProgressScoreMismatch = Effect.fn(
+  "tryouts.progress.test.expectProgressScoreMismatch"
+)(function* (scenario: ProgressScoreMismatch) {
   const t = createConvexTestWithBetterAuth();
 
-  await expect(
-    t.mutation(async (ctx) => {
-      const user = await seedAuthenticatedUser(ctx, {
-        now: TRYOUT_TEST_NOW,
-        suffix: `tryout-progress-score-${scenario.status}`,
-      });
-      const set = makeTryoutSet();
-      const attemptId = await insertTryoutAttempt(ctx, {
-        scoringStrategy: "raw",
-        sectionSnapshots: [],
-        set,
-        status: scenario.status,
-        userId: user.userId,
-      });
-      const attempt = await ctx.db.get(attemptId);
+  yield* Effect.promise(() =>
+    expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          Effect.gen(function* () {
+            const user = yield* Effect.promise(() =>
+              seedAuthenticatedUser(ctx, {
+                now: TRYOUT_TEST_NOW,
+                suffix: `tryout-progress-score-${scenario.status}`,
+              })
+            );
+            const set = makeTryoutSet();
+            const attemptId = yield* Effect.promise(() =>
+              insertTryoutAttempt(ctx, {
+                scoringStrategy: "raw",
+                sectionSnapshots: [],
+                set,
+                status: scenario.status,
+                userId: user.userId,
+              })
+            );
+            const attempt = yield* Effect.promise(() => ctx.db.get(attemptId));
 
-      if (!attempt) {
-        throw new Error("Expected progress score fixtures.");
-      }
+            if (!attempt) {
+              return yield* Effect.die("Expected progress score fixtures.");
+            }
 
-      await Effect.runPromise(
-        writeTryoutSetProgress(ctx, {
-          attempt,
-          publishedScore: scenario.publishedScore,
-          status: scenario.status,
-          updatedAt: TRYOUT_TEST_NOW,
-        })
-      );
+            yield* writeTryoutSetProgress(ctx, {
+              attempt,
+              publishedScore: scenario.publishedScore,
+              status: scenario.status,
+              updatedAt: TRYOUT_TEST_NOW,
+            });
+          })
+        )
+      )
+    ).rejects.toMatchObject({
+      data: {
+        code: scenario.code,
+        message: scenario.message,
+      },
     })
-  ).rejects.toThrow(scenario.message);
-}
+  );
+});
 
 describe("tryouts/progress", () => {
-  it("keeps only the latest attempt and maps every workflow rank", async () => {
-    const t = createConvexTestWithBetterAuth();
+  it.effect("keeps only the latest attempt and maps every workflow rank", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
 
-    const progress = await t.mutation(async (ctx) => {
-      const user = await seedAuthenticatedUser(ctx, {
-        now: TRYOUT_TEST_NOW,
-        suffix: "tryout-progress",
-      });
-      const set = makeTryoutSet();
+      const progress = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const user = yield* Effect.promise(() =>
+                seedAuthenticatedUser(ctx, {
+                  now: TRYOUT_TEST_NOW,
+                  suffix: "tryout-progress",
+                })
+              );
+              const set = makeTryoutSet();
 
-      const firstAttemptId = await insertTryoutAttempt(ctx, {
-        scoringStrategy: "raw",
-        sectionSnapshots: [],
-        set,
-        userId: user.userId,
-      });
-      const firstAttempt = await ctx.db.get(firstAttemptId);
+              const firstAttemptId = yield* Effect.promise(() =>
+                insertTryoutAttempt(ctx, {
+                  scoringStrategy: "raw",
+                  sectionSnapshots: [],
+                  set,
+                  userId: user.userId,
+                })
+              );
+              const firstAttempt = yield* Effect.promise(() =>
+                ctx.db.get(firstAttemptId)
+              );
 
-      if (!firstAttempt) {
-        throw new Error("Expected first attempt fixture.");
-      }
+              if (!firstAttempt) {
+                return yield* Effect.die("Expected first attempt fixture.");
+              }
 
-      await Effect.runPromise(
-        writeTryoutSetProgress(ctx, {
-          attempt: firstAttempt,
-          publishedScore: null,
-          status: "in-progress",
-          updatedAt: TRYOUT_TEST_NOW,
-        })
-      );
-      await Effect.runPromise(
-        writeTryoutSetProgress(ctx, {
-          attempt: firstAttempt,
-          publishedScore: 75,
-          status: "completed",
-          updatedAt: TRYOUT_TEST_NOW + 1,
-        })
-      );
+              yield* writeTryoutSetProgress(ctx, {
+                attempt: firstAttempt,
+                publishedScore: null,
+                status: "in-progress",
+                updatedAt: TRYOUT_TEST_NOW,
+              });
+              yield* writeTryoutSetProgress(ctx, {
+                attempt: firstAttempt,
+                publishedScore: 75,
+                status: "completed",
+                updatedAt: TRYOUT_TEST_NOW + 1,
+              });
 
-      const latestAttemptId = await insertTryoutAttempt(ctx, {
-        scoringStrategy: "raw",
-        sectionSnapshots: [],
-        set,
-        status: "expired",
-        userId: user.userId,
-      });
-      await ctx.db.patch(latestAttemptId, { attemptNumber: 2 });
-      const latestAttempt = await ctx.db.get(latestAttemptId);
+              const latestAttemptId = yield* Effect.promise(() =>
+                insertTryoutAttempt(ctx, {
+                  scoringStrategy: "raw",
+                  sectionSnapshots: [],
+                  set,
+                  status: "expired",
+                  userId: user.userId,
+                })
+              );
+              yield* Effect.promise(() =>
+                ctx.db.patch(latestAttemptId, { attemptNumber: 2 })
+              );
+              const latestAttempt = yield* Effect.promise(() =>
+                ctx.db.get(latestAttemptId)
+              );
 
-      if (!latestAttempt) {
-        throw new Error("Expected latest attempt fixture.");
-      }
+              if (!latestAttempt) {
+                return yield* Effect.die("Expected latest attempt fixture.");
+              }
 
-      await Effect.runPromise(
-        writeTryoutSetProgress(ctx, {
-          attempt: latestAttempt,
-          publishedScore: 50,
-          status: "expired",
-          updatedAt: TRYOUT_TEST_NOW + 2,
-        })
-      );
-      await Effect.runPromise(
-        writeTryoutSetProgress(ctx, {
-          attempt: firstAttempt,
-          publishedScore: null,
-          status: "in-progress",
-          updatedAt: TRYOUT_TEST_NOW + 3,
-        })
-      );
+              yield* writeTryoutSetProgress(ctx, {
+                attempt: latestAttempt,
+                publishedScore: 50,
+                status: "expired",
+                updatedAt: TRYOUT_TEST_NOW + 2,
+              });
+              yield* writeTryoutSetProgress(ctx, {
+                attempt: firstAttempt,
+                publishedScore: null,
+                status: "in-progress",
+                updatedAt: TRYOUT_TEST_NOW + 3,
+              });
 
-      return await ctx.db
-        .query("tryoutSetProgress")
-        .withIndex("by_userId_and_setIdentity", (query) =>
-          query.eq("userId", user.userId).eq("setIdentity", SIGNED_SET_IDENTITY)
+              return yield* Effect.promise(() =>
+                ctx.db
+                  .query("tryoutSetProgress")
+                  .withIndex("by_userId_and_setIdentity", (query) =>
+                    query
+                      .eq("userId", user.userId)
+                      .eq("setIdentity", SIGNED_SET_IDENTITY)
+                  )
+                  .unique()
+              );
+            })
+          )
         )
-        .unique();
-    });
+      );
 
-    expect(progress).toMatchObject({
-      attemptNumber: 2,
-      publishedScore: 50,
-      status: "expired",
-      statusRank: 3,
-    });
-  });
+      expect(progress).toMatchObject({
+        attemptNumber: 2,
+        publishedScore: 50,
+        status: "expired",
+        statusRank: 3,
+      });
+    })
+  );
 
-  it("rejects active progress that exposes a score", async () => {
-    await expectProgressScoreMismatch({
+  it.effect("rejects active progress that exposes a score", () =>
+    expectProgressScoreMismatch({
+      code: "TRYOUT_ACTIVE_PROGRESS_HAS_SCORE",
       message: "Active try-out progress cannot expose a score.",
       publishedScore: 80,
       status: "in-progress",
-    });
-  });
+    })
+  );
 
-  it("rejects terminal progress without a score", async () => {
-    await expectProgressScoreMismatch({
+  it.effect("rejects terminal progress without a score", () =>
+    expectProgressScoreMismatch({
+      code: "TRYOUT_TERMINAL_PROGRESS_SCORE_REQUIRED",
       message: "Terminal try-out progress requires a score.",
       publishedScore: null,
       status: "completed",
-    });
-  });
+    })
+  );
 });

--- a/packages/backend/convex/tryouts/progress/write.test.ts
+++ b/packages/backend/convex/tryouts/progress/write.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { tryoutCatalogNodeIdentity } from "@nakafa/aksara-contracts/tryout/identity";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -8,7 +9,6 @@ import {
 import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
 import { insertTryoutAttempt } from "@repo/backend/test/tryout-runtime";
 import { makeTryoutSet, TRYOUT_TEST_NOW } from "@repo/backend/test/tryouts";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 const SIGNED_SET_IDENTITY = tryoutCatalogNodeIdentity({


### PR DESCRIPTION
## Scope

Migrates the colocated tryout-progress integrity test to the installed Effect v4 Vitest surface. Production behavior is unchanged.

## Architecture

- all three effectful cases use `it.effect` from `@effect/vitest`;
- Convex IO is composed with `Effect.promise`;
- the existing `runConvexProgram` remains the only Convex runtime boundary;
- the reusable invalid-score assertion is a named `Effect.fn` program;
- fixture invariants use the Effect defect channel;
- runtime contracts remain derived from the production function input.

## Typed failure proof

The two invalid score states now assert both the stable Convex error code and message. This strengthens the prior message-only checks without changing production behavior.

The module has no direct Effect runner, raw async test body, raw parser, assertion cast, wrapper, allowlist, service, dependency, or global mock.

## Exact revision

- Base: `fa8694a11dcf6f04cff6a793fdf9bc18a134da7c`
- Head: `7afd7d96452f93e58da957cba11b7c0b043cc43f`
- Tree: `57f6fd1e02ce63e290712503cb15f232e424327b`
- Patch SHA-256: `64299602d9f1f64a88d9561d63f7582254672d9273c5aa2efde1d6e07720ab10`
- Exact diff: one colocated test file, 156 insertions and 121 deletions.

## Verification

- focused suite: 1 file and 3 tests passed on the exact protected base;
- backend TypeScript 7 typecheck passed;
- formatting and `pnpm lint` passed, including Effect RC110 source parity and test ownership;
- `pnpm boundaries` passed across 2,932 files in 18 packages before the conflict-free exact-base rebase;
- `pnpm test:scripts` passed: 3 files and 9 tests before the conflict-free exact-base rebase;
- complete diff and prohibited-pattern scans are clean;
- stable patch SHA-256 is unchanged by the rebase.

## Release

No Vercel Preview is requested or permitted. Merge only when this exact head remains current with protected `main`, review threads are resolved, and protected `Required` plus `Doctor` checks pass.
