### PR TITLE
ci(cli): use trusted publishing

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -35,12 +35,5 @@ jobs:
           pnpm --filter nakafa-cli test:coverage
           pnpm --filter nakafa-cli build
 
-      # Bootstrap only. Delete this registry token setup after 0.1.0 exists and
-      # cli-publish.yml is registered as the package's trusted publisher.
-      - name: Configure bootstrap authentication
-        run: npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
-
       - name: Publish package
         run: pnpm --filter nakafa-cli exec npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Remove the completed npm bootstrap token path from the CLI release workflow. Future `nakafa-cli` releases authenticate through npm Trusted Publishing and GitHub OIDC.

## Why

`nakafa-cli@0.1.0` is published. The npm package settings identify `nakafaai/nakafa.com` and `cli-publish.yml` as the trusted publisher. npm documents that Trusted Publishing uses short-lived workflow-specific OIDC credentials and requires `id-token: write`, a GitHub-hosted runner, and the exact repository and workflow filename: https://docs.npmjs.com/trusted-publishers/

The long-lived `NPM_BOOTSTRAP_TOKEN` path is obsolete technical debt.

## Scope

Delete only the temporary authentication step and secret reference. Preserve the manual main-only workflow, package verification, `id-token: write`, and public provenance publish command.

## Exact-head verification

Exact head `59352f792b2f586eaa57cb75452197457a03e674` is based directly on protected main `0be5e7875fc75867da7fe7e52fc077971a17bd26`. The rebase preserved stable patch ID `b839a9fbd612d9456cc14cc1423239b63306d0ed`. The diff is one file and seven deletions, and `git diff --check` passes. Exact-head CI run `33115891038` attempt 2 is green for Quality, Production Scope, Production, Browser, AFDocs, final runtime verification, cleanup, and Required. Doctor run `33115891010` is green. One fresh exact-head Codex review is requested and will be independently classified.

## Rollout

Merge after the fresh exact-head review is clean. This workflow-only cleanup creates no Vercel Preview, deployment, Convex mutation, or runtime migration.

## Risks

npm validates the OIDC exchange only during a real publish. The package setting, repository, workflow filename, GitHub-hosted runner, OIDC permission, and published bootstrap package are verified prerequisites. The next version publish remains the final end-to-end authentication proof.