### PR TITLE
test(analytics): use direct Effect Vitest

### DIFF
--- a/packages/analytics/consent.test.ts
+++ b/packages/analytics/consent.test.ts
@@ -1,3 +1,4 @@
+import { it as effectIt } from "@effect/vitest";
 import {
   ANALYTICS_CONSENT_NOTICE_VERSION,
   AnonymousAnalyticsConsentRecordSchema,
@@ -9,8 +10,8 @@ import {
   hasBrowserPrivacySignal,
   resolveAnalyticsConsentState,
 } from "@repo/analytics/consent";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Option, Schema } from "effect";
+import { describe, expect, it } from "vitest";
 
 const grantedAnonymousConsent = Schema.decodeSync(
   AnonymousAnalyticsConsentRecordSchema
@@ -37,7 +38,7 @@ const retainedAnonymousDenial = Schema.decodeSync(
 });
 
 describe("analytics consent contract", () => {
-  it.effect("round-trips the current anonymous consent record", () =>
+  effectIt.effect("round-trips the current anonymous consent record", () =>
     Effect.gen(function* () {
       const encoded = yield* encodeAnonymousAnalyticsConsent(
         grantedAnonymousConsent

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -15,6 +15,7 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/packages/analytics/posthog/browser.test.ts
+++ b/packages/analytics/posthog/browser.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Fiber, Ref } from "effect";
 import { vi } from "vitest";
 

--- a/packages/analytics/posthog/server.test.ts
+++ b/packages/analytics/posthog/server.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { vi } from "vitest";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,6 +556,9 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

Move the analytics test package from the legacy `@repo/testing/effect` wrapper to the official Effect v4 Vitest integration.

## Architecture

- Declare `@effect/vitest` directly in the owning analytics package.
- Run the one effectful consent case with direct `it.effect` while keeping eleven pure consent cases on ordinary Vitest.
- Import the official Effect Vitest API directly for the fully effectful browser and server PostHog suites.
- Keep `@repo/testing` only for the repository-owned Node Vitest configuration, not as an Effect test runtime wrapper.

## Commits

1. Add direct package dependency ownership and the exact lockfile importer entry.
2. Migrate consent tests.
3. Migrate browser PostHog tests.
4. Migrate server PostHog tests.

## Exact identity

- Base: `f0722c17b0c022d55734c1ab931ed801cd6f7d13`
- Head: `d473cacf3005ee6e023a127e2d0a72e17f88e7f7`
- Dependency patch id: `9e08eba91b3f7d5e5b136a20c2883f9d78034975`
- Consent patch id: `2d1d2c866b3ce526581c8d5d5a843d8ccb251ce8`
- Browser patch id: `ed6577f573bd3d22b544d5cd9eedbc5a68ef8de7`
- Server patch id: `d901279468145b7477fee38384b0e91c4172c5d6`

## Verification

- Focused changed tests: 29 passed.
- Full analytics suite: 8 files and 46 tests passed.
- Coverage: 100% statements, branches, functions, and lines.
- Analytics typecheck, Effect source parity, lockfile supply-chain policy, test policy, patch policy, lint, formatting, workspace boundaries, and dependency audit passed on the exact current base.

## Release impact

Test-only and development-dependency-only change. No production analytics behavior, Vercel deployment, Convex schema, or runtime dependency changed.