### PR TITLE
test(ai): use native Effect Vitest for weather

### DIFF
--- a/packages/ai/clients/weather/client.test.ts
+++ b/packages/ai/clients/weather/client.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { getCurrentWeather } from "@repo/ai/clients/weather/client";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Layer, Result } from "effect";
 import {
   HttpClient,
@@ -73,7 +73,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 describe("getCurrentWeather", () => {
-  it.live("returns a narrow summary from one current-weather request", () =>
+  it.effect("returns a narrow summary from one current-weather request", () =>
     Effect.gen(function* () {
       vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
       const observeRequest =
@@ -104,7 +104,7 @@ describe("getCurrentWeather", () => {
       ]);
     })
   );
-  it.live(
+  it.effect(
     "keeps an unavailable current-weather request in the typed error channel",
     () =>
       Effect.gen(function* () {
@@ -122,7 +122,7 @@ describe("getCurrentWeather", () => {
         });
       })
   );
-  it.live("keeps an invalid response in the schema error channel", () =>
+  it.effect("keeps an invalid response in the schema error channel", () =>
     Effect.gen(function* () {
       vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
       const result = yield* runWeather(() => Response.json({ cod: 200 }));
@@ -133,7 +133,7 @@ describe("getCurrentWeather", () => {
       expect(result.failure).toMatchObject({ _tag: "SchemaError" });
     })
   );
-  it.live(
+  it.effect(
     "preserves the visible condition defaults when conditions are absent",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/clients/weather/transport.test.ts
+++ b/packages/ai/clients/weather/transport.test.ts
@@ -1,6 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { requestWeatherJson } from "@repo/ai/clients/weather/transport";
-import { describe, expect, it } from "@repo/testing/effect";
-import { Effect, Layer, Result } from "effect";
+import { Effect, Fiber, Layer, Result } from "effect";
+import { TestClock } from "effect/testing";
 import {
   HttpClient,
   type HttpClientRequest,
@@ -28,7 +29,7 @@ function makeTestClient({
   );
 }
 describe("requestWeatherJson", () => {
-  it.live("sends query parameters and returns decoded JSON", () =>
+  it.effect("sends query parameters and returns decoded JSON", () =>
     Effect.gen(function* () {
       const observeRequest =
         vi.fn<(request: HttpClientRequest.HttpClientRequest) => void>();
@@ -61,7 +62,7 @@ describe("requestWeatherJson", () => {
       expect(request?.headers).not.toHaveProperty("traceparent");
     })
   );
-  it.live("maps rejected HTTP status into the weather error contract", () =>
+  it.effect("maps rejected HTTP status into the weather error contract", () =>
     Effect.gen(function* () {
       const result = yield* requestWeatherJson({
         endpoint: "current-weather",
@@ -95,17 +96,22 @@ describe("requestWeatherJson", () => {
       );
     })
   );
-  it.live("retries transient HTTP failures before returning JSON", () =>
+  it.effect("retries transient HTTP failures before returning JSON", () =>
     Effect.gen(function* () {
       const makeResponse = vi
         .fn<(request: HttpClientRequest.HttpClientRequest) => Response>()
         .mockReturnValueOnce(new Response("unavailable", { status: 503 }))
         .mockReturnValueOnce(Response.json({ cod: "200" }));
-      const result = yield* requestWeatherJson({
+      const resultFiber = yield* requestWeatherJson({
         endpoint: "current-weather",
         searchParams: {},
         url: "https://weather.example.test/weather",
-      }).pipe(Effect.provide(makeTestClient({ makeResponse })));
+      }).pipe(
+        Effect.provide(makeTestClient({ makeResponse })),
+        Effect.forkChild
+      );
+      yield* TestClock.adjust("300 millis");
+      const result = yield* Fiber.join(resultFiber);
       expect(result).toEqual({ cod: "200" });
       expect(makeResponse).toHaveBeenCalledTimes(2);
     })


### PR DESCRIPTION
## Summary

- replace the repository testing wrapper with direct `@effect/vitest` imports in the two weather test modules
- run Effect programs with `it.effect`
- drive retry timing with Effect v4 `TestClock` instead of live wall-clock delay

## Scope

This is a small stacked checkpoint on #394. It changes only weather tests and will be retargeted to the merged predecessor before release.

## Evidence

- focused weather tests: 2 files, 7 tests passed
- full `@repo/ai` suite: 62 files, 378 tests passed
- 100% statements, branches, functions, and lines
- AI typecheck, Effect source parity, test policy, script tests, lint, boundaries, and security audit passed
- no wrapper import, direct Effect runner, or raw async remains in the changed files

## Release

No Vercel Preview. This PR will merge only after its exact-head required checks and review are green.