### PR TITLE
fix(www): bound material route generation

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content.tsx
@@ -13,10 +13,8 @@ import {
   readMaterialRequest,
 } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/data";
 import { normalizeMaterialMetadata } from "@/lib/content/material/decode";
-import {
-  getMaterialCatalogRoute,
-  getMaterialPublication,
-} from "@/lib/content/material/publication";
+import { getMaterialPublication } from "@/lib/content/material/publication";
+import { getPublishedMaterialRoute } from "@/lib/content/material/route";
 import { hasPreviewConfig } from "@/lib/content/preview/config";
 import {
   type MaterialPreviewContent,
@@ -128,7 +126,7 @@ export async function readMaterialMetadata(
     };
   }
 
-  const model = await getMaterialCatalogRoute(owner.locale, owner.publicPath);
+  const model = await getPublishedMaterialRoute(owner.locale, owner.publicPath);
   if (!model.projection) {
     notFound();
   }

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -9,10 +9,8 @@ import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
-  getPublishedMaterialRelease,
   getPublishedMaterialRoutes,
   readPublishedMaterialPage,
-  readPublishedMaterialRelease,
   readPublishedMaterialRoutes,
 } from "@/lib/content/material/catalog";
 import { previewIdProjection, previewProjection } from "@/test/content-preview";
@@ -58,26 +56,6 @@ function materialPage({
     },
     sourceRevision: managed ? revision : null,
     stale,
-  };
-}
-
-/** Builds the signed material release identity returned by Convex. */
-function materialRelease({
-  activeAppLocales = ["en", "id", "de"],
-  manifest = manifestHash,
-  release = releaseId,
-  revision = sourceRevision,
-}: {
-  readonly activeAppLocales?: readonly string[];
-  readonly manifest?: null | string;
-  readonly release?: null | string;
-  readonly revision?: null | string;
-} = {}) {
-  return {
-    activeAppLocales,
-    activeManifestHash: manifest,
-    activeReleaseId: release,
-    sourceRevision: revision,
   };
 }
 
@@ -137,38 +115,6 @@ describe("published material catalog", () => {
     });
     expect(cacheMock).toHaveBeenCalledOnce();
   });
-
-  it("reads and caches signed release locale membership", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(materialRelease());
-
-    await expect(getPublishedMaterialRelease()).resolves.toMatchObject({
-      activeAppLocales: ["en", "id", "de"],
-      activeManifestHash: manifestHash,
-      activeReleaseId: releaseId,
-      sourceRevision,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "en",
-      publicPath: "materials",
-    });
-    expect(cacheMock).toHaveBeenCalledOnce();
-  });
-
-  it.effect("rejects malformed signed release identity", () =>
-    Effect.gen(function* () {
-      for (const result of [
-        materialRelease({ activeAppLocales: ["id", "en"] }),
-        materialRelease({ manifest: null }),
-        materialRelease({ release: null }),
-        materialRelease({ revision: "main" }),
-      ]) {
-        runtimeQueryMock.mockResolvedValueOnce(result);
-        expect(
-          yield* readPublishedMaterialRelease().pipe(Effect.flip)
-        ).toMatchObject({ _tag: "PublishedProjectionError" });
-      }
-    })
-  );
 
   it.effect("rejects unmanaged and stale ownership states", () =>
     Effect.gen(function* () {

--- a/apps/www/lib/content/material/catalog.ts
+++ b/apps/www/lib/content/material/catalog.ts
@@ -5,10 +5,7 @@ import {
   ReleaseIdSchema,
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
-import {
-  ActiveAppLocaleListSchema,
-  AppLocaleSchema,
-} from "@nakafa/aksara-contracts/locale";
+import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { api } from "@repo/backend/convex/_generated/api";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
@@ -63,14 +60,6 @@ export interface PublishedMaterialCatalog {
   readonly activeReleaseId: typeof ReleaseIdSchema.Type;
   readonly appLocale: typeof AppLocaleSchema.Type;
   readonly routes: readonly MaterialLessonProjection[];
-  readonly sourceRevision: null | typeof GitCommitShaSchema.Type;
-}
-
-/** Signed release identity shared by every localized material catalog. */
-export interface PublishedMaterialRelease {
-  readonly activeAppLocales: typeof ActiveAppLocaleListSchema.Type;
-  readonly activeManifestHash: typeof Sha256HashSchema.Type;
-  readonly activeReleaseId: typeof ReleaseIdSchema.Type;
   readonly sourceRevision: null | typeof GitCommitShaSchema.Type;
 }
 
@@ -209,54 +198,11 @@ export const readPublishedMaterialRoutes = Effect.fn(
   }
 });
 
-/** Reads signed locale membership from one guaranteed material tombstone. */
-export const readPublishedMaterialRelease = Effect.fn(
-  "NakafaMaterial.readPublishedRelease"
-)(function* () {
-  const appLocale = AppLocaleSchema.make("en");
-  const identity = { appLocale, publicPath: "materials" };
-  const result = yield* readRuntimeQuery(
-    api.contentRelease.material.publication,
-    identity
-  );
-  if (result.activeManifestHash === null || result.activeReleaseId === null) {
-    return yield* new PublishedProjectionError(identity);
-  }
-  const [
-    activeAppLocales,
-    activeManifestHash,
-    activeReleaseId,
-    sourceRevision,
-  ] = yield* Effect.all([
-    Schema.decodeUnknownEffect(ActiveAppLocaleListSchema)(
-      result.activeAppLocales
-    ),
-    Schema.decodeEffect(Sha256HashSchema)(result.activeManifestHash),
-    Schema.decodeEffect(ReleaseIdSchema)(result.activeReleaseId),
-    decodeSourceRevision(result.sourceRevision, identity),
-  ]).pipe(Effect.mapError(() => new PublishedProjectionError(identity)));
-  return {
-    activeAppLocales,
-    activeManifestHash,
-    activeReleaseId,
-    sourceRevision,
-  } satisfies PublishedMaterialRelease;
-});
-
 /** Caches all localized material routes under release invalidation. */
 export async function getPublishedMaterialRoutes(locale: Locale) {
   "use cache";
 
   const result = await Effect.runPromise(readPublishedMaterialRoutes(locale));
-  applyContentRuntimeCache();
-  return result;
-}
-
-/** Caches signed material release membership under release invalidation. */
-export async function getPublishedMaterialRelease() {
-  "use cache";
-
-  const result = await Effect.runPromise(readPublishedMaterialRelease());
   applyContentRuntimeCache();
   return result;
 }

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -1,55 +1,41 @@
 // @vitest-environment node
 
 import {
-  ContentKeySchema,
-  GitCommitShaSchema,
   PublicPathSchema,
   ReleaseIdSchema,
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
-import {
-  ACTIVE_APP_LOCALES,
-  type ActiveAppLocaleList,
-  type AppLocale,
-  AppLocaleSchema,
-} from "@nakafa/aksara-contracts/locale";
-import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
-import { MATERIAL_GROUP_LIMIT } from "@repo/backend/convex/contentRelease/material/limits";
-import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { beforeEach, describe, expect, it } from "@repo/testing/effect";
-import { Cause, Effect } from "effect";
-import type { Locale } from "next-intl";
+import { Effect } from "effect";
 import { vi } from "vitest";
-import type {
-  PublishedMaterialCatalog,
-  PublishedMaterialRelease,
-} from "@/lib/content/material/catalog";
-import {
-  getMaterialCatalogRoute,
-  getMaterialPublication,
-  readMaterialCatalogRoute,
-} from "@/lib/content/material/publication";
-import {
-  PublishedProjectionError,
-  PublishedReleaseMismatchError,
-} from "@/lib/content/published/errors";
+import { getMaterialPublication } from "@/lib/content/material/publication";
+import { PublishedProjectionError } from "@/lib/content/published/errors";
 import {
   previewArtifactHash,
   previewDeProjection,
   previewIdProjection,
   previewNextProjection,
   previewProjection,
+  previewSourcePath,
 } from "@/test/content-preview";
 
 const catalogCacheMock = vi.hoisted(() => vi.fn());
-const catalogMock = vi.hoisted(() => vi.fn());
 const contentCacheMock = vi.hoisted(() => vi.fn());
-const releaseMock = vi.hoisted(() => vi.fn());
+const routeMock = vi.hoisted(() => vi.fn());
 const renderMock = vi.hoisted(() => vi.fn());
 const activeManifestHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
 const activeReleaseId = ReleaseIdSchema.make("release-material");
-const sourceRevision = GitCommitShaSchema.make("a".repeat(40));
+const model = {
+  activeManifestHash,
+  activeReleaseId,
+  alternates: [previewProjection, previewIdProjection, previewDeProjection],
+  projection: previewProjection,
+  rendererDomain: "mathematics",
+  siblings: [previewProjection, previewNextProjection],
+  sourcePath: previewSourcePath,
+  sourceRevision: "a".repeat(40),
+};
 const published = {
   activeReleaseId,
   artifactHash: previewArtifactHash,
@@ -61,85 +47,45 @@ vi.mock("@/lib/content/cache", () => ({
   applyPublishedCatalogCache: catalogCacheMock,
   applyPublishedContentCache: contentCacheMock,
 }));
-vi.mock("@/lib/content/material/catalog", () => ({
-  getPublishedMaterialRelease: releaseMock,
-  getPublishedMaterialRoutes: catalogMock,
+vi.mock("@/lib/content/material/route", () => ({
+  readPublishedMaterialRoute: routeMock,
 }));
 vi.mock("@/lib/content/published/material", () => ({
   readRenderedMaterial: renderMock,
 }));
 
-function materialCatalog(
-  appLocale: AppLocale,
-  routes: readonly MaterialLessonProjection[],
-  releaseId = activeReleaseId,
-  revision: PublishedMaterialCatalog["sourceRevision"] = sourceRevision
-): PublishedMaterialCatalog {
-  return {
-    activeManifestHash,
-    activeReleaseId: releaseId,
-    appLocale,
-    routes,
-    sourceRevision: revision,
-  };
-}
-function materialRelease(
-  activeAppLocales: ActiveAppLocaleList = ACTIVE_APP_LOCALES
-): PublishedMaterialRelease {
-  return {
-    activeAppLocales,
-    activeManifestHash,
-    activeReleaseId,
-    sourceRevision,
-  };
-}
-const catalogs = [
-  materialCatalog(previewProjection.appLocale, [
-    previewProjection,
-    previewNextProjection,
-  ]),
-  materialCatalog(previewIdProjection.appLocale, [previewIdProjection]),
-  materialCatalog(previewDeProjection.appLocale, [previewDeProjection]),
-];
-function mockCatalogReads(source = catalogs) {
-  catalogMock.mockImplementation((locale: AppLocale) =>
-    Promise.resolve(source.find((catalog) => catalog.appLocale === locale))
-  );
-}
-
-function readCatalogRoute(
-  source: readonly PublishedMaterialCatalog[],
-  release = materialRelease(),
-  locale: Locale = "en",
-  publicPath = previewProjection.publicPath
-) {
-  return readMaterialCatalogRoute(release, source, locale, publicPath);
+function missingRuntime(publicPath: typeof PublicPathSchema.Type) {
+  return new ContentRuntimeMissingError({
+    request: {
+      appLocale: previewProjection.appLocale,
+      delivery: "public",
+      publicPath,
+    },
+  });
 }
 
 beforeEach(() => {
   catalogCacheMock.mockReset();
-  catalogMock.mockReset();
   contentCacheMock.mockReset();
-  releaseMock.mockReset();
+  routeMock.mockReset();
   renderMock.mockReset();
-  releaseMock.mockResolvedValue(materialRelease());
-  mockCatalogReads();
+  routeMock.mockReturnValue(Effect.succeed(model));
+  renderMock.mockReturnValue(Effect.succeed(published));
 });
 
 describe("material publication", () => {
-  it("starts every catalog and the signed body before either owner settles", async () => {
-    const catalogReleases: Array<() => void> = [];
-    catalogMock.mockImplementation(
-      (locale: AppLocale) =>
-        new Promise((resolve) => {
-          const catalog = catalogs.find(
-            (candidate) => candidate.appLocale === locale
-          );
-          catalogReleases.push(() => resolve(catalog));
-        })
-    );
+  it("starts one bounded route and one signed body before either settles", async () => {
+    let releaseRoute: () => void = () => undefined;
     let releasePublished: () => void = () => undefined;
-    renderMock.mockReturnValue(
+    routeMock.mockReturnValueOnce(
+      Effect.promise(
+        () =>
+          new Promise((resolve) => {
+            releaseRoute = () => resolve(model);
+          })
+      )
+    );
+    renderMock.mockReturnValueOnce(
       Effect.promise(
         () =>
           new Promise((resolve) => {
@@ -153,52 +99,44 @@ describe("material publication", () => {
       previewProjection.publicPath
     );
     await vi.waitFor(() => {
-      expect(catalogMock).toHaveBeenCalledTimes(3);
-      expect(releaseMock).toHaveBeenCalledOnce();
+      expect(routeMock).toHaveBeenCalledOnce();
+      expect(routeMock).toHaveBeenCalledWith(
+        "en",
+        previewProjection.publicPath
+      );
       expect(renderMock).toHaveBeenCalledOnce();
     });
-    for (const releaseCatalog of catalogReleases) {
-      releaseCatalog();
-    }
+    releaseRoute();
     releasePublished();
 
-    await expect(publication).resolves.toMatchObject({ published });
+    await expect(publication).resolves.toMatchObject({ model, published });
   });
 
-  it("returns a release-bound missing route without rendering an application error", async () => {
+  it("returns null only when both authenticated owners report a missing route", async () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    renderMock.mockReturnValueOnce(
-      Effect.fail(
-        new ContentRuntimeMissingError({
-          request: {
-            appLocale: previewProjection.appLocale,
-            delivery: "public",
-            publicPath,
-          },
-        })
-      )
+    routeMock.mockReturnValueOnce(
+      Effect.succeed({
+        ...model,
+        alternates: [],
+        projection: null,
+        rendererDomain: null,
+        siblings: [],
+        sourcePath: null,
+      })
     );
+    renderMock.mockReturnValueOnce(Effect.fail(missingRuntime(publicPath)));
 
     await expect(getMaterialPublication("en", publicPath)).resolves.toBeNull();
-    expect(catalogMock).toHaveBeenCalledTimes(3);
-    expect(catalogCacheMock).toHaveBeenCalledOnce();
+    expect(routeMock).toHaveBeenCalledOnce();
     expect(catalogCacheMock).toHaveBeenCalledWith("material");
     expect(contentCacheMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a missing body when the signed catalog route still exists", async () => {
+  it("rejects a missing body when the bounded route still exists", async () => {
     renderMock.mockReturnValueOnce(
-      Effect.fail(
-        new ContentRuntimeMissingError({
-          request: {
-            appLocale: previewProjection.appLocale,
-            delivery: "public",
-            publicPath: previewProjection.publicPath,
-          },
-        })
-      )
+      Effect.fail(missingRuntime(previewProjection.publicPath))
     );
 
     await expect(
@@ -210,11 +148,20 @@ describe("material publication", () => {
     });
   });
 
-  it("rejects a signed body that has no matching catalog route", async () => {
+  it("rejects a signed body when the bounded route is missing", async () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    renderMock.mockReturnValueOnce(Effect.succeed(published));
+    routeMock.mockReturnValueOnce(
+      Effect.succeed({
+        ...model,
+        alternates: [],
+        projection: null,
+        rendererDomain: null,
+        siblings: [],
+        sourcePath: null,
+      })
+    );
 
     await expect(
       getMaterialPublication("en", publicPath)
@@ -226,26 +173,10 @@ describe("material publication", () => {
   });
 
   it("verifies and caches one coherent material publication", async () => {
-    renderMock.mockReturnValueOnce(Effect.succeed(published));
-
     await expect(
       getMaterialPublication("en", previewProjection.publicPath)
-    ).resolves.toEqual({
-      model: {
-        activeManifestHash,
-        activeReleaseId,
-        alternates: [
-          previewProjection,
-          previewIdProjection,
-          previewDeProjection,
-        ],
-        projection: previewProjection,
-        siblings: [previewProjection, previewNextProjection],
-        sourceRevision,
-      },
-      published,
-    });
-    expect(catalogCacheMock).toHaveBeenCalledOnce();
+    ).resolves.toEqual({ model, published });
+    expect(routeMock).toHaveBeenCalledOnce();
     expect(catalogCacheMock).toHaveBeenCalledWith("material");
     expect(contentCacheMock).toHaveBeenCalledWith(
       "material",
@@ -253,247 +184,15 @@ describe("material publication", () => {
     );
   });
 
-  it("reads metadata from catalogs without evaluating the signed body", async () => {
-    await expect(
-      getMaterialCatalogRoute("en", previewProjection.publicPath)
-    ).resolves.toMatchObject({ projection: previewProjection });
-
-    expect(renderMock).not.toHaveBeenCalled();
-    expect(catalogCacheMock).toHaveBeenCalledWith("material");
-    expect(contentCacheMock).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    new NakafaAgentDataReadError({ message: "Catalog unavailable." }),
-    new PublishedProjectionError({
+  it("preserves typed route failures without a Promise adapter", async () => {
+    const failure = new PublishedProjectionError({
       appLocale: previewProjection.appLocale,
       publicPath: previewProjection.publicPath,
-    }),
-    new PublishedReleaseMismatchError({
-      actualReleaseId: ReleaseIdSchema.make("release-other"),
-      expectedReleaseId: activeReleaseId,
-    }),
-  ])(
-    "preserves typed failures across cached Promise boundaries",
-    async (failure) => {
-      releaseMock.mockRejectedValueOnce(failure);
-
-      await expect(
-        getMaterialCatalogRoute("en", previewProjection.publicPath)
-      ).rejects.toBe(failure);
-    }
-  );
-
-  it("maps unknown cached Promise failures explicitly", async () => {
-    releaseMock.mockRejectedValueOnce("unexpected");
+    });
+    routeMock.mockReturnValueOnce(Effect.fail(failure));
 
     await expect(
-      getMaterialCatalogRoute("en", previewProjection.publicPath)
-    ).rejects.toSatisfy(Cause.isUnknownError);
+      getMaterialPublication("en", previewProjection.publicPath)
+    ).rejects.toBe(failure);
   });
-
-  it.effect("uses only signed active locale membership", () =>
-    Effect.gen(function* () {
-      const release = materialRelease([
-        AppLocaleSchema.make("en"),
-        AppLocaleSchema.make("id"),
-      ]);
-      const subsetCatalogs = [
-        catalogs[0],
-        catalogs[1],
-        materialCatalog(previewDeProjection.appLocale, []),
-      ];
-      const route = yield* readCatalogRoute(subsetCatalogs, release);
-      expect(route.alternates).toEqual([
-        previewProjection,
-        previewIdProjection,
-      ]);
-      expect(
-        yield* readCatalogRoute(
-          subsetCatalogs,
-          release,
-          "de",
-          previewDeProjection.publicPath
-        )
-      ).toMatchObject({ projection: null });
-
-      const invalidInactiveCatalog = [
-        subsetCatalogs[0],
-        subsetCatalogs[1],
-        catalogs[2],
-      ];
-      expect(
-        yield* readCatalogRoute(invalidInactiveCatalog, release).pipe(
-          Effect.flip
-        )
-      ).toBeInstanceOf(PublishedProjectionError);
-    })
-  );
-
-  it.effect("preserves bounded coherent sibling ordering", () =>
-    Effect.gen(function* () {
-      const sameOrderNext = {
-        ...previewNextProjection,
-        order: previewProjection.order,
-      };
-      const reversedCatalogs = [
-        materialCatalog(previewProjection.appLocale, [
-          sameOrderNext,
-          previewProjection,
-        ]),
-        catalogs[1],
-        catalogs[2],
-      ];
-      const route = yield* readCatalogRoute(reversedCatalogs);
-      expect(route.siblings).toEqual([previewProjection, sameOrderNext]);
-
-      const splitSibling = {
-        ...previewNextProjection,
-        contentKey: ContentKeySchema.make("test:split-sibling"),
-        parentPath: PublicPathSchema.make("subjects/mathematics/other-topic"),
-      };
-      const oversizedGroup = Array.from(
-        { length: MATERIAL_GROUP_LIMIT },
-        (_, index) => ({
-          ...previewNextProjection,
-          contentKey: ContentKeySchema.make(`test:oversized-${index}`),
-          order: index + 6,
-          publicPath: PublicPathSchema.make(
-            `${previewProjection.parentPath}/oversized-${index}`
-          ),
-        })
-      );
-      for (const routes of [
-        [previewProjection, splitSibling],
-        [previewProjection, ...oversizedGroup],
-      ]) {
-        const malformed = [
-          materialCatalog(previewProjection.appLocale, routes),
-          catalogs[1],
-          catalogs[2],
-        ];
-        expect(
-          yield* readCatalogRoute(malformed).pipe(Effect.flip)
-        ).toBeInstanceOf(PublishedProjectionError);
-      }
-    })
-  );
-
-  it.effect("rejects catalogs from different active releases", () =>
-    Effect.gen(function* () {
-      const mismatched = [
-        catalogs[0],
-        materialCatalog(
-          previewIdProjection.appLocale,
-          [previewIdProjection],
-          ReleaseIdSchema.make("release-other")
-        ),
-        catalogs[2],
-      ];
-
-      expect(
-        yield* readCatalogRoute(mismatched).pipe(Effect.flip)
-      ).toMatchObject({ _tag: "PublishedReleaseMismatchError" });
-    })
-  );
-
-  it.effect("rejects catalogs from different source revisions", () =>
-    Effect.gen(function* () {
-      for (const revision of [GitCommitShaSchema.make("b".repeat(40)), null]) {
-        const mismatched = [
-          catalogs[0],
-          materialCatalog(
-            previewIdProjection.appLocale,
-            [previewIdProjection],
-            activeReleaseId,
-            revision
-          ),
-          catalogs[2],
-        ];
-        expect(
-          yield* readCatalogRoute(mismatched).pipe(Effect.flip)
-        ).toMatchObject({ _tag: "PublishedProjectionError" });
-      }
-    })
-  );
-
-  it.effect("rejects malformed catalog ownership", () =>
-    Effect.gen(function* () {
-      const otherManifestHash = Sha256HashSchema.make(
-        `sha256:${"b".repeat(64)}`
-      );
-      const malformedCatalogs = [
-        [
-          catalogs[0],
-          { ...catalogs[1], activeManifestHash: otherManifestHash },
-          catalogs[2],
-        ],
-        [
-          materialCatalog(previewProjection.appLocale, [
-            previewProjection,
-            previewProjection,
-          ]),
-          catalogs[1],
-          catalogs[2],
-        ],
-        [
-          materialCatalog(previewProjection.appLocale, [previewIdProjection]),
-          catalogs[1],
-          catalogs[2],
-        ],
-      ];
-
-      for (const source of malformedCatalogs) {
-        expect(yield* readCatalogRoute(source).pipe(Effect.flip)).toMatchObject(
-          { _tag: "PublishedProjectionError" }
-        );
-      }
-    })
-  );
-
-  it.effect("rejects incomplete locale and counterpart ownership", () =>
-    Effect.gen(function* () {
-      const missingLocale = catalogs.slice(0, 2);
-      const duplicateLocale = [catalogs[0], catalogs[0], catalogs[2]];
-      const duplicateCounterpart = {
-        ...previewIdProjection,
-        publicPath: PublicPathSchema.make(
-          `${previewIdProjection.parentPath}/duplicate-counterpart`
-        ),
-      };
-      const missingCounterpart = [
-        catalogs[0],
-        materialCatalog(previewIdProjection.appLocale, []),
-        catalogs[2],
-      ];
-      const ambiguousCounterpart = [
-        catalogs[0],
-        materialCatalog(previewIdProjection.appLocale, [
-          previewIdProjection,
-          duplicateCounterpart,
-        ]),
-        catalogs[2],
-      ];
-
-      for (const source of [
-        missingLocale,
-        duplicateLocale,
-        missingCounterpart,
-        ambiguousCounterpart,
-      ]) {
-        expect(yield* readCatalogRoute(source).pipe(Effect.flip)).toMatchObject(
-          { _tag: "PublishedProjectionError" }
-        );
-      }
-
-      expect(
-        yield* readCatalogRoute(
-          missingLocale,
-          materialRelease(),
-          "de",
-          previewDeProjection.publicPath
-        ).pipe(Effect.flip)
-      ).toMatchObject({ _tag: "PublishedProjectionError" });
-    })
-  );
 });

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/content/cache", () => ({
   applyPublishedContentCache: contentCacheMock,
 }));
 vi.mock("@/lib/content/material/route", () => ({
-  readPublishedMaterialRoute: routeMock,
+  getPublishedMaterialRoute: routeMock,
 }));
 vi.mock("@/lib/content/published/material", () => ({
   readRenderedMaterial: renderMock,
@@ -69,7 +69,7 @@ beforeEach(() => {
   contentCacheMock.mockReset();
   routeMock.mockReset();
   renderMock.mockReset();
-  routeMock.mockReturnValue(Effect.succeed(model));
+  routeMock.mockResolvedValue(model);
   renderMock.mockReturnValue(Effect.succeed(published));
 });
 
@@ -78,12 +78,9 @@ describe("material publication", () => {
     let releaseRoute: () => void = () => undefined;
     let releasePublished: () => void = () => undefined;
     routeMock.mockReturnValueOnce(
-      Effect.promise(
-        () =>
-          new Promise((resolve) => {
-            releaseRoute = () => resolve(model);
-          })
-      )
+      new Promise((resolve) => {
+        releaseRoute = () => resolve(model);
+      })
     );
     renderMock.mockReturnValueOnce(
       Effect.promise(
@@ -116,16 +113,14 @@ describe("material publication", () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    routeMock.mockReturnValueOnce(
-      Effect.succeed({
-        ...model,
-        alternates: [],
-        projection: null,
-        rendererDomain: null,
-        siblings: [],
-        sourcePath: null,
-      })
-    );
+    routeMock.mockResolvedValueOnce({
+      ...model,
+      alternates: [],
+      projection: null,
+      rendererDomain: null,
+      siblings: [],
+      sourcePath: null,
+    });
     renderMock.mockReturnValueOnce(Effect.fail(missingRuntime(publicPath)));
 
     await expect(getMaterialPublication("en", publicPath)).resolves.toBeNull();
@@ -152,16 +147,14 @@ describe("material publication", () => {
     const publicPath = PublicPathSchema.make(
       `${previewProjection.publicPath}-missing`
     );
-    routeMock.mockReturnValueOnce(
-      Effect.succeed({
-        ...model,
-        alternates: [],
-        projection: null,
-        rendererDomain: null,
-        siblings: [],
-        sourcePath: null,
-      })
-    );
+    routeMock.mockResolvedValueOnce({
+      ...model,
+      alternates: [],
+      projection: null,
+      rendererDomain: null,
+      siblings: [],
+      sourcePath: null,
+    });
 
     await expect(
       getMaterialPublication("en", publicPath)
@@ -189,7 +182,7 @@ describe("material publication", () => {
       appLocale: previewProjection.appLocale,
       publicPath: previewProjection.publicPath,
     });
-    routeMock.mockReturnValueOnce(Effect.fail(failure));
+    routeMock.mockRejectedValueOnce(failure);
 
     await expect(
       getMaterialPublication("en", previewProjection.publicPath)

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -177,7 +177,7 @@ describe("material publication", () => {
     );
   });
 
-  it("preserves typed route failures without a Promise adapter", async () => {
+  it("preserves route failure provenance across the cache boundary", async () => {
     const failure = new PublishedProjectionError({
       appLocale: previewProjection.appLocale,
       publicPath: previewProjection.publicPath,
@@ -186,6 +186,31 @@ describe("material publication", () => {
 
     await expect(
       getMaterialPublication("en", previewProjection.publicPath)
-    ).rejects.toBe(failure);
+    ).rejects.toMatchObject({
+      _tag: "MaterialRouteReadError",
+      appLocale: previewProjection.appLocale,
+      cause: failure,
+      publicPath: previewProjection.publicPath,
+    });
+  });
+
+  it("interrupts the signed body read when the bounded route fails", async () => {
+    const interrupted = vi.fn();
+    const failure = new PublishedProjectionError({
+      appLocale: previewProjection.appLocale,
+      publicPath: previewProjection.publicPath,
+    });
+    routeMock.mockRejectedValueOnce(failure);
+    renderMock.mockReturnValueOnce(
+      Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(interrupted)))
+    );
+
+    await expect(
+      getMaterialPublication("en", previewProjection.publicPath)
+    ).rejects.toMatchObject({
+      _tag: "MaterialRouteReadError",
+      cause: failure,
+    });
+    expect(interrupted).toHaveBeenCalledOnce();
   });
 });

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -11,50 +11,8 @@ import {
   makeMaterialProjectionError,
   verifyMaterialPublication,
 } from "@/lib/content/material/decode";
-import { readPublishedMaterialRoute } from "@/lib/content/material/route";
+import { getPublishedMaterialRoute } from "@/lib/content/material/route";
 import { readRenderedMaterial } from "@/lib/content/published/material";
-
-/** Reads one bounded route model and its signed body concurrently. */
-const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
-  function* (locale: Locale, publicPath: string) {
-    const appLocale = AppLocaleSchema.make(locale);
-    const [model, published] = yield* Effect.all(
-      [
-        readPublishedMaterialRoute(locale, publicPath),
-        readRenderedMaterial({ appLocale, publicPath }).pipe(
-          Effect.catchTag("ContentRuntimeMissingError", () =>
-            Effect.succeed(null)
-          )
-        ),
-      ],
-      { concurrency: "unbounded" }
-    );
-
-    yield* Effect.sync(() => applyPublishedCatalogCache("material"));
-    if (!model.projection) {
-      if (published) {
-        return yield* makeMaterialProjectionError({ appLocale, publicPath });
-      }
-      return null;
-    }
-    if (!published) {
-      return yield* makeMaterialProjectionError({ appLocale, publicPath });
-    }
-
-    yield* verifyMaterialPublication(
-      {
-        activeReleaseId: model.activeReleaseId,
-        projection: model.projection,
-      },
-      published
-    );
-    yield* Effect.sync(() =>
-      applyPublishedContentCache("material", published.artifactHash)
-    );
-
-    return { model, published };
-  }
-);
 
 /** Caches one coherent material publication at the Next.js boundary. */
 export async function getMaterialPublication(
@@ -63,5 +21,40 @@ export async function getMaterialPublication(
 ) {
   "use cache";
 
-  return await Effect.runPromise(readMaterialPublication(locale, publicPath));
+  const appLocale = AppLocaleSchema.make(locale);
+  const readPublished = readRenderedMaterial({ appLocale, publicPath }).pipe(
+    Effect.catchTag("ContentRuntimeMissingError", () => Effect.succeed(null))
+  );
+  const [model, published] = await Promise.all([
+    getPublishedMaterialRoute(locale, publicPath),
+    Effect.runPromise(readPublished),
+  ]);
+
+  applyPublishedCatalogCache("material");
+  if (!model.projection) {
+    if (published) {
+      return await Effect.runPromise(
+        Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
+      );
+    }
+    return null;
+  }
+  if (!published) {
+    return await Effect.runPromise(
+      Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
+    );
+  }
+
+  await Effect.runPromise(
+    verifyMaterialPublication(
+      {
+        activeReleaseId: model.activeReleaseId,
+        projection: model.projection,
+      },
+      published
+    )
+  );
+  applyPublishedContentCache("material", published.artifactHash);
+
+  return { model, published };
 }

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -1,263 +1,36 @@
 import "server-only";
 
-import {
-  APP_LOCALE_CODES,
-  AppLocaleSchema,
-} from "@nakafa/aksara-contracts/locale";
-import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
-import { MATERIAL_GROUP_LIMIT } from "@repo/backend/convex/contentRelease/material/limits";
-import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
-import { Cause, Effect } from "effect";
+import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import {
   applyPublishedCatalogCache,
   applyPublishedContentCache,
 } from "@/lib/content/cache";
 import {
-  getPublishedMaterialRelease,
-  getPublishedMaterialRoutes,
-  type PublishedMaterialCatalog,
-  type PublishedMaterialRelease,
-} from "@/lib/content/material/catalog";
-import {
-  isMaterialCounterpart,
-  isMaterialSibling,
   makeMaterialProjectionError,
   verifyMaterialPublication,
 } from "@/lib/content/material/decode";
-import {
-  PublishedProjectionError,
-  PublishedReleaseMismatchError,
-} from "@/lib/content/published/errors";
+import { readPublishedMaterialRoute } from "@/lib/content/material/route";
 import { readRenderedMaterial } from "@/lib/content/published/material";
 
-interface MaterialCatalogIdentity {
-  readonly activeManifestHash: PublishedMaterialCatalog["activeManifestHash"];
-  readonly activeReleaseId: PublishedMaterialCatalog["activeReleaseId"];
-  readonly sourceRevision: PublishedMaterialCatalog["sourceRevision"];
-}
-
-/** Route shell selected exclusively from authenticated release catalogs. */
-export type MaterialCatalogRoute = MaterialCatalogIdentity &
-  (
-    | {
-        readonly alternates: readonly [];
-        readonly projection: null;
-        readonly siblings: readonly [];
-      }
-    | {
-        readonly alternates: readonly MaterialLessonProjection[];
-        readonly projection: MaterialLessonProjection;
-        readonly siblings: readonly MaterialLessonProjection[];
-      }
-  );
-
-/** Checks a decoded route set for one unambiguous public identity. */
-function hasUniquePublicPaths(routes: readonly MaterialLessonProjection[]) {
-  return (
-    new Set(routes.map(({ publicPath }) => publicPath)).size === routes.length
-  );
-}
-
-/** Preserves typed catalog failures rejected by an Effect framework runner. */
-function preserveCatalogFailure(cause: unknown) {
-  if (
-    cause instanceof NakafaAgentDataReadError ||
-    cause instanceof PublishedProjectionError ||
-    cause instanceof PublishedReleaseMismatchError
-  ) {
-    return cause;
-  }
-  return new Cause.UnknownError(
-    cause,
-    "Unable to read the cached material catalog."
-  );
-}
-
-/** Lifts one cached locale catalog back into the publication program. */
-const readCachedMaterialCatalog = Effect.fn("NakafaMaterial.readCachedCatalog")(
-  (locale: Locale) =>
-    Effect.tryPromise({
-      catch: preserveCatalogFailure,
-      try: () => getPublishedMaterialRoutes(locale),
-    })
-);
-
-/** Lifts the signed release identity back into the publication program. */
-const readCachedMaterialRelease = Effect.fn("NakafaMaterial.readCachedRelease")(
-  () =>
-    Effect.tryPromise({
-      catch: preserveCatalogFailure,
-      try: () => getPublishedMaterialRelease(),
-    })
-);
-
-/** Orders one localized lesson group exactly like the backend index. */
-function compareMaterialSiblings(
-  left: MaterialLessonProjection,
-  right: MaterialLessonProjection
-) {
-  if (left.order !== right.order) {
-    return left.order - right.order;
-  }
-  return left.publicPath.localeCompare(right.publicPath);
-}
-
-/** Selects one complete shell from low-cardinality release-bound catalogs. */
-export const readMaterialCatalogRoute = Effect.fn(
-  "NakafaMaterial.readCatalogRoute"
-)(function* (
-  release: PublishedMaterialRelease,
-  catalogs: readonly PublishedMaterialCatalog[],
-  locale: Locale,
-  publicPath: string
-) {
-  const appLocale = AppLocaleSchema.make(locale);
-  const projectionIdentity = { appLocale, publicPath };
-  const catalogsByLocale = new Map(
-    catalogs.map((catalog) => [catalog.appLocale, catalog])
-  );
-  const currentCatalog = catalogsByLocale.get(appLocale);
-  if (!currentCatalog) {
-    return yield* makeMaterialProjectionError(projectionIdentity);
-  }
-  if (
-    catalogs.length !== APP_LOCALE_CODES.length ||
-    catalogsByLocale.size !== APP_LOCALE_CODES.length
-  ) {
-    return yield* makeMaterialProjectionError(projectionIdentity);
-  }
-  const activeLocaleSet = new Set(release.activeAppLocales);
-  for (const catalog of catalogs) {
-    if (catalog.activeReleaseId !== release.activeReleaseId) {
-      return yield* new PublishedReleaseMismatchError({
-        actualReleaseId: catalog.activeReleaseId,
-        expectedReleaseId: release.activeReleaseId,
-      });
-    }
-    if (
-      catalog.activeManifestHash !== release.activeManifestHash ||
-      catalog.sourceRevision !== release.sourceRevision ||
-      !hasUniquePublicPaths(catalog.routes) ||
-      catalog.routes.some((route) => route.appLocale !== catalog.appLocale) ||
-      (!activeLocaleSet.has(catalog.appLocale) && catalog.routes.length > 0)
-    ) {
-      return yield* makeMaterialProjectionError(projectionIdentity);
-    }
-  }
-
-  const missingRoute = {
-    activeManifestHash: release.activeManifestHash,
-    activeReleaseId: release.activeReleaseId,
-    alternates: [],
-    projection: null,
-    siblings: [],
-    sourceRevision: release.sourceRevision,
-  } satisfies MaterialCatalogRoute;
-  if (!activeLocaleSet.has(appLocale)) {
-    return missingRoute;
-  }
-
-  const projection = currentCatalog.routes.find(
-    (route) => route.publicPath === publicPath
-  );
-  if (!projection) {
-    return missingRoute;
-  }
-
-  const alternates: MaterialLessonProjection[] = [];
-  for (const activeLocale of release.activeAppLocales) {
-    const counterparts = catalogs.flatMap((catalog) =>
-      catalog.appLocale === activeLocale
-        ? catalog.routes.filter((candidate) =>
-            isMaterialCounterpart(projection, candidate)
-          )
-        : []
-    );
-    const counterpart = counterparts[0];
-    if (!counterpart || counterparts.length !== 1) {
-      return yield* makeMaterialProjectionError(projectionIdentity);
-    }
-    alternates.push(counterpart);
-  }
-
-  const siblingGroup = currentCatalog.routes.filter(
-    (candidate) => candidate.materialKey === projection.materialKey
-  );
-  if (
-    siblingGroup.length > MATERIAL_GROUP_LIMIT ||
-    siblingGroup.some((candidate) => !isMaterialSibling(projection, candidate))
-  ) {
-    return yield* makeMaterialProjectionError(projectionIdentity);
-  }
-  const siblings = [...siblingGroup].sort(compareMaterialSiblings);
-
-  return {
-    activeManifestHash: release.activeManifestHash,
-    activeReleaseId: release.activeReleaseId,
-    alternates,
-    projection,
-    siblings,
-    sourceRevision: release.sourceRevision,
-  } satisfies MaterialCatalogRoute;
-});
-
-/** Reads one release-bound route model from all authenticated catalogs. */
-const readMaterialCatalogModel = Effect.fn("NakafaMaterial.readCatalogModel")(
-  function* (locale: Locale, publicPath: string) {
-    const [release, catalogs] = yield* Effect.all(
-      [
-        readCachedMaterialRelease(),
-        Effect.forEach(APP_LOCALE_CODES, readCachedMaterialCatalog, {
-          concurrency: "unbounded",
-        }),
-      ],
-      { concurrency: "unbounded" }
-    );
-    return yield* readMaterialCatalogRoute(
-      release,
-      catalogs,
-      locale,
-      publicPath
-    );
-  }
-);
-
-/** Caches one metadata-safe shell without evaluating its MDX artifact. */
-export async function getMaterialCatalogRoute(
-  locale: Locale,
-  publicPath: string
-) {
-  "use cache";
-
-  const result = await Effect.runPromise(
-    readMaterialCatalogModel(locale, publicPath)
-  );
-  applyPublishedCatalogCache("material");
-  return result;
-}
-
-/** Reuses the metadata-safe route cache inside the full publication program. */
-const readCachedMaterialCatalogRoute = Effect.fn(
-  "NakafaMaterial.readCachedCatalogRoute"
-)((locale: Locale, publicPath: string) =>
-  Effect.tryPromise({
-    catch: preserveCatalogFailure,
-    try: () => getMaterialCatalogRoute(locale, publicPath),
-  })
-);
-
-/** Reads and verifies one coherent material shell and body concurrently. */
+/** Reads one bounded route model and its signed body concurrently. */
 const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
   function* (locale: Locale, publicPath: string) {
     const appLocale = AppLocaleSchema.make(locale);
-    const readPublished = readRenderedMaterial({ appLocale, publicPath }).pipe(
-      Effect.catchTag("ContentRuntimeMissingError", () => Effect.succeed(null))
-    );
     const [model, published] = yield* Effect.all(
-      [readCachedMaterialCatalogRoute(locale, publicPath), readPublished],
+      [
+        readPublishedMaterialRoute(locale, publicPath),
+        readRenderedMaterial({ appLocale, publicPath }).pipe(
+          Effect.catchTag("ContentRuntimeMissingError", () =>
+            Effect.succeed(null)
+          )
+        ),
+      ],
       { concurrency: "unbounded" }
     );
+
+    yield* Effect.sync(() => applyPublishedCatalogCache("material"));
     if (!model.projection) {
       if (published) {
         return yield* makeMaterialProjectionError({ appLocale, publicPath });
@@ -283,7 +56,7 @@ const readMaterialPublication = Effect.fn("NakafaMaterial.readPublication")(
   }
 );
 
-/** Caches one coherent material publication at the Next.js framework boundary. */
+/** Caches one coherent material publication at the Next.js boundary. */
 export async function getMaterialPublication(
   locale: Locale,
   publicPath: string

--- a/apps/www/lib/content/material/publication.ts
+++ b/apps/www/lib/content/material/publication.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import type { Locale } from "next-intl";
 import {
   applyPublishedCatalogCache,
@@ -14,6 +14,15 @@ import {
 import { getPublishedMaterialRoute } from "@/lib/content/material/route";
 import { readRenderedMaterial } from "@/lib/content/published/material";
 
+class MaterialRouteReadError extends Schema.TaggedError<MaterialRouteReadError>()(
+  "MaterialRouteReadError",
+  {
+    appLocale: AppLocaleSchema,
+    cause: Schema.Unknown,
+    publicPath: Schema.String,
+  }
+) {}
+
 /** Caches one coherent material publication at the Next.js boundary. */
 export async function getMaterialPublication(
   locale: Locale,
@@ -22,39 +31,40 @@ export async function getMaterialPublication(
   "use cache";
 
   const appLocale = AppLocaleSchema.make(locale);
+  const readModel = Effect.tryPromise({
+    catch: (cause) =>
+      new MaterialRouteReadError({ appLocale, cause, publicPath }),
+    try: () => getPublishedMaterialRoute(locale, publicPath),
+  });
   const readPublished = readRenderedMaterial({ appLocale, publicPath }).pipe(
     Effect.catchTag("ContentRuntimeMissingError", () => Effect.succeed(null))
   );
-  const [model, published] = await Promise.all([
-    getPublishedMaterialRoute(locale, publicPath),
-    Effect.runPromise(readPublished),
-  ]);
-
-  applyPublishedCatalogCache("material");
-  if (!model.projection) {
-    if (published) {
-      return await Effect.runPromise(
-        Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
-      );
+  const program = Effect.gen(function* () {
+    const [model, published] = yield* Effect.all([readModel, readPublished], {
+      concurrency: "unbounded",
+    });
+    yield* Effect.sync(() => applyPublishedCatalogCache("material"));
+    if (!model.projection) {
+      if (published) {
+        return yield* makeMaterialProjectionError({ appLocale, publicPath });
+      }
+      return null;
     }
-    return null;
-  }
-  if (!published) {
-    return await Effect.runPromise(
-      Effect.fail(makeMaterialProjectionError({ appLocale, publicPath }))
-    );
-  }
-
-  await Effect.runPromise(
-    verifyMaterialPublication(
+    if (!published) {
+      return yield* makeMaterialProjectionError({ appLocale, publicPath });
+    }
+    yield* verifyMaterialPublication(
       {
         activeReleaseId: model.activeReleaseId,
         projection: model.projection,
       },
       published
-    )
-  );
-  applyPublishedContentCache("material", published.artifactHash);
+    );
+    yield* Effect.sync(() =>
+      applyPublishedContentCache("material", published.artifactHash)
+    );
+    return { model, published };
+  });
 
-  return { model, published };
+  return await Effect.runPromise(program);
 }

--- a/apps/www/lib/content/material/route.test.ts
+++ b/apps/www/lib/content/material/route.test.ts
@@ -104,6 +104,7 @@ describe("published material route", () => {
       siblings: [previewProjection, previewNextProjection],
       sourceRevision,
     });
+    expect(runtimeQueryMock).toHaveBeenCalledOnce();
     expect(cacheMock).toHaveBeenCalledOnce();
   });
 

--- a/packages/backend/convex/contentRelease/material/model.test.ts
+++ b/packages/backend/convex/contentRelease/material/model.test.ts
@@ -70,6 +70,47 @@ describe("contentRelease/material/model", () => {
     ]);
   });
 
+  it.each([
+    ["locale counterpart", makeMaterialProjection("id", 1)],
+    ["sibling", makeMaterialProjection("en", 2)],
+  ])("rejects a stale %s row", async (_label, stale) => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    await target.mutation(async (ctx) => {
+      const row = await ctx.db
+        .query("materialCatalog")
+        .withIndex("by_appLocale_and_publicPath", (index) =>
+          index
+            .eq("appLocale", stale.appLocale)
+            .eq("publicPath", stale.publicPath)
+        )
+        .unique();
+      if (!row) {
+        throw new Error("Expected one related material row.");
+      }
+      await ctx.db.patch("materialCatalog", row._id, {
+        releaseId: "stale-release",
+        sequence: 0,
+      });
+    });
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(
+          readMaterialModel(
+            ctx,
+            requested.appLocale,
+            requested.publicPath,
+            "publication"
+          )
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
   it("returns a missing route inside the current signed family", async () => {
     const target = convexTest(schema, convexModules);
     await activateMaterialCatalog(target);

--- a/packages/backend/convex/contentRelease/material/model.ts
+++ b/packages/backend/convex/contentRelease/material/model.ts
@@ -8,7 +8,7 @@ import {
   type MaterialProjectionContract,
 } from "@repo/backend/convex/contentRelease/material/predecessor";
 import { resolveMaterialRoute } from "@repo/backend/convex/contentRelease/material/route";
-import { verifyMaterial } from "@repo/backend/convex/contentRelease/material/verify";
+import { verifyEffectiveMaterial } from "@repo/backend/convex/contentRelease/material/verify";
 import { readSourceRevision } from "@repo/backend/convex/contentRelease/runtime/origin";
 import { requireExpectedActiveRelease } from "@repo/backend/convex/contentRelease/runtime/pin";
 import { Effect } from "effect";
@@ -18,7 +18,8 @@ const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
   function* (
     ctx: QueryCtx,
     row: Doc<"materialCatalog">,
-    activeAppLocales: ActiveAppLocaleList
+    activeAppLocales: ActiveAppLocaleList,
+    activeSequence: number
   ) {
     const counterparts = yield* Effect.forEach(activeAppLocales, (appLocale) =>
       Effect.gen(function* () {
@@ -31,8 +32,16 @@ const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
             .unique()
         );
         if (alternate) {
-          const verified = yield* verifyMaterial(alternate);
-          return { ...verified, row: alternate };
+          const { projection, resolved } = yield* verifyEffectiveMaterial(
+            ctx,
+            alternate,
+            activeSequence
+          );
+          return {
+            projection,
+            projectionJson: resolved.projectionJson,
+            row: alternate,
+          };
         }
         return yield* releaseFail(
           "CONTENT_RELEASE_INTEGRITY",
@@ -46,7 +55,11 @@ const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
 
 /** Reads every ordered lesson section sharing one localized material key. */
 const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
-  function* (ctx: QueryCtx, row: Doc<"materialCatalog">) {
+  function* (
+    ctx: QueryCtx,
+    row: Doc<"materialCatalog">,
+    activeSequence: number
+  ) {
     const siblings = yield* Effect.promise(() =>
       ctx.db
         .query("materialCatalog")
@@ -66,9 +79,18 @@ const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
       );
     }
     const verified = yield* Effect.forEach(siblings, (sibling) =>
-      verifyMaterial(sibling).pipe(
-        Effect.map((material) => ({ ...material, row: sibling }))
-      )
+      Effect.gen(function* () {
+        const { projection, resolved } = yield* verifyEffectiveMaterial(
+          ctx,
+          sibling,
+          activeSequence
+        );
+        return {
+          projection,
+          projectionJson: resolved.projectionJson,
+          row: sibling,
+        };
+      })
     );
     if (
       !verified.some(({ row: candidate }) => candidate._id === row._id) ||
@@ -123,8 +145,13 @@ export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
     }
     const { projectionJson, row } = route.material;
     const [alternates, siblings] = yield* Effect.all([
-      readAlternates(ctx, row, route.active.signed.manifest.activeAppLocales),
-      readSiblings(ctx, row),
+      readAlternates(
+        ctx,
+        row,
+        route.active.signed.manifest.activeAppLocales,
+        route.active.sequence
+      ),
+      readSiblings(ctx, row, route.active.sequence),
     ]);
     const encodeProjection = (material: (typeof alternates)[number]) => {
       if (contract === "publication") {


### PR DESCRIPTION
## Summary

Replace per-route three-locale material catalog reconstruction with the bounded signed material route query. Metadata and page rendering share the exact-route Next cache, while the page still loads its route shell and signed body concurrently.

## Why

Exact-main Vercel deployment `dpl_2kFc7HZ68KrTgbf4Zf4AtudWJ7xA` completed compilation, then remained in `Collecting page data` until the owner canceled it for cost control. PR #358 introduced `getMaterialCatalogRoute(locale, publicPath)`, which loaded every EN, ID, and DE catalog for each route-specific cache key. Each locale currently needs 12 pages.

A five-minute production sample recorded 431 `contentRelease/material:publications` calls, 35,004 documents and 67.5 MB read, and 17.9 MB returned. Installed Next 16.3.2 documentation confirms that cache keys include build ID, function ID, and serializable arguments, so every route argument created a distinct build cache entry.

## Scope

Eight WWW and backend owner files change. Static params remain the only complete-catalog reader. Metadata and page rendering use `getPublishedMaterialRoute`, backed by bounded `contentRelease/material:publication`. The signed body and route now run in one fail-fast Effect program. Every related locale and sibling row is authenticated against the effective active release. The orphan release-wide reader and obsolete tests are deleted.

Net change is 205 insertions and 753 deletions. No schema, workflow, dependency, UI, compatibility, Vercel configuration, Convex deployment, Gemini, or authored-content behavior changes.

## Exact-head verification

Head `5668fb96eadf50ef5b81e9896378fc00ebe57976` contains protected main `8f03b177cb8b012cd501179e2751c2fbb28819e1`. The current-main integration is conflict-free, introduces no PR-owned source delta, and range-diff proves all five patches remain identical.

Focused WWW material tests pass 36 of 36 and backend material integrity tests pass 9 of 9. Full WWW passes 209 files and 1,510 tests at 100 percent coverage. Full backend passes 354 files and 1,517 tests when run serially; the initial parallel run's timeout cohort passes 70 of 70 serially. WWW and backend TypeScript, lint, boundaries, Effect RC110 source identity, security audit, import scan, diff check, and LOC gates pass. Three review findings were independently reproduced, corrected, evidence-replied, and resolved.

Patch-equivalent CI `33058588074` passed Quality, Production, Browser, AFDocs, cleanup, and Required; React `33058588059` passed Doctor. Automated fresh Codex review is unavailable because the account code-review quota is exhausted, so exact-head source review is independently owned by the Thermo-Nuclear audit and verified range-diff. Fresh protected checks for the current integration head are running in CI `33066286310` and React `33066286332`.

## Rollout

Protected auto-merge may merge only after exact-head Required and Doctor succeed, main remains current, and all review threads remain resolved. Production deploys only through main Git integration. Acceptance requires a READY exact-main WWW deployment, restored sub-10-minute build behavior, no runtime error cluster, and material catalog pagination bounded to static-parameter discovery instead of generated routes. No Preview.

## Risks

The direct query must preserve active release identity, localized alternates, sibling order, renderer ownership, tombstones, cancellation, and typed failures. Those contracts remain domain-owned and covered at the route, publication, and backend model seams.
