### PR TITLE
refactor(content): make bounded preview requests Effect native

### DIFF
--- a/apps/www/lib/content/preview/request.test.ts
+++ b/apps/www/lib/content/preview/request.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { SigningKeyIdSchema } from "@nakafa/aksara-contracts/ids";
-import { Effect, Fiber, Redacted } from "effect";
+import { Deferred, Effect, Fiber, Redacted } from "effect";
 import { TestClock } from "effect/testing";
 import { vi } from "vitest";
 import type { PreviewConfig } from "@/lib/content/preview/config";
@@ -179,6 +179,32 @@ describe("local preview JSON requests", () => {
     })
   );
 
+  it.effect.each([false, true])(
+    "cancels an unread invalid response even when cancellation rejects: %s",
+    (rejectCancellation) =>
+      Effect.gen(function* () {
+        const cancel = vi.fn(() => {
+          if (rejectCancellation) {
+            return Promise.reject(new TypeError("cancel failed"));
+          }
+        });
+        const invalid = response(new ReadableStream({ cancel }), {
+          status: 409,
+        });
+        vi.stubGlobal(
+          "fetch",
+          vi.fn<typeof fetch>().mockResolvedValue(invalid)
+        );
+
+        expect(yield* runFailure()).toMatchObject({
+          _tag: "PreviewRequestError",
+          stage: "response",
+          status: 409,
+        });
+        expect(cancel).toHaveBeenCalledOnce();
+      })
+  );
+
   it.effect("rejects a response without a body", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
@@ -272,6 +298,64 @@ describe("local preview JSON requests", () => {
       expect(yield* runFailure()).toMatchObject({ stage: "body" });
       expect(yield* runFailure()).toMatchObject({ stage: "body" });
       expect(yield* runFailure()).toMatchObject({ stage: "body" });
+    })
+  );
+
+  it.effect("maps synchronous stream-reader acquisition failures", () =>
+    Effect.gen(function* () {
+      const unreadable = new ReadableStream<Uint8Array>();
+      Object.defineProperty(unreadable, "getReader", {
+        /** Fails after response validation but before the first body pull. */
+        value() {
+          throw new TypeError("reader unavailable");
+        },
+      });
+      const value = response("{}", {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+      Object.defineProperty(value, "body", { value: unreadable });
+      vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(value));
+
+      expect(yield* runFailure()).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "body",
+      });
+    })
+  );
+
+  it.effect("classifies and cancels a stalled response body", () =>
+    Effect.gen(function* () {
+      const pullStarted = yield* Deferred.make<void>();
+      const cancel = vi.fn();
+      const stalled = new ReadableStream<Uint8Array>({
+        cancel,
+        /** Marks the body phase active without completing its first read. */
+        pull() {
+          Deferred.doneUnsafe(pullStarted, Effect.void);
+        },
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>().mockResolvedValue(
+          response(stalled, {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          })
+        )
+      );
+      const fiber = yield* runFailure().pipe(
+        Effect.forkChild({ startImmediately: true })
+      );
+
+      yield* Deferred.await(pullStarted);
+      yield* TestClock.adjust("1 hour");
+
+      expect(yield* Fiber.join(fiber)).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "body",
+      });
+      expect(cancel).toHaveBeenCalledOnce();
     })
   );
 

--- a/apps/www/lib/content/preview/request.test.ts
+++ b/apps/www/lib/content/preview/request.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment node
 
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { SigningKeyIdSchema } from "@nakafa/aksara-contracts/ids";
-import { Effect, Redacted } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { Effect, Fiber, Redacted } from "effect";
+import { TestClock } from "effect/testing";
+import { vi } from "vitest";
 import type { PreviewConfig } from "@/lib/content/preview/config";
 import {
   fetchPreviewJson,
+  fetchPreviewJsonForPrerender,
   MAX_PREVIEW_MANIFEST_BYTES,
 } from "@/lib/content/preview/request";
 
@@ -35,11 +38,9 @@ function response(
   return value;
 }
 
-/** Runs one preview fetch at the Effect boundary. */
+/** Builds one preview fetch for the Effect test runtime. */
 function run(maxBytes = MAX_PREVIEW_MANIFEST_BYTES) {
-  return Effect.runPromise(
-    fetchPreviewJson(config, config.manifestPath, maxBytes)
-  );
+  return fetchPreviewJson(config, config.manifestPath, maxBytes);
 }
 
 /** Returns one typed request failure without losing its error channel. */
@@ -47,98 +48,106 @@ function runFailure(
   maxBytes = MAX_PREVIEW_MANIFEST_BYTES,
   path: string = config.manifestPath
 ) {
-  return Effect.runPromise(
-    fetchPreviewJson(config, path, maxBytes).pipe(Effect.flip)
-  );
+  return fetchPreviewJson(config, path, maxBytes).pipe(Effect.flip);
 }
 
 describe("local preview JSON requests", () => {
-  it("sends a private bearer request and decodes bounded JSON", async () => {
-    const fetcher = vi.fn(() =>
-      Promise.resolve(
+  it.effect("sends a private bearer request and decodes bounded JSON", () =>
+    Effect.gen(function* () {
+      const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
         response('{"status":"ready"}', {
           headers: { "content-type": "application/json; charset=utf-8" },
           status: 200,
         })
-      )
-    );
-    vi.stubGlobal("fetch", fetcher);
+      );
+      vi.stubGlobal("fetch", fetcher);
 
-    await expect(run()).resolves.toEqual({ status: "ready" });
-    expect(fetcher).toHaveBeenCalledWith(
-      new URL(target),
-      expect.objectContaining({
-        cache: "no-store",
-        credentials: "omit",
-        headers: {
-          accept: "application/json",
-          authorization: "Bearer secret-token",
-        },
-        redirect: "error",
-        referrerPolicy: "no-referrer",
-      })
-    );
-  });
+      expect(yield* run()).toEqual({ status: "ready" });
+      expect(fetcher).toHaveBeenCalledWith(
+        new URL(target),
+        expect.objectContaining({
+          cache: "no-store",
+          credentials: "omit",
+          headers: {
+            accept: "application/json",
+            authorization: "Bearer secret-token",
+          },
+          redirect: "error",
+          referrerPolicy: "no-referrer",
+        })
+      );
+    })
+  );
 
-  it("maps connection failures without exposing their cause", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => Promise.reject(new TypeError("secret")))
-    );
-    await expect(runFailure()).resolves.toMatchObject({
-      _tag: "PreviewRequestError",
-      stage: "connect",
-    });
-  });
+  it.effect("maps connection failures without exposing their cause", () =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>().mockRejectedValue(new TypeError("secret"))
+      );
+      expect(yield* runFailure()).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "connect",
+      });
+    })
+  );
 
-  it.each([
+  it.effect.each([
     "//attacker.test/steal",
     "/v1/artifacts/%2e%2e%2fmanifest",
     `/v1/artifacts/sha256%3a${"a".repeat(64)}`,
-  ])(
-    "rejects non-contract path %s before sending its bearer token",
-    async (path) => {
-      const fetcher = vi.fn();
+  ])("rejects non-contract path %s before sending its bearer token", (path) =>
+    Effect.gen(function* () {
+      const fetcher = vi.fn<typeof fetch>();
       vi.stubGlobal("fetch", fetcher);
 
-      await expect(
-        runFailure(MAX_PREVIEW_MANIFEST_BYTES, path)
-      ).resolves.toMatchObject({ _tag: "PreviewConfigError" });
+      expect(yield* runFailure(MAX_PREVIEW_MANIFEST_BYTES, path)).toMatchObject(
+        { _tag: "PreviewConfigError" }
+      );
       expect(fetcher).not.toHaveBeenCalled();
-    }
+    })
   );
 
-  it("sends the bearer token only to an exact content-addressed artifact", async () => {
-    const artifactPath = `/v1/artifacts/sha256%3A${"a".repeat(64)}`;
-    const artifactTarget = `http://127.0.0.1:4000${artifactPath}`;
-    const fetcher = vi.fn(() =>
-      Promise.resolve(
-        response("{}", {
-          headers: { "content-type": "application/json" },
-          status: 200,
-          url: artifactTarget,
-        })
+  it("rejects an invalid path at the Next prerender boundary", () =>
+    expect(
+      fetchPreviewJsonForPrerender(
+        config,
+        "//attacker.test/steal",
+        MAX_PREVIEW_MANIFEST_BYTES
       )
-    );
-    vi.stubGlobal("fetch", fetcher);
+    ).rejects.toMatchObject({ _tag: "PreviewConfigError" }));
 
-    await expect(
-      Effect.runPromise(fetchPreviewJson(config, artifactPath, 1024))
-    ).resolves.toEqual({});
-    expect(fetcher).toHaveBeenCalledWith(
-      new URL(artifactTarget),
-      expect.objectContaining({
-        credentials: "omit",
-        headers: expect.objectContaining({
-          authorization: "Bearer secret-token",
-        }),
-        redirect: "error",
-        referrerPolicy: "no-referrer",
+  it.effect(
+    "sends the bearer token only to an exact content-addressed artifact",
+    () =>
+      Effect.gen(function* () {
+        const artifactPath = `/v1/artifacts/sha256%3A${"a".repeat(64)}`;
+        const artifactTarget = `http://127.0.0.1:4000${artifactPath}`;
+        const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+          response("{}", {
+            headers: { "content-type": "application/json" },
+            status: 200,
+            url: artifactTarget,
+          })
+        );
+        vi.stubGlobal("fetch", fetcher);
+
+        expect(yield* fetchPreviewJson(config, artifactPath, 1024)).toEqual({});
+        expect(fetcher).toHaveBeenCalledWith(
+          new URL(artifactTarget),
+          expect.objectContaining({
+            credentials: "omit",
+            headers: expect.objectContaining({
+              authorization: "Bearer secret-token",
+            }),
+            redirect: "error",
+            referrerPolicy: "no-referrer",
+          })
+        );
       })
-    );
-  });
+  );
 
-  it.each([
+  it.effect.each([
     ["status", response("{}", { status: 409 })],
     [
       "redirected URL",
@@ -159,127 +168,132 @@ describe("local preview JSON requests", () => {
         status: 200,
       }),
     ],
-  ])("rejects an invalid %s response", async (_label, value) => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => Promise.resolve(value))
-    );
-    await expect(runFailure()).resolves.toMatchObject({
-      _tag: "PreviewRequestError",
-      stage: "response",
-      status: value.status,
-    });
-  });
+  ] as const)("rejects an invalid %s response", ([_label, value]) =>
+    Effect.gen(function* () {
+      vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(value));
+      expect(yield* runFailure()).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "response",
+        status: value.status,
+      });
+    })
+  );
 
-  it("rejects a response without a body", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() =>
-        Promise.resolve(
+  it.effect("rejects a response without a body", () =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>().mockResolvedValue(
           response(null, {
             headers: { "content-type": "application/json" },
             status: 200,
           })
         )
-      )
-    );
-    await expect(runFailure()).resolves.toMatchObject({
-      _tag: "PreviewRequestError",
-      stage: "body",
-    });
-  });
-
-  it("cancels a response that crosses its byte ceiling", async () => {
-    const fetcher = vi
-      .fn()
-      .mockResolvedValueOnce(
-        response('{"value":"too large"}', {
-          headers: { "content-type": "application/json" },
-          status: 200,
-        })
-      )
-      .mockResolvedValueOnce({
-        body: {
-          /** Returns one oversized chunk before provider cancellation. */
-          getReader: () => ({
-            cancel: () => Promise.reject(new TypeError("cancel failed")),
-            read: () =>
-              Promise.resolve({
-                done: false,
-                value: new TextEncoder().encode("oversized"),
-              }),
-          }),
-        },
-        headers: new Headers({ "content-type": "application/json" }),
-        status: 200,
-        url: target,
+      );
+      expect(yield* runFailure()).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "body",
       });
-    vi.stubGlobal("fetch", fetcher);
+    })
+  );
 
-    await expect(runFailure(4)).resolves.toMatchObject({
-      _tag: "PreviewBodyLimitError",
-      maxBytes: 4,
-    });
-    await expect(runFailure(4)).resolves.toMatchObject({
-      _tag: "PreviewBodyLimitError",
-      maxBytes: 4,
-    });
-  });
-
-  it("maps stream, UTF-8, and JSON decoding failures", async () => {
-    const stream = new ReadableStream({
-      /** Fails before exposing provider bytes. */
-      pull(controller) {
-        controller.error(new TypeError("stream failed"));
-      },
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
+  it.effect("cancels a response that crosses its byte ceiling", () =>
+    Effect.gen(function* () {
+      const cancel = vi.fn(() =>
+        Promise.reject(new TypeError("cancel failed"))
+      );
+      const oversized = new ReadableStream<Uint8Array>({
+        cancel,
+        /** Emits one oversized chunk before provider cancellation. */
+        pull(controller) {
+          controller.enqueue(new TextEncoder().encode("oversized"));
+        },
+      });
+      const fetcher = vi
+        .fn<typeof fetch>()
         .mockResolvedValueOnce(
-          response(stream, {
+          response('{"value":"too large"}', {
             headers: { "content-type": "application/json" },
             status: 200,
           })
         )
         .mockResolvedValueOnce(
-          response(new Uint8Array([255]), {
+          response(oversized, {
             headers: { "content-type": "application/json" },
             status: 200,
           })
-        )
-        .mockResolvedValueOnce(
-          response("not-json", {
-            headers: { "content-type": "application/json" },
-            status: 200,
-          })
-        )
-    );
+        );
+      vi.stubGlobal("fetch", fetcher);
 
-    await expect(runFailure()).resolves.toMatchObject({ stage: "body" });
-    await expect(runFailure()).resolves.toMatchObject({ stage: "body" });
-    await expect(runFailure()).resolves.toMatchObject({ stage: "body" });
-  });
+      expect(yield* runFailure(4)).toMatchObject({
+        _tag: "PreviewBodyLimitError",
+        maxBytes: 4,
+      });
+      expect(yield* runFailure(4)).toMatchObject({
+        _tag: "PreviewBodyLimitError",
+        maxBytes: 4,
+      });
+      expect(cancel).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("maps synchronous stream-reader acquisition failures", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() =>
-        Promise.resolve({
-          body: {
-            /** Fails before the response body exposes a reader. */
-            getReader() {
-              throw new TypeError("reader unavailable");
-            },
-          },
-          headers: new Headers({ "content-type": "application/json" }),
-          status: 200,
-          url: target,
-        })
-      )
-    );
+  it.effect("maps stream, UTF-8, and JSON decoding failures", () =>
+    Effect.gen(function* () {
+      const stream = new ReadableStream({
+        /** Fails before exposing provider bytes. */
+        pull(controller) {
+          controller.error(new TypeError("stream failed"));
+        },
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            response(stream, {
+              headers: { "content-type": "application/json" },
+              status: 200,
+            })
+          )
+          .mockResolvedValueOnce(
+            response(new Uint8Array([255]), {
+              headers: { "content-type": "application/json" },
+              status: 200,
+            })
+          )
+          .mockResolvedValueOnce(
+            response("not-json", {
+              headers: { "content-type": "application/json" },
+              status: 200,
+            })
+          )
+      );
 
-    await expect(runFailure()).resolves.toMatchObject({ stage: "body" });
-  });
+      expect(yield* runFailure()).toMatchObject({ stage: "body" });
+      expect(yield* runFailure()).toMatchObject({ stage: "body" });
+      expect(yield* runFailure()).toMatchObject({ stage: "body" });
+    })
+  );
+
+  it.effect("interrupts a stalled request at its typed timeout", () =>
+    Effect.gen(function* () {
+      /** Keeps Fetch pending until Effect interrupts its AbortSignal. */
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockImplementation(() => new Promise<Response>(() => undefined));
+      vi.stubGlobal("fetch", fetcher);
+      const fiber = yield* runFailure().pipe(
+        Effect.forkChild({ startImmediately: true })
+      );
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("1 hour");
+
+      expect(yield* Fiber.join(fiber)).toMatchObject({
+        _tag: "PreviewRequestError",
+        stage: "connect",
+      });
+      expect(fetcher.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    })
+  );
 });

--- a/apps/www/lib/content/preview/request.ts
+++ b/apps/www/lib/content/preview/request.ts
@@ -18,13 +18,16 @@ import {
 
 /** Maximum UTF-8 bytes accepted from the small current-state manifest. */
 export const MAX_PREVIEW_MANIFEST_BYTES = 128 * 1024;
-const PREVIEW_REQUEST_TIMEOUT_MS = 5000;
-/** Applies the one typed timeout contract shared by both request boundaries. */
-function withPreviewRequestTimeout<A, E, R>(effect: Effect.Effect<A, E, R>) {
+const PREVIEW_PHASE_TIMEOUT_MS = 5000;
+/** Applies the typed timeout for one preview request phase. */
+function withPreviewRequestTimeout<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  stage: "body" | "connect"
+) {
   return effect.pipe(
     Effect.timeoutOrElse({
-      duration: PREVIEW_REQUEST_TIMEOUT_MS,
-      orElse: () => Effect.fail(new PreviewRequestError({ stage: "connect" })),
+      duration: PREVIEW_PHASE_TIMEOUT_MS,
+      orElse: () => Effect.fail(new PreviewRequestError({ stage })),
     })
   );
 }
@@ -72,6 +75,17 @@ function mapBodyError(
   }
   return new PreviewRequestError({ stage: "body" });
 }
+/** Cancels an unread response body without replacing its primary result. */
+function cancelUnreadResponse(response: Response) {
+  const body = response.body;
+  if (body === null || response.bodyUsed) {
+    return Effect.void;
+  }
+  return Effect.tryPromise({
+    catch: () => undefined,
+    try: () => body.cancel(),
+  }).pipe(Effect.ignore);
+}
 /** Builds the private request shared by Effect and Next framework boundaries. */
 function previewRequestInit(config: PreviewConfig, signal: AbortSignal) {
   return {
@@ -98,11 +112,21 @@ const requestPreviewResponse = Effect.fn(
 /** Validates and decodes one fetched response through the Effect error channel. */
 const decodePreviewResponse = Effect.fn("NakafaContent.decodePreviewResponse")(
   function* (response: Response, target: URL, maxBytes: number) {
-    const validated = yield* validateResponse(response, target);
-    const bytes = yield* readBoundedBody(validated.body, maxBytes).pipe(
-      Effect.mapError(mapBodyError)
+    return yield* Effect.acquireUseRelease(
+      Effect.succeed(response),
+      (activeResponse) =>
+        Effect.gen(function* () {
+          const validated = yield* validateResponse(activeResponse, target);
+          return yield* withPreviewRequestTimeout(
+            readBoundedBody(validated.body, maxBytes).pipe(
+              Effect.mapError(mapBodyError),
+              Effect.flatMap(decodeJson)
+            ),
+            "body"
+          );
+        }),
+      cancelUnreadResponse
     );
-    return yield* decodeJson(bytes);
   }
 );
 /**
@@ -126,20 +150,21 @@ export function fetchPreviewJsonForPrerender(
     previewRequestInit(config, controller.signal)
   );
   return Effect.runPromise(
-    withPreviewRequestTimeout(
-      Effect.acquireUseRelease(
-        Effect.succeed(controller),
-        () =>
+    Effect.acquireUseRelease(
+      Effect.succeed(controller),
+      () =>
+        withPreviewRequestTimeout(
           Effect.tryPromise({
             catch: () => new PreviewRequestError({ stage: "connect" }),
             try: () => response,
-          }).pipe(
-            Effect.flatMap((value) =>
-              decodePreviewResponse(value, target.success, maxBytes)
-            )
-          ),
-        (activeController) => Effect.sync(() => activeController.abort())
-      )
+          }),
+          "connect"
+        ).pipe(
+          Effect.flatMap((value) =>
+            decodePreviewResponse(value, target.success, maxBytes)
+          )
+        ),
+      (activeController) => Effect.sync(() => activeController.abort())
     )
   );
 }
@@ -150,12 +175,10 @@ export const fetchPreviewJson = Effect.fn("NakafaContent.fetchPreviewJson")(
     if (Result.isFailure(target)) {
       return yield* target.failure;
     }
-    return yield* withPreviewRequestTimeout(
-      requestPreviewResponse(config, target.success).pipe(
-        Effect.flatMap((response) =>
-          decodePreviewResponse(response, target.success, maxBytes)
-        )
-      )
+    const response = yield* withPreviewRequestTimeout(
+      requestPreviewResponse(config, target.success),
+      "connect"
     );
+    return yield* decodePreviewResponse(response, target.success, maxBytes);
   }
 );

--- a/apps/www/lib/content/preview/request.ts
+++ b/apps/www/lib/content/preview/request.ts
@@ -3,66 +3,63 @@ import {
   type BodyLimitError,
   type BodyMissingError,
   type BodyReadError,
-  readBoundedBodyResult,
+  readBoundedBody,
 } from "@repo/utilities/body";
 import { isJsonContentType } from "@repo/utilities/mime";
 import { Effect, Redacted, Result, Schema } from "effect";
 import {
   decodePreviewUrl,
   type PreviewConfig,
-  type PreviewConfigError,
 } from "@/lib/content/preview/config";
 import {
   PreviewBodyLimitError,
   PreviewRequestError,
 } from "@/lib/content/preview/errors";
 
-type PreviewJsonError =
-  | PreviewBodyLimitError
-  | PreviewConfigError
-  | PreviewRequestError;
-type PreviewJsonResult = Result.Result<unknown, PreviewJsonError>;
 /** Maximum UTF-8 bytes accepted from the small current-state manifest. */
 export const MAX_PREVIEW_MANIFEST_BYTES = 128 * 1024;
-/** Parses an authenticated JSON body without weakening its unknown boundary. */
-const decodePreviewJson = Schema.decodeUnknownResult(
+const PREVIEW_REQUEST_TIMEOUT_MS = 5000;
+/** Applies the one typed timeout contract shared by both request boundaries. */
+function withPreviewRequestTimeout<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return effect.pipe(
+    Effect.timeoutOrElse({
+      duration: PREVIEW_REQUEST_TIMEOUT_MS,
+      orElse: () => Effect.fail(new PreviewRequestError({ stage: "connect" })),
+    })
+  );
+}
+/** Parses authenticated JSON without weakening its unknown boundary. */
+const decodePreviewJson = Schema.decodeUnknownEffect(
   Schema.fromJsonString(Schema.Unknown)
 );
 /** Validates the exact successful JSON response before reading its body. */
-function validateResponse(
-  response: Response,
-  target: URL
-): Result.Result<Response, PreviewRequestError> {
-  if (
-    response.status !== 200 ||
-    response.url !== target.toString() ||
-    !isJsonContentType(response.headers.get("content-type"))
-  ) {
-    return Result.fail(
-      new PreviewRequestError({
+const validateResponse = Effect.fn("NakafaContent.validatePreviewResponse")(
+  function* (response: Response, target: URL) {
+    if (
+      response.status !== 200 ||
+      response.url !== target.toString() ||
+      !isJsonContentType(response.headers.get("content-type"))
+    ) {
+      return yield* new PreviewRequestError({
         stage: "response",
         status: response.status,
-      })
-    );
+      });
+    }
+    return response;
   }
-  return Result.succeed(response);
-}
-/** Decodes bounded UTF-8 JSON without starting an Effect runtime. */
-function decodeJsonResult(
+);
+/** Decodes bounded UTF-8 JSON through typed Effect failures. */
+const decodeJson = Effect.fn("NakafaContent.decodePreviewJson")(function* (
   bytes: Uint8Array
-): Result.Result<unknown, PreviewRequestError> {
-  const source = Result.try({
+) {
+  const source = yield* Effect.try({
     catch: () => new PreviewRequestError({ stage: "body" }),
     try: () => new TextDecoder("utf-8", { fatal: true }).decode(bytes),
   });
-  if (Result.isFailure(source)) {
-    return source;
-  }
-  return Result.mapError(
-    decodePreviewJson(source.success),
-    () => new PreviewRequestError({ stage: "body" })
+  return yield* decodePreviewJson(source).pipe(
+    Effect.mapError(() => new PreviewRequestError({ stage: "body" }))
   );
-}
+});
 /** Maps a generic bounded-body failure into the preview error vocabulary. */
 function mapBodyError(
   error: BodyLimitError | BodyMissingError | BodyReadError
@@ -75,66 +72,39 @@ function mapBodyError(
   }
   return new PreviewRequestError({ stage: "body" });
 }
-/** Sends one loopback request after a framework-visible Promise suspension. */
-function requestPreviewResponse(
-  config: PreviewConfig,
-  target: URL
-): Promise<Result.Result<Response, PreviewRequestError>> {
-  return Promise.resolve()
-    .then(() =>
-      fetch(target, {
-        cache: "no-store",
-        credentials: "omit",
-        headers: {
-          accept: "application/json",
-          authorization: `Bearer ${Redacted.value(config.token)}`,
-        },
-        redirect: "error",
-        referrerPolicy: "no-referrer",
-        signal: AbortSignal.timeout(5000),
-      })
-    )
-    .then(
-      (response) => Result.succeed(response),
-      () => Result.fail(new PreviewRequestError({ stage: "connect" }))
+/** Builds the private request shared by Effect and Next framework boundaries. */
+function previewRequestInit(config: PreviewConfig, signal: AbortSignal) {
+  return {
+    cache: "no-store",
+    credentials: "omit",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${Redacted.value(config.token)}`,
+    },
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+    signal,
+  } satisfies RequestInit;
+}
+/** Sends one interruptible loopback request with typed connection failure. */
+const requestPreviewResponse = Effect.fn(
+  "NakafaContent.requestPreviewResponse"
+)(function* (config: PreviewConfig, target: URL) {
+  return yield* Effect.tryPromise({
+    catch: () => new PreviewRequestError({ stage: "connect" }),
+    try: (signal) => fetch(target, previewRequestInit(config, signal)),
+  });
+});
+/** Validates and decodes one fetched response through the Effect error channel. */
+const decodePreviewResponse = Effect.fn("NakafaContent.decodePreviewResponse")(
+  function* (response: Response, target: URL, maxBytes: number) {
+    const validated = yield* validateResponse(response, target);
+    const bytes = yield* readBoundedBody(validated.body, maxBytes).pipe(
+      Effect.mapError(mapBodyError)
     );
-}
-/** Validates and decodes one fetched response without rejecting its Promise. */
-function decodeResponseResult(
-  result: Result.Result<Response, PreviewRequestError>,
-  target: URL,
-  maxBytes: number
-): Promise<PreviewJsonResult> {
-  if (Result.isFailure(result)) {
-    return Promise.resolve(Result.fail(result.failure));
+    return yield* decodeJson(bytes);
   }
-  const validated = validateResponse(result.success, target);
-  if (Result.isFailure(validated)) {
-    return Promise.resolve(Result.fail(validated.failure));
-  }
-  return readBoundedBodyResult(validated.success.body, maxBytes).then(
-    (bytes) => {
-      if (Result.isFailure(bytes)) {
-        return Result.fail(mapBodyError(bytes.failure));
-      }
-      return decodeJsonResult(bytes.success);
-    }
-  );
-}
-/** Resolves one preview request into a never-rejecting typed result. */
-function fetchPreviewJsonResult(
-  config: PreviewConfig,
-  path: string,
-  maxBytes: number
-): Promise<PreviewJsonResult> {
-  const target = decodePreviewUrl(config, path);
-  if (Result.isFailure(target)) {
-    return Promise.resolve(Result.fail(target.failure));
-  }
-  return requestPreviewResponse(config, target.success).then((response) =>
-    decodeResponseResult(response, target.success, maxBytes)
-  );
-}
+);
 /**
  * Fetches one bounded preview resource through Next's direct Promise boundary.
  *
@@ -146,22 +116,46 @@ export function fetchPreviewJsonForPrerender(
   path: string,
   maxBytes: number
 ) {
-  return fetchPreviewJsonResult(config, path, maxBytes).then((result) => {
-    if (Result.isFailure(result)) {
-      return Promise.reject(result.failure);
-    }
-    return result.success;
-  });
+  const target = decodePreviewUrl(config, path);
+  if (Result.isFailure(target)) {
+    return Promise.reject(target.failure);
+  }
+  const controller = new AbortController();
+  const response = fetch(
+    target.success,
+    previewRequestInit(config, controller.signal)
+  );
+  return Effect.runPromise(
+    withPreviewRequestTimeout(
+      Effect.acquireUseRelease(
+        Effect.succeed(controller),
+        () =>
+          Effect.tryPromise({
+            catch: () => new PreviewRequestError({ stage: "connect" }),
+            try: () => response,
+          }).pipe(
+            Effect.flatMap((value) =>
+              decodePreviewResponse(value, target.success, maxBytes)
+            )
+          ),
+        (activeController) => Effect.sync(() => activeController.abort())
+      )
+    )
+  );
 }
 /** Fetches one bearer-protected loopback JSON resource with strict bounds. */
 export const fetchPreviewJson = Effect.fn("NakafaContent.fetchPreviewJson")(
   function* (config: PreviewConfig, path: string, maxBytes: number) {
-    const result = yield* Effect.promise(() =>
-      fetchPreviewJsonResult(config, path, maxBytes)
-    );
-    if (Result.isFailure(result)) {
-      return yield* result.failure;
+    const target = decodePreviewUrl(config, path);
+    if (Result.isFailure(target)) {
+      return yield* target.failure;
     }
-    return result.success;
+    return yield* withPreviewRequestTimeout(
+      requestPreviewResponse(config, target.success).pipe(
+        Effect.flatMap((response) =>
+          decodePreviewResponse(response, target.success, maxBytes)
+        )
+      )
+    );
   }
 );

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -74,6 +74,7 @@
     "zustand": "^5.0.15"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@next/playwright": "16.3.2",
     "@playwright/test": "^1.62.1",
     "@repo/testing": "workspace:*",

--- a/packages/utilities/body.test.ts
+++ b/packages/utilities/body.test.ts
@@ -1,10 +1,6 @@
-import { describe, expect, it } from "@repo/testing/effect";
-import {
-  parseContentLength,
-  readBoundedBody,
-  readBoundedBodyResult,
-} from "@repo/utilities/body";
-import { Effect, Fiber, Result } from "effect";
+import { describe, expect, it } from "@effect/vitest";
+import { parseContentLength, readBoundedBody } from "@repo/utilities/body";
+import { Deferred, Effect, Fiber } from "effect";
 import { vi } from "vitest";
 
 /** Builds one bounded body read for the Effect test runtime. */
@@ -61,18 +57,6 @@ describe("bounded response body", () => {
       expect(yield* read(stream)).toEqual(new TextEncoder().encode("abcd"));
     })
   );
-  it("exposes the same bounded result without starting a runtime", async () => {
-    const stream = new ReadableStream<Uint8Array>({
-      /** Emits one direct-boundary chunk. */
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode("direct"));
-        controller.close();
-      },
-    });
-    await expect(readBoundedBodyResult(stream, 8)).resolves.toEqual(
-      Result.succeed(new TextEncoder().encode("direct"))
-    );
-  });
   it.effect("rejects missing and unreadable bodies", () =>
     Effect.gen(function* () {
       const locked = new ReadableStream<Uint8Array>();
@@ -100,24 +84,20 @@ describe("bounded response body", () => {
   );
   it.effect("cancels an unfinished reader when its Effect is interrupted", () =>
     Effect.gen(function* () {
-      let markCancelled: () => void = () => undefined;
-      const cancelled = new Promise<void>((resolve) => {
-        markCancelled = resolve;
-      });
-      const cancel = vi.fn(markCancelled);
-      let markPullStarted: () => void = () => undefined;
-      const pullStarted = new Promise<void>((resolve) => {
-        markPullStarted = resolve;
-      });
+      const pullStarted = yield* Deferred.make<void>();
+      const cancel = vi.fn();
       const stream = new ReadableStream<Uint8Array>({
         cancel,
-        pull: markPullStarted,
+        /** Marks the native reader as active without completing its read. */
+        pull() {
+          Deferred.doneUnsafe(pullStarted, Effect.void);
+        },
       });
-      const fiber = yield* Effect.forkChild(readBoundedBody(stream, 8));
-      yield* Effect.promise(() => pullStarted);
-      yield* Effect.yieldNow;
+      const fiber = yield* readBoundedBody(stream, 8).pipe(
+        Effect.forkChild({ startImmediately: true })
+      );
+      yield* Deferred.await(pullStarted);
       yield* Fiber.interrupt(fiber);
-      yield* Effect.promise(() => cancelled);
       expect(cancel).toHaveBeenCalledOnce();
     })
   );
@@ -125,11 +105,11 @@ describe("bounded response body", () => {
     "cancels an oversized body even when cancellation rejects: %s",
     (rejectCancellation) =>
       Effect.gen(function* () {
-        const cancel = vi.fn(() =>
-          rejectCancellation
-            ? Promise.reject(new TypeError("cancel failed"))
-            : Promise.resolve()
-        );
+        const cancel = vi.fn(() => {
+          if (rejectCancellation) {
+            return Promise.reject(new TypeError("cancel failed"));
+          }
+        });
         const stream = new ReadableStream<Uint8Array>({
           cancel,
           /** Emits one oversized chunk before provider cancellation. */

--- a/packages/utilities/body.test.ts
+++ b/packages/utilities/body.test.ts
@@ -59,12 +59,17 @@ describe("bounded response body", () => {
   );
   it.effect("rejects missing and unreadable bodies", () =>
     Effect.gen(function* () {
-      const locked = new ReadableStream<Uint8Array>();
-      locked.getReader();
+      const unreadable = new ReadableStream<Uint8Array>();
+      Object.defineProperty(unreadable, "getReader", {
+        /** Simulates an acquisition race after the stream appeared unlocked. */
+        value() {
+          throw new TypeError("reader unavailable");
+        },
+      });
       expect(yield* reject(null)).toMatchObject({
         _tag: "BodyMissingError",
       });
-      expect(yield* reject(locked)).toMatchObject({
+      expect(yield* reject(unreadable)).toMatchObject({
         _tag: "BodyReadError",
       });
     })

--- a/packages/utilities/body.ts
+++ b/packages/utilities/body.ts
@@ -1,4 +1,4 @@
-import { Effect, Result, Schema } from "effect";
+import { Effect, Schema, Stream } from "effect";
 
 const DECIMAL_BYTES = /^\d+$/u;
 /** A request or response omitted the readable body required by its contract. */
@@ -42,78 +42,9 @@ function concatenateChunks(chunks: readonly Uint8Array[], totalBytes: number) {
   }
   return result;
 }
-type BoundedBodyError = BodyLimitError | BodyMissingError | BodyReadError;
-interface BoundedBodyRead {
-  readonly interruption: Effect.Effect<void>;
-  readonly result: Promise<Result.Result<Uint8Array, BoundedBodyError>>;
-}
-/** Settles reader cancellation without hiding the primary body result. */
-function settleReaderCancellation(
-  reader: ReadableStreamDefaultReader<Uint8Array>
-) {
-  return Promise.resolve()
-    .then(() => reader.cancel())
-    .then(
-      () => undefined,
-      () => undefined
-    );
-}
-/** Starts one bounded body read with an interruptible cancellation handle. */
-function startBoundedBodyRead(
-  body: ReadableStream<Uint8Array> | null,
-  maxBytes: number
-): BoundedBodyRead {
-  if (!body) {
-    return {
-      interruption: Effect.void,
-      result: Promise.resolve(Result.fail(new BodyMissingError())),
-    };
-  }
-  const readerResult = Result.try({
-    catch: () => new BodyReadError(),
-    try: () => body.getReader(),
-  });
-  if (Result.isFailure(readerResult)) {
-    return {
-      interruption: Effect.void,
-      result: Promise.resolve(Result.fail(readerResult.failure)),
-    };
-  }
-  const reader = readerResult.success;
-  let cancelled = false;
-  function cancel() {
-    cancelled = true;
-    return settleReaderCancellation(reader);
-  }
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-  /** Pulls one provider chunk and preserves its typed result. */
-  function pull(): Promise<Result.Result<Uint8Array, BoundedBodyError>> {
-    return Promise.resolve()
-      .then(() => reader.read())
-      .then(
-        ({ done, value }) => {
-          if (cancelled) {
-            return Result.fail(new BodyReadError());
-          }
-          if (done) {
-            return Result.succeed(concatenateChunks(chunks, totalBytes));
-          }
-          totalBytes += value.byteLength;
-          if (totalBytes > maxBytes) {
-            const failure = new BodyLimitError({
-              actualBytes: totalBytes,
-              maxBytes,
-            });
-            return cancel().then(() => Result.fail(failure));
-          }
-          chunks.push(value);
-          return pull();
-        },
-        () => Result.fail(new BodyReadError())
-      );
-  }
-  return { interruption: Effect.promise(cancel), result: pull() };
+interface BoundedBodyState {
+  readonly chunks: Uint8Array[];
+  readonly totalBytes: number;
 }
 /** Parses an optional decimal Content-Length without unsafe number coercion. */
 export const parseContentLength = Effect.fn("Utilities.parseContentLength")(
@@ -134,23 +65,33 @@ export const parseContentLength = Effect.fn("Utilities.parseContentLength")(
     return byteLength;
   }
 );
-/** Reads a web body without a runtime or buffering beyond the declared limit. */
-export function readBoundedBodyResult(
-  body: ReadableStream<Uint8Array> | null,
-  maxBytes: number
-) {
-  return startBoundedBodyRead(body, maxBytes).result;
-}
 /** Reads a web body stream with typed failure and interruption cancellation. */
 export const readBoundedBody = Effect.fn("Utilities.readBoundedBody")(
   function* (body: ReadableStream<Uint8Array> | null, maxBytes: number) {
-    const read = startBoundedBodyRead(body, maxBytes);
-    const result = yield* Effect.promise(() => read.result).pipe(
-      Effect.onInterrupt(() => read.interruption)
-    );
-    if (Result.isFailure(result)) {
-      return yield* result.failure;
+    if (body === null) {
+      return yield* new BodyMissingError();
     }
-    return result.success;
+    if (body.locked) {
+      return yield* new BodyReadError();
+    }
+    const state = yield* Stream.fromReadableStream({
+      evaluate: () => body,
+      onError: () => new BodyReadError(),
+    }).pipe(
+      Stream.runFoldEffect(
+        (): BoundedBodyState => ({ chunks: [], totalBytes: 0 }),
+        (current, chunk) => {
+          const totalBytes = current.totalBytes + chunk.byteLength;
+          if (totalBytes > maxBytes) {
+            return Effect.fail(
+              new BodyLimitError({ actualBytes: totalBytes, maxBytes })
+            );
+          }
+          current.chunks.push(chunk);
+          return Effect.succeed({ chunks: current.chunks, totalBytes });
+        }
+      )
+    );
+    return concatenateChunks(state.chunks, state.totalBytes);
   }
 );

--- a/packages/utilities/body.ts
+++ b/packages/utilities/body.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, Stream } from "effect";
+import { Cause, Effect, Array as EffectArray, Schema, Stream } from "effect";
 
 const DECIMAL_BYTES = /^\d+$/u;
 /** A request or response omitted the readable body required by its contract. */
@@ -46,6 +46,33 @@ interface BoundedBodyState {
   readonly chunks: Uint8Array[];
   readonly totalBytes: number;
 }
+/** Acquires one reader in the typed channel and cancels it when its stream ends. */
+function streamBody(body: ReadableStream<Uint8Array>) {
+  return Stream.fromPull(
+    Effect.acquireRelease(
+      Effect.try({
+        catch: () => new BodyReadError(),
+        try: () => body.getReader(),
+      }),
+      (reader) =>
+        Effect.tryPromise({
+          catch: () => undefined,
+          try: () => reader.cancel(),
+        }).pipe(Effect.ignore)
+    ).pipe(
+      Effect.map((reader) =>
+        Effect.tryPromise({
+          catch: () => new BodyReadError(),
+          try: () => reader.read(),
+        }).pipe(
+          Effect.flatMap(({ done, value }) =>
+            done ? Cause.done() : Effect.succeed(EffectArray.of(value))
+          )
+        )
+      )
+    )
+  ).pipe(Stream.scoped);
+}
 /** Parses an optional decimal Content-Length without unsafe number coercion. */
 export const parseContentLength = Effect.fn("Utilities.parseContentLength")(
   function* (value: string | null, maxBytes: number) {
@@ -71,13 +98,7 @@ export const readBoundedBody = Effect.fn("Utilities.readBoundedBody")(
     if (body === null) {
       return yield* new BodyMissingError();
     }
-    if (body.locked) {
-      return yield* new BodyReadError();
-    }
-    const state = yield* Stream.fromReadableStream({
-      evaluate: () => body,
-      onError: () => new BodyReadError(),
-    }).pipe(
+    const state = yield* streamBody(body).pipe(
       Stream.runFoldEffect(
         (): BoundedBodyState => ({ chunks: [], totalBytes: 0 }),
         (current, chunk) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
         specifier: ^5.0.15
         version: 5.0.15(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@next/playwright':
         specifier: 16.3.2
         version: 16.3.2(@playwright/test@1.62.1)


### PR DESCRIPTION
## Summary

- replace the hand-written Promise body reader with an Effect v4 scoped pull stream
- type synchronous reader acquisition and asynchronous reader failures as `BodyReadError`
- cancel unread invalid responses without replacing their primary typed failure
- apply distinct connect and body timeout errors, with cancellation in both phases
- migrate the owning tests directly to `@effect/vitest`

## Effect v4 architecture

The bounded reader uses `Effect.try`, `Effect.acquireRelease`, `Stream.fromPull`, and `Stream.scoped`. Request decoding uses `Effect.acquireUseRelease`, phase-specific `Effect.timeoutOrElse`, Schema decoding, and tagged errors. The implementation follows vendored Effect v4 source rather than a repository wrapper.

## Next.js boundary

`fetchPreviewJsonForPrerender` remains the one intentional framework Promise boundary required by request-less static generation. It starts the uncached fetch before `Effect.runPromise`, then keeps an AbortController scoped across connect, validation, and body decoding.

## Review closure

The prior exact-head review correctly identified three release blockers. This head now:

- catches reader-acquisition races in the typed body channel
- cancels invalid response bodies, including rejected cancellation
- reports stalled body reads as `stage: "body"` and cancels them

Dedicated tests cover all three paths.

## Scope and identity

- base: `991ade4eca4667a788912bf555a1816e540d2e4e`
- head: `b102a8f1bf`
- four package-owned commits
- six changed files

## Verification

- www: 209 files, 1,526 tests, 100% statements, branches, functions, and lines
- utilities: 6 files, 111 tests, 100% statements, branches, functions, and lines
- www and utilities typechecks passed
- Effect source parity, test ownership, script tests, lint, boundaries, frozen install, and security audit passed
- React Doctor: 100
- no repository wrapper, raw async effectful test, or Vercel Preview

## Release

This changes production preview request behavior. The previous green checks belonged to the superseded `c6dbe00087` head. Protected exact-head CI must pass again on `b102a8f1bf` before squash merge, then production deploys only from protected `main` through the existing Vercel Git integration.