### PR TITLE
test(ai): use direct Effect Vitest for math workflows

### DIFF
--- a/packages/ai/agents/math/repair.test.ts
+++ b/packages/ai/agents/math/repair.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { repairMathToolCall } from "@repo/ai/agents/math/repair";
 import {
   mathAlgebraInput,
   mathEquationInput,
 } from "@repo/ai/agents/math/schema";
 import { ModelIdSchema } from "@repo/ai/config/model";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import type { JSONSchema7, ToolCallRepairFunction, ToolSet } from "ai";
 import { InvalidToolInputError, NoSuchToolError, tool } from "ai";
 import { Effect } from "effect";
@@ -72,7 +72,7 @@ afterEach(() => {
 });
 
 describe("math tool repair", () => {
-  it.live("repairs invalid math arguments from the original task", () =>
+  it.effect("repairs invalid math arguments from the original task", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         output: {
@@ -119,7 +119,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("keeps the failed operation when the repair model changes it", () =>
+  it.effect("keeps the failed operation when the repair model changes it", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         output: {
@@ -153,7 +153,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "preserves valid solve-domain fields while repairing bounded systems",
     () =>
       Effect.gen(function* () {
@@ -235,7 +235,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live("does not repair when the repair output is not object-shaped", () =>
+  it.effect("does not repair when the repair output is not object-shaped", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({ output: null });
 
@@ -254,7 +254,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "uses repaired arguments when the failed call has no operation field",
     () =>
       Effect.gen(function* () {
@@ -295,7 +295,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "keeps malformed failed arguments readable in the repair prompt",
     () =>
       Effect.gen(function* () {
@@ -341,7 +341,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live("does not repair unavailable tools", () =>
+  it.effect("does not repair unavailable tools", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: new NoSuchToolError({ toolName: "unknown" }),
@@ -359,7 +359,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair missing tool definitions", () =>
+  it.effect("does not repair missing tool definitions", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,
@@ -377,7 +377,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair when schema lookup fails", () =>
+  it.effect("does not repair when schema lookup fails", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,
@@ -395,7 +395,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair when the repair model fails", () =>
+  it.effect("does not repair when the repair model fails", () =>
     Effect.gen(function* () {
       generateText.mockRejectedValue(new Error("model unavailable"));
 

--- a/packages/ai/agents/math/tools/compute.test.ts
+++ b/packages/ai/agents/math/tools/compute.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { compute } from "@repo/ai/agents/math/tools/compute";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import type { MathRequest } from "@repo/math/schema/request";
 import type { MathResult } from "@repo/math/schema/result";
 import type { MathToolInput } from "@repo/math/schema/tool-input";
 import { MathService } from "@repo/math/service";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { ConfigProvider, Effect } from "effect";
 import { vi } from "vitest";
@@ -74,7 +74,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 describe("math compute tool", () => {
-  it.live("writes loading and done math data parts", () =>
+  it.effect("writes loading and done math data parts", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json(result));
       const { parts, writer } = createWriter();
@@ -112,7 +112,7 @@ describe("math compute tool", () => {
       ]);
     })
   );
-  it.live("writes an error data part for math request failures", () =>
+  it.effect("writes an error data part for math request failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();
@@ -150,7 +150,7 @@ describe("math compute tool", () => {
       );
     })
   );
-  it.live("writes an error data part for math response failures", () =>
+  it.effect("writes an error data part for math response failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         Response.json({ status: "verified" })
@@ -180,7 +180,7 @@ describe("math compute tool", () => {
       );
     })
   );
-  it.live(
+  it.effect(
     "asks the model to retry ambiguous symbolic calculus with the explicit variable",
     () =>
       Effect.gen(function* () {
@@ -220,7 +220,7 @@ describe("math compute tool", () => {
         );
       })
   );
-  it.live(
+  it.effect(
     "returns a model-readable error before writing data for invalid tool input",
     () =>
       Effect.gen(function* () {
@@ -243,7 +243,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live(
+  it.effect(
     "tells the model how to retry bounded systems with the same bounds",
     () =>
       Effect.gen(function* () {
@@ -274,7 +274,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live(
+  it.effect(
     "tells the model how to retry incomplete bounded system expressions",
     () =>
       Effect.gen(function* () {
@@ -304,7 +304,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live("keeps invalid input errors locale-free", () =>
+  it.effect("keeps invalid input errors locale-free", () =>
     Effect.gen(function* () {
       const fetch = vi.spyOn(globalThis, "fetch");
       const { parts, writer } = createWriter();
@@ -321,7 +321,7 @@ describe("math compute tool", () => {
       expect(parts).toEqual([]);
     })
   );
-  it.live("writes locale-free error data for math service failures", () =>
+  it.effect("writes locale-free error data for math service failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();


### PR DESCRIPTION
## Summary

- migrate math repair tests directly to `@effect/vitest`
- migrate math compute tests directly to `@effect/vitest`
- replace unnecessary `it.live` calls with `it.effect`
- retain Vitest `vi` only at the mock and transform seams

## Stack

This two-commit checkpoint is stacked on #388 and shows only the two owning test modules. After its parent merges, it will move to the exact protected `main` head with patch identity preserved.

## Verification

- focused: 2 files, 19 tests
- full AI suite: 62 files, 378 tests
- 100% statements, branches, functions, and lines
- AI typecheck
- Effect source parity
- test ownership and script tests
- lint, boundaries, frozen install, and security audit
- no repository wrapper, direct Effect runner, or Vercel Preview