### PR TITLE
test(contents): use direct Effect Vitest

### DIFF
--- a/packages/contents/_types/llms/mdx.test.ts
+++ b/packages/contents/_types/llms/mdx.test.ts
@@ -1,12 +1,13 @@
+import { it } from "@effect/vitest";
 import {
   MdxAgentProjectionError,
   projectMdxForAgentMarkdown,
 } from "@repo/contents/_types/llms/mdx";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
+import { describe, expect } from "vitest";
 
 describe("MDX agent markdown projection", () => {
-  it.live(
+  it.effect(
     "preserves authored math, diagrams, visual data, and agent context",
     () =>
       Effect.gen(function* () {
@@ -127,7 +128,7 @@ A-->B\`} />
       })
   );
 
-  it.live("handles edge MDX syntax without adding fake semantics", () =>
+  it.effect("handles edge MDX syntax without adding fake semantics", () =>
     Effect.gen(function* () {
       const markdown = yield* projectMdxForAgentMarkdown(`
 <>
@@ -158,7 +159,7 @@ Fragment child with <InlineMath math="x" />.
     })
   );
 
-  it.live(
+  it.effect(
     "keeps unknown instructional components bounded instead of using a hardcoded allowlist",
     () =>
       Effect.gen(function* () {
@@ -186,7 +187,7 @@ The scene compares entry speed and orbit height.
       })
   );
 
-  it.live("keeps escaped nested code fences inside CodeBlock data", () =>
+  it.effect("keeps escaped nested code fences inside CodeBlock data", () =>
     Effect.gen(function* () {
       const markdown = yield* projectMdxForAgentMarkdown(`
 <CodeBlock
@@ -213,7 +214,7 @@ print("Hello, World!")
     })
   );
 
-  it.live(
+  it.effect(
     "projects the cooked backslashes rendered by template literal code",
     () =>
       Effect.gen(function* () {
@@ -233,7 +234,7 @@ print("Hello, World!")
       })
   );
 
-  it.live(
+  it.effect(
     "reports malformed standalone fragments as typed projection failures",
     () =>
       Effect.gen(function* () {

--- a/packages/contents/package.json
+++ b/packages/contents/package.json
@@ -21,6 +21,7 @@
     "unified": "11.0.5"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/mdast": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
         specifier: 11.0.5
         version: 11.0.5
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

- add the package-owned `@effect/vitest` development dependency
- import `it` directly from the official Effect v4 Vitest package
- use `it.effect` for the synchronous Effect projection programs
- retain ordinary Vitest for `describe` and `expect`

## Architecture

The MDX projection returns an Effect and has no live clock or external service dependency. Vendored Effect v4 source therefore supports `it.effect`; the prior `it.live` wrapper path provided unnecessary live-runtime behavior.

## Scope

Three files in `@repo/contents`, split into two package-owned commits. No production code, runtime dependency, Vercel configuration, Convex surface, or deployment behavior changes.

## Exact-head proof

- 22 test files and 143 tests passed
- 100% statements, branches, functions, and lines
- contents typecheck passed
- Effect source parity, patch policy, and test ownership passed
- lint and package boundaries passed
- security audit found no known vulnerabilities
- diff check and direct-runner scan passed

## Source basis

Implementation follows the repository's vendored Effect v4 source at `repos/effect`, pinned to `effect@4.0.0-rc.110`, and the official `@effect/vitest` API.

## Deployment

Test-only plus development dependency. No Vercel Preview and no production deployment required.