### PR TITLE
test(ai): use native Effect Vitest for Nina state

### DIFF
--- a/packages/ai/nina/memory/pack.test.ts
+++ b/packages/ai/nina/memory/pack.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import {
   type NinaLearningSessionInput,
   openNinaLearningSession,
 } from "@repo/ai/nina/memory/pack";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Exit } from "effect";
 
 const learning = {
@@ -23,7 +23,7 @@ const placementProgramKey = LearningProgramKeySchema.make(
 );
 
 describe("nina/memory/pack", () => {
-  it.live(
+  it.effect(
     "opens a verified page session with a durable snapshot and page-fetch policy",
     () =>
       Effect.gen(function* () {
@@ -57,7 +57,7 @@ describe("nina/memory/pack", () => {
       })
   );
 
-  it.live("keeps invalid session input in the Effect failure channel", () =>
+  it.effect("keeps invalid session input in the Effect failure channel", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
         openNinaLearningSession({
@@ -74,7 +74,7 @@ describe("nina/memory/pack", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "opens an unverified canonical session without current-page fetch permission",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/nina/runtime/usage.test.ts
+++ b/packages/ai/nina/runtime/usage.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
+import { describe, expect, it } from "@effect/vitest";
 import { defaultModel, getModelCreditCost } from "@repo/ai/config/model";
 import { trackUsage } from "@repo/ai/nina/runtime/usage";
-import { describe, expect, it } from "@repo/testing/effect";
 import type { LanguageModelUsage } from "ai";
 import { Effect } from "effect";
 
@@ -33,7 +33,7 @@ function usageRow({
 }
 
 describe("nina/runtime/usage", () => {
-  it.live("tracks sub-agent usage and creates final metadata", () =>
+  it.effect("tracks sub-agent usage and creates final metadata", () =>
     Effect.gen(function* () {
       const usage = yield* trackUsage();
 
@@ -68,7 +68,7 @@ describe("nina/runtime/usage", () => {
     })
   );
 
-  it.live("defaults missing usage tokens to zero", () =>
+  it.effect("defaults missing usage tokens to zero", () =>
     Effect.gen(function* () {
       const usage = yield* trackUsage();
 


### PR DESCRIPTION
## Summary

- replace the repository testing wrapper with direct `@effect/vitest` in Nina memory and usage tests
- run the effectful state programs with `it.effect`
- preserve typed failure assertions and existing behavior

## Scope

This is a two-file stacked checkpoint on #396. Each file is isolated in its own commit.

## Evidence

- focused tests: 2 files, 5 tests passed
- full `@repo/ai` suite: 62 files, 378 tests passed
- 100% statements, branches, functions, and lines
- AI typecheck passed
- no wrapper import, direct Effect runner, raw async, or `it.live` remains in the changed files

## Release

No Vercel Preview. This PR will merge only after its exact-head required checks and review are green.