### PR TITLE
test(math): use direct Effect Vitest

### DIFF
--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -14,6 +14,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/packages/math/service.test.ts
+++ b/packages/math/service.test.ts
@@ -1,7 +1,8 @@
+import { it } from "@effect/vitest";
 import { MathCasRequestError } from "@repo/math/errors";
 import { MathService } from "@repo/math/service";
-import { afterEach, describe, expect, it, vi } from "@repo/testing/effect";
 import { ConfigProvider, Effect, Exit } from "effect";
+import { afterEach, describe, expect, vi } from "vitest";
 
 const provider = ConfigProvider.fromEnvRecord({
   MATH_CAS_API_KEY: "secret",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1054,6 +1054,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-rc.110
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

Move the math package's Effectful CAS service tests from the legacy test wrapper to the official Effect v4 Vitest API.

## Architecture

- Declare `@effect/vitest` directly in the owning math package.
- Import `it` from the official Effect v4 Vitest integration.
- Keep ordinary Vitest APIs for assertions, mocks, suite structure, and cleanup.
- Preserve the existing Web `Response.text()` rejection fixture because it models the host Promise boundary that the Effect service must map to its typed error.

## Commits

1. Add direct package dependency ownership and the exact lockfile importer entry.
2. Migrate the CAS service test module to direct Effect Vitest.

## Exact identity

- Base: `a90841887e992b05711b3fd73b19133c172ec5e1`
- Head: `5cec48614f14039f27b41f727379f1de8f462ec5`
- Dependency patch id: `a0c846c94ee7ef5fa5b046f2dcd526732487b9ba`
- Test patch id: `c6a2978bfc2b13c5511556950002a9609d70efb1`

## Verification

- Full math suite: 11 files and 38 tests passed.
- Coverage: 100% statements, branches, functions, and lines.
- Math typecheck, Effect source parity, lockfile supply-chain policy, test policy, patch policy, lint, formatting, workspace boundaries, dependency audit, raw-runner scan, and diff checks passed on the exact current base.

## Release impact

Test-only and development-dependency-only change. No CAS behavior, runtime dependency, production application, Vercel deployment, or Convex schema changed.