### PR TITLE
fix(www): isolate Vercel typechecking

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -19,6 +19,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 import { AGENT_DISCOVERY_HEADERS } from "@/lib/agent-discovery";
 import { hasPreviewRendererEnvironment } from "@/lib/content/preview/environment";
 import { createOgRouteAliasRewrites } from "@/lib/og/route";
+import { hasIsolatedTypecheck } from "@/vercel";
 
 const configEnv = createEnv({
   extends: [analyzeKeys(), convexKeys()],
@@ -180,7 +181,7 @@ const nextConfig = {
   // Local and CI builds keep Next's built-in typecheck as an independent gate.
   // https://nextjs.org/docs/app/guides/memory-usage#disable-static-analysis
   typescript: {
-    ignoreBuildErrors: configEnv.VERCEL === "1",
+    ignoreBuildErrors: hasIsolatedTypecheck(configEnv.VERCEL),
   },
   // Cache Components enables prerender source maps by default. The anonymous
   // CI build does not publish those artifacts, and retaining them exhausted

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -29,10 +29,12 @@ const configEnv = createEnv({
     NEXT_EXPOSE_TESTING_API: Schema.toStandardSchemaV1(
       Schema.UndefinedOr(Schema.Literal("true"))
     ),
+    VERCEL: Schema.toStandardSchemaV1(Schema.UndefinedOr(Schema.Literal("1"))),
   },
   runtimeEnv: {
     CONVEX_AGENT_MODE: process.env.CONVEX_AGENT_MODE,
     NEXT_EXPOSE_TESTING_API: process.env.NEXT_EXPOSE_TESTING_API,
+    VERCEL: process.env.VERCEL,
   },
 });
 const localConvexConnectSources = createLoopbackConnectSources(
@@ -172,6 +174,14 @@ const nextConfig = {
   ...config,
   cacheComponents: true,
   partialPrefetching: true,
+  // The Vercel command completes an isolated app typecheck before `next build`.
+  // Repeating static analysis after Turbopack compilation retained enough
+  // memory to exceed Vercel's build limit on every cold-cache production build.
+  // Local and CI builds keep Next's built-in typecheck as an independent gate.
+  // https://nextjs.org/docs/app/guides/memory-usage#disable-static-analysis
+  typescript: {
+    ignoreBuildErrors: configEnv.VERCEL === "1",
+  },
   // Cache Components enables prerender source maps by default. The anonymous
   // CI build does not publish those artifacts, and retaining them exhausted
   // the static worker's isolated 4 GiB heap with two pages in flight.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",
-    "build:vercel": "pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
+    "build:vercel": "pnpm --dir ../../apps/www typecheck && pnpm --dir ../../packages/backend typecheck && pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck disable --typecheck-components --cmd 'NEXT_PUBLIC_CONVEX_SITE_URL=\"$VITE_CONVEX_SITE_URL\" pnpm --dir ../../apps/www build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "next dev -p 3000 --turbopack",
     "doctor": "pnpm dlx react-doctor@0.9.12",

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import packageJson from "@/package.json";
-import { config } from "@/vercel";
+import { config, hasIsolatedTypecheck } from "@/vercel";
 
 describe("www Vercel configuration", () => {
   it("builds only affected production commits", () => {
@@ -43,5 +43,10 @@ describe("www Vercel configuration", () => {
     expect(deploymentCommand.indexOf(webBuild)).toBeGreaterThan(
       deploymentCommand.indexOf(convexDeploy)
     );
+  });
+
+  it("skips only the duplicate Vercel typecheck", () => {
+    expect(hasIsolatedTypecheck("1")).toBe(true);
+    expect(hasIsolatedTypecheck(undefined)).toBe(false);
   });
 });

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -17,6 +17,7 @@ describe("www Vercel configuration", () => {
   it("deploys the matching Convex backend with the production web build", () => {
     const buildCommand = config.buildCommand ?? "";
     const deploymentCommand = packageJson.scripts["build:vercel"];
+    const webTypecheck = "pnpm --dir ../../apps/www typecheck";
     const backendTypecheck = "pnpm --dir ../../packages/backend typecheck";
     const convexDeploy = "pnpm --dir ../../packages/backend exec convex deploy";
     const webBuild = "pnpm --dir ../../apps/www build";
@@ -32,7 +33,10 @@ describe("www Vercel configuration", () => {
     expect(deploymentCommand).toContain(
       "--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL"
     );
-    expect(deploymentCommand.indexOf(backendTypecheck)).toBe(0);
+    expect(deploymentCommand.indexOf(webTypecheck)).toBe(0);
+    expect(deploymentCommand.indexOf(backendTypecheck)).toBeGreaterThan(
+      deploymentCommand.indexOf(webTypecheck)
+    );
     expect(deploymentCommand.indexOf(convexDeploy)).toBeGreaterThan(
       deploymentCommand.indexOf(backendTypecheck)
     );

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -1,5 +1,10 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
+/** Identifies the Vercel build that already ran the isolated app typecheck. */
+export function hasIsolatedTypecheck(vercel: "1" | undefined) {
+  return vercel === "1";
+}
+
 export const config: VercelConfig = {
   buildCommand: "pnpm run build:vercel",
   ignoreCommand:


### PR DESCRIPTION
## Summary

Runs the www typecheck in its own process before the production Convex and Next build, then skips only Next's duplicate in-process TypeScript pass on Vercel.

## Why

The last successful production build invalidated its 1.52 GB cache because Vercel's limit was 1.50 GB. Three later cold-cache production deployments compiled successfully, then stopped at `Running TypeScript ...`; the latest was canceled after producing no later build line. Installed Next 16.3.2 guidance identifies this exact high-memory static-analysis phase and recommends separating it when another gate already owns type safety.

## Scope

- Prepend `pnpm --dir ../../apps/www typecheck` to the fail-closed Vercel build command.
- Validate Vercel's documented `VERCEL=1` system identity.
- Set `typescript.ignoreBuildErrors` only on Vercel, after the standalone typecheck succeeds.
- Preserve Next's built-in typecheck for local and GitHub builds.
- Own and test the deployment-specific predicate directly.

## Exact-head verification

Head `1e86d4088048df926921a759ba580232faaf88ae`, tree `0cf17b08f4ea9992f79140f260d668b189f0d09f`. Focused tests pass 3 of 3 and full www tests pass 209 files and 1,519 tests at 100 percent. www typecheck, lint, Effect RC110 source identity, React Doctor 100 of 100, formatting, diff, import, and LOC checks pass. Exact-head CI `33038533837` has Quality, Production, browser, AFDocs, runtime verification, cleanup, and Required green. Doctor run `33038533834` is green. Zero review threads remain.

## Rollout state

No Preview exists or is required. Production verification will occur only after this protected merge through the existing main Git integration.

## Material risks

Skipping Next's duplicate pass would be unsafe without the preceding app typecheck. The command-order test requires app typecheck, backend typecheck, Convex deployment wrapper, and Next build in that exact fail-closed order.