### PR TITLE
test(utilities): use direct Effect Vitest for logging

### DIFF
--- a/packages/utilities/logging/effect.test.ts
+++ b/packages/utilities/logging/effect.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "@repo/testing/effect";
+import { it } from "@effect/vitest";
 import {
   logError,
   logHttpRequest,
   timeOperation,
 } from "@repo/utilities/logging/effect";
 import { Effect, Logger } from "effect";
+import { describe, expect } from "vitest";
 
 type StructuredLogEntry = ReturnType<typeof Logger.formatStructured.log>;
 

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -13,6 +13,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,6 +1183,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-rc.110
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

- add the package-owned `@effect/vitest` development dependency
- import `it` directly from the official Effect v4 Vitest package
- retain ordinary Vitest for `describe` and `expect`
- keep each logging program returned directly to `it.effect`

## Architecture

The logging tests already compose Effect programs and use Effect logger layers. This checkpoint removes the repository wrapper from that seam without adding another abstraction. The official Effect Vitest runtime now owns scope and test execution directly.

## Scope

Three files in `@repo/utilities`, split into one dependency commit and one test migration commit. No utility implementation, runtime dependency, Vercel configuration, Convex surface, or production behavior changes.

## Exact identity

- Base: `700ba8345f112047525e862213b763f54c436285`
- Head: `5cfe6d03843302a696269c28607e7e5e982778bb`
- Dependency patch id: `28ea453079a903ea9807e20cd837b2be9fee5b4a`
- Test patch id: `370b89e8d88a046b8002e75f507dba06eae7ede3`

## Verification

- utilities suite: 6 files and 112 tests passed
- 100% statements, branches, functions, and lines
- utilities typecheck passed
- Effect source parity, patch policy, and test ownership passed
- lint and package boundaries passed
- frozen lockfile install passed
- security audit found no known vulnerabilities
- wrapper-import, direct-runner, async, Promise, and diff scans passed for the migrated module

## Release impact

Test-only plus development dependency. No Vercel Preview and no production deployment required.