### PR TITLE
feat(cli): publish public agent client

### DIFF
--- a/.changeset/public-cli.md
+++ b/.changeset/public-cli.md
@@ -1,0 +1,5 @@
+---
+"nakafa-cli": minor
+---
+
+Publish the official read-only Nakafa command-line client.

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,46 @@
+name: CLI Package
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: CLI-Package
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup toolchain
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify package
+        run: |
+          pnpm --filter nakafa-cli typecheck
+          pnpm --filter nakafa-cli test:coverage
+          pnpm --filter nakafa-cli build
+
+      # Bootstrap only. Delete this registry token setup after 0.1.0 exists and
+      # cli-publish.yml is registered as the package's trusted publisher.
+      - name: Configure bootstrap authentication
+        run: npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+
+      - name: Publish package
+        run: pnpm --filter nakafa-cli exec npm publish --access public --provenance

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,185 @@
+# Nakafa Source Available License 1.0
+
+Effective date: April 24, 2026
+
+Copyright (c) 2026 PT NAKAFA TEKNO KREATIF. All rights reserved.
+
+This is not an open-source license. Nakafa source code is public so people can
+inspect it, learn from it, review it, and propose improvements. The public
+source code does not grant permission to rebrand, redistribute, host, sell,
+monetize, or turn Nakafa into another product without written permission.
+
+## 1. Definitions
+
+`Nakafa` means the software, source code, build files, configuration, scripts,
+database schema, prompts, UI, and related code made available in this repository.
+
+`You` means the individual or entity receiving or using Nakafa.
+
+`Personal use` means use by one individual for that individual's own learning,
+research, testing, security review, or hobby evaluation. Personal use does not
+include use for an employer, client, school, organization, product, service,
+team, or business purpose.
+
+`Local use` means use on a device or development environment controlled by you,
+without making Nakafa available to any other person over the internet, an
+intranet, a private network, a shared server, or any hosted environment.
+
+`Written permission` means a separate written agreement signed by PT NAKAFA
+TEKNO KREATIF, or a written approval sent from an official Nakafa email address.
+
+## 2. Scope
+
+This license applies to the software source code in this repository unless a
+file says that a different license applies.
+
+This license does not apply to:
+
+- Third-party dependencies, packages, services, fonts, or libraries, which keep
+  their own licenses.
+- Educational content, articles, exercises, explanations, datasets, copy,
+  images, video, audio, and other non-code materials, which are covered by
+  `CONTENT_LICENSE.md` unless a file says otherwise.
+- The Nakafa name, logos, domains, product names, visual identity, and other
+  brand assets, which are covered by `TRADEMARKS.md`.
+- Prior copies of Nakafa that were lawfully received under a previous license.
+  Those older copies remain under the license terms that applied when they were
+  received. New changes published after the effective date above are covered by
+  this license.
+
+All rights not expressly granted by this license are reserved by PT NAKAFA TEKNO
+KREATIF.
+
+## 3. Allowed Use Without Written Permission
+
+You may do only the following without written permission from PT NAKAFA TEKNO
+KREATIF:
+
+- View, read, inspect, and audit the source code.
+- Clone or download one copy for personal review.
+- Create a GitHub fork only to prepare and submit contributions back to Nakafa,
+  as long as the fork is not used as a standalone project, hosted service,
+  mirror, product, rebrand, or distribution channel.
+- Run the unmodified software locally for your own personal, non-commercial
+  learning, research, testing, security review, or hobby evaluation.
+- Make temporary technical copies that are necessary for the allowed personal
+  local use above.
+- Submit issues, suggestions, or pull requests under the contribution terms in
+  `.github/CONTRIBUTING.md`.
+
+These permissions are personal, limited, non-exclusive, non-transferable, and
+revocable if you violate this license.
+
+## 4. Permission Required
+
+You must get prior written permission from PT NAKAFA TEKNO KREATIF before doing
+anything not listed in Section 3.
+
+The following uses always require prior written permission:
+
+- Commercial use.
+- Revenue-generating use.
+- Use in a product, service, course, school system, learning management system,
+  SaaS, API, internal company tool, agency project, client project, consulting
+  work, paid training, or paid content.
+- Use by a company, school, institution, nonprofit organization, government
+  organization, team, or other entity outside personal local evaluation.
+- Any hosted deployment outside your own local machine, whether public or
+  private, and whether or not anyone else can access it.
+- Distribution, redistribution, mirroring, publishing, uploading, packaging,
+  reselling, sublicensing, or sharing copies of the software.
+- Modification, forked product development, derivative works, white-label use,
+  private-label use, rebranding, or presenting Nakafa as your own project.
+- Removing, hiding, or changing copyright, license, attribution, source,
+  trademark, or brand notices.
+- Using Nakafa code, content, structure, datasets, or outputs to train,
+  fine-tune, benchmark, evaluate, seed, or improve AI models, search indexes,
+  datasets, embeddings, retrieval systems, or competing educational products.
+
+Commercial or revenue-generating use includes use connected to subscriptions,
+ads, sponsorships, affiliate revenue, lead generation, paid access, paid
+support, paid tutoring, paid courses, paid school services, sales enablement,
+customer acquisition, investor demos, or any other direct or indirect business
+benefit.
+
+## 5. Brand Rights
+
+This license grants no trademark, service mark, trade name, domain name, logo,
+design, or brand rights. You may not use the Nakafa brand in a way that suggests
+ownership, endorsement, partnership, official status, or source confusion.
+
+See `TRADEMARKS.md` for the brand rules.
+
+## 6. Content Rights
+
+This license grants no rights to copy, redistribute, sell, mirror, scrape,
+repackage, rebrand, or monetize Nakafa educational content.
+
+See `CONTENT_LICENSE.md` for the content rules.
+
+## 7. Contributions
+
+By submitting a contribution, you agree to the contribution terms in
+`.github/CONTRIBUTING.md`.
+
+If you cannot grant those contribution rights, do not submit the contribution.
+
+## 8. Termination
+
+Your rights under this license end immediately if you violate any term.
+
+After termination, you must stop using the software and delete all copies under
+your control, except copies you are required to keep for legal compliance.
+
+PT NAKAFA TEKNO KREATIF may reinstate your rights only in writing.
+
+## 9. Mandatory Legal Rights
+
+This license does not limit rights that applicable law says cannot be waived,
+limited, or conditioned by contract.
+
+## 10. No Warranty
+
+Nakafa is provided "as is" and "as available", without warranties or conditions
+of any kind, whether express, implied, statutory, or otherwise.
+
+PT NAKAFA TEKNO KREATIF does not warrant that Nakafa is accurate, secure,
+complete, uninterrupted, error-free, fit for a particular purpose, or
+non-infringing.
+
+## 11. Limitation of Liability
+
+To the fullest extent permitted by law, PT NAKAFA TEKNO KREATIF will not be
+liable for any indirect, incidental, special, consequential, exemplary, punitive,
+or similar damages, or for any loss of profits, revenue, data, goodwill, or
+business opportunity, arising from or related to Nakafa or this license.
+
+## 12. Governing Law and Venue
+
+This license is governed by the laws of the Republic of Indonesia, without
+regard to conflict of law principles.
+
+Except where prohibited by applicable law, any dispute arising out of or related
+to this license or Nakafa must be brought exclusively in the courts of the
+Republic of Indonesia.
+
+## 13. No Waiver
+
+If PT NAKAFA TEKNO KREATIF does not enforce a term immediately, that does not
+waive the right to enforce that term later.
+
+Any waiver must be in writing and signed by PT NAKAFA TEKNO KREATIF.
+
+## 14. Severability
+
+If any part of this license is found unenforceable, the rest remains in effect.
+The unenforceable part will be interpreted as narrowly as possible so it becomes
+enforceable while preserving the original intent.
+
+## 15. Written Permission
+
+Commercial, hosted, institutional, redistribution, modification, white-label,
+private-label, rebrand, AI-training, or other non-personal use requires a
+separate written agreement.
+
+Contact: nakafaai@gmail.com

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,27 @@
+# Nakafa CLI
+
+The official Node 24 command-line client for Nakafa's public, read-only REST API and MCP server. No Nakafa account or API key is required.
+
+## Install
+
+```sh
+npm install --global nakafa-cli
+```
+
+## Commands
+
+```sh
+nakafa search linear equations
+nakafa get https://nakafa.com/en/quran/1
+nakafa taxonomy
+nakafa quran 1 --from-verse 1 --to-verse 7
+nakafa mcp
+nakafa --help
+nakafa --version
+```
+
+Commands emit compact JSON to standard output. Add `--pretty` for indented output. Add `--api-base <url>` to use another public HTTP edge. The CLI never reads or sends Nakafa's internal edge secrets. Direct Convex origins therefore remain inaccessible through this public package.
+
+HTTP API failures preserve Nakafa's RFC 9457 Problem Details object on standard error. A non-JSON edge failure emits `HTTP_RESPONSE_ERROR` with its status and optional `retry_after` value. Exit status `2` means invalid CLI invocation, `3` means an API request failure, and `4` means a network, server, or response-decoding failure.
+
+See [Nakafa Developer Resources](https://nakafa.com/developers/llms.txt) and the [OpenAPI 3.1 contract](https://api.nakafa.com/openapi.json).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "nakafa-cli",
+  "version": "0.0.0",
+  "description": "Official command-line client for the public Nakafa REST API and MCP server.",
+  "keywords": [
+    "nakafa",
+    "education",
+    "agent",
+    "mcp",
+    "openapi"
+  ],
+  "homepage": "https://nakafa.com/developers/llms.txt",
+  "bugs": {
+    "url": "https://github.com/nakafaai/nakafa.com/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nakafaai/nakafa.com.git",
+    "directory": "packages/cli"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "type": "module",
+  "bin": {
+    "nakafa": "dist/main.js"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "node scripts/build.ts",
+    "prepack": "pnpm build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@effect/platform-node": "catalog:",
+    "@repo/contents": "workspace:*",
+    "@repo/testing": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@vitest/coverage-istanbul": "^4.1.11",
+    "effect": "catalog:",
+    "esbuild": "0.28.2",
+    "typescript": "7.0.2",
+    "vite": "^8.2.2",
+    "vitest": "^4.1.11"
+  },
+  "engines": {
+    "node": ">=24 <25"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -1,0 +1,40 @@
+import { fileURLToPath } from "node:url";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { Effect, FileSystem, Schema } from "effect";
+import { build } from "esbuild";
+
+class CliBuildError extends Schema.TaggedError<CliBuildError>()(
+  "CliBuildError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
+
+const outputDirectory = fileURLToPath(new URL("../dist/", import.meta.url));
+const outputFile = fileURLToPath(new URL("../dist/main.js", import.meta.url));
+const entryPoint = fileURLToPath(new URL("../src/main.ts", import.meta.url));
+
+const buildCli = Effect.fn("NakafaCli.build")(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  yield* fileSystem.remove(outputDirectory, { force: true, recursive: true });
+  yield* Effect.tryPromise({
+    catch: (cause) =>
+      new CliBuildError({
+        cause,
+        message: "Unable to build the Nakafa CLI distribution.",
+      }),
+    try: () =>
+      build({
+        bundle: true,
+        entryPoints: [entryPoint],
+        format: "esm",
+        legalComments: "none",
+        outfile: outputFile,
+        platform: "node",
+        target: "node24",
+      }),
+  });
+});
+
+Effect.runPromise(buildCli().pipe(Effect.provide(NodeFileSystem.layer)));

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "@repo/testing/effect";
+import { Effect, Result } from "effect";
+import { type FetchImplementation, requestNakafaApi } from "./client.js";
+
+const problem = {
+  code: "NOT_FOUND",
+  detail: "The requested content does not exist.",
+  instance: "/v1/content",
+  request_id: "request-123",
+  resolution: "Use a content ID returned by search.",
+  status: 404,
+  title: "Not found",
+  type: "https://nakafa.com/problems/not-found",
+};
+
+function runFailure(fetchImplementation: FetchImplementation) {
+  return requestNakafaApi({
+    apiBase: "https://api.nakafa.com",
+    fetchImplementation,
+    path: "/v1/health",
+  }).pipe(Effect.result);
+}
+
+describe("Nakafa API client", () => {
+  it.live("requests and decodes a successful JSON response", () =>
+    Effect.gen(function* () {
+      const fetchImplementation = vi.fn<FetchImplementation>(async () =>
+        Response.json({ status: "ok" })
+      );
+
+      expect(
+        yield* requestNakafaApi({
+          apiBase: "https://api.nakafa.com",
+          fetchImplementation,
+          path: "/v1/health",
+        })
+      ).toEqual({ status: "ok" });
+      expect(fetchImplementation).toHaveBeenCalledWith(
+        "https://api.nakafa.com/v1/health",
+        {
+          headers: expect.any(Headers),
+          method: "GET",
+        }
+      );
+      const request = fetchImplementation.mock.calls[0]?.[1];
+      expect(new Headers(request?.headers).get("accept")).toBe(
+        "application/json, application/problem+json"
+      );
+    })
+  );
+
+  it.live("never forwards an internal edge secret to a custom API origin", () =>
+    Effect.gen(function* () {
+      const fetchImplementation = vi.fn<FetchImplementation>(async () =>
+        Response.json({ status: "ok" })
+      );
+
+      yield* requestNakafaApi({
+        apiBase: "https://attacker.example",
+        fetchImplementation,
+        path: "/v1/health",
+      });
+
+      const request = fetchImplementation.mock.calls[0]?.[1];
+      expect([...new Headers(request?.headers)]).toEqual([
+        ["accept", "application/json, application/problem+json"],
+      ]);
+    })
+  );
+
+  it.live("preserves a valid Problem Details response", () =>
+    Effect.gen(function* () {
+      const result = yield* runFailure(async () =>
+        Response.json(problem, { status: 404 })
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "ApiResponseError",
+          problem,
+          status: 404,
+        });
+      }
+    })
+  );
+
+  it.live("rejects non-JSON and malformed error responses", () =>
+    Effect.gen(function* () {
+      const nonJson = yield* runFailure(
+        async () =>
+          new Response("not JSON", {
+            headers: { "content-type": "application/problem+json" },
+            status: 502,
+          })
+      );
+      const malformedProblem = yield* runFailure(async () =>
+        Response.json({ message: "missing fields" }, { status: 400 })
+      );
+
+      expect(Result.isFailure(nonJson) && nonJson.failure._tag).toBe(
+        "ResponseDecodeError"
+      );
+      expect(
+        Result.isFailure(malformedProblem) && malformedProblem.failure._tag
+      ).toBe("ResponseDecodeError");
+    })
+  );
+
+  it.live("preserves non-JSON edge status and retry guidance", () =>
+    Effect.gen(function* () {
+      const result = yield* runFailure(
+        async () =>
+          new Response("<html>rate limited</html>", {
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "retry-after": "30",
+            },
+            status: 429,
+          })
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "HttpResponseError",
+          retryAfter: "30",
+          status: 429,
+        });
+      }
+    })
+  );
+
+  it.live("preserves non-JSON edge failures without retry guidance", () =>
+    Effect.gen(function* () {
+      const result = yield* runFailure(
+        async () => new Response("unavailable", { status: 503 })
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "HttpResponseError",
+          retryAfter: undefined,
+          status: 503,
+        });
+      }
+    })
+  );
+
+  it.live(
+    "classifies request and response-reading failures as network errors",
+    () =>
+      Effect.gen(function* () {
+        const requestFailure = yield* runFailure(() => {
+          throw new Error("offline");
+        });
+        class UnreadableResponse extends Response {
+          override text() {
+            return Promise.reject(new Error("body unavailable"));
+          }
+        }
+        const readFailure = yield* runFailure(
+          async () => new UnreadableResponse()
+        );
+
+        expect(
+          Result.isFailure(requestFailure) && requestFailure.failure._tag
+        ).toBe("NetworkError");
+        expect(Result.isFailure(readFailure) && readFailure.failure._tag).toBe(
+          "NetworkError"
+        );
+      })
+  );
+});

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,0 +1,88 @@
+import { Effect, Schema } from "effect";
+import {
+  ApiResponseError,
+  HttpResponseError,
+  NetworkError,
+  ProblemDetailsSchema,
+  ResponseDecodeError,
+} from "./error.js";
+
+export type FetchImplementation = (
+  input: string,
+  init?: RequestInit
+) => Promise<Response>;
+
+interface ApiRequest {
+  readonly apiBase: string;
+  readonly fetchImplementation: FetchImplementation;
+  readonly path: string;
+}
+
+/** Calls one public Nakafa endpoint and preserves typed Problem Details. */
+export const requestNakafaApi = Effect.fn("NakafaCli.requestApi")(function* (
+  request: ApiRequest
+) {
+  const url = new URL(request.path, `${request.apiBase}/`).href;
+  const headers = new Headers({
+    Accept: "application/json, application/problem+json",
+  });
+  const response = yield* Effect.tryPromise({
+    catch: (cause) =>
+      new NetworkError({
+        cause,
+        message: `Unable to reach ${url}.`,
+      }),
+    try: () =>
+      request.fetchImplementation(url, {
+        headers,
+        method: "GET",
+      }),
+  });
+  const text = yield* Effect.tryPromise({
+    catch: (cause) =>
+      new NetworkError({
+        cause,
+        message: `Unable to read the response from ${url}.`,
+      }),
+    try: () => response.text(),
+  });
+  if (!(response.ok || isJsonMediaType(response.headers.get("content-type")))) {
+    return yield* new HttpResponseError({
+      retryAfter: response.headers.get("retry-after") ?? undefined,
+      status: response.status,
+    });
+  }
+  const payload = yield* Effect.try({
+    catch: (cause) =>
+      new ResponseDecodeError({
+        cause,
+        message: `Nakafa returned non-JSON data for ${url}.`,
+        status: response.status,
+      }),
+    try: () => JSON.parse(text),
+  });
+  if (response.ok) {
+    return payload;
+  }
+  const problem = yield* Schema.decodeUnknownEffect(ProblemDetailsSchema)(
+    payload
+  ).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ResponseDecodeError({
+          cause,
+          message: `Nakafa returned an invalid Problem Details response for ${url}.`,
+          status: response.status,
+        })
+    )
+  );
+  return yield* new ApiResponseError({
+    problem,
+    status: response.status,
+  });
+});
+
+function isJsonMediaType(contentType: string | null) {
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json" || mediaType?.endsWith("+json");
+}

--- a/packages/cli/src/command/read.test.ts
+++ b/packages/cli/src/command/read.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "@repo/testing/effect";
+import { Effect } from "effect";
+import { readCliRequest } from "./read.js";
+import { HELP_TEXT } from "./spec.js";
+
+function readFailure(argv: readonly string[]) {
+  return readCliRequest(argv).pipe(
+    Effect.match({
+      onFailure: (error) => error,
+      onSuccess: () => undefined,
+    })
+  );
+}
+
+describe("Nakafa CLI command parsing", () => {
+  it.live("uses help for an empty invocation", () =>
+    Effect.gen(function* () {
+      expect(yield* readCliRequest([])).toEqual({
+        apiBase: "https://api.nakafa.com",
+        command: { kind: "help" },
+        pretty: false,
+      });
+      expect(HELP_TEXT).toContain("nakafa search <query...>");
+    })
+  );
+
+  it.live("honors global help, version, pretty, and API base options", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* readCliRequest([
+          "search",
+          "ignored",
+          "--help",
+          "--pretty",
+          "--api-base",
+          "https://isolated.example.com/",
+        ])
+      ).toEqual({
+        apiBase: "https://isolated.example.com",
+        command: { kind: "help" },
+        pretty: true,
+      });
+      expect(yield* readCliRequest(["--version"])).toMatchObject({
+        command: { kind: "version" },
+      });
+    })
+  );
+
+  it.live("parses search arguments and typed filters", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* readCliRequest([
+          "search",
+          "linear",
+          "equations",
+          "--section",
+          "material",
+          "--locale",
+          "de",
+          "--limit",
+          "10",
+          "--offset",
+          "9",
+        ])
+      ).toEqual({
+        apiBase: "https://api.nakafa.com",
+        command: {
+          kind: "search",
+          limit: 10,
+          locale: "de",
+          offset: 9,
+          query: "linear equations",
+          section: "material",
+        },
+        pretty: false,
+      });
+    })
+  );
+
+  it.live.each([
+    {
+      argv: ["get", "content-id"],
+      command: { kind: "get", ref: "content-id" },
+    },
+    {
+      argv: ["taxonomy", "--locale", "id"],
+      command: { kind: "taxonomy", locale: "id" },
+    },
+    { argv: ["mcp"], command: { kind: "mcp" } },
+  ])("parses $argv", ({ argv, command }) =>
+    Effect.gen(function* () {
+      expect(yield* readCliRequest(argv)).toMatchObject({ command });
+    })
+  );
+
+  it.live("parses Quran range and tafsir options", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* readCliRequest([
+          "quran",
+          "2",
+          "--from-verse",
+          "255",
+          "--to-verse",
+          "257",
+          "--locale",
+          "en",
+          "--tafsir",
+        ])
+      ).toMatchObject({
+        command: {
+          fromVerse: 255,
+          includeTafsir: true,
+          kind: "quran",
+          locale: "en",
+          surah: 2,
+          toVerse: 257,
+        },
+      });
+    })
+  );
+
+  it.live.each([
+    { argv: ["unknown"], message: "Unknown command" },
+    { argv: ["search"], message: "search requires a query" },
+    { argv: ["get"], message: "get requires exactly one argument" },
+    {
+      argv: ["get", "one", "two"],
+      message: "get requires exactly one argument",
+    },
+    {
+      argv: ["taxonomy", "extra"],
+      message: "taxonomy does not accept positional arguments",
+    },
+    {
+      argv: ["mcp", "--locale", "en"],
+      message: "--locale is not valid for mcp",
+    },
+    {
+      argv: ["search", "query", "--limit", "11"],
+      message: "Invalid command options",
+    },
+    {
+      argv: ["search", "query", "--limit", "zero"],
+      message: "Invalid command options",
+    },
+    {
+      argv: ["search", "query", "--offset=-1"],
+      message: "Invalid command options",
+    },
+    {
+      argv: ["search", "query", "--offset", "10"],
+      message: "Invalid command options",
+    },
+    {
+      argv: ["search", "query", "--locale", "fr"],
+      message: "Invalid command options",
+    },
+    { argv: ["quran", "0"], message: "Invalid command options" },
+    { argv: ["quran", "115"], message: "Invalid command options" },
+    { argv: ["--api-base", "not-a-url"], message: "Invalid command options" },
+    {
+      argv: ["--api-base", "https://user@example.com"],
+      message: "Invalid command options",
+    },
+    {
+      argv: ["--api-base", "ftp://api.example.com"],
+      message: "Invalid command options",
+    },
+    { argv: ["--unknown"], message: "Unknown option" },
+  ])("rejects $argv", ({ argv, message }) =>
+    Effect.gen(function* () {
+      const error = yield* readFailure(argv);
+
+      expect(error?._tag).toBe("InvocationError");
+      expect(error?.message).toContain(message);
+    })
+  );
+});

--- a/packages/cli/src/command/read.ts
+++ b/packages/cli/src/command/read.ts
@@ -1,0 +1,209 @@
+import { parseArgs } from "node:util";
+import { NAKAFA_API_BASE_URL } from "@repo/contents/_lib/agent/constants";
+import { Effect, Schema } from "effect";
+import { InvocationError } from "../error.js";
+import { CliRequestSchema, isHttpOrigin } from "./spec.js";
+
+const optionDefinitions = {
+  "api-base": { type: "string" },
+  "from-verse": { type: "string" },
+  help: { short: "h", type: "boolean" },
+  limit: { type: "string" },
+  locale: { type: "string" },
+  offset: { type: "string" },
+  pretty: { short: "p", type: "boolean" },
+  section: { type: "string" },
+  tafsir: { type: "boolean" },
+  "to-verse": { type: "string" },
+  version: { short: "v", type: "boolean" },
+} as const;
+
+const globalOptions = new Set(["api-base", "help", "pretty", "version"]);
+const commandOptions = {
+  get: new Set<string>(),
+  mcp: new Set<string>(),
+  quran: new Set(["from-verse", "locale", "tafsir", "to-verse"]),
+  search: new Set(["limit", "locale", "offset", "section"]),
+  taxonomy: new Set(["locale"]),
+};
+
+/** Parses and validates one complete CLI invocation. */
+export const readCliRequest = Effect.fn("NakafaCli.readRequest")(function* (
+  argv: readonly string[]
+) {
+  const parsed = yield* Effect.try({
+    catch: (cause) => new InvocationError({ message: String(cause) }),
+    try: () =>
+      parseArgs({
+        allowNegative: true,
+        allowPositionals: true,
+        args: [...argv],
+        options: optionDefinitions,
+        strict: true,
+      }),
+  });
+  const apiBase = normalizeApiBase(
+    readStringOption(parsed.values["api-base"]) ?? NAKAFA_API_BASE_URL
+  );
+  const pretty = parsed.values.pretty === true;
+  if (parsed.values.help === true) {
+    return yield* decodeCliRequest({
+      apiBase,
+      command: { kind: "help" },
+      pretty,
+    });
+  }
+  if (parsed.values.version === true) {
+    return yield* decodeCliRequest({
+      apiBase,
+      command: { kind: "version" },
+      pretty,
+    });
+  }
+  if (parsed.positionals.length === 0) {
+    return yield* decodeCliRequest({
+      apiBase,
+      command: { kind: "help" },
+      pretty,
+    });
+  }
+
+  const [commandName, ...positionals] = parsed.positionals;
+  if (!isCommandName(commandName)) {
+    return yield* new InvocationError({
+      message: `Unknown command: ${String(commandName)}. Run nakafa --help.`,
+    });
+  }
+  yield* rejectUnsupportedOptions(commandName, parsed.values);
+  const command = yield* buildCommand(commandName, positionals, parsed.values);
+  return yield* decodeCliRequest({ apiBase, command, pretty });
+});
+
+function buildCommand(
+  commandName: keyof typeof commandOptions,
+  positionals: readonly string[],
+  values: Readonly<Record<string, boolean | string | undefined>>
+) {
+  if (commandName === "search") {
+    if (positionals.length === 0) {
+      return Effect.fail(
+        new InvocationError({ message: "search requires a query." })
+      );
+    }
+    return Effect.succeed({
+      kind: "search",
+      limit: readNumberOption(values.limit),
+      locale: readStringOption(values.locale),
+      offset: readNumberOption(values.offset),
+      query: positionals.join(" "),
+      section: readStringOption(values.section),
+    });
+  }
+  if (commandName === "get") {
+    return requireOneArgument(commandName, positionals).pipe(
+      Effect.map((ref) => ({ kind: "get", ref }))
+    );
+  }
+  if (commandName === "taxonomy") {
+    return requireNoArguments(commandName, positionals).pipe(
+      Effect.as({
+        kind: "taxonomy",
+        locale: readStringOption(values.locale),
+      })
+    );
+  }
+  if (commandName === "quran") {
+    return requireOneArgument(commandName, positionals).pipe(
+      Effect.map((surah) => ({
+        fromVerse: readNumberOption(values["from-verse"]),
+        includeTafsir: values.tafsir === true,
+        kind: "quran",
+        locale: readStringOption(values.locale),
+        surah: Number(surah),
+        toVerse: readNumberOption(values["to-verse"]),
+      }))
+    );
+  }
+  return requireNoArguments(commandName, positionals).pipe(
+    Effect.as({ kind: "mcp" })
+  );
+}
+
+function decodeCliRequest(input: unknown) {
+  return Schema.decodeUnknownEffect(CliRequestSchema, {
+    onExcessProperty: "error",
+  })(input).pipe(
+    Effect.mapError(
+      (cause) =>
+        new InvocationError({
+          message: `Invalid command options: ${String(cause)}`,
+        })
+    )
+  );
+}
+
+function rejectUnsupportedOptions(
+  commandName: keyof typeof commandOptions,
+  values: Readonly<Record<string, boolean | string | undefined>>
+) {
+  const allowed = commandOptions[commandName];
+  const unsupported = Object.entries(values).find(
+    ([name, value]) =>
+      value !== undefined && !globalOptions.has(name) && !allowed.has(name)
+  );
+  if (!unsupported) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    new InvocationError({
+      message: `--${unsupported[0]} is not valid for ${commandName}.`,
+    })
+  );
+}
+
+function requireOneArgument(
+  command: string,
+  positionals: readonly string[]
+): Effect.Effect<string, InvocationError> {
+  if (positionals.length === 1) {
+    return Effect.succeed(positionals.join(""));
+  }
+  return Effect.fail(
+    new InvocationError({
+      message: `${command} requires exactly one argument.`,
+    })
+  );
+}
+
+function requireNoArguments(
+  command: string,
+  positionals: readonly string[]
+): Effect.Effect<void, InvocationError> {
+  if (positionals.length === 0) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    new InvocationError({
+      message: `${command} does not accept positional arguments.`,
+    })
+  );
+}
+
+function readStringOption(value: boolean | string | undefined) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumberOption(value: boolean | string | undefined) {
+  const source = readStringOption(value);
+  return source === undefined ? undefined : Number(source);
+}
+
+function normalizeApiBase(value: string) {
+  return isHttpOrigin(value) ? new URL(value).origin : value;
+}
+
+function isCommandName(
+  value: string | undefined
+): value is keyof typeof commandOptions {
+  return value !== undefined && Object.hasOwn(commandOptions, value);
+}

--- a/packages/cli/src/command/spec.ts
+++ b/packages/cli/src/command/spec.ts
@@ -1,0 +1,105 @@
+import { NAKAFA_API_BASE_URL } from "@repo/contents/_lib/agent/constants";
+import { NakafaAgentQuranReferenceOptionsSchema } from "@repo/contents/_lib/agent/schema/quran";
+import { NakafaAgentSectionSchema } from "@repo/contents/_lib/agent/schema/ref";
+import {
+  NAKAFA_AGENT_MAX_LIMIT,
+  NAKAFA_AGENT_MAX_OFFSET,
+} from "@repo/contents/_types/agent/search";
+import { LocaleSchema } from "@repo/contents/_types/content";
+import { Schema } from "effect";
+
+const PositiveIntegerSchema = Schema.Finite.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isGreaterThan(0))
+);
+const SearchLimitSchema = PositiveIntegerSchema.pipe(
+  Schema.check(Schema.isLessThanOrEqualTo(NAKAFA_AGENT_MAX_LIMIT))
+);
+const SearchOffsetSchema = Schema.Finite.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(
+    Schema.isBetween({ minimum: 0, maximum: NAKAFA_AGENT_MAX_OFFSET })
+  )
+);
+const ApiBaseSchema = Schema.String.check(
+  Schema.makeFilter(isHttpOrigin, {
+    message: "Expected --api-base to be an HTTP or HTTPS origin.",
+  })
+);
+
+const SearchCommandSchema = Schema.Struct({
+  kind: Schema.Literal("search"),
+  limit: Schema.optional(SearchLimitSchema),
+  locale: Schema.optional(LocaleSchema),
+  offset: Schema.optional(SearchOffsetSchema),
+  query: Schema.Trim.pipe(Schema.check(Schema.isNonEmpty())),
+  section: Schema.optional(NakafaAgentSectionSchema),
+});
+const GetCommandSchema = Schema.Struct({
+  kind: Schema.Literal("get"),
+  ref: Schema.Trim.pipe(Schema.check(Schema.isNonEmpty())),
+});
+const TaxonomyCommandSchema = Schema.Struct({
+  kind: Schema.Literal("taxonomy"),
+  locale: Schema.optional(LocaleSchema),
+});
+const QuranCommandSchema = Schema.Struct({
+  fromVerse: Schema.optional(PositiveIntegerSchema),
+  includeTafsir: Schema.Boolean,
+  kind: Schema.Literal("quran"),
+  locale: Schema.optional(LocaleSchema),
+  surah: NakafaAgentQuranReferenceOptionsSchema.fields.surah,
+  toVerse: Schema.optional(PositiveIntegerSchema),
+});
+const CliCommandSchema = Schema.Union([
+  SearchCommandSchema,
+  GetCommandSchema,
+  TaxonomyCommandSchema,
+  QuranCommandSchema,
+  Schema.Struct({ kind: Schema.Literal("mcp") }),
+  Schema.Struct({ kind: Schema.Literal("help") }),
+  Schema.Struct({ kind: Schema.Literal("version") }),
+]);
+
+export const CliRequestSchema = Schema.Struct({
+  apiBase: ApiBaseSchema,
+  command: CliCommandSchema,
+  pretty: Schema.Boolean,
+});
+
+export type CliRequest = Schema.Schema.Type<typeof CliRequestSchema>;
+export type CliCommand = Schema.Schema.Type<typeof CliCommandSchema>;
+
+/** Checks that an API override is exactly one HTTP or HTTPS origin. */
+export function isHttpOrigin(value: string) {
+  if (!URL.canParse(value)) {
+    return false;
+  }
+  const url = new URL(value);
+  return (
+    (url.protocol === "http:" || url.protocol === "https:") &&
+    url.username === "" &&
+    url.password === "" &&
+    url.pathname === "/" &&
+    url.search === "" &&
+    url.hash === ""
+  );
+}
+
+export const HELP_TEXT = `Nakafa CLI
+
+Usage:
+  nakafa search <query...> [--section <name>] [--locale <code>]
+  nakafa get <content-ref>
+  nakafa taxonomy [--locale <code>]
+  nakafa quran <surah> [--from-verse <n>] [--to-verse <n>] [--tafsir]
+  nakafa mcp
+  nakafa --help
+  nakafa --version
+
+Global options:
+  --pretty, -p          Indent JSON output
+  --api-base <url>      Override ${NAKAFA_API_BASE_URL}
+  --help, -h            Show this help
+  --version, -v         Show the CLI version
+`;

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -1,0 +1,58 @@
+import { Schema } from "effect";
+
+export const ProblemDetailsSchema = Schema.Struct({
+  code: Schema.String,
+  detail: Schema.String,
+  instance: Schema.String,
+  request_id: Schema.String,
+  resolution: Schema.String,
+  status: Schema.Finite.pipe(Schema.check(Schema.isInt())),
+  title: Schema.String,
+  type: Schema.String,
+});
+
+export class InvocationError extends Schema.TaggedError<InvocationError>()(
+  "InvocationError",
+  { message: Schema.String }
+) {}
+
+export class NetworkError extends Schema.TaggedError<NetworkError>()(
+  "NetworkError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}
+
+export class ResponseDecodeError extends Schema.TaggedError<ResponseDecodeError>()(
+  "ResponseDecodeError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+    status: Schema.Finite.pipe(Schema.check(Schema.isInt())),
+  }
+) {}
+
+export class ApiResponseError extends Schema.TaggedError<ApiResponseError>()(
+  "ApiResponseError",
+  {
+    problem: ProblemDetailsSchema,
+    status: Schema.Finite.pipe(Schema.check(Schema.isInt())),
+  }
+) {}
+
+export class HttpResponseError extends Schema.TaggedError<HttpResponseError>()(
+  "HttpResponseError",
+  {
+    retryAfter: Schema.optional(Schema.String),
+    status: Schema.Finite.pipe(Schema.check(Schema.isInt())),
+  }
+) {}
+
+export class CliStartupError extends Schema.TaggedError<CliStartupError>()(
+  "CliStartupError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  }
+) {}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { Cause, Effect } from "effect";
+import { readPackageVersion } from "./package.js";
+import { runCli } from "./program.js";
+
+const program = Effect.gen(function* () {
+  const version = yield* readPackageVersion(
+    new URL("../package.json", import.meta.url)
+  );
+  return yield* runCli(process.argv.slice(2), {
+    fetchImplementation: fetch,
+    stderr: process.stderr,
+    stdout: process.stdout,
+    version,
+  });
+}).pipe(
+  Effect.catchCause((cause) =>
+    Effect.sync(() => {
+      process.stderr.write(
+        `${JSON.stringify({
+          code: "CLI_STARTUP_ERROR",
+          message: Cause.pretty(cause),
+        })}\n`
+      );
+      return 4;
+    })
+  ),
+  Effect.provide(NodeFileSystem.layer)
+);
+
+Effect.runPromise(program).then((exitCode) => {
+  process.exitCode = exitCode;
+});

--- a/packages/cli/src/package.test.ts
+++ b/packages/cli/src/package.test.ts
@@ -1,0 +1,156 @@
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@repo/testing/effect";
+import { Effect, FileSystem, Path, Result, Schema, Stream } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import {
+  isAllowedPackedFile,
+  REQUIRED_PACKED_FILES,
+  readPackageVersion,
+} from "./package.js";
+
+class CliTestCommandError extends Schema.TaggedError<CliTestCommandError>()(
+  "CliTestCommandError",
+  {
+    command: Schema.String,
+    exitCode: Schema.Finite.pipe(Schema.check(Schema.isInt())),
+    stderr: Schema.String,
+  }
+) {}
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+const PackResultSchema = Schema.fromJsonString(
+  Schema.NonEmptyArray(
+    Schema.Struct({
+      filename: Schema.String,
+      files: Schema.Array(Schema.Struct({ path: Schema.String })),
+    })
+  )
+);
+
+const runCommand = Effect.fn("NakafaCli.test.runCommand")(function* (
+  command: string,
+  args: readonly string[],
+  cwd: string
+) {
+  const [stdout, stderr, exitCode] = yield* Effect.scoped(
+    Effect.gen(function* () {
+      const childProcess = yield* ChildProcess.make(command, args, { cwd });
+      return yield* Effect.all(
+        [
+          Stream.mkString(Stream.decodeText(childProcess.stdout)),
+          Stream.mkString(Stream.decodeText(childProcess.stderr)),
+          childProcess.exitCode,
+        ],
+        { concurrency: "unbounded" }
+      );
+    })
+  );
+  if (exitCode !== 0) {
+    return yield* new CliTestCommandError({
+      command: [command, ...args].join(" "),
+      exitCode,
+      stderr: stderr.trim(),
+    });
+  }
+  return stdout;
+});
+
+describe("Nakafa CLI package", () => {
+  it("allows only runtime distribution files", () => {
+    for (const file of REQUIRED_PACKED_FILES) {
+      expect(isAllowedPackedFile(file)).toBe(true);
+    }
+    expect(isAllowedPackedFile("dist/client.js")).toBe(true);
+    expect(isAllowedPackedFile("src/main.ts")).toBe(false);
+    expect(isAllowedPackedFile("vitest.config.mts")).toBe(false);
+  });
+
+  it.effect("reads valid package metadata and reports typed failures", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "nakafa-cli-metadata-",
+      });
+      const validPath = path.join(directory, "valid.json");
+      const invalidPath = path.join(directory, "invalid.json");
+      yield* fileSystem.writeFileString(validPath, '{"version":"9.8.7"}');
+      yield* fileSystem.writeFileString(invalidPath, '{"version":7}');
+
+      const valid = yield* readPackageVersion(pathToFileURL(validPath));
+      const invalid = yield* readPackageVersion(
+        pathToFileURL(invalidPath)
+      ).pipe(Effect.result);
+      const missing = yield* readPackageVersion(
+        pathToFileURL(path.join(directory, "missing.json"))
+      ).pipe(Effect.result);
+
+      expect(valid).toBe("9.8.7");
+      expect(Result.isFailure(invalid) && invalid.failure.message).toContain(
+        "metadata is invalid"
+      );
+      expect(Result.isFailure(missing) && missing.failure.message).toContain(
+        "Unable to read"
+      );
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+
+  it.effect("packs only the allowlist and installs a working executable", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "nakafa-cli-pack-",
+      });
+      const packageVersion = yield* readPackageVersion(
+        pathToFileURL(path.join(packageRoot, "package.json"))
+      );
+      const packOutput = yield* runCommand(
+        "npm",
+        ["pack", "--json", "--pack-destination", directory],
+        packageRoot
+      );
+      const [pack] = yield* Schema.decodeEffect(PackResultSchema)(packOutput);
+      const files = pack.files.map(({ path: file }) => file);
+      const tarballPath = path.join(directory, pack.filename);
+
+      yield* fileSystem.writeFileString(
+        path.join(directory, "package.json"),
+        '{"name":"nakafa-cli-smoke","private":true}'
+      );
+      yield* runCommand(
+        "npm",
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--package-lock=false",
+          tarballPath,
+        ],
+        directory
+      );
+
+      const binary = path.join(directory, "node_modules", ".bin", "nakafa");
+      const installedRoot = path.join(directory, "node_modules", "nakafa-cli");
+      const bundle = yield* fileSystem.readFileString(
+        path.join(installedRoot, "dist", "main.js")
+      );
+      const manifest = yield* fileSystem.readFileString(
+        path.join(installedRoot, "package.json")
+      );
+      const help = yield* runCommand(binary, ["--help"], directory);
+      const version = yield* runCommand(binary, ["--version"], directory);
+
+      expect(REQUIRED_PACKED_FILES.every((file) => files.includes(file))).toBe(
+        true
+      );
+      expect(files.every(isAllowedPackedFile)).toBe(true);
+      expect(help).toContain("Nakafa CLI");
+      expect(version).toBe(`${packageVersion}\n`);
+      expect(manifest).not.toContain('"dependencies"');
+      expect(bundle).not.toContain("@repo/contents");
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+});

--- a/packages/cli/src/package.test.ts
+++ b/packages/cli/src/package.test.ts
@@ -96,61 +96,68 @@ describe("Nakafa CLI package", () => {
     }).pipe(Effect.provide(NodeServices.layer))
   );
 
-  it.effect("packs only the allowlist and installs a working executable", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const directory = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "nakafa-cli-pack-",
-      });
-      const packageVersion = yield* readPackageVersion(
-        pathToFileURL(path.join(packageRoot, "package.json"))
-      );
-      const packOutput = yield* runCommand(
-        "npm",
-        ["pack", "--json", "--pack-destination", directory],
-        packageRoot
-      );
-      const [pack] = yield* Schema.decodeEffect(PackResultSchema)(packOutput);
-      const files = pack.files.map(({ path: file }) => file);
-      const tarballPath = path.join(directory, pack.filename);
+  it.effect(
+    "packs only the allowlist and installs a working executable",
+    () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "nakafa-cli-pack-",
+        });
+        const packageVersion = yield* readPackageVersion(
+          pathToFileURL(path.join(packageRoot, "package.json"))
+        );
+        const packOutput = yield* runCommand(
+          "npm",
+          ["pack", "--json", "--pack-destination", directory],
+          packageRoot
+        );
+        const [pack] = yield* Schema.decodeEffect(PackResultSchema)(packOutput);
+        const files = pack.files.map(({ path: file }) => file);
+        const tarballPath = path.join(directory, pack.filename);
 
-      yield* fileSystem.writeFileString(
-        path.join(directory, "package.json"),
-        '{"name":"nakafa-cli-smoke","private":true}'
-      );
-      yield* runCommand(
-        "npm",
-        [
-          "install",
-          "--ignore-scripts",
-          "--no-audit",
-          "--no-fund",
-          "--package-lock=false",
-          tarballPath,
-        ],
-        directory
-      );
+        yield* fileSystem.writeFileString(
+          path.join(directory, "package.json"),
+          '{"name":"nakafa-cli-smoke","private":true}'
+        );
+        yield* runCommand(
+          "npm",
+          [
+            "install",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--package-lock=false",
+            tarballPath,
+          ],
+          directory
+        );
 
-      const binary = path.join(directory, "node_modules", ".bin", "nakafa");
-      const installedRoot = path.join(directory, "node_modules", "nakafa-cli");
-      const bundle = yield* fileSystem.readFileString(
-        path.join(installedRoot, "dist", "main.js")
-      );
-      const manifest = yield* fileSystem.readFileString(
-        path.join(installedRoot, "package.json")
-      );
-      const help = yield* runCommand(binary, ["--help"], directory);
-      const version = yield* runCommand(binary, ["--version"], directory);
+        const binary = path.join(directory, "node_modules", ".bin", "nakafa");
+        const installedRoot = path.join(
+          directory,
+          "node_modules",
+          "nakafa-cli"
+        );
+        const bundle = yield* fileSystem.readFileString(
+          path.join(installedRoot, "dist", "main.js")
+        );
+        const manifest = yield* fileSystem.readFileString(
+          path.join(installedRoot, "package.json")
+        );
+        const help = yield* runCommand(binary, ["--help"], directory);
+        const version = yield* runCommand(binary, ["--version"], directory);
 
-      expect(REQUIRED_PACKED_FILES.every((file) => files.includes(file))).toBe(
-        true
-      );
-      expect(files.every(isAllowedPackedFile)).toBe(true);
-      expect(help).toContain("Nakafa CLI");
-      expect(version).toBe(`${packageVersion}\n`);
-      expect(manifest).not.toContain('"dependencies"');
-      expect(bundle).not.toContain("@repo/contents");
-    }).pipe(Effect.provide(NodeServices.layer))
+        expect(
+          REQUIRED_PACKED_FILES.every((file) => files.includes(file))
+        ).toBe(true);
+        expect(files.every(isAllowedPackedFile)).toBe(true);
+        expect(help).toContain("Nakafa CLI");
+        expect(version).toBe(`${packageVersion}\n`);
+        expect(manifest).not.toContain('"dependencies"');
+        expect(bundle).not.toContain("@repo/contents");
+      }).pipe(Effect.provide(NodeServices.layer)),
+    { timeout: 30_000 }
   );
 });

--- a/packages/cli/src/package.ts
+++ b/packages/cli/src/package.ts
@@ -1,0 +1,52 @@
+import { fileURLToPath } from "node:url";
+import { Effect, FileSystem, Schema } from "effect";
+import { CliStartupError } from "./error.js";
+
+export const REQUIRED_PACKED_FILES = [
+  "LICENSE",
+  "README.md",
+  "dist/main.js",
+  "package.json",
+];
+
+const PackageMetadataSchema = Schema.Struct({ version: Schema.String });
+
+/** Reads and validates the version bundled with the installed CLI package. */
+export const readPackageVersion = Effect.fn("NakafaCli.readPackageVersion")(
+  function* (packageUrl: URL) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const source = yield* fileSystem
+      .readFileString(fileURLToPath(packageUrl))
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new CliStartupError({
+              cause,
+              message: "Unable to read the Nakafa CLI package metadata.",
+            })
+        )
+      );
+    const metadata = yield* Schema.decodeEffect(
+      Schema.fromJsonString(PackageMetadataSchema)
+    )(source).pipe(
+      Effect.mapError(
+        (cause) =>
+          new CliStartupError({
+            cause,
+            message: "The Nakafa CLI package metadata is invalid.",
+          })
+      )
+    );
+    return metadata.version;
+  }
+);
+
+/** Keeps source, tests, and workspace-only files out of the npm tarball. */
+export function isAllowedPackedFile(path: string) {
+  return (
+    path === "LICENSE" ||
+    path === "README.md" ||
+    path === "package.json" ||
+    path.startsWith("dist/")
+  );
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,0 +1,234 @@
+import { NAKAFA_MCP_PROTOCOL_VERSION } from "@repo/contents/_lib/agent/constants";
+import { describe, expect, it, vi } from "@repo/testing/effect";
+import { Effect } from "effect";
+import type { FetchImplementation } from "./client.js";
+import { runCli } from "./program.js";
+
+const problem = {
+  code: "NOT_FOUND",
+  detail: "The requested content does not exist.",
+  instance: "/v1/content",
+  request_id: "request-123",
+  resolution: "Use a content ID returned by search.",
+  status: 404,
+  title: "Not found",
+  type: "https://nakafa.com/problems/not-found",
+};
+
+function createOutput() {
+  let value = "";
+  return {
+    read: () => value,
+    stream: {
+      write(chunk: string) {
+        value += chunk;
+      },
+    },
+  };
+}
+
+function execute(
+  argv: readonly string[],
+  fetchImplementation: FetchImplementation = async () =>
+    Response.json({ ok: true })
+) {
+  const stdout = createOutput();
+  const stderr = createOutput();
+  return runCli(argv, {
+    fetchImplementation,
+    stderr: stderr.stream,
+    stdout: stdout.stream,
+    version: "0.1.0",
+  }).pipe(
+    Effect.map((exitCode) => ({
+      exitCode,
+      stderr: stderr.read(),
+      stdout: stdout.read(),
+    }))
+  );
+}
+
+describe("Nakafa CLI execution", () => {
+  it.live("prints help, version, and MCP metadata without network calls", () =>
+    Effect.gen(function* () {
+      const fetchImplementation = vi.fn<FetchImplementation>();
+      const help = yield* execute(["--help"], fetchImplementation);
+      const version = yield* execute(["--version"], fetchImplementation);
+      const mcp = yield* execute(["mcp"], fetchImplementation);
+
+      expect(help).toMatchObject({ exitCode: 0, stderr: "" });
+      expect(help.stdout).toContain("Nakafa CLI");
+      expect(version).toEqual({
+        exitCode: 0,
+        stderr: "",
+        stdout: "0.1.0\n",
+      });
+      expect(JSON.parse(mcp.stdout)).toEqual({
+        endpoint: "https://nakafa.com/mcp",
+        manifest: "https://nakafa.com/mcp",
+        protocol_version: NAKAFA_MCP_PROTOCOL_VERSION,
+        transport: "streamable-http",
+      });
+      expect(fetchImplementation).not.toHaveBeenCalled();
+    })
+  );
+
+  it.live.each([
+    {
+      argv: ["search", "linear", "equations", "--locale", "de", "--limit", "5"],
+      expectedUrl:
+        "https://api.nakafa.com/v1/search?query=linear+equations&locale=de&limit=5",
+    },
+    {
+      argv: ["get", "https://nakafa.com/en/content?id=1"],
+      expectedUrl:
+        "https://api.nakafa.com/v1/content?ref=https%3A%2F%2Fnakafa.com%2Fen%2Fcontent%3Fid%3D1",
+    },
+    {
+      argv: ["taxonomy", "--locale", "id"],
+      expectedUrl: "https://api.nakafa.com/v1/taxonomy?locale=id",
+    },
+    {
+      argv: ["taxonomy"],
+      expectedUrl: "https://api.nakafa.com/v1/taxonomy",
+    },
+    {
+      argv: [
+        "quran",
+        "1",
+        "--from-verse",
+        "1",
+        "--to-verse",
+        "7",
+        "--locale",
+        "en",
+        "--tafsir",
+      ],
+      expectedUrl:
+        "https://api.nakafa.com/v1/quran/1?from_verse=1&to_verse=7&locale=en&include_tafsir=true",
+    },
+    {
+      argv: ["quran", "114"],
+      expectedUrl: "https://api.nakafa.com/v1/quran/114",
+    },
+  ])("calls the public endpoint for $argv", ({ argv, expectedUrl }) =>
+    Effect.gen(function* () {
+      const fetchImplementation = vi.fn(async () =>
+        Response.json({ ok: true })
+      );
+
+      const result = yield* execute(argv, fetchImplementation);
+
+      expect(result).toEqual({
+        exitCode: 0,
+        stderr: "",
+        stdout: '{"ok":true}\n',
+      });
+      expect(fetchImplementation).toHaveBeenCalledWith(
+        expectedUrl,
+        expect.any(Object)
+      );
+    })
+  );
+
+  it.live(
+    "supports custom public API bases without forwarding edge secrets",
+    () =>
+      Effect.gen(function* () {
+        const fetchImplementation = vi.fn<FetchImplementation>(async () =>
+          Response.json({ nested: { ok: true } })
+        );
+
+        const result = yield* execute(
+          [
+            "taxonomy",
+            "--pretty",
+            "--api-base",
+            "https://isolated.example.com",
+          ],
+          fetchImplementation
+        );
+
+        expect(result.stdout).toBe(
+          '{\n  "nested": {\n    "ok": true\n  }\n}\n'
+        );
+        expect(fetchImplementation).toHaveBeenCalledWith(
+          "https://isolated.example.com/v1/taxonomy",
+          expect.any(Object)
+        );
+        const request = fetchImplementation.mock.calls[0]?.[1];
+        expect([...new Headers(request?.headers)]).toEqual([
+          ["accept", "application/json, application/problem+json"],
+        ]);
+      })
+  );
+
+  it.live(
+    "returns stable invocation, API, server, network, and decoding exits",
+    () =>
+      Effect.gen(function* () {
+        const invocation = yield* execute(["search"]);
+        const api = yield* execute(["get", "missing"], async () =>
+          Response.json(problem, { status: 404 })
+        );
+        const server = yield* execute(["taxonomy"], async () =>
+          Response.json({ ...problem, status: 503 }, { status: 503 })
+        );
+        const network = yield* execute(["taxonomy"], () => {
+          throw new Error("offline");
+        });
+        const decoding = yield* execute(
+          ["taxonomy"],
+          async () =>
+            new Response("not JSON", {
+              headers: { "content-type": "application/problem+json" },
+              status: 502,
+            })
+        );
+        const edge = yield* execute(
+          ["taxonomy"],
+          async () =>
+            new Response("<html>rate limited</html>", {
+              headers: {
+                "content-type": "text/html",
+                "retry-after": "30",
+              },
+              status: 429,
+            })
+        );
+        const unavailableEdge = yield* execute(
+          ["taxonomy"],
+          async () => new Response("unavailable", { status: 503 })
+        );
+
+        expect(invocation.exitCode).toBe(2);
+        expect(JSON.parse(invocation.stderr)).toMatchObject({
+          code: "INVOCATION_ERROR",
+        });
+        expect(api.exitCode).toBe(3);
+        expect(JSON.parse(api.stderr)).toEqual(problem);
+        expect(server.exitCode).toBe(4);
+        expect(JSON.parse(server.stderr)).toMatchObject({ status: 503 });
+        expect(network.exitCode).toBe(4);
+        expect(JSON.parse(network.stderr)).toMatchObject({
+          code: "NETWORK_ERROR",
+        });
+        expect(decoding.exitCode).toBe(4);
+        expect(JSON.parse(decoding.stderr)).toMatchObject({
+          code: "INVALID_SERVER_RESPONSE",
+          status: 502,
+        });
+        expect(edge.exitCode).toBe(3);
+        expect(JSON.parse(edge.stderr)).toEqual({
+          code: "HTTP_RESPONSE_ERROR",
+          retry_after: "30",
+          status: 429,
+        });
+        expect(unavailableEdge.exitCode).toBe(4);
+        expect(JSON.parse(unavailableEdge.stderr)).toEqual({
+          code: "HTTP_RESPONSE_ERROR",
+          status: 503,
+        });
+      })
+  );
+});

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -65,7 +65,6 @@ describe("Nakafa CLI execution", () => {
       });
       expect(JSON.parse(mcp.stdout)).toEqual({
         endpoint: "https://nakafa.com/mcp",
-        manifest: "https://nakafa.com/mcp",
         protocol_version: NAKAFA_MCP_PROTOCOL_VERSION,
         transport: "streamable-http",
       });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -114,7 +114,6 @@ function executeCommand(
       kind: "json",
       value: {
         endpoint: NAKAFA_MCP_RECOMMENDED_ENDPOINT,
-        manifest: NAKAFA_MCP_RECOMMENDED_ENDPOINT,
         protocol_version: NAKAFA_MCP_PROTOCOL_VERSION,
         transport: "streamable-http",
       },

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,0 +1,187 @@
+import {
+  NAKAFA_MCP_PROTOCOL_VERSION,
+  NAKAFA_MCP_RECOMMENDED_ENDPOINT,
+} from "@repo/contents/_lib/agent/constants";
+import { Effect } from "effect";
+import { type FetchImplementation, requestNakafaApi } from "./client.js";
+import { readCliRequest } from "./command/read.js";
+import { type CliCommand, type CliRequest, HELP_TEXT } from "./command/spec.js";
+import type {
+  ApiResponseError,
+  HttpResponseError,
+  NetworkError,
+  ResponseDecodeError,
+} from "./error.js";
+
+const INVOCATION_EXIT_CODE = 2;
+const API_EXIT_CODE = 3;
+const NETWORK_OR_SERVER_EXIT_CODE = 4;
+
+export interface CliDependencies {
+  readonly fetchImplementation: FetchImplementation;
+  readonly stderr: { write(value: string): unknown };
+  readonly stdout: { write(value: string): unknown };
+  readonly version: string;
+}
+
+interface CliOutput {
+  readonly kind: "json" | "text";
+  readonly value: unknown;
+}
+
+/** Executes one CLI invocation and returns its stable process exit category. */
+export function runCli(argv: readonly string[], dependencies: CliDependencies) {
+  return executeCli(argv, dependencies).pipe(
+    Effect.catchTags({
+      ApiResponseError: (error) =>
+        writeJson(dependencies.stderr, error.problem, false).pipe(
+          Effect.as(
+            error.status >= 500 ? NETWORK_OR_SERVER_EXIT_CODE : API_EXIT_CODE
+          )
+        ),
+      InvocationError: (error) =>
+        writeJson(
+          dependencies.stderr,
+          { code: "INVOCATION_ERROR", message: error.message },
+          false
+        ).pipe(Effect.as(INVOCATION_EXIT_CODE)),
+      HttpResponseError: (error) =>
+        writeJson(
+          dependencies.stderr,
+          {
+            code: "HTTP_RESPONSE_ERROR",
+            ...(error.retryAfter === undefined
+              ? {}
+              : { retry_after: error.retryAfter }),
+            status: error.status,
+          },
+          false
+        ).pipe(
+          Effect.as(
+            error.status >= 500 ? NETWORK_OR_SERVER_EXIT_CODE : API_EXIT_CODE
+          )
+        ),
+      NetworkError: (error) =>
+        writeJson(
+          dependencies.stderr,
+          { code: "NETWORK_ERROR", message: error.message },
+          false
+        ).pipe(Effect.as(NETWORK_OR_SERVER_EXIT_CODE)),
+      ResponseDecodeError: (error) =>
+        writeJson(
+          dependencies.stderr,
+          {
+            code: "INVALID_SERVER_RESPONSE",
+            message: error.message,
+            status: error.status,
+          },
+          false
+        ).pipe(Effect.as(NETWORK_OR_SERVER_EXIT_CODE)),
+    })
+  );
+}
+
+const executeCli = Effect.fn("NakafaCli.execute")(function* (
+  argv: readonly string[],
+  dependencies: CliDependencies
+) {
+  const request = yield* readCliRequest(argv);
+  const output = yield* executeCommand(request, dependencies);
+  if (output.kind === "text") {
+    yield* writeText(dependencies.stdout, String(output.value));
+    return 0;
+  }
+  yield* writeJson(dependencies.stdout, output.value, request.pretty);
+  return 0;
+});
+
+function executeCommand(
+  request: CliRequest,
+  dependencies: CliDependencies
+): Effect.Effect<
+  CliOutput,
+  ApiResponseError | HttpResponseError | NetworkError | ResponseDecodeError
+> {
+  const command = request.command;
+  if (command.kind === "help") {
+    return Effect.succeed({ kind: "text", value: HELP_TEXT });
+  }
+  if (command.kind === "version") {
+    return Effect.succeed({ kind: "text", value: `${dependencies.version}\n` });
+  }
+  if (command.kind === "mcp") {
+    return Effect.succeed({
+      kind: "json",
+      value: {
+        endpoint: NAKAFA_MCP_RECOMMENDED_ENDPOINT,
+        manifest: NAKAFA_MCP_RECOMMENDED_ENDPOINT,
+        protocol_version: NAKAFA_MCP_PROTOCOL_VERSION,
+        transport: "streamable-http",
+      },
+    });
+  }
+  return requestNakafaApi({
+    apiBase: request.apiBase,
+    fetchImplementation: dependencies.fetchImplementation,
+    path: buildApiPath(command),
+  }).pipe(Effect.map((value) => ({ kind: "json", value })));
+}
+
+function buildApiPath(
+  command: Exclude<CliCommand, { kind: "help" | "mcp" | "version" }>
+) {
+  if (command.kind === "get") {
+    const query = new URLSearchParams({ ref: command.ref });
+    return `/v1/content?${query}`;
+  }
+  if (command.kind === "taxonomy") {
+    const query = new URLSearchParams();
+    appendOptional(query, "locale", command.locale);
+    return withQuery("/v1/taxonomy", query);
+  }
+  if (command.kind === "quran") {
+    const query = new URLSearchParams();
+    appendOptional(query, "from_verse", command.fromVerse);
+    appendOptional(query, "to_verse", command.toVerse);
+    appendOptional(query, "locale", command.locale);
+    if (command.includeTafsir) {
+      query.set("include_tafsir", "true");
+    }
+    return withQuery(`/v1/quran/${command.surah}`, query);
+  }
+  const query = new URLSearchParams({ query: command.query });
+  appendOptional(query, "section", command.section);
+  appendOptional(query, "locale", command.locale);
+  appendOptional(query, "limit", command.limit);
+  appendOptional(query, "offset", command.offset);
+  return `/v1/search?${query}`;
+}
+
+function appendOptional(
+  query: URLSearchParams,
+  name: string,
+  value: number | string | undefined
+) {
+  if (value !== undefined) {
+    query.set(name, String(value));
+  }
+}
+
+function withQuery(path: string, query: URLSearchParams) {
+  const source = query.toString();
+  return source.length === 0 ? path : `${path}?${source}`;
+}
+
+function writeJson(
+  output: CliDependencies["stdout"],
+  value: unknown,
+  pretty: boolean
+) {
+  return writeText(output, `${JSON.stringify(value, null, pretty ? 2 : 0)}\n`);
+}
+
+function writeText(output: CliDependencies["stdout"], value: string) {
+  return Effect.sync(() => {
+    output.write(value);
+  });
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@repo/typescript-config/library.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/*": ["../*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"],
+  "exclude": ["coverage", "dist", "node_modules"]
+}

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,0 +1,13 @@
+import config from "@repo/testing/node";
+import { mergeConfig } from "vitest/config";
+
+export default mergeConfig(config, {
+  test: {
+    coverage: {
+      thresholds: {
+        100: true,
+        perFile: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,39 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@edge-runtime/vm@5.0.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/cli:
+    devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(redis@6.2.1)
+      '@repo/contents':
+        specifier: workspace:*
+        version: link:../contents
+      '@repo/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@vitest/coverage-istanbul':
+        specifier: ^4.1.11
+        version: 4.1.11(supports-color@7.2.0)(vitest@4.1.11)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110
+      esbuild:
+        specifier: 0.28.2
+        version: 0.28.2
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      vite:
+        specifier: ^8.2.2
+        version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
   packages/contents:
     dependencies:
       '@hugeicons/core-free-icons':

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -76,7 +76,7 @@ describe("GitHub Action policy", () => {
     }
     actionUses[setupIndex] = {
       ...setupUse,
-      inputs: { cache: false, install: false },
+      inputs: { cache: "unexpected", install: false },
     };
     actionUses.splice(setupIndex + 1, 1);
 
@@ -86,7 +86,7 @@ describe("GitHub Action policy", () => {
       true
     );
     expect(problems.some((problem) => problem.includes("cache"))).toBe(true);
-    expect(problems.some((problem) => problem.includes("expected 4"))).toBe(
+    expect(problems.some((problem) => problem.includes("expected 5"))).toBe(
       true
     );
   });

--- a/scripts/github-action-policy.ts
+++ b/scripts/github-action-policy.ts
@@ -32,7 +32,7 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     action: "actions/checkout",
     approvedSha: "3d3c42e5aac5ba805825da76410c181273ba90b1",
     expectedTag: "v7.0.1",
-    expectedUsages: 4,
+    expectedUsages: 5,
     reason: "Checkout is pinned to the latest reviewed stable release.",
   },
   {
@@ -40,7 +40,7 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     approvedSha: "84cb39b217b10273981911c288cd62326dc7c6d2",
     expectedInputs: { cache: "true", install: "false" },
     expectedTag: "v2.0.2",
-    expectedUsages: 4,
+    expectedUsages: 5,
     reason:
       "The signed successor action owns Node, pnpm, and dependency caching.",
   },


### PR DESCRIPTION
## Summary

Adds the official `nakafa-cli` package for Nakafa's public read-only REST API and MCP discovery contract. The standalone Node 24 executable uses typed Effect failures, strict command decoding, deterministic JSON output, and no internal edge credentials.

## Why

Aksara developer resources need one installable official CLI instead of documenting an unpublished command. The npm registry currently returns 404 for `nakafa-cli`, so no existing package or legacy interface needs preservation.

## Scope

- Search, content, taxonomy, Quran, and MCP metadata commands.
- Bundled runtime with no published workspace dependencies.
- Strict API response validation, edge failure handling, and rate-limit evidence.
- Truthful MCP metadata limited to the POST endpoint, protocol revision, and transport. No false GET manifest field remains.
- Tarball allowlist plus real pack, install, help, and version smoke coverage.
- One changeset and a protected-main-only npm publish workflow.

## Exact-head verification

Exact head: `2c2452e8e8`. Local CLI typecheck, build, lint, Effect RC110 source identity, 43 tests, and statement, branch, function, and line coverage are green at 100%. The real pack-install-executable smoke is green. The prior exact-head Production job, signed build/start, Browser, AFDocs, runtime verification, and cleanup were green. Quality exposed the pack smoke exceeding Vitest's default 5-second budget under full CI concurrency at 5.013 seconds; the test now uses the installed Effect Vitest per-test timeout contract with a bounded 30-second integration budget. Fresh exact-head Required and Doctor restarted after deletion of the stale MCP manifest field.

## Rollout state

No Vercel Preview, manual production deployment, Convex write, or npm publication is part of this PR. The first `0.1.0` publication needs one temporary npm bootstrap token because npm trusted publishing requires an existing package. Immediately after the first publication, this workflow becomes the trusted publisher and both `NPM_BOOTSTRAP_TOKEN` and its bootstrap authentication step are deleted. That cleanup is part of this rollout.

## Risks

The CLI depends only on current public REST and MCP contracts. Non-JSON edge failures preserve status and optional `Retry-After` without echoing HTML, while malformed claimed JSON fails closed. The package allowlist excludes source, tests, workspace files, and coverage artifacts.
