### PR TITLE
test(ai): use native Effect Vitest for Nina boundaries

### DIFF
--- a/packages/ai/nina/capability/result.test.ts
+++ b/packages/ai/nina/capability/result.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   capabilityResult,
   recordSpecialistUsage,
@@ -8,7 +9,6 @@ import {
 } from "@repo/ai/nina/capability/result";
 import type { LearningCapabilityName } from "@repo/ai/nina/capability/spec";
 import type { NinaReporter } from "@repo/ai/nina/runtime/report";
-import { describe, expect, it } from "@repo/testing/effect";
 import type { LanguageModelUsage } from "ai";
 import { type Context, Effect, Logger, Option } from "effect";
 
@@ -81,7 +81,7 @@ describe("nina/capability/result", () => {
     expect(result.evidence.summary.endsWith("...")).toBe(true);
   });
 
-  it.live("preserves real usage for successful specialists", () =>
+  it.effect("preserves real usage for successful specialists", () =>
     Effect.gen(function* () {
       const tracker = usageRecorder();
       const result = specialistSuccess({
@@ -105,7 +105,7 @@ describe("nina/capability/result", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "does not invent usage when a specialist fails before completion",
     () =>
       Effect.gen(function* () {
@@ -142,7 +142,7 @@ describe("nina/capability/result", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "normalizes non-Error failures into model-facing recovery evidence",
     () =>
       Effect.gen(function* () {
@@ -170,7 +170,7 @@ describe("nina/capability/result", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "reports the provider cause preserved by a typed capability error",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/nina/harness/stream.test.ts
+++ b/packages/ai/nina/harness/stream.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import { NakafaSearch } from "@repo/ai/agents/nakafa/search";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
@@ -10,7 +11,6 @@ import {
 } from "@repo/ai/nina/harness/stream";
 import { NinaReporter } from "@repo/ai/nina/runtime/report";
 import { NinaStore } from "@repo/ai/nina/runtime/store";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Cause, Effect, Exit, Option } from "effect";
 import { vi } from "vitest";
 
@@ -109,7 +109,7 @@ describe("nina/harness/stream", () => {
       Effect.succeed(new Response(input.page.slug))
     );
   });
-  it.live(
+  it.effect(
     "decodes one turn and delegates response creation through the harness Interface",
     () =>
       Effect.gen(function* () {
@@ -121,7 +121,7 @@ describe("nina/harness/stream", () => {
         expect(createNinaStreamResponseMock).toHaveBeenCalledWith(turn);
       })
   );
-  it.live("rejects invalid route input with a tagged harness error", () =>
+  it.effect("rejects invalid route input with a tagged harness error", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
         provideHarnessServices(


### PR DESCRIPTION
## Summary

- replace the repository testing wrapper with direct `@effect/vitest` in Nina capability-result and harness tests
- keep pure capability projection checks on ordinary Vitest
- run only the effectful usage, recovery, service, and typed-failure cases with `it.effect`

## Scope

This is a two-file stacked checkpoint on #397. Each file is isolated in its own commit.

## Evidence

- focused tests: 2 files, 8 tests passed
- full `@repo/ai` suite: 62 files, 378 tests passed
- 100% statements, branches, functions, and lines
- AI typecheck passed
- no wrapper import, direct Effect runner, raw async, or `it.live` remains in the changed files

## Release

No Vercel Preview. This PR will merge only after its exact-head required checks and review are green.