### PR TITLE
feat(content): cut over article publication dates

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -272,7 +272,6 @@ import type * as contentRelease_quran_document from "../contentRelease/quran/doc
 import type * as contentRelease_quran_facts from "../contentRelease/quran/facts.js";
 import type * as contentRelease_quran_input from "../contentRelease/quran/input.js";
 import type * as contentRelease_quran_interpretation from "../contentRelease/quran/interpretation.js";
-import type * as contentRelease_quran_legacy from "../contentRelease/quran/legacy.js";
 import type * as contentRelease_quran_limits from "../contentRelease/quran/limits.js";
 import type * as contentRelease_quran_markdown from "../contentRelease/quran/markdown.js";
 import type * as contentRelease_quran_owner from "../contentRelease/quran/owner.js";
@@ -282,7 +281,6 @@ import type * as contentRelease_quran_sources from "../contentRelease/quran/sour
 import type * as contentRelease_quran_spec from "../contentRelease/quran/spec.js";
 import type * as contentRelease_quran_surah from "../contentRelease/quran/surah.js";
 import type * as contentRelease_quran_translation from "../contentRelease/quran/translation.js";
-import type * as contentRelease_quran_v1 from "../contentRelease/quran/v1.js";
 import type * as contentRelease_quran_verify from "../contentRelease/quran/verify.js";
 import type * as contentRelease_quran_view from "../contentRelease/quran/view.js";
 import type * as contentRelease_receipt from "../contentRelease/receipt.js";
@@ -867,7 +865,6 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/quran/facts": typeof contentRelease_quran_facts;
   "contentRelease/quran/input": typeof contentRelease_quran_input;
   "contentRelease/quran/interpretation": typeof contentRelease_quran_interpretation;
-  "contentRelease/quran/legacy": typeof contentRelease_quran_legacy;
   "contentRelease/quran/limits": typeof contentRelease_quran_limits;
   "contentRelease/quran/markdown": typeof contentRelease_quran_markdown;
   "contentRelease/quran/owner": typeof contentRelease_quran_owner;
@@ -877,7 +874,6 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/quran/spec": typeof contentRelease_quran_spec;
   "contentRelease/quran/surah": typeof contentRelease_quran_surah;
   "contentRelease/quran/translation": typeof contentRelease_quran_translation;
-  "contentRelease/quran/v1": typeof contentRelease_quran_v1;
   "contentRelease/quran/verify": typeof contentRelease_quran_verify;
   "contentRelease/quran/view": typeof contentRelease_quran_view;
   "contentRelease/receipt": typeof contentRelease_receipt;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -140,6 +140,9 @@ import type * as contentRelease_article_agent from "../contentRelease/article/ag
 import type * as contentRelease_article_bucket from "../contentRelease/article/bucket.js";
 import type * as contentRelease_article_category from "../contentRelease/article/category.js";
 import type * as contentRelease_article_cursor from "../contentRelease/article/cursor.js";
+import type * as contentRelease_article_cutover_internal from "../contentRelease/article/cutover/internal.js";
+import type * as contentRelease_article_cutover_model from "../contentRelease/article/cutover/model.js";
+import type * as contentRelease_article_cutover_spec from "../contentRelease/article/cutover/spec.js";
 import type * as contentRelease_article_dates from "../contentRelease/article/dates.js";
 import type * as contentRelease_article_discovery from "../contentRelease/article/discovery.js";
 import type * as contentRelease_article_internal from "../contentRelease/article/internal.js";
@@ -269,6 +272,7 @@ import type * as contentRelease_quran_document from "../contentRelease/quran/doc
 import type * as contentRelease_quran_facts from "../contentRelease/quran/facts.js";
 import type * as contentRelease_quran_input from "../contentRelease/quran/input.js";
 import type * as contentRelease_quran_interpretation from "../contentRelease/quran/interpretation.js";
+import type * as contentRelease_quran_legacy from "../contentRelease/quran/legacy.js";
 import type * as contentRelease_quran_limits from "../contentRelease/quran/limits.js";
 import type * as contentRelease_quran_markdown from "../contentRelease/quran/markdown.js";
 import type * as contentRelease_quran_owner from "../contentRelease/quran/owner.js";
@@ -278,6 +282,7 @@ import type * as contentRelease_quran_sources from "../contentRelease/quran/sour
 import type * as contentRelease_quran_spec from "../contentRelease/quran/spec.js";
 import type * as contentRelease_quran_surah from "../contentRelease/quran/surah.js";
 import type * as contentRelease_quran_translation from "../contentRelease/quran/translation.js";
+import type * as contentRelease_quran_v1 from "../contentRelease/quran/v1.js";
 import type * as contentRelease_quran_verify from "../contentRelease/quran/verify.js";
 import type * as contentRelease_quran_view from "../contentRelease/quran/view.js";
 import type * as contentRelease_receipt from "../contentRelease/receipt.js";
@@ -730,6 +735,9 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/article/bucket": typeof contentRelease_article_bucket;
   "contentRelease/article/category": typeof contentRelease_article_category;
   "contentRelease/article/cursor": typeof contentRelease_article_cursor;
+  "contentRelease/article/cutover/internal": typeof contentRelease_article_cutover_internal;
+  "contentRelease/article/cutover/model": typeof contentRelease_article_cutover_model;
+  "contentRelease/article/cutover/spec": typeof contentRelease_article_cutover_spec;
   "contentRelease/article/dates": typeof contentRelease_article_dates;
   "contentRelease/article/discovery": typeof contentRelease_article_discovery;
   "contentRelease/article/internal": typeof contentRelease_article_internal;
@@ -859,6 +867,7 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/quran/facts": typeof contentRelease_quran_facts;
   "contentRelease/quran/input": typeof contentRelease_quran_input;
   "contentRelease/quran/interpretation": typeof contentRelease_quran_interpretation;
+  "contentRelease/quran/legacy": typeof contentRelease_quran_legacy;
   "contentRelease/quran/limits": typeof contentRelease_quran_limits;
   "contentRelease/quran/markdown": typeof contentRelease_quran_markdown;
   "contentRelease/quran/owner": typeof contentRelease_quran_owner;
@@ -868,6 +877,7 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/quran/spec": typeof contentRelease_quran_spec;
   "contentRelease/quran/surah": typeof contentRelease_quran_surah;
   "contentRelease/quran/translation": typeof contentRelease_quran_translation;
+  "contentRelease/quran/v1": typeof contentRelease_quran_v1;
   "contentRelease/quran/verify": typeof contentRelease_quran_verify;
   "contentRelease/quran/view": typeof contentRelease_quran_view;
   "contentRelease/receipt": typeof contentRelease_receipt;

--- a/packages/backend/convex/contentRelease/article.test.ts
+++ b/packages/backend/convex/contentRelease/article.test.ts
@@ -117,7 +117,18 @@ describe("contentRelease/article", () => {
 
   it("continues an in-flight predecessor article cursor", async () => {
     const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) => insertRuntimeArticles(ctx, 3));
+    await t.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 3);
+      const rows = await ctx.db.query("articleCatalog").collect();
+      for (const row of rows) {
+        if (!("datePublished" in row)) {
+          throw new Error("Expected one current article date shape.");
+        }
+        await ctx.db.patch("articleCatalog", row._id, {
+          date: row.datePublished,
+        });
+      }
+    });
     const stored = await t.run((ctx) =>
       ctx.db.query("articleCatalog").collect()
     );

--- a/packages/backend/convex/contentRelease/article/cutover/internal.test.ts
+++ b/packages/backend/convex/contentRelease/article/cutover/internal.test.ts
@@ -1,0 +1,62 @@
+import type {
+  ArticleDateCutoverReceipt,
+  ArticleDateCutoverRequest,
+  ArticleDateCutoverStatus,
+} from "@repo/backend/convex/contentRelease/article/cutover/spec";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { insertRuntimeArticles } from "@repo/backend/test/content-runtime";
+import { TEST_RUNTIME_RELEASE } from "@repo/backend/test/runtime-values";
+import { makeFunctionReference } from "convex/server";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+const REQUEST = {
+  expectedManifestHash: TEST_RUNTIME_RELEASE.manifestHash,
+  expectedReleaseId: TEST_RUNTIME_RELEASE.releaseId,
+  expectedSequence: TEST_RUNTIME_RELEASE.sequence,
+} satisfies ArticleDateCutoverRequest;
+
+const statusReference = makeFunctionReference<
+  "query",
+  ArticleDateCutoverRequest,
+  ArticleDateCutoverStatus
+>("contentRelease/article/cutover/internal:status");
+const removeReference = makeFunctionReference<
+  "mutation",
+  ArticleDateCutoverRequest,
+  ArticleDateCutoverReceipt
+>("contentRelease/article/cutover/internal:removeLegacyDate");
+const restoreReference = makeFunctionReference<
+  "mutation",
+  ArticleDateCutoverRequest,
+  ArticleDateCutoverReceipt
+>("contentRelease/article/cutover/internal:restoreLegacyDate");
+
+describe("contentRelease/article/cutover/internal", () => {
+  it("registers exact status, removal, and inverse boundaries", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 1);
+      const row = await ctx.db.query("articleCatalog").unique();
+      if (!(row && "datePublished" in row)) {
+        throw new Error("Expected one current article date.");
+      }
+      await ctx.db.patch("articleCatalog", row._id, {
+        date: row.datePublished,
+      });
+    });
+
+    await expect(t.query(statusReference, REQUEST)).resolves.toMatchObject({
+      counts: { currentOnly: 0, dual: 1, legacyOnly: 0, total: 1 },
+    });
+    await expect(t.mutation(removeReference, REQUEST)).resolves.toMatchObject({
+      changed: 1,
+      operation: "remove",
+    });
+    await expect(t.mutation(restoreReference, REQUEST)).resolves.toMatchObject({
+      changed: 1,
+      operation: "restore",
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/article/cutover/internal.ts
+++ b/packages/backend/convex/contentRelease/article/cutover/internal.ts
@@ -1,0 +1,37 @@
+import {
+  internalMutation,
+  internalQuery,
+} from "@repo/backend/convex/_generated/server";
+import {
+  readArticleDateCutover,
+  removeLegacyArticleDates,
+  restoreLegacyArticleDates,
+} from "@repo/backend/convex/contentRelease/article/cutover/model";
+import {
+  articleDateCutoverReceiptValidator,
+  articleDateCutoverRequestValidator,
+  articleDateCutoverStatusValidator,
+} from "@repo/backend/convex/contentRelease/article/cutover/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+
+/** Inspects the identity-bound article date transition state. */
+export const status = internalQuery({
+  args: articleDateCutoverRequestValidator.fields,
+  returns: articleDateCutoverStatusValidator,
+  handler: (ctx, args) => runConvexProgram(readArticleDateCutover(ctx, args)),
+});
+
+/** Removes every verified bridge date in one bounded transaction. */
+export const removeLegacyDate = internalMutation({
+  args: articleDateCutoverRequestValidator.fields,
+  returns: articleDateCutoverReceiptValidator,
+  handler: (ctx, args) => runConvexProgram(removeLegacyArticleDates(ctx, args)),
+});
+
+/** Restores bridge dates only while the strict cutover is reversible. */
+export const restoreLegacyDate = internalMutation({
+  args: articleDateCutoverRequestValidator.fields,
+  returns: articleDateCutoverReceiptValidator,
+  handler: (ctx, args) =>
+    runConvexProgram(restoreLegacyArticleDates(ctx, args)),
+});

--- a/packages/backend/convex/contentRelease/article/cutover/model.test.ts
+++ b/packages/backend/convex/contentRelease/article/cutover/model.test.ts
@@ -1,0 +1,204 @@
+import {
+  readArticleDateCutover,
+  removeLegacyArticleDates,
+  restoreLegacyArticleDates,
+} from "@repo/backend/convex/contentRelease/article/cutover/model";
+import { ARTICLE_DATE_CUTOVER_LIMIT } from "@repo/backend/convex/contentRelease/article/cutover/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  insertRuntimeArticles,
+  insertRuntimeRelease,
+} from "@repo/backend/test/content-runtime";
+import { TEST_RUNTIME_RELEASE } from "@repo/backend/test/runtime-values";
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const REQUEST = {
+  expectedManifestHash: TEST_RUNTIME_RELEASE.manifestHash,
+  expectedReleaseId: TEST_RUNTIME_RELEASE.releaseId,
+  expectedSequence: TEST_RUNTIME_RELEASE.sequence,
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("contentRelease/article/cutover/model", () => {
+  it("removes and restores exact dual-written dates idempotently", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 7, 27, 12));
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 2);
+      for (const row of await ctx.db.query("articleCatalog").take(2)) {
+        if (!("datePublished" in row)) {
+          throw new Error("Expected one current article date.");
+        }
+        await ctx.db.patch("articleCatalog", row._id, {
+          date: row.datePublished,
+        });
+      }
+    });
+
+    await expect(
+      t.run((ctx) => runConvexProgram(readArticleDateCutover(ctx, REQUEST)))
+    ).resolves.toMatchObject({
+      active: {
+        manifestHash: REQUEST.expectedManifestHash,
+        releaseId: REQUEST.expectedReleaseId,
+        sequence: REQUEST.expectedSequence,
+      },
+      counts: { currentOnly: 0, dual: 2, legacyOnly: 0, total: 2 },
+    });
+
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(removeLegacyArticleDates(ctx, REQUEST))
+      )
+    ).resolves.toMatchObject({
+      changed: 2,
+      counts: { currentOnly: 2, dual: 0, legacyOnly: 0, total: 2 },
+      executedAt: Date.UTC(2026, 7, 27, 12),
+      operation: "remove",
+      unchanged: 0,
+    });
+    const current = await t.run((ctx) =>
+      ctx.db.query("articleCatalog").take(2)
+    );
+    expect(current.every((row) => !("date" in row))).toBe(true);
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(removeLegacyArticleDates(ctx, REQUEST))
+      )
+    ).resolves.toMatchObject({ changed: 0, unchanged: 2 });
+
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(restoreLegacyArticleDates(ctx, REQUEST))
+      )
+    ).resolves.toMatchObject({
+      changed: 2,
+      counts: { currentOnly: 0, dual: 2, legacyOnly: 0, total: 2 },
+      operation: "restore",
+      unchanged: 0,
+    });
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(restoreLegacyArticleDates(ctx, REQUEST))
+      )
+    ).resolves.toMatchObject({ changed: 0, unchanged: 2 });
+  });
+
+  it("fails closed for release drift, staged work, and unsafe dates", async () => {
+    const drift = convexTest(schema, convexModules);
+    await drift.mutation((ctx) => insertRuntimeArticles(ctx, 1));
+    await expect(
+      drift.run((ctx) =>
+        runConvexProgram(
+          readArticleDateCutover(ctx, {
+            ...REQUEST,
+            expectedSequence: REQUEST.expectedSequence + 1,
+          })
+        )
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_STATE" } });
+
+    const staged = convexTest(schema, convexModules);
+    await staged.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 1);
+      const state = await ctx.db.query("contentState").unique();
+      if (!state) {
+        throw new Error("Expected one content state.");
+      }
+      await ctx.db.patch("contentState", state._id, {
+        candidateManifestHash: `sha256:${"a".repeat(64)}`,
+        candidateReleaseId: "release-candidate",
+        candidateSequence: REQUEST.expectedSequence + 1,
+      });
+    });
+    await expect(
+      staged.run((ctx) =>
+        runConvexProgram(readArticleDateCutover(ctx, REQUEST))
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_STATE" } });
+
+    const legacy = convexTest(schema, convexModules);
+    await legacy.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 1);
+      const row = await ctx.db.query("articleCatalog").unique();
+      if (!(row && "datePublished" in row)) {
+        throw new Error("Expected one current article date.");
+      }
+      const {
+        _creationTime,
+        _id,
+        date: _date,
+        dateModified: _dateModified,
+        datePublished,
+        ...legacyFields
+      } = row;
+      await ctx.db.replace("articleCatalog", row._id, {
+        ...legacyFields,
+        date: datePublished,
+      });
+    });
+    await expect(
+      legacy.mutation((ctx) =>
+        runConvexProgram(removeLegacyArticleDates(ctx, REQUEST))
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_INTEGRITY" } });
+
+    const conflict = convexTest(schema, convexModules);
+    await conflict.mutation(async (ctx) => {
+      await insertRuntimeArticles(ctx, 1);
+      const row = await ctx.db.query("articleCatalog").unique();
+      if (!row) {
+        throw new Error("Expected one current article date.");
+      }
+      await ctx.db.patch("articleCatalog", row._id, { date: "2020-01-01" });
+    });
+    await expect(
+      conflict.run((ctx) =>
+        runConvexProgram(readArticleDateCutover(ctx, REQUEST))
+      )
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_INTEGRITY" } });
+  });
+
+  it("rejects a catalog larger than the atomic transaction bound", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      const state = await ctx.db.query("contentState").unique();
+      if (!state) {
+        throw new Error("Expected one content state.");
+      }
+      await ctx.db.patch("contentState", state._id, {
+        articleManifestHash: TEST_RUNTIME_RELEASE.manifestHash,
+        articleReleaseId: TEST_RUNTIME_RELEASE.releaseId,
+        articleSequence: TEST_RUNTIME_RELEASE.sequence,
+      });
+      for (let index = 0; index <= ARTICLE_DATE_CUTOVER_LIMIT; index += 1) {
+        await ctx.db.insert("articleCatalog", {
+          appLocale: "en",
+          assetId: `article-${index}`,
+          bucket: "aaa",
+          category: "politics",
+          categoryTitle: "Politics",
+          contentKey: `articles/politics/${index}`,
+          datePublished: "2026-08-22",
+          projectionHash: `sha256:${index.toString(16).padStart(64, "0")}`,
+          publicPath: `articles/politics/${index}`,
+          releaseId: TEST_RUNTIME_RELEASE.releaseId,
+          rendererDomain: "politics",
+          sequence: TEST_RUNTIME_RELEASE.sequence,
+        });
+      }
+    });
+
+    await expect(
+      t.run((ctx) => runConvexProgram(readArticleDateCutover(ctx, REQUEST)))
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_LIMIT" } });
+  });
+});

--- a/packages/backend/convex/contentRelease/article/cutover/model.ts
+++ b/packages/backend/convex/contentRelease/article/cutover/model.ts
@@ -1,0 +1,193 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import {
+  ARTICLE_DATE_CUTOVER_LIMIT,
+  type ArticleDateCutoverCounts,
+  type ArticleDateCutoverIdentity,
+  type ArticleDateCutoverReceipt,
+  type ArticleDateCutoverRequest,
+  type ArticleDateCutoverStatus,
+} from "@repo/backend/convex/contentRelease/article/cutover/spec";
+import { readArticleDates } from "@repo/backend/convex/contentRelease/article/dates";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadState } from "@repo/backend/convex/contentRelease/model";
+import { Clock, Effect } from "effect";
+
+type ReadCtx = MutationCtx | QueryCtx;
+type ArticleRow = Doc<"articleCatalog">;
+type CurrentArticleRow = Extract<ArticleRow, { datePublished: string }>;
+
+/** Requires one idle publication state at the caller's exact active identity. */
+const loadCutoverIdentity = Effect.fn(
+  "contentRelease.article.cutover.loadIdentity"
+)(function* (ctx: ReadCtx, expected: ArticleDateCutoverRequest) {
+  const state = yield* loadState(ctx);
+  if (
+    !state ||
+    state.activeManifestHash !== expected.expectedManifestHash ||
+    state.activeReleaseId !== expected.expectedReleaseId ||
+    state.activeSequence !== expected.expectedSequence ||
+    state.articleManifestHash !== expected.expectedManifestHash ||
+    state.articleReleaseId !== expected.expectedReleaseId ||
+    state.articleSequence !== expected.expectedSequence
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Article date cutover does not own the exact active article release."
+    );
+  }
+  if (
+    state.candidateManifestHash !== undefined ||
+    state.candidateReleaseId !== undefined ||
+    state.candidateSequence !== undefined ||
+    state.recoveryManifestHash !== undefined ||
+    state.recoveryReleaseId !== undefined ||
+    state.recoverySequence !== undefined
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Article date cutover requires empty candidate and recovery slots."
+    );
+  }
+  return {
+    manifestHash: state.activeManifestHash,
+    releaseId: state.activeReleaseId,
+    sequence: state.activeSequence,
+  } satisfies ArticleDateCutoverIdentity;
+});
+
+/** Reads the complete small article catalog or fails before any write. */
+const loadCutoverRows = Effect.fn("contentRelease.article.cutover.loadRows")(
+  function* (ctx: ReadCtx) {
+    const rows = yield* Effect.promise(() =>
+      ctx.db.query("articleCatalog").take(ARTICLE_DATE_CUTOVER_LIMIT + 1)
+    );
+    if (rows.length > ARTICLE_DATE_CUTOVER_LIMIT) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_LIMIT",
+        `Article date cutover exceeds ${ARTICLE_DATE_CUTOVER_LIMIT} rows.`
+      );
+    }
+    return rows;
+  }
+);
+
+/** Validates every date pair before classifying the transition state. */
+const classifyRows = Effect.fn("contentRelease.article.cutover.classifyRows")(
+  function* (rows: readonly ArticleRow[]) {
+    yield* Effect.forEach(rows, readArticleDates);
+    let currentOnly = 0;
+    let dual = 0;
+    let legacyOnly = 0;
+    for (const row of rows) {
+      if (!("datePublished" in row)) {
+        legacyOnly += 1;
+      } else if (row.date === undefined) {
+        currentOnly += 1;
+      } else {
+        dual += 1;
+      }
+    }
+    return {
+      currentOnly,
+      dual,
+      legacyOnly,
+      total: rows.length,
+    } satisfies ArticleDateCutoverCounts;
+  }
+);
+
+/** Loads one identity-bound, fully validated migration snapshot. */
+const loadCutover = Effect.fn("contentRelease.article.cutover.load")(function* (
+  ctx: ReadCtx,
+  expected: ArticleDateCutoverRequest
+) {
+  const active = yield* loadCutoverIdentity(ctx, expected);
+  const rows = yield* loadCutoverRows(ctx);
+  const counts = yield* classifyRows(rows);
+  return { active, counts, rows };
+});
+
+/** Refuses to guess a publication date for an unconverted legacy row. */
+const requireCurrentDates = Effect.fn(
+  "contentRelease.article.cutover.requireCurrentDates"
+)(function* (rows: readonly ArticleRow[], counts: ArticleDateCutoverCounts) {
+  if (counts.legacyOnly > 0) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Article date cutover found rows without datePublished."
+    );
+  }
+  return rows.filter((row): row is CurrentArticleRow => "datePublished" in row);
+});
+
+/** Returns the exact current storage shape without deriving transient time. */
+export const readArticleDateCutover = Effect.fn(
+  "contentRelease.article.cutover.status"
+)(function* (ctx: ReadCtx, expected: ArticleDateCutoverRequest) {
+  const { active, counts } = yield* loadCutover(ctx, expected);
+  return { active, counts } satisfies ArticleDateCutoverStatus;
+});
+
+/** Removes the bridge date atomically after all rows prove current dates. */
+export const removeLegacyArticleDates = Effect.fn(
+  "contentRelease.article.cutover.remove"
+)(function* (ctx: MutationCtx, expected: ArticleDateCutoverRequest) {
+  const { active, counts, rows } = yield* loadCutover(ctx, expected);
+  const currentRows = yield* requireCurrentDates(rows, counts);
+  for (const row of currentRows) {
+    if (row.date !== undefined) {
+      yield* Effect.promise(() =>
+        ctx.db.patch("articleCatalog", row._id, { date: undefined })
+      );
+    }
+  }
+  const executedAt = yield* Clock.currentTimeMillis;
+  return {
+    active,
+    changed: counts.dual,
+    counts: {
+      currentOnly: counts.total,
+      dual: 0,
+      legacyOnly: 0,
+      total: counts.total,
+    },
+    executedAt,
+    operation: "remove",
+    unchanged: counts.currentOnly,
+  } satisfies ArticleDateCutoverReceipt;
+});
+
+/** Restores the exact bridge value for rollback before strict contraction. */
+export const restoreLegacyArticleDates = Effect.fn(
+  "contentRelease.article.cutover.restore"
+)(function* (ctx: MutationCtx, expected: ArticleDateCutoverRequest) {
+  const { active, counts, rows } = yield* loadCutover(ctx, expected);
+  const currentRows = yield* requireCurrentDates(rows, counts);
+  for (const row of currentRows) {
+    if (row.date === undefined) {
+      yield* Effect.promise(() =>
+        ctx.db.patch("articleCatalog", row._id, {
+          date: row.datePublished,
+        })
+      );
+    }
+  }
+  const executedAt = yield* Clock.currentTimeMillis;
+  return {
+    active,
+    changed: counts.currentOnly,
+    counts: {
+      currentOnly: 0,
+      dual: counts.total,
+      legacyOnly: 0,
+      total: counts.total,
+    },
+    executedAt,
+    operation: "restore",
+    unchanged: counts.dual,
+  } satisfies ArticleDateCutoverReceipt;
+});

--- a/packages/backend/convex/contentRelease/article/cutover/spec.ts
+++ b/packages/backend/convex/contentRelease/article/cutover/spec.ts
@@ -1,0 +1,57 @@
+import { EXACT_SCOPE_LIMIT } from "@repo/backend/convex/contentRelease/spec";
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+import { literals } from "convex-helpers/validators";
+
+/** Maximum article rows owned by the one-time atomic date cutover. */
+export const ARTICLE_DATE_CUTOVER_LIMIT = EXACT_SCOPE_LIMIT;
+
+/** Exact active publication identity required by every cutover operation. */
+export const articleDateCutoverRequestValidator = v.object({
+  expectedManifestHash: v.string(),
+  expectedReleaseId: v.string(),
+  expectedSequence: v.number(),
+});
+export type ArticleDateCutoverRequest = Infer<
+  typeof articleDateCutoverRequestValidator
+>;
+
+const articleDateCutoverIdentityValidator = v.object({
+  manifestHash: v.string(),
+  releaseId: v.string(),
+  sequence: v.number(),
+});
+export type ArticleDateCutoverIdentity = Infer<
+  typeof articleDateCutoverIdentityValidator
+>;
+
+const articleDateCutoverCountsValidator = v.object({
+  currentOnly: v.number(),
+  dual: v.number(),
+  legacyOnly: v.number(),
+  total: v.number(),
+});
+export type ArticleDateCutoverCounts = Infer<
+  typeof articleDateCutoverCountsValidator
+>;
+
+/** Server-derived article storage state for the selected publication. */
+export const articleDateCutoverStatusValidator = v.object({
+  active: articleDateCutoverIdentityValidator,
+  counts: articleDateCutoverCountsValidator,
+});
+export type ArticleDateCutoverStatus = Infer<
+  typeof articleDateCutoverStatusValidator
+>;
+
+/** Atomic mutation receipt retained by the external rollout record. */
+export const articleDateCutoverReceiptValidator =
+  articleDateCutoverStatusValidator.extend({
+    changed: v.number(),
+    executedAt: v.number(),
+    operation: literals("remove", "restore"),
+    unchanged: v.number(),
+  });
+export type ArticleDateCutoverReceipt = Infer<
+  typeof articleDateCutoverReceiptValidator
+>;

--- a/packages/backend/convex/contentRelease/article/dates.test.ts
+++ b/packages/backend/convex/contentRelease/article/dates.test.ts
@@ -18,6 +18,12 @@ describe("contentRelease/article/dates", () => {
     await expect(Effect.runPromise(readArticleDates(row))).resolves.toEqual({
       datePublished: row.datePublished,
     });
+    const { date: _date, ...current } = row;
+    await expect(Effect.runPromise(readArticleDates(current))).resolves.toEqual(
+      {
+        datePublished: row.datePublished,
+      }
+    );
     await expect(
       Effect.runPromise(readArticleDates({ ...row, date: "2020-01-01" }))
     ).rejects.toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });

--- a/packages/backend/convex/contentRelease/article/dates.ts
+++ b/packages/backend/convex/contentRelease/article/dates.ts
@@ -3,10 +3,14 @@ import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { normalizePublicationDates } from "@repo/contents/_types/publication";
 import { Effect } from "effect";
 
-/** Validates and normalizes one legacy or dual-written article date row. */
+/** Validates and normalizes one transition article date row. */
 export const readArticleDates = Effect.fn("contentRelease.readArticleDates")(
   function* (row: Doc<"articleCatalog">) {
-    if ("datePublished" in row && row.date !== row.datePublished) {
+    if (
+      "datePublished" in row &&
+      row.date !== undefined &&
+      row.date !== row.datePublished
+    ) {
       return yield* releaseFail(
         "CONTENT_RELEASE_INTEGRITY",
         `Article ${row.contentKey}/${row.appLocale} has contradictory bridge dates.`

--- a/packages/backend/convex/contentRelease/article/order.test.ts
+++ b/packages/backend/convex/contentRelease/article/order.test.ts
@@ -15,12 +15,32 @@ import { convexTest } from "convex-test";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
+/** Preserves the worst-case duplicate-index bridge fixture after current writes. */
+async function insertTransitionArticles(
+  ctx: Parameters<typeof insertRuntimeArticles>[0],
+  count: number,
+  projectionAt: Parameters<
+    typeof insertRuntimeArticles
+  >[2] = testArticleProjection
+) {
+  await insertRuntimeArticles(ctx, count, projectionAt);
+  const rows = await ctx.db.query("articleCatalog").collect();
+  for (const row of rows) {
+    if (!("datePublished" in row)) {
+      throw new Error("Expected one current article date shape.");
+    }
+    await ctx.db.patch("articleCatalog", row._id, {
+      date: row.datePublished,
+    });
+  }
+}
+
 describe("contentRelease/article/order", () => {
   it("returns one full page without a false split boundary", async () => {
     const t = convexTest(schema, convexModules);
     const articleCount = PROJECTION_PAGE_LIMIT + 2;
     await t.mutation((ctx) =>
-      insertRuntimeArticles(ctx, articleCount, (index) =>
+      insertTransitionArticles(ctx, articleCount, (index) =>
         testArticleProjection(index, "2026-07-23")
       )
     );
@@ -77,7 +97,7 @@ describe("contentRelease/article/order", () => {
 
   it("bounds merged lookahead by physical rows and bytes", async () => {
     const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) => insertRuntimeArticles(ctx, 3));
+    await t.mutation((ctx) => insertTransitionArticles(ctx, 3));
 
     const rowBound = await t.query(async (ctx) => {
       const result = await Effect.runPromise(

--- a/packages/backend/convex/contentRelease/article/schema.ts
+++ b/packages/backend/convex/contentRelease/article/schema.ts
@@ -26,7 +26,7 @@ const tables = {
       v.object({ ...articleFields, date: v.string() }),
       v.object({
         ...articleFields,
-        date: v.string(),
+        date: v.optional(v.string()),
         dateModified: v.optional(v.string()),
         datePublished: v.string(),
       })

--- a/packages/backend/convex/contentRelease/article/write.test.ts
+++ b/packages/backend/convex/contentRelease/article/write.test.ts
@@ -84,11 +84,11 @@ describe("contentRelease/article/write", () => {
     expect(rows[0]).toMatchObject({
       assetId: TEST_ARTICLE_PROJECTION.graph.assetId,
       categoryTitle: "Public Affairs",
-      date: TEST_ARTICLE_PROJECTION.metadata.datePublished,
       dateModified: "2026-07-24",
       datePublished: TEST_ARTICLE_PROJECTION.metadata.datePublished,
       sequence: 2,
     });
+    expect(rows[0]).not.toHaveProperty("date");
     expect(stored.categories).toHaveLength(1);
     expect(stored.categories[0]).toMatchObject({
       bucket: "444",
@@ -149,12 +149,15 @@ describe("contentRelease/article/write", () => {
     ).resolves.toMatchObject({
       articles: [
         {
-          date: TEST_ARTICLE_PROJECTION.metadata.datePublished,
           datePublished: TEST_ARTICLE_PROJECTION.metadata.datePublished,
         },
       ],
       categories: [{ category: "politics" }],
     });
+    const [article] = await t.run((ctx) =>
+      ctx.db.query("articleCatalog").take(1)
+    );
+    expect(article).not.toHaveProperty("date");
     await t.mutation((ctx) =>
       runConvexProgram(
         deleteArticle(

--- a/packages/backend/convex/contentRelease/article/write.ts
+++ b/packages/backend/convex/contentRelease/article/write.ts
@@ -56,7 +56,6 @@ export const writeArticle = Effect.fn("contentRelease.writeArticle")(function* (
     categoryTitle: projection.categoryTitle,
     contentKey: head.contentKey,
     ...dates,
-    date: dates.datePublished,
     projectionHash: head.projectionHash,
     publicPath: projection.publicPath,
     releaseId: head.releaseId,

--- a/packages/backend/scripts/content-runtime/tables.test.ts
+++ b/packages/backend/scripts/content-runtime/tables.test.ts
@@ -14,7 +14,7 @@ import { v } from "convex/values";
 import { Effect } from "effect";
 
 const EXPECTED_RUNTIME_SCHEMA_FINGERPRINT =
-  "55954ab66f0d953ce2bf62a6f63b7a58488ca903a279ade4e93de61b1a31a83e";
+  "9f0f733f9336b64d4076f48d49eb848354b4952410af30560d65a92bf1361d80";
 
 describe("content runtime tables", () => {
   it.live(


### PR DESCRIPTION
## Summary

Moves article catalog writes to the truthful current date shape: required `datePublished`, optional `dateModified`, and no newly written legacy `date`. Adds one bounded, identity-locked production removal operation and its exact inverse.

## Why

Nakafa already serves current signed article projections, but production still contains 21 dual-written article catalog rows. The temporary `date` field must be removed before Aksara can publish a strict current-only contract and Nakafa can delete every compatibility reader and index.

## Scope

- Make all new article writes current-only.
- Accept current-only rows while rejecting contradictory bridge values.
- Scan at most 64 article rows, using one 65th-row overflow probe, and require the exact active article release with empty candidate and recovery slots.
- Remove legacy dates atomically and restore only the exact `datePublished` value through the inverse.
- Register only status, removal, and inverse internal functions.
- Preserve worst-case duplicate-index transition tests and generated Convex function declarations.
- Regenerate declarations after the latest main integration so no removed Quran function remains.

## Exact-head verification

Exact head `74e81fe2adfa401af3b9110428f9742b883aed4b` is based directly on protected main `a39dfe217e9feac9a05787d300bc6dce6fa21ae3`. All five commits are patch-identical across the current-main rebase. Focused cutover tests pass, the full backend suite passes 348 files and 1,506 tests, and the post-rebase generated surface passes backend typecheck. Repository lint, security audit, Effect RC110 source identity, diff checks, import checks, and touched handwritten module limits pass. Exact-head CI run `33113241310` is green for Quality, Production Scope, Production, and Required, including signed build and start, browser acceptance, AFDocs, final runtime verification, and cleanup. Exact-head Doctor run `33113241300` is green.

## Rollout state

No production write has been executed from this PR. Current production evidence shows active release `quran-sources-345c5fe5` at sequence 15, no candidate or recovery, 21 article rows with matching bridge and current dates, and zero observed predecessor singular or batch reads. The user explicitly selected immediate contraction instead of a fixed waiting interval. After protected merge and exact-main Convex deployment verification, the rollout will execute status, removal, current-only EN/ID/DE verification, inverse restoration proof, final removal, and then the strict Aksara and Nakafa cleanup. Vercel Preview remains prohibited.

## Material risks

An old unobserved reader could still depend on the legacy field. The operation therefore fails closed on release identity drift, slot occupancy, row count, malformed dates, or contradictory bridge values, and retains an exact inverse until strict current-only verification succeeds. Final cleanup must delete the legacy schema branch, indexes, readers, adapters, observer, migration functions, compatibility dependencies, and their tests.