### PR TITLE
test(ai): use direct Effect Vitest for Nakafa tools

### DIFF
--- a/packages/ai/agents/nakafa/error.test.ts
+++ b/packages/ai/agents/nakafa/error.test.ts
@@ -1,12 +1,12 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   makeNakafaGenerationError,
   NakafaGenerationError,
 } from "@repo/ai/agents/nakafa/error";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("Nakafa generation error", () => {
-  it.live(
+  it.effect(
     "maps unknown provider failures into the capability error channel",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/agents/nakafa/tools/quran.test.ts
+++ b/packages/ai/agents/nakafa/tools/quran.test.ts
@@ -1,14 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { quran } from "@repo/ai/agents/nakafa/tools/quran";
 import {
   createNakafaTestService,
   createWriter,
 } from "@repo/ai/agents/nakafa/tools/test";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("nakafa Quran tool", () => {
-  it.live("writes loading and done parts for bounded Quran references", () =>
+  it.effect("writes loading and done parts for bounded Quran references", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* quran({
@@ -37,7 +37,7 @@ describe("nakafa Quran tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "applies defaults and preserves tafsir requests in persisted input",
     () =>
       Effect.gen(function* () {
@@ -68,7 +68,7 @@ describe("nakafa Quran tool", () => {
       })
   );
 
-  it.live.each([
+  it.effect.each([
     [
       "reversed range",
       { from_verse: 2, locale: "en", surah: 1, to_verse: 1 },

--- a/packages/ai/agents/nakafa/tools/read.test.ts
+++ b/packages/ai/agents/nakafa/tools/read.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { read } from "@repo/ai/agents/nakafa/tools/read";
 import {
@@ -7,7 +8,6 @@ import {
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { NakafaAgentContentRefInputSchema } from "@repo/contents/_lib/agent/schema/read";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 const ARTICLE_CONTENT_ID = NakafaAgentContentRefInputSchema.make(
@@ -28,7 +28,7 @@ const TRYOUT_URL = NakafaAgentContentRefInputSchema.make(
   "https://nakafa.com/en/try-out/indonesia/snbt/2027/set-2"
 );
 describe("nakafa read tool", () => {
-  it.live("writes loading and done parts for content reads", () =>
+  it.effect("writes loading and done parts for content reads", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -51,7 +51,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("accepts canonical URL projections for current-page reads", () =>
+  it.effect("accepts canonical URL projections for current-page reads", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -70,7 +70,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("writes an error part when content is missing", () =>
+  it.effect("writes an error part when content is missing", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -86,7 +86,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("does not invent a markdown read for tryout references", () =>
+  it.effect("does not invent a markdown read for tryout references", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -102,7 +102,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("writes an error part when content reading fails", () =>
+  it.effect("writes an error part when content reading fails", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({

--- a/packages/ai/agents/nakafa/tools/taxonomy.test.ts
+++ b/packages/ai/agents/nakafa/tools/taxonomy.test.ts
@@ -1,14 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { taxonomy } from "@repo/ai/agents/nakafa/tools/taxonomy";
 import {
   createNakafaTestService,
   createWriter,
 } from "@repo/ai/agents/nakafa/tools/test";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("nakafa taxonomy tool", () => {
-  it.live("writes loading and done parts for taxonomy", () =>
+  it.effect("writes loading and done parts for taxonomy", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* taxonomy({
@@ -41,14 +41,16 @@ describe("nakafa taxonomy tool", () => {
     })
   );
 
-  it.live("uses the injected test service for invalid route verification", () =>
-    Effect.gen(function* () {
-      const service = createNakafaTestService();
-      const isVerified = yield* service.verify("");
-      const taxonomyResult = yield* service.taxonomy();
+  it.effect(
+    "uses the injected test service for invalid route verification",
+    () =>
+      Effect.gen(function* () {
+        const service = createNakafaTestService();
+        const isVerified = yield* service.verify("");
+        const taxonomyResult = yield* service.taxonomy();
 
-      expect(isVerified).toBe(false);
-      expect(taxonomyResult.locale).toBe("en");
-    })
+        expect(isVerified).toBe(false);
+        expect(taxonomyResult.locale).toBe("en");
+      })
   );
 });


### PR DESCRIPTION
## Summary

- migrate Nakafa generation error tests to direct `@effect/vitest`
- migrate Quran, read, and taxonomy tool tests to direct `@effect/vitest`
- use `it.effect` and `it.effect.each` because these cases need neither live time nor a runtime boundary
- keep one owning module per commit

## Stack

This four-file checkpoint is stacked on #391 and shows only its own package-owned callers. After its parent merges, it will move to the exact protected `main` head with patch identity preserved.

## Verification

- focused: 4 files, 14 tests
- full AI suite: 62 files, 378 tests
- 100% statements, branches, functions, and lines
- AI typecheck
- Effect source parity
- test ownership and script tests
- lint, boundaries, frozen install, and security audit
- no repository wrapper, direct Effect runner, raw async test, or Vercel Preview