### PR TITLE
test(ai): use direct Effect Vitest for research tools

### DIFF
--- a/packages/ai/agents/research/tools/markdown.test.ts
+++ b/packages/ai/agents/research/tools/markdown.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { fetchSourceMarkdown } from "@repo/ai/agents/research/tools/markdown";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -8,7 +8,7 @@ describe("source markdown fetcher", () => {
     vi.unstubAllGlobals();
   });
 
-  it.live(
+  it.effect(
     "reads markdown from the original URL when it is already markdown",
     () =>
       Effect.gen(function* () {
@@ -29,7 +29,7 @@ describe("source markdown fetcher", () => {
       })
   );
 
-  it.live("uses the adjacent markdown URL when the page shell is HTML", () =>
+  it.effect("uses the adjacent markdown URL when the page shell is HTML", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -56,34 +56,36 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("rejects markdown-looking HTML before using adjacent markdown", () =>
-    Effect.gen(function* () {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn((input: Parameters<typeof fetch>[0]) => {
-          if (String(input) === "https://example.com/docs/devtools.md") {
+  it.effect(
+    "rejects markdown-looking HTML before using adjacent markdown",
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn((input: Parameters<typeof fetch>[0]) => {
+            if (String(input) === "https://example.com/docs/devtools.md") {
+              return Promise.resolve(
+                new Response("# DevTools\n\n- Input parameters and prompts", {
+                  headers: { "content-type": "text/markdown" },
+                })
+              );
+            }
+
             return Promise.resolve(
-              new Response("# DevTools\n\n- Input parameters and prompts", {
-                headers: { "content-type": "text/markdown" },
+              new Response("# DevTools\n\n- Navigation item", {
+                headers: { "content-type": "text/html" },
               })
             );
-          }
+          })
+        );
 
-          return Promise.resolve(
-            new Response("# DevTools\n\n- Navigation item", {
-              headers: { "content-type": "text/html" },
-            })
-          );
-        })
-      );
-
-      expect(
-        yield* fetchSourceMarkdown("https://example.com/docs/devtools")
-      ).toBe("# DevTools\n\n- Input parameters and prompts");
-    })
+        expect(
+          yield* fetchSourceMarkdown("https://example.com/docs/devtools")
+        ).toBe("# DevTools\n\n- Input parameters and prompts");
+      })
   );
 
-  it.live("supports trailing slash docs pages with adjacent markdown", () =>
+  it.effect("supports trailing slash docs pages with adjacent markdown", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -106,26 +108,28 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when root pages do not expose readable markdown", () =>
-    Effect.gen(function* () {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(() =>
-          Promise.resolve(
-            new Response("<body>home</body>", {
-              headers: { "content-type": "text/html" },
-            })
+  it.effect(
+    "returns empty when root pages do not expose readable markdown",
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(() =>
+            Promise.resolve(
+              new Response("<body>home</body>", {
+                headers: { "content-type": "text/html" },
+              })
+            )
           )
-        )
-      );
+        );
 
-      expect(
-        yield* fetchSourceMarkdown("https://example.com/")
-      ).toBeUndefined();
-    })
+        expect(
+          yield* fetchSourceMarkdown("https://example.com/")
+        ).toBeUndefined();
+      })
   );
 
-  it.live(
+  it.effect(
     "accepts markdown-looking content from unknown text-compatible responses",
     () =>
       Effect.gen(function* () {
@@ -146,7 +150,7 @@ describe("source markdown fetcher", () => {
       })
   );
 
-  it.live("accepts markdown-looking content without a content type", () =>
+  it.effect("accepts markdown-looking content without a content type", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -163,7 +167,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("rejects unknown responses that do not look like markdown", () =>
+  it.effect("rejects unknown responses that do not look like markdown", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -182,7 +186,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when source fetches fail", () =>
+  it.effect("returns empty when source fetches fail", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -195,7 +199,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when response bodies cannot be read", () =>
+  it.effect("returns empty when response bodies cannot be read", () =>
     Effect.gen(function* () {
       const stream = new ReadableStream({
         start(controller) {

--- a/packages/ai/agents/research/tools/safety.test.ts
+++ b/packages/ai/agents/research/tools/safety.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { assertPublicResearchUrl } from "@repo/ai/agents/research/tools/safety";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Result } from "effect";
 import { vi } from "vitest";
 
@@ -11,7 +11,7 @@ describe("assertPublicResearchUrl", () => {
   beforeEach(() => {
     lookup.mockReset();
   });
-  it.live("rejects unsafe URL syntax before DNS lookup", () =>
+  it.effect("rejects unsafe URL syntax before DNS lookup", () =>
     Effect.gen(function* () {
       const result = yield* Effect.result(
         assertPublicResearchUrl("http://localhost:3000/admin")
@@ -20,7 +20,7 @@ describe("assertPublicResearchUrl", () => {
       expect(lookup).not.toHaveBeenCalled();
     })
   );
-  it.live("allows public IP literals without DNS lookup", () =>
+  it.effect("allows public IP literals without DNS lookup", () =>
     Effect.gen(function* () {
       const result = yield* assertPublicResearchUrl(
         "https://93.184.216.34/docs"
@@ -32,7 +32,7 @@ describe("assertPublicResearchUrl", () => {
       expect(lookup).not.toHaveBeenCalled();
     })
   );
-  it.live("rejects hostnames when DNS resolution fails", () =>
+  it.effect("rejects hostnames when DNS resolution fails", () =>
     Effect.gen(function* () {
       lookup.mockRejectedValue(new Error("DNS failure"));
       const result = yield* Effect.result(
@@ -41,7 +41,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live("rejects hostnames without DNS addresses", () =>
+  it.effect("rejects hostnames without DNS addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([]);
       const result = yield* Effect.result(
@@ -50,7 +50,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live("rejects hostnames that resolve to private addresses", () =>
+  it.effect("rejects hostnames that resolve to private addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([{ address: "10.0.0.1", family: 4 }]);
       const result = yield* Effect.result(
@@ -59,7 +59,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live(
+  it.effect(
     "allows public hostnames without enabling native server fetches",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/agents/research/tools/scrape.test.ts
+++ b/packages/ai/agents/research/tools/scrape.test.ts
@@ -1,16 +1,10 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   formatScrapeOutput,
   isSuccessfulScrapeOutput,
   scrapeUrl,
 } from "@repo/ai/agents/research/tools/scrape";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -67,7 +61,7 @@ describe("research scrape tool", () => {
     vi.unstubAllGlobals();
   });
 
-  it.live("keeps Firecrawl metadata in tool text and UI data", () =>
+  it.effect("keeps Firecrawl metadata in tool text and UI data", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools",
@@ -114,7 +108,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("rejects private scrape targets before fetching or crawling", () =>
+  it.effect("rejects private scrape targets before fetching or crawling", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
 
@@ -145,7 +139,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("rejects public hostnames that resolve to private addresses", () =>
+  it.effect("rejects public hostnames that resolve to private addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
       const { writer } = createWriter();
@@ -161,7 +155,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("prefers source-native markdown for IP-literal URLs", () =>
+  it.effect("prefers source-native markdown for IP-literal URLs", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -225,7 +219,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("keeps source-native markdown when Firecrawl scrape fails", () =>
+  it.effect("keeps source-native markdown when Firecrawl scrape fails", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -260,7 +254,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "falls back to alternate metadata fields when markdown is missing",
     () =>
       Effect.gen(function* () {
@@ -296,7 +290,7 @@ describe("research scrape tool", () => {
       })
   );
 
-  it.live("keeps scrape output valid when metadata is unavailable", () =>
+  it.effect("keeps scrape output valid when metadata is unavailable", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# Plain source",
@@ -325,7 +319,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("passes the selection query to relevant content selection", () =>
+  it.effect("passes the selection query to relevant content selection", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools\n\nUse AI SDK DevTools for local debugging.",
@@ -348,7 +342,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("allows exact-source callers to keep more source evidence", () =>
+  it.effect("allows exact-source callers to keep more source evidence", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools\n\nUse AI SDK DevTools for local debugging.",
@@ -372,7 +366,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("writes an error part when Firecrawl scrape fails", () =>
+  it.effect("writes an error part when Firecrawl scrape fails", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();

--- a/packages/ai/agents/research/tools/search.test.ts
+++ b/packages/ai/agents/research/tools/search.test.ts
@@ -1,6 +1,6 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { searchWeb } from "@repo/ai/agents/research/tools/search";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -67,7 +67,7 @@ describe("research web search tool", () => {
     firecrawlApp.search.mockReset();
   });
 
-  it.live(
+  it.effect(
     "writes loading and done parts while returning text and structured sources",
     () =>
       Effect.gen(function* () {
@@ -174,7 +174,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("deduplicates blank and repeated queries before searching", () =>
+  it.effect("deduplicates blank and repeated queries before searching", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockResolvedValue({
         web: [
@@ -216,7 +216,7 @@ describe("research web search tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "searches each optimized query with query-scoped visible results",
     () =>
       Effect.gen(function* () {
@@ -276,7 +276,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("keeps successful query results when another query fails", () =>
+  it.effect("keeps successful query results when another query fails", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockImplementation((query: string) => {
         if (query === "AI SDK DevTools") {
@@ -328,7 +328,7 @@ describe("research web search tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "writes an empty done part when Firecrawl returns no result groups",
     () =>
       Effect.gen(function* () {
@@ -357,7 +357,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("writes an error part when Firecrawl search fails", () =>
+  it.effect("writes an error part when Firecrawl search fails", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();


### PR DESCRIPTION
## Summary

- migrate research markdown, URL-safety, scraping, and search tests directly to `@effect/vitest`
- replace unnecessary live-clock tests with `it.effect`
- retain raw Promise values only inside mocked Fetch and third-party SDK interfaces
- keep one owning module per commit

## Stack

This four-file checkpoint is stacked on #393 and shows only its own research-tool callers. Every touched file remains below the repository’s 500-line readiness limit. After its parent merges, it will move to the exact protected `main` head with patch identity preserved.

## Verification

- focused: 4 files, 33 tests
- full AI suite: 62 files, 378 tests
- 100% statements, branches, functions, and lines
- AI typecheck
- Effect source parity
- test ownership and script tests
- lint, boundaries, frozen install, and security audit
- no repository wrapper, direct Effect runner, raw async test, or Vercel Preview