### PR TITLE
test(ai): adopt native Effect Vitest across the package

### DIFF
--- a/packages/ai/agents/math/error.test.ts
+++ b/packages/ai/agents/math/error.test.ts
@@ -1,12 +1,12 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   MathGenerationError,
   makeMathGenerationError,
 } from "@repo/ai/agents/math/error";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("math generation error", () => {
-  it.live(
+  it.effect(
     "maps unknown provider failures into the capability error channel",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/agents/math/repair.test.ts
+++ b/packages/ai/agents/math/repair.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { repairMathToolCall } from "@repo/ai/agents/math/repair";
 import {
   mathAlgebraInput,
   mathEquationInput,
 } from "@repo/ai/agents/math/schema";
 import { ModelIdSchema } from "@repo/ai/config/model";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import type { JSONSchema7, ToolCallRepairFunction, ToolSet } from "ai";
 import { InvalidToolInputError, NoSuchToolError, tool } from "ai";
 import { Effect } from "effect";
@@ -72,7 +72,7 @@ afterEach(() => {
 });
 
 describe("math tool repair", () => {
-  it.live("repairs invalid math arguments from the original task", () =>
+  it.effect("repairs invalid math arguments from the original task", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         output: {
@@ -119,7 +119,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("keeps the failed operation when the repair model changes it", () =>
+  it.effect("keeps the failed operation when the repair model changes it", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         output: {
@@ -153,7 +153,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "preserves valid solve-domain fields while repairing bounded systems",
     () =>
       Effect.gen(function* () {
@@ -235,7 +235,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live("does not repair when the repair output is not object-shaped", () =>
+  it.effect("does not repair when the repair output is not object-shaped", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({ output: null });
 
@@ -254,7 +254,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "uses repaired arguments when the failed call has no operation field",
     () =>
       Effect.gen(function* () {
@@ -295,7 +295,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "keeps malformed failed arguments readable in the repair prompt",
     () =>
       Effect.gen(function* () {
@@ -341,7 +341,7 @@ describe("math tool repair", () => {
       })
   );
 
-  it.live("does not repair unavailable tools", () =>
+  it.effect("does not repair unavailable tools", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: new NoSuchToolError({ toolName: "unknown" }),
@@ -359,7 +359,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair missing tool definitions", () =>
+  it.effect("does not repair missing tool definitions", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,
@@ -377,7 +377,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair when schema lookup fails", () =>
+  it.effect("does not repair when schema lookup fails", () =>
     Effect.gen(function* () {
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,
@@ -395,7 +395,7 @@ describe("math tool repair", () => {
     })
   );
 
-  it.live("does not repair when the repair model fails", () =>
+  it.effect("does not repair when the repair model fails", () =>
     Effect.gen(function* () {
       generateText.mockRejectedValue(new Error("model unavailable"));
 

--- a/packages/ai/agents/math/repair.test.ts
+++ b/packages/ai/agents/math/repair.test.ts
@@ -6,26 +6,20 @@ import {
 } from "@repo/ai/agents/math/schema";
 import { ModelIdSchema } from "@repo/ai/config/model";
 import type { JSONSchema7, ToolCallRepairFunction, ToolSet } from "ai";
-import { InvalidToolInputError, NoSuchToolError, tool } from "ai";
+import { generateText, InvalidToolInputError, NoSuchToolError, tool } from "ai";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
-const generateText = vi.hoisted(() => vi.fn());
+const generateTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", { spy: true });
+vi.mocked(generateText).mockImplementation(generateTextMock);
 
 vi.mock("@repo/ai/config/app", () => ({
   provider: {
     languageModel: (modelId: string) => modelId,
   },
 }));
-
-vi.mock("ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ai")>();
-
-  return {
-    ...actual,
-    generateText,
-  };
-});
 
 const tools = {
   algebra: tool({
@@ -67,14 +61,14 @@ const inputSchema = vi.fn<
 const modelId = ModelIdSchema.make("nakafa-lite");
 
 afterEach(() => {
-  generateText.mockReset();
+  generateTextMock.mockReset();
   inputSchema.mockClear();
 });
 
 describe("math tool repair", () => {
   it.effect("repairs invalid math arguments from the original task", () =>
     Effect.gen(function* () {
-      generateText.mockResolvedValue({
+      generateTextMock.mockResolvedValue({
         output: {
           expression: "(x^2 - 9)/(x - 3)",
           operation: "simplify",
@@ -103,7 +97,7 @@ describe("math tool repair", () => {
           2
         ),
       });
-      expect(generateText).toHaveBeenCalledWith(
+      expect(generateTextMock).toHaveBeenCalledWith(
         expect.objectContaining({
           model: "nakafa-lite",
           prompt: expect.stringContaining("# Original User Request"),
@@ -111,7 +105,7 @@ describe("math tool repair", () => {
         })
       );
       expect(inputSchema).toHaveBeenCalledWith(toolCall);
-      expect(generateText).toHaveBeenCalledWith(
+      expect(generateTextMock).toHaveBeenCalledWith(
         expect.objectContaining({
           prompt: expect.not.stringContaining("student request"),
         })
@@ -121,7 +115,7 @@ describe("math tool repair", () => {
 
   it.effect("keeps the failed operation when the repair model changes it", () =>
     Effect.gen(function* () {
-      generateText.mockResolvedValue({
+      generateTextMock.mockResolvedValue({
         output: {
           expression: "(x^2 - 9)/(x - 3)",
           operation: "factor",
@@ -188,7 +182,7 @@ describe("math tool repair", () => {
         });
 
         inputSchema.mockResolvedValueOnce(equationSchema);
-        generateText.mockResolvedValue({
+        generateTextMock.mockResolvedValue({
           output: {
             expressions: ["x^2 = 1", "y = 0"],
             lower: "0",
@@ -222,12 +216,12 @@ describe("math tool repair", () => {
           variable: "x",
           variables: ["x", "y"],
         });
-        expect(generateText).toHaveBeenCalledWith(
+        expect(generateTextMock).toHaveBeenCalledWith(
           expect.objectContaining({
             prompt: expect.stringContaining('"lower": "0"'),
           })
         );
-        expect(generateText).toHaveBeenCalledWith(
+        expect(generateTextMock).toHaveBeenCalledWith(
           expect.objectContaining({
             prompt: expect.stringContaining("Do not drop bounds"),
           })
@@ -237,7 +231,7 @@ describe("math tool repair", () => {
 
   it.effect("does not repair when the repair output is not object-shaped", () =>
     Effect.gen(function* () {
-      generateText.mockResolvedValue({ output: null });
+      generateTextMock.mockResolvedValue({ output: null });
 
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,
@@ -258,7 +252,7 @@ describe("math tool repair", () => {
     "uses repaired arguments when the failed call has no operation field",
     () =>
       Effect.gen(function* () {
-        generateText.mockResolvedValue({
+        generateTextMock.mockResolvedValue({
           output: {
             expression: "(x^2 - 9)/(x - 3)",
             operation: "simplify",
@@ -299,7 +293,7 @@ describe("math tool repair", () => {
     "keeps malformed failed arguments readable in the repair prompt",
     () =>
       Effect.gen(function* () {
-        generateText.mockResolvedValue({
+        generateTextMock.mockResolvedValue({
           output: {
             expression: "(x^2 - 9)/(x - 3)",
             operation: "simplify",
@@ -333,7 +327,7 @@ describe("math tool repair", () => {
             2
           ),
         });
-        expect(generateText).toHaveBeenCalledWith(
+        expect(generateTextMock).toHaveBeenCalledWith(
           expect.objectContaining({
             prompt: expect.stringContaining('{"operation":"simplify"'),
           })
@@ -355,7 +349,7 @@ describe("math tool repair", () => {
       });
 
       expect(repaired).toBeNull();
-      expect(generateText).not.toHaveBeenCalled();
+      expect(generateTextMock).not.toHaveBeenCalled();
     })
   );
 
@@ -373,7 +367,7 @@ describe("math tool repair", () => {
       });
 
       expect(repaired).toBeNull();
-      expect(generateText).not.toHaveBeenCalled();
+      expect(generateTextMock).not.toHaveBeenCalled();
     })
   );
 
@@ -391,13 +385,13 @@ describe("math tool repair", () => {
       });
 
       expect(repaired).toBeNull();
-      expect(generateText).not.toHaveBeenCalled();
+      expect(generateTextMock).not.toHaveBeenCalled();
     })
   );
 
   it.effect("does not repair when the repair model fails", () =>
     Effect.gen(function* () {
-      generateText.mockRejectedValue(new Error("model unavailable"));
+      generateTextMock.mockRejectedValue(new Error("model unavailable"));
 
       const repaired = yield* repairMathToolCall({
         error: invalidInputError,

--- a/packages/ai/agents/math/schema.test.ts
+++ b/packages/ai/agents/math/schema.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   mathAlgebraInput,
   mathArithmeticInput,
@@ -11,154 +12,141 @@ import {
   mathStatisticsInput,
 } from "@repo/ai/agents/math/schema";
 import { asSchema } from "ai";
-import { describe, expect, it } from "vitest";
+import { Effect, Predicate } from "effect";
 
+/** Proves that Effect-backed AI schemas keep their deterministic sync contract. */
+function readSynchronous<A>(value: A | PromiseLike<A>, operation: string): A {
+  if (Predicate.isPromiseLike(value)) {
+    expect.fail(`${operation} must remain synchronous.`);
+  }
+  return value;
+}
+/** Awaits one AI SDK validator inside Effect and returns its Vitest matcher. */
+function expectValidation<A>(value: A | PromiseLike<A>) {
+  return Effect.promise(() => Promise.resolve(value)).pipe(
+    Effect.map((result) => expect(result))
+  );
+}
+/** Requires the validator promised by an AI SDK schema adapter. */
+function requireValidator<A>(value: A | undefined) {
+  return Effect.suspend(() =>
+    value === undefined
+      ? Effect.die("AI SDK schema adapter omitted its validator.")
+      : Effect.succeed(value)
+  );
+}
 describe("math AI input schemas", () => {
-  it("exposes Effect schemas as AI SDK-compatible JSON schemas", async () => {
-    const schema = asSchema(mathArithmeticInput);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math input schema must validate model tool input.");
-    }
-
-    expect(jsonSchema).toMatchObject({
-      description: "Exact arithmetic tool input.",
-      properties: {
-        expression: {
-          description:
-            "A math expression in plain text syntax, for example (x^2 - 9)/(x - 3).",
-          type: "string",
+  it.effect("exposes Effect schemas as AI SDK-compatible JSON schemas", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathArithmeticInput);
+      const jsonSchema = readSynchronous(schema.jsonSchema, "Math JSON Schema");
+      const validate = yield* requireValidator(schema.validate);
+      expect(jsonSchema).toMatchObject({
+        description: "Exact arithmetic tool input.",
+        properties: {
+          expression: {
+            description:
+              "A math expression in plain text syntax, for example (x^2 - 9)/(x - 3).",
+            type: "string",
+          },
+          operation: {
+            description: "Evaluate an exact arithmetic or numeric expression.",
+            enum: ["evaluate"],
+            type: "string",
+          },
         },
-        operation: {
-          description: "Evaluate an exact arithmetic or numeric expression.",
-          enum: ["evaluate"],
-          type: "string",
-        },
-      },
-      required: ["expression", "operation"],
-      type: "object",
-    });
-
-    await expect(
-      Promise.resolve(
+        required: ["expression", "operation"],
+        type: "object",
+      });
+      (yield* expectValidation(
         validate({
           expression: "2 + 2",
           operation: "evaluate",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "2 + 2",
-        operation: "evaluate",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          expression: "2 + 2",
+          operation: "evaluate",
+        },
+      });
+      (yield* expectValidation(
         validate({
           expression: "2 + 2",
           operation: "simplify",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-  });
-
-  it("rejects algebra operations that omit their required expression fields", async () => {
-    const schema = asSchema(mathAlgebraInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math algebra schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
-        validate({
-          operation: "simplify",
-        })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          operation: "domain",
-        })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          expression: "(x^2 - 9)/(x - 3)",
-          operation: "simplify",
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "(x^2 - 9)/(x - 3)",
-        operation: "simplify",
-      },
-    });
-  });
-
-  it("requires both sides for algebra comparison", async () => {
-    const schema = asSchema(mathAlgebraInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math algebra schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+    })
+  );
+  it.effect(
+    "rejects algebra operations that omit their required expression fields",
+    () =>
+      Effect.gen(function* () {
+        const schema = asSchema(mathAlgebraInput);
+        const validate = yield* requireValidator(schema.validate);
+        (yield* expectValidation(
+          validate({
+            operation: "simplify",
+          })
+        )).toMatchObject({
+          success: false,
+        });
+        (yield* expectValidation(
+          validate({
+            operation: "domain",
+          })
+        )).toMatchObject({
+          success: false,
+        });
+        (yield* expectValidation(
+          validate({
+            expression: "(x^2 - 9)/(x - 3)",
+            operation: "simplify",
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            expression: "(x^2 - 9)/(x - 3)",
+            operation: "simplify",
+          },
+        });
+      })
+  );
+  it.effect("requires both sides for algebra comparison", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathAlgebraInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           left: "(x^2 - 9)/(x - 3)",
           operation: "compare",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           left: "(x^2 - 9)/(x - 3)",
           operation: "compare",
           right: "x + 3",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        left: "(x^2 - 9)/(x - 3)",
-        operation: "compare",
-        right: "x + 3",
-      },
-    });
-  });
-
-  it("allows equation solve domains for restricted variables", async () => {
-    const schema = asSchema(mathEquationInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math equation schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          left: "(x^2 - 9)/(x - 3)",
+          operation: "compare",
+          right: "x + 3",
+        },
+      });
+    })
+  );
+  it.effect("allows equation solve domains for restricted variables", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathEquationInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           expression: "x^x * (ln(x) + 1) = 0",
           lower: "0",
@@ -166,87 +154,71 @@ describe("math AI input schemas", () => {
           operation: "solve",
           variable: "x",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "x^x * (ln(x) + 1) = 0",
-        lower: "0",
-        lowerInclusive: false,
-        operation: "solve",
-        variable: "x",
-      },
-    });
-  });
-
-  it("allows system solve domains with an explicit bounded variable", async () => {
-    const schema = asSchema(mathEquationInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math equation schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
-        validate({
-          expressions: ["x^2 - 1 = 0", "y = 0"],
+      )).toEqual({
+        success: true,
+        value: {
+          expression: "x^x * (ln(x) + 1) = 0",
           lower: "0",
           lowerInclusive: false,
           operation: "solve",
           variable: "x",
-          variables: ["x", "y"],
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expressions: ["x^2 - 1 = 0", "y = 0"],
-        lower: "0",
-        lowerInclusive: false,
-        operation: "solve",
-        variable: "x",
-        variables: ["x", "y"],
-      },
-    });
-  });
-
-  it("rejects unsupported equation domain shapes", async () => {
-    const schema = asSchema(mathEquationInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math equation schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+        },
+      });
+    })
+  );
+  it.effect(
+    "allows system solve domains with an explicit bounded variable",
+    () =>
+      Effect.gen(function* () {
+        const schema = asSchema(mathEquationInput);
+        const validate = yield* requireValidator(schema.validate);
+        (yield* expectValidation(
+          validate({
+            expressions: ["x^2 - 1 = 0", "y = 0"],
+            lower: "0",
+            lowerInclusive: false,
+            operation: "solve",
+            variable: "x",
+            variables: ["x", "y"],
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            expressions: ["x^2 - 1 = 0", "y = 0"],
+            lower: "0",
+            lowerInclusive: false,
+            operation: "solve",
+            variable: "x",
+            variables: ["x", "y"],
+          },
+        });
+      })
+  );
+  it.effect("rejects unsupported equation domain shapes", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathEquationInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           expression: "x^2 - 1 = 0",
           lower: "0",
           operation: "roots",
           variable: "x",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           expressions: ["x + y = 3", "y = 1"],
           lower: "0",
           operation: "solve",
           variable: "x",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           expressions: ["x^2 - 1 = 0", "y = 0"],
           lower: "0",
@@ -254,106 +226,81 @@ describe("math AI input schemas", () => {
           variable: "z",
           variables: ["x", "y"],
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-  });
-
-  it("requires values for discrete operations that use integer lists", async () => {
-    const schema = asSchema(mathDiscreteInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math discrete schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
-        validate({
-          operation: "gcd",
-        })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          operation: "gcd",
-          values: ["84", "30"],
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        operation: "gcd",
-        values: ["84", "30"],
-      },
-    });
-  });
-
-  it("requires the second matrix for matrix multiplication", async () => {
-    const schema = asSchema(mathMatrixInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math matrix schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+    })
+  );
+  it.effect(
+    "requires values for discrete operations that use integer lists",
+    () =>
+      Effect.gen(function* () {
+        const schema = asSchema(mathDiscreteInput);
+        const validate = yield* requireValidator(schema.validate);
+        (yield* expectValidation(
+          validate({
+            operation: "gcd",
+          })
+        )).toMatchObject({
+          success: false,
+        });
+        (yield* expectValidation(
+          validate({
+            operation: "gcd",
+            values: ["84", "30"],
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            operation: "gcd",
+            values: ["84", "30"],
+          },
+        });
+      })
+  );
+  it.effect("requires the second matrix for matrix multiplication", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathMatrixInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           matrix: [["1"]],
           operation: "matrix_multiply",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           matrix: [["1"]],
           operation: "matrix_multiply",
           right_matrix: [["2"]],
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        matrix: [["1"]],
-        operation: "matrix_multiply",
-        right_matrix: [["2"]],
-      },
-    });
-  });
-
-  it("requires a calculus variable for parameterized expressions", async () => {
-    const schema = asSchema(mathCalculusInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math calculus schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          matrix: [["1"]],
+          operation: "matrix_multiply",
+          right_matrix: [["2"]],
+        },
+      });
+    })
+  );
+  it.effect("requires a calculus variable for parameterized expressions", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathCalculusInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           expression: "x^(a-1) * exp(-x)",
           lower: "0",
           operation: "integrate",
           upper: "oo",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           expression: "x^(a-1) * exp(-x)",
           lower: "0",
@@ -361,67 +308,55 @@ describe("math AI input schemas", () => {
           upper: "oo",
           variable: "x",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "x^(a-1) * exp(-x)",
-        lower: "0",
-        operation: "integrate",
-        upper: "oo",
-        variable: "x",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          expression: "x^(a-1) * exp(-x)",
+          lower: "0",
+          operation: "integrate",
+          upper: "oo",
+          variable: "x",
+        },
+      });
+      (yield* expectValidation(
         validate({
           expression: "x^2",
           operation: "differentiate",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "x^2",
-        operation: "differentiate",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          expression: "x^2",
+          operation: "differentiate",
+        },
+      });
+      (yield* expectValidation(
         validate({
           expression: "x^x",
           operation: "differentiate",
           order: 2,
           variable: "x",
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "x^x",
-        operation: "differentiate",
-        order: 2,
-        variable: "x",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toEqual({
+        success: true,
+        value: {
+          expression: "x^x",
+          operation: "differentiate",
+          order: 2,
+          variable: "x",
+        },
+      });
+      (yield* expectValidation(
         validate({
           expression: "x^2",
           operation: "integrate",
           order: 2,
           variable: "x",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           expression: "sin(x) / x",
           operation: "limit",
@@ -429,138 +364,111 @@ describe("math AI input schemas", () => {
           point: "0",
           variable: "x",
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-  });
-
-  it("requires event bounds for named probability event operations", async () => {
-    const schema = asSchema(mathProbabilityInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error(
-        "Math probability schema must validate model tool input."
-      );
-    }
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "normal",
-          operation: "cumulative_probability",
-          parameters: {},
-          upper: "85",
-        })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "normal",
-          operation: "cumulative_probability",
-          parameters: { mean: "70", standard_deviation: "10" },
-        })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "normal",
-          operation: "cumulative_probability",
-          parameters: { mean: "70", standard_deviation: "10" },
-          upper: "85",
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        distribution: "normal",
-        operation: "cumulative_probability",
-        parameters: { mean: "70", standard_deviation: "10" },
-        upper: "85",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "binomial",
-          operation: "point_probability",
-          parameters: { n: "10", p: "1/5" },
-          point: "3",
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        distribution: "binomial",
-        operation: "point_probability",
-        parameters: { n: "10", p: "1/5" },
-        point: "3",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "normal",
-          lower: "60",
-          operation: "interval_probability",
-          parameters: { mean: "70", standard_deviation: "10" },
-          upper: "85",
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        distribution: "normal",
-        lower: "60",
-        operation: "interval_probability",
-        parameters: { mean: "70", standard_deviation: "10" },
-        upper: "85",
-      },
-    });
-
-    await expect(
-      Promise.resolve(
-        validate({
-          distribution: "poisson",
-          inclusive: false,
-          lower: "2",
-          operation: "tail_probability",
-          parameters: { lambda: "3" },
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        distribution: "poisson",
-        inclusive: false,
-        lower: "2",
-        operation: "tail_probability",
-        parameters: { lambda: "3" },
-      },
-    });
-  });
-
-  it("rejects malformed geometry points before tool execution", async () => {
-    const schema = asSchema(mathGeometryInput);
-    const validate = schema.validate;
-
-    if (!validate) {
-      throw new Error("Math geometry schema must validate model tool input.");
-    }
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+    })
+  );
+  it.effect(
+    "requires event bounds for named probability event operations",
+    () =>
+      Effect.gen(function* () {
+        const schema = asSchema(mathProbabilityInput);
+        const validate = yield* requireValidator(schema.validate);
+        (yield* expectValidation(
+          validate({
+            distribution: "normal",
+            operation: "cumulative_probability",
+            parameters: {},
+            upper: "85",
+          })
+        )).toMatchObject({
+          success: false,
+        });
+        (yield* expectValidation(
+          validate({
+            distribution: "normal",
+            operation: "cumulative_probability",
+            parameters: { mean: "70", standard_deviation: "10" },
+          })
+        )).toMatchObject({
+          success: false,
+        });
+        (yield* expectValidation(
+          validate({
+            distribution: "normal",
+            operation: "cumulative_probability",
+            parameters: { mean: "70", standard_deviation: "10" },
+            upper: "85",
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            distribution: "normal",
+            operation: "cumulative_probability",
+            parameters: { mean: "70", standard_deviation: "10" },
+            upper: "85",
+          },
+        });
+        (yield* expectValidation(
+          validate({
+            distribution: "binomial",
+            operation: "point_probability",
+            parameters: { n: "10", p: "1/5" },
+            point: "3",
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            distribution: "binomial",
+            operation: "point_probability",
+            parameters: { n: "10", p: "1/5" },
+            point: "3",
+          },
+        });
+        (yield* expectValidation(
+          validate({
+            distribution: "normal",
+            lower: "60",
+            operation: "interval_probability",
+            parameters: { mean: "70", standard_deviation: "10" },
+            upper: "85",
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            distribution: "normal",
+            lower: "60",
+            operation: "interval_probability",
+            parameters: { mean: "70", standard_deviation: "10" },
+            upper: "85",
+          },
+        });
+        (yield* expectValidation(
+          validate({
+            distribution: "poisson",
+            inclusive: false,
+            lower: "2",
+            operation: "tail_probability",
+            parameters: { lambda: "3" },
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            distribution: "poisson",
+            inclusive: false,
+            lower: "2",
+            operation: "tail_probability",
+            parameters: { lambda: "3" },
+          },
+        });
+      })
+  );
+  it.effect("rejects malformed geometry points before tool execution", () =>
+    Effect.gen(function* () {
+      const schema = asSchema(mathGeometryInput);
+      const validate = yield* requireValidator(schema.validate);
+      (yield* expectValidation(
         validate({
           operation: "midpoint",
           points: [
@@ -568,13 +476,10 @@ describe("math AI input schemas", () => {
             { x: "4,y:", y: "6" },
           ],
         })
-      )
-    ).resolves.toMatchObject({
-      success: false,
-    });
-
-    await expect(
-      Promise.resolve(
+      )).toMatchObject({
+        success: false,
+      });
+      (yield* expectValidation(
         validate({
           operation: "midpoint",
           points: [
@@ -582,29 +487,25 @@ describe("math AI input schemas", () => {
             { x: "4", y: "6" },
           ],
         })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        operation: "midpoint",
-        points: [
-          { x: "1", y: "2" },
-          { x: "4", y: "6" },
-        ],
-      },
-    });
-  });
-
-  it("keeps geometry model metadata clear for two-point and four-point operations", async () => {
+      )).toEqual({
+        success: true,
+        value: {
+          operation: "midpoint",
+          points: [
+            { x: "1", y: "2" },
+            { x: "4", y: "6" },
+          ],
+        },
+      });
+    })
+  );
+  it("keeps geometry model metadata clear for two-point and four-point operations", () => {
     const schema = asSchema(mathGeometryInput);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-
+    const jsonSchema = readSynchronous(schema.jsonSchema, "Math JSON Schema");
     if (!("properties" in jsonSchema && jsonSchema.properties)) {
-      throw new Error("Math geometry schema must expose object properties.");
+      expect.fail("Math geometry schema must expose object properties.");
     }
-
     const { properties } = jsonSchema;
-
     expect(jsonSchema).toMatchObject({
       properties: {
         operation: {
@@ -632,29 +533,43 @@ describe("math AI input schemas", () => {
       },
     });
   });
-
-  it("exposes grouped tool schemas as provider-compatible objects", async () => {
+  it("exposes grouped tool schemas as provider-compatible objects", () => {
     const jsonSchemas = [
-      await Promise.resolve(asSchema(mathAlgebraInput).jsonSchema),
-      await Promise.resolve(asSchema(mathEquationInput).jsonSchema),
-      await Promise.resolve(asSchema(mathGeometryInput).jsonSchema),
-      await Promise.resolve(asSchema(mathDiscreteInput).jsonSchema),
-      await Promise.resolve(asSchema(mathMatrixInput).jsonSchema),
-      await Promise.resolve(asSchema(mathSeriesInput).jsonSchema),
-      await Promise.resolve(asSchema(mathStatisticsInput).jsonSchema),
-      await Promise.resolve(asSchema(mathProbabilityInput).jsonSchema),
+      readSynchronous(
+        asSchema(mathAlgebraInput).jsonSchema,
+        "Math JSON Schema"
+      ),
+      readSynchronous(
+        asSchema(mathEquationInput).jsonSchema,
+        "Math JSON Schema"
+      ),
+      readSynchronous(
+        asSchema(mathGeometryInput).jsonSchema,
+        "Math JSON Schema"
+      ),
+      readSynchronous(
+        asSchema(mathDiscreteInput).jsonSchema,
+        "Math JSON Schema"
+      ),
+      readSynchronous(asSchema(mathMatrixInput).jsonSchema, "Math JSON Schema"),
+      readSynchronous(asSchema(mathSeriesInput).jsonSchema, "Math JSON Schema"),
+      readSynchronous(
+        asSchema(mathStatisticsInput).jsonSchema,
+        "Math JSON Schema"
+      ),
+      readSynchronous(
+        asSchema(mathProbabilityInput).jsonSchema,
+        "Math JSON Schema"
+      ),
     ];
-
     for (const jsonSchema of jsonSchemas) {
       expect(jsonSchema).not.toHaveProperty("anyOf");
       expect(jsonSchema).toMatchObject({ type: "object" });
     }
   });
-
-  it("keeps probability event fields visible behind one model-facing tool", async () => {
+  it("keeps probability event fields visible behind one model-facing tool", () => {
     const schema = asSchema(mathProbabilityInput);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-
+    const jsonSchema = readSynchronous(schema.jsonSchema, "Math JSON Schema");
     expect(jsonSchema).toMatchObject({
       properties: {
         distribution: {
@@ -699,11 +614,9 @@ describe("math AI input schemas", () => {
       },
     });
   });
-
-  it("keeps model-facing field metadata for grouped algebra tools", async () => {
+  it("keeps model-facing field metadata for grouped algebra tools", () => {
     const schema = asSchema(mathAlgebraInput);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-
+    const jsonSchema = readSynchronous(schema.jsonSchema, "Math JSON Schema");
     expect(jsonSchema).toMatchObject({
       properties: {
         expression: {

--- a/packages/ai/agents/math/tools/compute.test.ts
+++ b/packages/ai/agents/math/tools/compute.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { compute } from "@repo/ai/agents/math/tools/compute";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import type { MathRequest } from "@repo/math/schema/request";
 import type { MathResult } from "@repo/math/schema/result";
 import type { MathToolInput } from "@repo/math/schema/tool-input";
 import { MathService } from "@repo/math/service";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { ConfigProvider, Effect } from "effect";
 import { vi } from "vitest";
@@ -74,7 +74,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 describe("math compute tool", () => {
-  it.live("writes loading and done math data parts", () =>
+  it.effect("writes loading and done math data parts", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json(result));
       const { parts, writer } = createWriter();
@@ -112,7 +112,7 @@ describe("math compute tool", () => {
       ]);
     })
   );
-  it.live("writes an error data part for math request failures", () =>
+  it.effect("writes an error data part for math request failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();
@@ -150,7 +150,7 @@ describe("math compute tool", () => {
       );
     })
   );
-  it.live("writes an error data part for math response failures", () =>
+  it.effect("writes an error data part for math response failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         Response.json({ status: "verified" })
@@ -180,7 +180,7 @@ describe("math compute tool", () => {
       );
     })
   );
-  it.live(
+  it.effect(
     "asks the model to retry ambiguous symbolic calculus with the explicit variable",
     () =>
       Effect.gen(function* () {
@@ -220,7 +220,7 @@ describe("math compute tool", () => {
         );
       })
   );
-  it.live(
+  it.effect(
     "returns a model-readable error before writing data for invalid tool input",
     () =>
       Effect.gen(function* () {
@@ -243,7 +243,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live(
+  it.effect(
     "tells the model how to retry bounded systems with the same bounds",
     () =>
       Effect.gen(function* () {
@@ -274,7 +274,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live(
+  it.effect(
     "tells the model how to retry incomplete bounded system expressions",
     () =>
       Effect.gen(function* () {
@@ -304,7 +304,7 @@ describe("math compute tool", () => {
         expect(parts).toEqual([]);
       })
   );
-  it.live("keeps invalid input errors locale-free", () =>
+  it.effect("keeps invalid input errors locale-free", () =>
     Effect.gen(function* () {
       const fetch = vi.spyOn(globalThis, "fetch");
       const { parts, writer } = createWriter();
@@ -321,7 +321,7 @@ describe("math compute tool", () => {
       expect(parts).toEqual([]);
     })
   );
-  it.live("writes locale-free error data for math service failures", () =>
+  it.effect("writes locale-free error data for math service failures", () =>
     Effect.gen(function* () {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();

--- a/packages/ai/agents/nakafa/error.test.ts
+++ b/packages/ai/agents/nakafa/error.test.ts
@@ -1,12 +1,12 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   makeNakafaGenerationError,
   NakafaGenerationError,
 } from "@repo/ai/agents/nakafa/error";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("Nakafa generation error", () => {
-  it.live(
+  it.effect(
     "maps unknown provider failures into the capability error channel",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/agents/nakafa/tools/fixture.test.ts
+++ b/packages/ai/agents/nakafa/tools/fixture.test.ts
@@ -1,3 +1,4 @@
+import { it as effectIt } from "@effect/vitest";
 import { makeQuranV2Fixture } from "@repo/ai/agents/nakafa/tools/fixture";
 import { createNakafaTestService } from "@repo/ai/agents/nakafa/tools/test";
 import { Effect, Option } from "effect";
@@ -33,37 +34,43 @@ describe("Nakafa Quran V2 AI fixtures", () => {
     }
   );
 
-  it("retains the injected V1 service for compatibility consumers", async () => {
-    const service = createNakafaTestService();
-    const [plain, interpreted, missing, invalid] = await Effect.runPromise(
-      Effect.all([
-        service.quran({ include_tafsir: false, locale: "en", surah: 1 }),
-        service.quran({ include_tafsir: true, locale: "id", surah: 1 }),
-        service.quran({ from_verse: 999, locale: "en", surah: 1 }),
-        Effect.result(service.quran({ locale: "en", surah: 999 })),
-      ])
-    );
+  effectIt.effect(
+    "retains the injected V1 service for compatibility consumers",
+    () =>
+      Effect.gen(function* () {
+        const service = createNakafaTestService();
+        const [plain, interpreted, missing, invalid] = yield* Effect.all([
+          service.quran({ include_tafsir: false, locale: "en", surah: 1 }),
+          service.quran({ include_tafsir: true, locale: "id", surah: 1 }),
+          service.quran({ from_verse: 999, locale: "en", surah: 1 }),
+          Effect.result(service.quran({ locale: "en", surah: 999 })),
+        ]);
 
-    expect(Option.getOrUndefined(plain)?.verses[0]?.tafsir).toBeUndefined();
-    expect(Option.getOrUndefined(interpreted)?.verses[0]?.tafsir).toBeTruthy();
-    expect(Option.isNone(missing)).toBe(true);
-    expect(invalid._tag).toBe("Failure");
-  });
+        expect(Option.getOrUndefined(plain)?.verses[0]?.tafsir).toBeUndefined();
+        expect(
+          Option.getOrUndefined(interpreted)?.verses[0]?.tafsir
+        ).toBeTruthy();
+        expect(Option.isNone(missing)).toBe(true);
+        expect(invalid._tag).toBe("Failure");
+      })
+  );
 
-  it("exposes the explicit V2 service without switching V1 consumers", async () => {
-    const service = createNakafaTestService();
-    const [reference, missing, invalid] = await Effect.runPromise(
-      Effect.all([
-        service.quranV2({ locale: "de", surah: 1 }),
-        service.quranV2({ from_verse: 999, locale: "en", surah: 1 }),
-        Effect.result(service.quranV2({ locale: "en", surah: 999 })),
-      ])
-    );
+  effectIt.effect(
+    "exposes the explicit V2 service without switching V1 consumers",
+    () =>
+      Effect.gen(function* () {
+        const service = createNakafaTestService();
+        const [reference, missing, invalid] = yield* Effect.all([
+          service.quranV2({ locale: "de", surah: 1 }),
+          service.quranV2({ from_verse: 999, locale: "en", surah: 1 }),
+          Effect.result(service.quranV2({ locale: "en", surah: 999 })),
+        ]);
 
-    expect(Option.getOrUndefined(reference)?.sources.translation.id).toBe(
-      "quranenc-german"
-    );
-    expect(Option.isNone(missing)).toBe(true);
-    expect(invalid._tag).toBe("Failure");
-  });
+        expect(Option.getOrUndefined(reference)?.sources.translation.id).toBe(
+          "quranenc-german"
+        );
+        expect(Option.isNone(missing)).toBe(true);
+        expect(invalid._tag).toBe("Failure");
+      })
+  );
 });

--- a/packages/ai/agents/nakafa/tools/quran.test.ts
+++ b/packages/ai/agents/nakafa/tools/quran.test.ts
@@ -1,14 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { quran } from "@repo/ai/agents/nakafa/tools/quran";
 import {
   createNakafaTestService,
   createWriter,
 } from "@repo/ai/agents/nakafa/tools/test";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("nakafa Quran tool", () => {
-  it.live("writes loading and done parts for bounded Quran references", () =>
+  it.effect("writes loading and done parts for bounded Quran references", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* quran({
@@ -37,7 +37,7 @@ describe("nakafa Quran tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "applies defaults and preserves tafsir requests in persisted input",
     () =>
       Effect.gen(function* () {
@@ -68,7 +68,7 @@ describe("nakafa Quran tool", () => {
       })
   );
 
-  it.live.each([
+  it.effect.each([
     [
       "reversed range",
       { from_verse: 2, locale: "en", surah: 1, to_verse: 1 },

--- a/packages/ai/agents/nakafa/tools/read.test.ts
+++ b/packages/ai/agents/nakafa/tools/read.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { read } from "@repo/ai/agents/nakafa/tools/read";
 import {
@@ -7,7 +8,6 @@ import {
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { NakafaAgentContentRefInputSchema } from "@repo/contents/_lib/agent/schema/read";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 const ARTICLE_CONTENT_ID = NakafaAgentContentRefInputSchema.make(
@@ -28,7 +28,7 @@ const TRYOUT_URL = NakafaAgentContentRefInputSchema.make(
   "https://nakafa.com/en/try-out/indonesia/snbt/2027/set-2"
 );
 describe("nakafa read tool", () => {
-  it.live("writes loading and done parts for content reads", () =>
+  it.effect("writes loading and done parts for content reads", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -51,7 +51,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("accepts canonical URL projections for current-page reads", () =>
+  it.effect("accepts canonical URL projections for current-page reads", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -70,7 +70,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("writes an error part when content is missing", () =>
+  it.effect("writes an error part when content is missing", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -86,7 +86,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("does not invent a markdown read for tryout references", () =>
+  it.effect("does not invent a markdown read for tryout references", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({
@@ -102,7 +102,7 @@ describe("nakafa read tool", () => {
       );
     })
   );
-  it.live("writes an error part when content reading fails", () =>
+  it.effect("writes an error part when content reading fails", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* read({

--- a/packages/ai/agents/nakafa/tools/search.test.ts
+++ b/packages/ai/agents/nakafa/tools/search.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { NakafaSearch } from "@repo/ai/agents/nakafa/search";
 import { search } from "@repo/ai/agents/nakafa/tools/search";
 import {
@@ -9,7 +10,6 @@ import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import type { NakafaAgentSection } from "@repo/contents/_lib/agent/schema/ref";
 import { NakafaAgentSearchResultSchema } from "@repo/contents/_lib/agent/schema/search";
 import type { Locale } from "@repo/contents/_types/content";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
 
 /** Extracts Nakafa search data parts from a recorded test writer stream. */
@@ -64,7 +64,7 @@ function searchItem({
 }
 
 describe("nakafa search tool", () => {
-  it.live("writes loading and done parts for search results", () =>
+  it.effect("writes loading and done parts for search results", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* search({
@@ -121,7 +121,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live("writes an error part when Convex-backed search fails", () =>
+  it.effect("writes an error part when Convex-backed search fails", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* search({
@@ -157,7 +157,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live("formats empty search results without a next offset", () =>
+  it.effect("formats empty search results without a next offset", () =>
     Effect.gen(function* () {
       const { writer } = createWriter();
       const output = yield* search({
@@ -190,7 +190,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "formats unscoped search results when no query text is provided",
     () =>
       Effect.gen(function* () {
@@ -242,7 +242,7 @@ describe("nakafa search tool", () => {
       })
   );
 
-  it.live("uses the server locale instead of the model-provided locale", () =>
+  it.effect("uses the server locale instead of the model-provided locale", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* search({
@@ -297,7 +297,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live("preserves model-selected section filters", () =>
+  it.effect("preserves model-selected section filters", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* search({
@@ -346,7 +346,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live("preserves alternate query variants for one section", () =>
+  it.effect("preserves alternate query variants for one section", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const capturedQueries: string[][] = [];
@@ -408,7 +408,7 @@ describe("nakafa search tool", () => {
     })
   );
 
-  it.live("executes the model-provided try-out query unchanged", () =>
+  it.effect("executes the model-provided try-out query unchanged", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const capturedQueries: string[][] = [];

--- a/packages/ai/agents/nakafa/tools/taxonomy.test.ts
+++ b/packages/ai/agents/nakafa/tools/taxonomy.test.ts
@@ -1,14 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
 import { taxonomy } from "@repo/ai/agents/nakafa/tools/taxonomy";
 import {
   createNakafaTestService,
   createWriter,
 } from "@repo/ai/agents/nakafa/tools/test";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("nakafa taxonomy tool", () => {
-  it.live("writes loading and done parts for taxonomy", () =>
+  it.effect("writes loading and done parts for taxonomy", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
       const output = yield* taxonomy({
@@ -41,14 +41,16 @@ describe("nakafa taxonomy tool", () => {
     })
   );
 
-  it.live("uses the injected test service for invalid route verification", () =>
-    Effect.gen(function* () {
-      const service = createNakafaTestService();
-      const isVerified = yield* service.verify("");
-      const taxonomyResult = yield* service.taxonomy();
+  it.effect(
+    "uses the injected test service for invalid route verification",
+    () =>
+      Effect.gen(function* () {
+        const service = createNakafaTestService();
+        const isVerified = yield* service.verify("");
+        const taxonomyResult = yield* service.taxonomy();
 
-      expect(isVerified).toBe(false);
-      expect(taxonomyResult.locale).toBe("en");
-    })
+        expect(isVerified).toBe(false);
+        expect(taxonomyResult.locale).toBe("en");
+      })
   );
 });

--- a/packages/ai/agents/research/tools/markdown.test.ts
+++ b/packages/ai/agents/research/tools/markdown.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { fetchSourceMarkdown } from "@repo/ai/agents/research/tools/markdown";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -8,7 +8,7 @@ describe("source markdown fetcher", () => {
     vi.unstubAllGlobals();
   });
 
-  it.live(
+  it.effect(
     "reads markdown from the original URL when it is already markdown",
     () =>
       Effect.gen(function* () {
@@ -29,7 +29,7 @@ describe("source markdown fetcher", () => {
       })
   );
 
-  it.live("uses the adjacent markdown URL when the page shell is HTML", () =>
+  it.effect("uses the adjacent markdown URL when the page shell is HTML", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -56,34 +56,36 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("rejects markdown-looking HTML before using adjacent markdown", () =>
-    Effect.gen(function* () {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn((input: Parameters<typeof fetch>[0]) => {
-          if (String(input) === "https://example.com/docs/devtools.md") {
+  it.effect(
+    "rejects markdown-looking HTML before using adjacent markdown",
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn((input: Parameters<typeof fetch>[0]) => {
+            if (String(input) === "https://example.com/docs/devtools.md") {
+              return Promise.resolve(
+                new Response("# DevTools\n\n- Input parameters and prompts", {
+                  headers: { "content-type": "text/markdown" },
+                })
+              );
+            }
+
             return Promise.resolve(
-              new Response("# DevTools\n\n- Input parameters and prompts", {
-                headers: { "content-type": "text/markdown" },
+              new Response("# DevTools\n\n- Navigation item", {
+                headers: { "content-type": "text/html" },
               })
             );
-          }
+          })
+        );
 
-          return Promise.resolve(
-            new Response("# DevTools\n\n- Navigation item", {
-              headers: { "content-type": "text/html" },
-            })
-          );
-        })
-      );
-
-      expect(
-        yield* fetchSourceMarkdown("https://example.com/docs/devtools")
-      ).toBe("# DevTools\n\n- Input parameters and prompts");
-    })
+        expect(
+          yield* fetchSourceMarkdown("https://example.com/docs/devtools")
+        ).toBe("# DevTools\n\n- Input parameters and prompts");
+      })
   );
 
-  it.live("supports trailing slash docs pages with adjacent markdown", () =>
+  it.effect("supports trailing slash docs pages with adjacent markdown", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -106,26 +108,28 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when root pages do not expose readable markdown", () =>
-    Effect.gen(function* () {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(() =>
-          Promise.resolve(
-            new Response("<body>home</body>", {
-              headers: { "content-type": "text/html" },
-            })
+  it.effect(
+    "returns empty when root pages do not expose readable markdown",
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(() =>
+            Promise.resolve(
+              new Response("<body>home</body>", {
+                headers: { "content-type": "text/html" },
+              })
+            )
           )
-        )
-      );
+        );
 
-      expect(
-        yield* fetchSourceMarkdown("https://example.com/")
-      ).toBeUndefined();
-    })
+        expect(
+          yield* fetchSourceMarkdown("https://example.com/")
+        ).toBeUndefined();
+      })
   );
 
-  it.live(
+  it.effect(
     "accepts markdown-looking content from unknown text-compatible responses",
     () =>
       Effect.gen(function* () {
@@ -146,7 +150,7 @@ describe("source markdown fetcher", () => {
       })
   );
 
-  it.live("accepts markdown-looking content without a content type", () =>
+  it.effect("accepts markdown-looking content without a content type", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -163,7 +167,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("rejects unknown responses that do not look like markdown", () =>
+  it.effect("rejects unknown responses that do not look like markdown", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -182,7 +186,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when source fetches fail", () =>
+  it.effect("returns empty when source fetches fail", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -195,7 +199,7 @@ describe("source markdown fetcher", () => {
     })
   );
 
-  it.live("returns empty when response bodies cannot be read", () =>
+  it.effect("returns empty when response bodies cannot be read", () =>
     Effect.gen(function* () {
       const stream = new ReadableStream({
         start(controller) {

--- a/packages/ai/agents/research/tools/safety.test.ts
+++ b/packages/ai/agents/research/tools/safety.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { assertPublicResearchUrl } from "@repo/ai/agents/research/tools/safety";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Result } from "effect";
 import { vi } from "vitest";
 
@@ -11,7 +11,7 @@ describe("assertPublicResearchUrl", () => {
   beforeEach(() => {
     lookup.mockReset();
   });
-  it.live("rejects unsafe URL syntax before DNS lookup", () =>
+  it.effect("rejects unsafe URL syntax before DNS lookup", () =>
     Effect.gen(function* () {
       const result = yield* Effect.result(
         assertPublicResearchUrl("http://localhost:3000/admin")
@@ -20,7 +20,7 @@ describe("assertPublicResearchUrl", () => {
       expect(lookup).not.toHaveBeenCalled();
     })
   );
-  it.live("allows public IP literals without DNS lookup", () =>
+  it.effect("allows public IP literals without DNS lookup", () =>
     Effect.gen(function* () {
       const result = yield* assertPublicResearchUrl(
         "https://93.184.216.34/docs"
@@ -32,7 +32,7 @@ describe("assertPublicResearchUrl", () => {
       expect(lookup).not.toHaveBeenCalled();
     })
   );
-  it.live("rejects hostnames when DNS resolution fails", () =>
+  it.effect("rejects hostnames when DNS resolution fails", () =>
     Effect.gen(function* () {
       lookup.mockRejectedValue(new Error("DNS failure"));
       const result = yield* Effect.result(
@@ -41,7 +41,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live("rejects hostnames without DNS addresses", () =>
+  it.effect("rejects hostnames without DNS addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([]);
       const result = yield* Effect.result(
@@ -50,7 +50,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live("rejects hostnames that resolve to private addresses", () =>
+  it.effect("rejects hostnames that resolve to private addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([{ address: "10.0.0.1", family: 4 }]);
       const result = yield* Effect.result(
@@ -59,7 +59,7 @@ describe("assertPublicResearchUrl", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live(
+  it.effect(
     "allows public hostnames without enabling native server fetches",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/agents/research/tools/scrape.test.ts
+++ b/packages/ai/agents/research/tools/scrape.test.ts
@@ -1,16 +1,10 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   formatScrapeOutput,
   isSuccessfulScrapeOutput,
   scrapeUrl,
 } from "@repo/ai/agents/research/tools/scrape";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -67,7 +61,7 @@ describe("research scrape tool", () => {
     vi.unstubAllGlobals();
   });
 
-  it.live("keeps Firecrawl metadata in tool text and UI data", () =>
+  it.effect("keeps Firecrawl metadata in tool text and UI data", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools",
@@ -114,7 +108,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("rejects private scrape targets before fetching or crawling", () =>
+  it.effect("rejects private scrape targets before fetching or crawling", () =>
     Effect.gen(function* () {
       const { parts, writer } = createWriter();
 
@@ -145,7 +139,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("rejects public hostnames that resolve to private addresses", () =>
+  it.effect("rejects public hostnames that resolve to private addresses", () =>
     Effect.gen(function* () {
       lookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
       const { writer } = createWriter();
@@ -161,7 +155,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("prefers source-native markdown for IP-literal URLs", () =>
+  it.effect("prefers source-native markdown for IP-literal URLs", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -225,7 +219,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("keeps source-native markdown when Firecrawl scrape fails", () =>
+  it.effect("keeps source-native markdown when Firecrawl scrape fails", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -260,7 +254,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "falls back to alternate metadata fields when markdown is missing",
     () =>
       Effect.gen(function* () {
@@ -296,7 +290,7 @@ describe("research scrape tool", () => {
       })
   );
 
-  it.live("keeps scrape output valid when metadata is unavailable", () =>
+  it.effect("keeps scrape output valid when metadata is unavailable", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# Plain source",
@@ -325,7 +319,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("passes the selection query to relevant content selection", () =>
+  it.effect("passes the selection query to relevant content selection", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools\n\nUse AI SDK DevTools for local debugging.",
@@ -348,7 +342,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("allows exact-source callers to keep more source evidence", () =>
+  it.effect("allows exact-source callers to keep more source evidence", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockResolvedValue({
         markdown: "# DevTools\n\nUse AI SDK DevTools for local debugging.",
@@ -372,7 +366,7 @@ describe("research scrape tool", () => {
     })
   );
 
-  it.live("writes an error part when Firecrawl scrape fails", () =>
+  it.effect("writes an error part when Firecrawl scrape fails", () =>
     Effect.gen(function* () {
       firecrawlApp.scrape.mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();

--- a/packages/ai/agents/research/tools/search.test.ts
+++ b/packages/ai/agents/research/tools/search.test.ts
@@ -1,6 +1,6 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { searchWeb } from "@repo/ai/agents/research/tools/search";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -67,7 +67,7 @@ describe("research web search tool", () => {
     firecrawlApp.search.mockReset();
   });
 
-  it.live(
+  it.effect(
     "writes loading and done parts while returning text and structured sources",
     () =>
       Effect.gen(function* () {
@@ -174,7 +174,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("deduplicates blank and repeated queries before searching", () =>
+  it.effect("deduplicates blank and repeated queries before searching", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockResolvedValue({
         web: [
@@ -216,7 +216,7 @@ describe("research web search tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "searches each optimized query with query-scoped visible results",
     () =>
       Effect.gen(function* () {
@@ -276,7 +276,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("keeps successful query results when another query fails", () =>
+  it.effect("keeps successful query results when another query fails", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockImplementation((query: string) => {
         if (query === "AI SDK DevTools") {
@@ -328,7 +328,7 @@ describe("research web search tool", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "writes an empty done part when Firecrawl returns no result groups",
     () =>
       Effect.gen(function* () {
@@ -357,7 +357,7 @@ describe("research web search tool", () => {
       })
   );
 
-  it.live("writes an error part when Firecrawl search fails", () =>
+  it.effect("writes an error part when Firecrawl search fails", () =>
     Effect.gen(function* () {
       firecrawlApp.search.mockRejectedValue(new Error("offline"));
       const { parts, writer } = createWriter();

--- a/packages/ai/clients/weather/client.test.ts
+++ b/packages/ai/clients/weather/client.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { getCurrentWeather } from "@repo/ai/clients/weather/client";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Layer, Result } from "effect";
 import {
   HttpClient,
@@ -73,7 +73,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 describe("getCurrentWeather", () => {
-  it.live("returns a narrow summary from one current-weather request", () =>
+  it.effect("returns a narrow summary from one current-weather request", () =>
     Effect.gen(function* () {
       vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
       const observeRequest =
@@ -104,7 +104,7 @@ describe("getCurrentWeather", () => {
       ]);
     })
   );
-  it.live(
+  it.effect(
     "keeps an unavailable current-weather request in the typed error channel",
     () =>
       Effect.gen(function* () {
@@ -122,7 +122,7 @@ describe("getCurrentWeather", () => {
         });
       })
   );
-  it.live("keeps an invalid response in the schema error channel", () =>
+  it.effect("keeps an invalid response in the schema error channel", () =>
     Effect.gen(function* () {
       vi.stubEnv("OPENWEATHER_API_KEY", "weather-key");
       const result = yield* runWeather(() => Response.json({ cod: 200 }));
@@ -133,7 +133,7 @@ describe("getCurrentWeather", () => {
       expect(result.failure).toMatchObject({ _tag: "SchemaError" });
     })
   );
-  it.live(
+  it.effect(
     "preserves the visible condition defaults when conditions are absent",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/clients/weather/transport.test.ts
+++ b/packages/ai/clients/weather/transport.test.ts
@@ -1,6 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { requestWeatherJson } from "@repo/ai/clients/weather/transport";
-import { describe, expect, it } from "@repo/testing/effect";
-import { Effect, Layer, Result } from "effect";
+import { Effect, Fiber, Layer, Result } from "effect";
+import { TestClock } from "effect/testing";
 import {
   HttpClient,
   type HttpClientRequest,
@@ -28,7 +29,7 @@ function makeTestClient({
   );
 }
 describe("requestWeatherJson", () => {
-  it.live("sends query parameters and returns decoded JSON", () =>
+  it.effect("sends query parameters and returns decoded JSON", () =>
     Effect.gen(function* () {
       const observeRequest =
         vi.fn<(request: HttpClientRequest.HttpClientRequest) => void>();
@@ -61,7 +62,7 @@ describe("requestWeatherJson", () => {
       expect(request?.headers).not.toHaveProperty("traceparent");
     })
   );
-  it.live("maps rejected HTTP status into the weather error contract", () =>
+  it.effect("maps rejected HTTP status into the weather error contract", () =>
     Effect.gen(function* () {
       const result = yield* requestWeatherJson({
         endpoint: "current-weather",
@@ -95,17 +96,22 @@ describe("requestWeatherJson", () => {
       );
     })
   );
-  it.live("retries transient HTTP failures before returning JSON", () =>
+  it.effect("retries transient HTTP failures before returning JSON", () =>
     Effect.gen(function* () {
       const makeResponse = vi
         .fn<(request: HttpClientRequest.HttpClientRequest) => Response>()
         .mockReturnValueOnce(new Response("unavailable", { status: 503 }))
         .mockReturnValueOnce(Response.json({ cod: "200" }));
-      const result = yield* requestWeatherJson({
+      const resultFiber = yield* requestWeatherJson({
         endpoint: "current-weather",
         searchParams: {},
         url: "https://weather.example.test/weather",
-      }).pipe(Effect.provide(makeTestClient({ makeResponse })));
+      }).pipe(
+        Effect.provide(makeTestClient({ makeResponse })),
+        Effect.forkChild
+      );
+      yield* TestClock.adjust("300 millis");
+      const result = yield* Fiber.join(resultFiber);
       expect(result).toEqual({ cod: "200" });
       expect(makeResponse).toHaveBeenCalledTimes(2);
     })

--- a/packages/ai/config/devtools.test.ts
+++ b/packages/ai/config/devtools.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { registerTelemetry } from "ai";
+import { Effect } from "effect";
+import { vi } from "vitest";
 
 const originalAiSdkDevTools = process.env.AI_SDK_DEVTOOLS;
 const originalNodeEnv = process.env.NODE_ENV;
@@ -14,7 +17,10 @@ const telemetryIntegration = vi.hoisted(() => ({
   name: "ai-sdk-devtools",
 }));
 const DevToolsTelemetry = vi.hoisted(() => vi.fn(() => telemetryIntegration));
-const registerTelemetry = vi.hoisted(() => vi.fn());
+const registerTelemetryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", { spy: true });
+vi.mocked(registerTelemetry).mockImplementation(registerTelemetryMock);
 
 vi.mock("@repo/ai/config/provider", () => ({
   gateway,
@@ -24,25 +30,15 @@ vi.mock("@ai-sdk/devtools", () => ({
   DevToolsTelemetry,
 }));
 
-vi.mock("ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ai")>();
-
-  return {
-    ...actual,
-    registerTelemetry,
-  };
+const importDevToolsConfig = Effect.fn("test.ai.devtools.import")(function* () {
+  yield* Effect.sync(() => vi.resetModules());
+  return yield* Effect.promise(() => import("@repo/ai/config/devtools"));
 });
-
-async function importDevToolsConfig() {
-  vi.resetModules();
-
-  return await import("@repo/ai/config/devtools");
-}
 
 function resetDevToolsEnvironment() {
   gateway.mockClear();
   DevToolsTelemetry.mockClear();
-  registerTelemetry.mockClear();
+  registerTelemetryMock.mockClear();
   globalThis.NAKAFA_AI_SDK_DEVTOOLS_REGISTERED = undefined;
   process.env.NODE_ENV = "development";
   delete process.env.AI_SDK_DEVTOOLS;
@@ -76,75 +72,89 @@ describe("AI SDK DevTools configuration", () => {
     restoreOriginalEnvironment();
   });
 
-  it("registers v7 telemetry once and returns the plain Gateway model", async () => {
-    resetDevToolsEnvironment();
-    process.env.AI_SDK_DEVTOOLS = "true";
-    process.env.NODE_ENV = "development";
+  it.effect(
+    "registers v7 telemetry once and returns the plain Gateway model",
+    () =>
+      Effect.gen(function* () {
+        resetDevToolsEnvironment();
+        process.env.AI_SDK_DEVTOOLS = "true";
+        process.env.NODE_ENV = "development";
 
-    const { createAppLanguageModel, registerAiSdkDevToolsTelemetry } =
-      await importDevToolsConfig();
+        const { createAppLanguageModel, registerAiSdkDevToolsTelemetry } =
+          yield* importDevToolsConfig();
 
-    registerAiSdkDevToolsTelemetry();
-    const model = createAppLanguageModel("google/gemini-3.5-flash-lite");
+        registerAiSdkDevToolsTelemetry();
+        const model = createAppLanguageModel("google/gemini-3.5-flash-lite");
 
-    expect(model).toBe(languageModel);
-    expect(gateway).toHaveBeenCalledTimes(1);
-    expect(gateway).toHaveBeenCalledWith("google/gemini-3.5-flash-lite");
-    expect(DevToolsTelemetry).toHaveBeenCalledTimes(1);
-    expect(registerTelemetry).toHaveBeenCalledTimes(1);
-    expect(registerTelemetry).toHaveBeenCalledWith(telemetryIntegration);
-  });
+        expect(model).toBe(languageModel);
+        expect(gateway).toHaveBeenCalledTimes(1);
+        expect(gateway).toHaveBeenCalledWith("google/gemini-3.5-flash-lite");
+        expect(DevToolsTelemetry).toHaveBeenCalledTimes(1);
+        expect(registerTelemetryMock).toHaveBeenCalledTimes(1);
+        expect(registerTelemetryMock).toHaveBeenCalledWith(
+          telemetryIntegration
+        );
+      })
+  );
 
-  it("leaves DevTools disabled when the flag is off", async () => {
-    resetDevToolsEnvironment();
+  it.effect("leaves DevTools disabled when the flag is off", () =>
+    Effect.gen(function* () {
+      resetDevToolsEnvironment();
 
-    const { createAppLanguageModel } = await importDevToolsConfig();
+      const { createAppLanguageModel } = yield* importDevToolsConfig();
 
-    expect(createAppLanguageModel("google/gemini-3.5-flash-lite")).toBe(
-      languageModel
-    );
-    expect(DevToolsTelemetry).not.toHaveBeenCalled();
-    expect(registerTelemetry).not.toHaveBeenCalled();
-  });
+      expect(createAppLanguageModel("google/gemini-3.5-flash-lite")).toBe(
+        languageModel
+      );
+      expect(DevToolsTelemetry).not.toHaveBeenCalled();
+      expect(registerTelemetryMock).not.toHaveBeenCalled();
+    })
+  );
 
-  it("never registers DevTools in production", async () => {
-    resetDevToolsEnvironment();
-    process.env.AI_SDK_DEVTOOLS = "true";
-    process.env.NODE_ENV = "production";
+  it.effect("never registers DevTools in production", () =>
+    Effect.gen(function* () {
+      resetDevToolsEnvironment();
+      process.env.AI_SDK_DEVTOOLS = "true";
+      process.env.NODE_ENV = "production";
 
-    const { registerAiSdkDevToolsTelemetry } = await importDevToolsConfig();
+      const { registerAiSdkDevToolsTelemetry } = yield* importDevToolsConfig();
 
-    registerAiSdkDevToolsTelemetry();
+      registerAiSdkDevToolsTelemetry();
 
-    expect(DevToolsTelemetry).not.toHaveBeenCalled();
-    expect(registerTelemetry).not.toHaveBeenCalled();
-  });
+      expect(DevToolsTelemetry).not.toHaveBeenCalled();
+      expect(registerTelemetryMock).not.toHaveBeenCalled();
+    })
+  );
 
-  it("allows explicit development deployments", async () => {
-    resetDevToolsEnvironment();
-    process.env.AI_SDK_DEVTOOLS = "true";
-    process.env.NODE_ENV = "development";
-    process.env.VERCEL_ENV = "development";
+  it.effect("allows explicit development deployments", () =>
+    Effect.gen(function* () {
+      resetDevToolsEnvironment();
+      process.env.AI_SDK_DEVTOOLS = "true";
+      process.env.NODE_ENV = "development";
+      process.env.VERCEL_ENV = "development";
 
-    const { registerAiSdkDevToolsTelemetry } = await importDevToolsConfig();
+      const { registerAiSdkDevToolsTelemetry } = yield* importDevToolsConfig();
 
-    registerAiSdkDevToolsTelemetry();
+      registerAiSdkDevToolsTelemetry();
 
-    expect(DevToolsTelemetry).toHaveBeenCalledTimes(1);
-    expect(registerTelemetry).toHaveBeenCalledTimes(1);
-  });
+      expect(DevToolsTelemetry).toHaveBeenCalledTimes(1);
+      expect(registerTelemetryMock).toHaveBeenCalledTimes(1);
+    })
+  );
 
-  it("keeps Vercel preview and production deployments clean", async () => {
-    resetDevToolsEnvironment();
-    process.env.AI_SDK_DEVTOOLS = "true";
-    process.env.NODE_ENV = "development";
-    process.env.VERCEL_ENV = "preview";
+  it.effect("keeps Vercel preview and production deployments clean", () =>
+    Effect.gen(function* () {
+      resetDevToolsEnvironment();
+      process.env.AI_SDK_DEVTOOLS = "true";
+      process.env.NODE_ENV = "development";
+      process.env.VERCEL_ENV = "preview";
 
-    const { registerAiSdkDevToolsTelemetry } = await importDevToolsConfig();
+      const { registerAiSdkDevToolsTelemetry } = yield* importDevToolsConfig();
 
-    registerAiSdkDevToolsTelemetry();
+      registerAiSdkDevToolsTelemetry();
 
-    expect(DevToolsTelemetry).not.toHaveBeenCalled();
-    expect(registerTelemetry).not.toHaveBeenCalled();
-  });
+      expect(DevToolsTelemetry).not.toHaveBeenCalled();
+      expect(registerTelemetryMock).not.toHaveBeenCalled();
+    })
+  );
 });

--- a/packages/ai/eval/suites.test.ts
+++ b/packages/ai/eval/suites.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   EvalRenderer,
   evaluateRenderedCase,
@@ -7,11 +8,10 @@ import {
 } from "@repo/ai/eval/runner";
 import { EvalCase, EvalExpectation } from "@repo/ai/eval/spec";
 import { createNinaEvalSuite, renderNinaEvalCase } from "@repo/ai/eval/suites";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("nina deterministic eval suite", () => {
-  it.live(
+  it.effect(
     "passes every local NinaHarness and LearningCapability eval case",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/features/title.test.ts
+++ b/packages/ai/features/title.test.ts
@@ -22,50 +22,52 @@ afterEach(() => {
 });
 
 describe("generateTitle", () => {
-  it.effect("summarizes the first user message without assistant internals", () =>
-    Effect.gen(function* () {
-      generateText.mockResolvedValue({
-        text: "Latihan Matriks Eigen",
-      });
+  it.effect(
+    "summarizes the first user message without assistant internals",
+    () =>
+      Effect.gen(function* () {
+        generateText.mockResolvedValue({
+          text: "Latihan Matriks Eigen",
+        });
 
-      yield* generateTitle({
-        messages: [
-          {
-            id: "user-1",
-            metadata: { model: modelId },
-            parts: [
-              {
-                text: "Cek apakah matriks ini bisa didiagonalkan.",
-                type: "text",
-              },
-            ],
-            role: "user",
-          },
-          {
-            id: "assistant-1",
-            metadata: { model: modelId },
-            parts: [
-              {
-                text: "Internal reasoning that should not title the chat.",
-                type: "reasoning",
-              },
-            ],
-            role: "assistant",
-          },
-        ] satisfies MyUIMessage[],
-      });
+        yield* generateTitle({
+          messages: [
+            {
+              id: "user-1",
+              metadata: { model: modelId },
+              parts: [
+                {
+                  text: "Cek apakah matriks ini bisa didiagonalkan.",
+                  type: "text",
+                },
+              ],
+              role: "user",
+            },
+            {
+              id: "assistant-1",
+              metadata: { model: modelId },
+              parts: [
+                {
+                  text: "Internal reasoning that should not title the chat.",
+                  type: "reasoning",
+                },
+              ],
+              role: "assistant",
+            },
+          ] satisfies MyUIMessage[],
+        });
 
-      expect(generateText).toHaveBeenCalledWith(
-        expect.objectContaining({
-          prompt: "Cek apakah matriks ini bisa didiagonalkan.",
-        })
-      );
-      expect(generateText).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          prompt: expect.stringContaining("Internal reasoning"),
-        })
-      );
-    })
+        expect(generateText).toHaveBeenCalledWith(
+          expect.objectContaining({
+            prompt: "Cek apakah matriks ini bisa didiagonalkan.",
+          })
+        );
+        expect(generateText).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            prompt: expect.stringContaining("Internal reasoning"),
+          })
+        );
+      })
   );
 
   it.effect("removes surrounding title quotes", () =>

--- a/packages/ai/features/title.test.ts
+++ b/packages/ai/features/title.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { ModelIdSchema } from "@repo/ai/config/model";
 import { DEFAULT_TITLE, MAX_TITLE_LENGTH } from "@repo/ai/features/constants";
 import { generateTitle } from "@repo/ai/features/title";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -15,21 +15,14 @@ vi.mock("@repo/ai/config/app", () => ({
   },
 }));
 
-vi.mock("ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ai")>();
-
-  return {
-    ...actual,
-    generateText,
-  };
-});
+vi.mock("ai", () => ({ generateText }));
 
 afterEach(() => {
   generateText.mockReset();
 });
 
 describe("generateTitle", () => {
-  it.live("summarizes the first user message without assistant internals", () =>
+  it.effect("summarizes the first user message without assistant internals", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         text: "Latihan Matriks Eigen",
@@ -75,7 +68,7 @@ describe("generateTitle", () => {
     })
   );
 
-  it.live("removes surrounding title quotes", () =>
+  it.effect("removes surrounding title quotes", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         text: '"Belajar Fungsi Kuadrat"',
@@ -101,7 +94,7 @@ describe("generateTitle", () => {
     })
   );
 
-  it.live("truncates long generated titles", () =>
+  it.effect("truncates long generated titles", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         text: "Analisis Persamaan Diferensial Linear Orde Dua Homogen dengan Koefisien Variabel dan Kondisi Awal",
@@ -128,7 +121,7 @@ describe("generateTitle", () => {
     })
   );
 
-  it.live("falls back when generation fails", () =>
+  it.effect("falls back when generation fails", () =>
     Effect.gen(function* () {
       generateText.mockRejectedValue(new Error("model unavailable"));
 
@@ -152,7 +145,7 @@ describe("generateTitle", () => {
     })
   );
 
-  it.live("uses an empty title prompt when no user text exists", () =>
+  it.effect("uses an empty title prompt when no user text exists", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         text: "Obrolan Baru",
@@ -182,7 +175,7 @@ describe("generateTitle", () => {
     })
   );
 
-  it.live("ignores non-text user parts when building the title prompt", () =>
+  it.effect("ignores non-text user parts when building the title prompt", () =>
     Effect.gen(function* () {
       generateText.mockResolvedValue({
         text: "Latihan Kombinatorika",

--- a/packages/ai/lib/effect-schema.test.ts
+++ b/packages/ai/lib/effect-schema.test.ts
@@ -1,10 +1,34 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createEffectSchema,
   providerCompatibleObjectSchema,
 } from "@repo/ai/lib/effect-schema";
 import { asSchema } from "ai";
-import { type JsonSchema, Schema, Struct } from "effect";
-import { describe, expect, it } from "vitest";
+import { Effect, type JsonSchema, Predicate, Schema, Struct } from "effect";
+
+/** Proves that AI SDK JSON Schema projection remains synchronous. */
+function readSynchronous<A>(value: A | PromiseLike<A>): A {
+  if (Predicate.isPromiseLike(value)) {
+    expect.fail("AI SDK JSON Schema projection must remain synchronous.");
+  }
+  return value;
+}
+
+/** Awaits one AI SDK validator inside Effect and returns its Vitest matcher. */
+function expectValidation<A>(value: A | PromiseLike<A>) {
+  return Effect.promise(() => Promise.resolve(value)).pipe(
+    Effect.map((result) => expect(result))
+  );
+}
+
+/** Requires the validator promised by an AI SDK schema adapter. */
+function requireValidator<A>(value: A | undefined) {
+  return Effect.suspend(() =>
+    value === undefined
+      ? Effect.die("AI SDK schema adapter omitted its validator.")
+      : Effect.succeed(value)
+  );
+}
 
 /** Builds one controlled generated JSON Schema for adapter edge cases. */
 function jsonSchemaFixture(jsonSchema: JsonSchema.JsonSchema) {
@@ -18,164 +42,161 @@ function jsonSchemaFixture(jsonSchema: JsonSchema.JsonSchema) {
 }
 
 describe("createEffectSchema", () => {
-  it("keeps Effect descriptions in AI SDK JSON Schema", async () => {
-    const inputSchema = createEffectSchema(
-      Schema.Struct({
-        query: Schema.String.annotate({
-          description: "Search query for the model to generate.",
-        }),
-      }).annotate({ description: "Search tool input." })
-    );
-    const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-    const validate = schema.validate;
-    if (!validate) {
-      throw new Error("Effect tool input schema must validate model input.");
-    }
-    expect(jsonSchema).toMatchObject({
-      description: "Search tool input.",
-      properties: {
-        query: {
-          description: "Search query for the model to generate.",
-          type: "string",
-        },
-      },
-      required: ["query"],
-      type: "object",
-    });
-    await expect(
-      Promise.resolve(validate({ query: "fungsi rasional" }))
-    ).resolves.toEqual({
-      success: true,
-      value: { query: "fungsi rasional" },
-    });
-    await expect(Promise.resolve(validate({ query: 123 }))).resolves.toEqual(
-      expect.objectContaining({ success: false })
-    );
-  });
-  it("uses custom model metadata without weakening Effect validation", async () => {
-    const inputSchema = createEffectSchema(
-      Schema.Struct({
-        expression: Schema.String,
-      }),
-      {
-        anyOf: [
-          {
-            properties: {
-              expression: { type: "string" },
-            },
-            required: ["expression"],
-            type: "object",
+  it.effect("keeps Effect descriptions in AI SDK JSON Schema", () =>
+    Effect.gen(function* () {
+      const inputSchema = createEffectSchema(
+        Schema.Struct({
+          query: Schema.String.annotate({
+            description: "Search query for the model to generate.",
+          }),
+        }).annotate({ description: "Search tool input." })
+      );
+      const schema = asSchema(inputSchema);
+      const jsonSchema = readSynchronous(schema.jsonSchema);
+      const validate = yield* requireValidator(schema.validate);
+      expect(jsonSchema).toMatchObject({
+        description: "Search tool input.",
+        properties: {
+          query: {
+            description: "Search query for the model to generate.",
+            type: "string",
           },
-        ],
+        },
+        required: ["query"],
         type: "object",
-      }
-    );
-    const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-    const validate = schema.validate;
-    if (!validate) {
-      throw new Error("Effect tool input schema must validate model input.");
-    }
-    expect(jsonSchema).toMatchObject({
-      anyOf: [
+      });
+      (yield* expectValidation(validate({ query: "fungsi rasional" }))).toEqual(
         {
-          properties: {
-            expression: { type: "string" },
-          },
-          required: ["expression"],
+          success: true,
+          value: { query: "fungsi rasional" },
+        }
+      );
+      (yield* expectValidation(validate({ query: 123 }))).toEqual(
+        expect.objectContaining({ success: false })
+      );
+    })
+  );
+  it.effect(
+    "uses custom model metadata without weakening Effect validation",
+    () =>
+      Effect.gen(function* () {
+        const inputSchema = createEffectSchema(
+          Schema.Struct({
+            expression: Schema.String,
+          }),
+          {
+            anyOf: [
+              {
+                properties: {
+                  expression: { type: "string" },
+                },
+                required: ["expression"],
+                type: "object",
+              },
+            ],
+            type: "object",
+          }
+        );
+        const schema = asSchema(inputSchema);
+        const jsonSchema = readSynchronous(schema.jsonSchema);
+        const validate = yield* requireValidator(schema.validate);
+        expect(jsonSchema).toMatchObject({
+          anyOf: [
+            {
+              properties: {
+                expression: { type: "string" },
+              },
+              required: ["expression"],
+              type: "object",
+            },
+          ],
           type: "object",
-        },
-      ],
-      type: "object",
-    });
-    await expect(Promise.resolve(validate({}))).resolves.toMatchObject({
-      success: false,
-    });
-  });
-  it("adapts Effect union schemas for provider-compatible tool parameters", async () => {
-    const expressionSchema = Schema.Struct({
-      expression: Schema.String.annotate({
-        description: "Expression to simplify.",
-      }),
-      operation: Schema.Literal("simplify").annotate({
-        description: "Simplify one expression.",
-      }),
-    }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
-    const compareSchema = Schema.Struct({
-      left: Schema.String.annotate({
-        description: "Left side to compare.",
-      }),
-      operation: Schema.Literal("compare").annotate({
-        description: "Compare two expressions.",
-      }),
-      right: Schema.String.annotate({
-        description: "Right side to compare.",
-      }),
-    }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
-    const groupedSchema = Schema.Union([
-      expressionSchema,
-      compareSchema,
-    ]).annotate({
-      description: "Grouped math input.",
-    });
-    const inputSchema = createEffectSchema(
-      groupedSchema,
-      providerCompatibleObjectSchema(groupedSchema)
-    );
-    const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-    const validate = schema.validate;
-    if (!validate) {
-      throw new Error("Effect tool input schema must validate model input.");
-    }
-    expect(jsonSchema).not.toHaveProperty("anyOf");
-    expect(jsonSchema).toMatchObject({
-      description: "Grouped math input.",
-      properties: {
-        expression: {
-          description: "Expression to simplify.",
-          type: "string",
-        },
-        left: {
-          description: "Left side to compare.",
-          type: "string",
-        },
-        operation: {
-          enum: ["simplify", "compare"],
-          type: "string",
-        },
-        right: {
-          description: "Right side to compare.",
-          type: "string",
-        },
-      },
-      required: [],
-      type: "object",
-    });
-    await expect(
-      Promise.resolve(
-        validate({
-          operation: "simplify",
-        })
-      )
-    ).resolves.toMatchObject({ success: false });
-    await expect(
-      Promise.resolve(
-        validate({
-          expression: "x + x",
-          operation: "simplify",
-        })
-      )
-    ).resolves.toEqual({
-      success: true,
-      value: {
-        expression: "x + x",
-        operation: "simplify",
-      },
-    });
-  });
-  it("keeps fallback descriptions when merging repeated union fields", async () => {
+        });
+        (yield* expectValidation(validate({}))).toMatchObject({
+          success: false,
+        });
+      })
+  );
+  it.effect(
+    "adapts Effect union schemas for provider-compatible tool parameters",
+    () =>
+      Effect.gen(function* () {
+        const expressionSchema = Schema.Struct({
+          expression: Schema.String.annotate({
+            description: "Expression to simplify.",
+          }),
+          operation: Schema.Literal("simplify").annotate({
+            description: "Simplify one expression.",
+          }),
+        }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+        const compareSchema = Schema.Struct({
+          left: Schema.String.annotate({
+            description: "Left side to compare.",
+          }),
+          operation: Schema.Literal("compare").annotate({
+            description: "Compare two expressions.",
+          }),
+          right: Schema.String.annotate({
+            description: "Right side to compare.",
+          }),
+        }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+        const groupedSchema = Schema.Union([
+          expressionSchema,
+          compareSchema,
+        ]).annotate({
+          description: "Grouped math input.",
+        });
+        const inputSchema = createEffectSchema(
+          groupedSchema,
+          providerCompatibleObjectSchema(groupedSchema)
+        );
+        const schema = asSchema(inputSchema);
+        const jsonSchema = readSynchronous(schema.jsonSchema);
+        const validate = yield* requireValidator(schema.validate);
+        expect(jsonSchema).not.toHaveProperty("anyOf");
+        expect(jsonSchema).toMatchObject({
+          description: "Grouped math input.",
+          properties: {
+            expression: {
+              description: "Expression to simplify.",
+              type: "string",
+            },
+            left: {
+              description: "Left side to compare.",
+              type: "string",
+            },
+            operation: {
+              enum: ["simplify", "compare"],
+              type: "string",
+            },
+            right: {
+              description: "Right side to compare.",
+              type: "string",
+            },
+          },
+          required: [],
+          type: "object",
+        });
+        (yield* expectValidation(
+          validate({
+            operation: "simplify",
+          })
+        )).toMatchObject({ success: false });
+        (yield* expectValidation(
+          validate({
+            expression: "x + x",
+            operation: "simplify",
+          })
+        )).toEqual({
+          success: true,
+          value: {
+            expression: "x + x",
+            operation: "simplify",
+          },
+        });
+      })
+  );
+  it("keeps fallback descriptions when merging repeated union fields", () => {
     const leftSchema = Schema.Struct({
       operation: Schema.Literal("left"),
       value: Schema.String,
@@ -193,7 +214,7 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(Schema.Union([leftSchema, rightSchema]))
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     expect(jsonSchema).toMatchObject({
       properties: {
         operation: {
@@ -235,7 +256,7 @@ describe("createEffectSchema", () => {
       },
     });
   });
-  it("combines branch descriptions and relaxes shared array bounds", async () => {
+  it("combines branch descriptions and relaxes shared array bounds", () => {
     const twoValues = Schema.Array(Schema.String)
       .pipe(Schema.mutable, Schema.check(Schema.isLengthBetween(2, 2)))
       .annotate({
@@ -261,7 +282,7 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(groupedSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     expect(jsonSchema).toMatchObject({
       properties: {
         values: {
@@ -273,7 +294,7 @@ describe("createEffectSchema", () => {
       },
     });
   });
-  it("merges shared arrays without optional descriptions or symmetric bounds", async () => {
+  it("merges shared arrays without optional descriptions or symmetric bounds", () => {
     const unboundedValues = Schema.Array(Schema.String).pipe(Schema.mutable);
     const boundedValues = Schema.Array(Schema.String).pipe(
       Schema.mutable,
@@ -295,9 +316,9 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(groupedSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     if (!("properties" in jsonSchema && jsonSchema.properties)) {
-      throw new Error("Grouped schema must expose object properties.");
+      expect.fail("Grouped schema must expose object properties.");
     }
     const { properties } = jsonSchema;
     expect(jsonSchema).toMatchObject({
@@ -314,7 +335,7 @@ describe("createEffectSchema", () => {
     );
     expect(properties.values).not.toHaveProperty("maxItems");
   });
-  it("keeps shared unconstrained arrays valid when no descriptions exist", async () => {
+  it("keeps shared unconstrained arrays valid when no descriptions exist", () => {
     const groupedSchema = Schema.Union([
       Schema.Struct({
         operation: Schema.Literal("left"),
@@ -330,9 +351,9 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(groupedSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     if (!("properties" in jsonSchema && jsonSchema.properties)) {
-      throw new Error("Grouped schema must expose object properties.");
+      expect.fail("Grouped schema must expose object properties.");
     }
     const { properties } = jsonSchema;
     expect(jsonSchema).toMatchObject({
@@ -344,7 +365,7 @@ describe("createEffectSchema", () => {
     });
     expect(properties.values).not.toHaveProperty("description");
   });
-  it("keeps shared array bounds valid when the bounded branch comes first", async () => {
+  it("keeps shared array bounds valid when the bounded branch comes first", () => {
     const groupedSchema = Schema.Union([
       Schema.Struct({
         operation: Schema.Literal("bounded"),
@@ -363,7 +384,7 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(groupedSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     expect(jsonSchema).toMatchObject({
       properties: {
         values: {
@@ -373,7 +394,7 @@ describe("createEffectSchema", () => {
       },
     });
   });
-  it("keeps undecorated repeated fields valid when no description exists", async () => {
+  it("keeps undecorated repeated fields valid when no description exists", () => {
     const leftSchema = Schema.Struct({
       operation: Schema.Literal("left"),
       value: Schema.String,
@@ -388,7 +409,7 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(groupedSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     expect(jsonSchema).toMatchObject({
       properties: {
         operation: {
@@ -400,7 +421,7 @@ describe("createEffectSchema", () => {
       },
     });
   });
-  it("keeps already object-shaped schemas unchanged for model metadata", async () => {
+  it("keeps already object-shaped schemas unchanged for model metadata", () => {
     const objectSchema = Schema.Struct({
       query: Schema.String.annotate({
         description: "Query text.",
@@ -413,7 +434,7 @@ describe("createEffectSchema", () => {
       providerCompatibleObjectSchema(objectSchema)
     );
     const schema = asSchema(inputSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
+    const jsonSchema = readSynchronous(schema.jsonSchema);
     expect(jsonSchema).toMatchObject({
       description: "Object input.",
       properties: {

--- a/packages/ai/nina/capability/result.test.ts
+++ b/packages/ai/nina/capability/result.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   capabilityResult,
   recordSpecialistUsage,
@@ -8,7 +9,6 @@ import {
 } from "@repo/ai/nina/capability/result";
 import type { LearningCapabilityName } from "@repo/ai/nina/capability/spec";
 import type { NinaReporter } from "@repo/ai/nina/runtime/report";
-import { describe, expect, it } from "@repo/testing/effect";
 import type { LanguageModelUsage } from "ai";
 import { type Context, Effect, Logger, Option } from "effect";
 
@@ -81,7 +81,7 @@ describe("nina/capability/result", () => {
     expect(result.evidence.summary.endsWith("...")).toBe(true);
   });
 
-  it.live("preserves real usage for successful specialists", () =>
+  it.effect("preserves real usage for successful specialists", () =>
     Effect.gen(function* () {
       const tracker = usageRecorder();
       const result = specialistSuccess({
@@ -105,7 +105,7 @@ describe("nina/capability/result", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "does not invent usage when a specialist fails before completion",
     () =>
       Effect.gen(function* () {
@@ -142,7 +142,7 @@ describe("nina/capability/result", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "normalizes non-Error failures into model-facing recovery evidence",
     () =>
       Effect.gen(function* () {
@@ -170,7 +170,7 @@ describe("nina/capability/result", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "reports the provider cause preserved by a typed capability error",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/nina/harness/stream.test.ts
+++ b/packages/ai/nina/harness/stream.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import { NakafaSearch } from "@repo/ai/agents/nakafa/search";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
@@ -10,7 +11,6 @@ import {
 } from "@repo/ai/nina/harness/stream";
 import { NinaReporter } from "@repo/ai/nina/runtime/report";
 import { NinaStore } from "@repo/ai/nina/runtime/store";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Cause, Effect, Exit, Option } from "effect";
 import { vi } from "vitest";
 
@@ -109,7 +109,7 @@ describe("nina/harness/stream", () => {
       Effect.succeed(new Response(input.page.slug))
     );
   });
-  it.live(
+  it.effect(
     "decodes one turn and delegates response creation through the harness Interface",
     () =>
       Effect.gen(function* () {
@@ -121,7 +121,7 @@ describe("nina/harness/stream", () => {
         expect(createNinaStreamResponseMock).toHaveBeenCalledWith(turn);
       })
   );
-  it.live("rejects invalid route input with a tagged harness error", () =>
+  it.effect("rejects invalid route input with a tagged harness error", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
         provideHarnessServices(

--- a/packages/ai/nina/memory/pack.test.ts
+++ b/packages/ai/nina/memory/pack.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import {
   type NinaLearningSessionInput,
   openNinaLearningSession,
 } from "@repo/ai/nina/memory/pack";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Exit } from "effect";
 
 const learning = {
@@ -23,7 +23,7 @@ const placementProgramKey = LearningProgramKeySchema.make(
 );
 
 describe("nina/memory/pack", () => {
-  it.live(
+  it.effect(
     "opens a verified page session with a durable snapshot and page-fetch policy",
     () =>
       Effect.gen(function* () {
@@ -57,7 +57,7 @@ describe("nina/memory/pack", () => {
       })
   );
 
-  it.live("keeps invalid session input in the Effect failure channel", () =>
+  it.effect("keeps invalid session input in the Effect failure channel", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
         openNinaLearningSession({
@@ -74,7 +74,7 @@ describe("nina/memory/pack", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "opens an unverified canonical session without current-page fetch permission",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/nina/runtime/agent.test.ts
+++ b/packages/ai/nina/runtime/agent.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import { ModelIdSchema } from "@repo/ai/config/model";
 import {
@@ -15,14 +16,13 @@ import {
   textOutputSchema,
 } from "@repo/ai/schema/tools";
 import type { MyMetadata, MyUIMessage } from "@repo/ai/types/message";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import type {
   LanguageModelUsage,
   ModelMessage,
   TextStreamPart,
   UIMessageStreamWriter,
 } from "ai";
-import { tool } from "ai";
+import { ToolLoopAgent, tool, toUIMessageStream } from "ai";
 import { Cause, Effect, Exit, Option } from "effect";
 import { vi } from "vitest";
 
@@ -54,6 +54,11 @@ interface FakeAgentState {
   streamOptions?: CapturedStreamOptions;
 }
 const fakeAgentState = vi.hoisted((): FakeAgentState => ({}));
+const toolLoopAgentMock = vi.hoisted(() => vi.fn());
+const toUIMessageStreamMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", { spy: true });
+
 /** Returns a complete AI SDK usage object for metadata callbacks. */
 function createUsage(): LanguageModelUsage {
   return {
@@ -72,73 +77,75 @@ function createUsage(): LanguageModelUsage {
     totalTokens: 10,
   };
 }
-vi.mock("ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ai")>();
-  /** Captures ToolLoopAgent settings and returns a deterministic stream result. */
-  class FakeToolLoopAgent {
-    constructor(settings: CapturedAgentSettings) {
-      fakeAgentState.settings = settings;
-    }
-    /** Streams a single assistant response without contacting a provider. */
-    stream(options: CapturedStreamOptions) {
-      if (fakeAgentState.streamFailure) {
-        return Promise.reject(fakeAgentState.streamFailure);
-      }
-      fakeAgentState.streamOptions = options;
-      fakeAgentState.settings?.prepareStep?.({
-        initialInstructions: fakeAgentState.settings.instructions,
-        initialMessages: options.messages,
-        instructions: fakeAgentState.settings.instructions,
-        messages: options.messages,
-        model: "google/gemini-3.5-flash-lite",
-        responseMessages: [],
-        runtimeContext: {},
-        stepNumber: 0,
-        steps: [],
-        toolsContext: {},
-      });
-      return Promise.resolve({
-        response: fakeAgentState.responseFailure
-          ? Promise.reject(fakeAgentState.responseFailure)
-          : Promise.resolve({
-              messages: [
-                {
-                  content: [{ text: "Ready.", type: "text" }],
-                  role: "assistant",
-                },
-              ],
-            }),
-        stream: new ReadableStream(),
-      });
-    }
+/** Captures ToolLoopAgent settings and returns a deterministic stream result. */
+class FakeToolLoopAgent {
+  constructor(settings: CapturedAgentSettings) {
+    fakeAgentState.settings = settings;
   }
-  /** Captures stream metadata callbacks without opening an SSE stream. */
-  function fakeToUIMessageStream(streamOptions: CapturedMessageStreamOptions) {
-    fakeAgentState.startMetadata = streamOptions.messageMetadata?.({
-      part: { type: "start" },
+  /** Streams a single assistant response without contacting a provider. */
+  stream(options: CapturedStreamOptions) {
+    if (fakeAgentState.streamFailure) {
+      return Promise.reject(fakeAgentState.streamFailure);
+    }
+    fakeAgentState.streamOptions = options;
+    fakeAgentState.settings?.prepareStep?.({
+      initialInstructions: fakeAgentState.settings.instructions,
+      initialMessages: options.messages,
+      instructions: fakeAgentState.settings.instructions,
+      messages: options.messages,
+      model: "google/gemini-3.5-flash-lite",
+      responseMessages: [],
+      runtimeContext: {},
+      stepNumber: 0,
+      steps: [],
+      toolsContext: {},
     });
-    fakeAgentState.deltaMetadata = streamOptions.messageMetadata?.({
-      part: { id: "text-1", text: "ignored", type: "text-delta" },
+    return Promise.resolve({
+      response: fakeAgentState.responseFailure
+        ? Promise.reject(fakeAgentState.responseFailure)
+        : Promise.resolve({
+            messages: [
+              {
+                content: [{ text: "Ready.", type: "text" }],
+                role: "assistant",
+              },
+            ],
+          }),
+      stream: new ReadableStream(),
     });
-    fakeAgentState.finishMetadata = streamOptions.messageMetadata?.({
-      part: {
-        finishReason: "stop",
-        rawFinishReason: "stop",
-        totalUsage: createUsage(),
-        type: "finish",
-      },
-    });
-    fakeAgentState.streamErrorMessage = streamOptions.onError?.(
-      new Error("stream failed")
-    );
-    return new ReadableStream();
   }
-  return {
-    ...actual,
-    toUIMessageStream: fakeToUIMessageStream,
-    ToolLoopAgent: FakeToolLoopAgent,
-  };
+}
+
+/** Captures stream metadata callbacks without opening an SSE stream. */
+function fakeToUIMessageStream(streamOptions: CapturedMessageStreamOptions) {
+  fakeAgentState.startMetadata = streamOptions.messageMetadata?.({
+    part: { type: "start" },
+  });
+  fakeAgentState.deltaMetadata = streamOptions.messageMetadata?.({
+    part: { id: "text-1", text: "ignored", type: "text-delta" },
+  });
+  fakeAgentState.finishMetadata = streamOptions.messageMetadata?.({
+    part: {
+      finishReason: "stop",
+      rawFinishReason: "stop",
+      totalUsage: createUsage(),
+      type: "finish",
+    },
+  });
+  fakeAgentState.streamErrorMessage = streamOptions.onError?.(
+    new Error("stream failed")
+  );
+  return new ReadableStream();
+}
+
+toolLoopAgentMock.mockImplementation(function fakeToolLoopAgent(
+  settings: CapturedAgentSettings
+) {
+  return new FakeToolLoopAgent(settings);
 });
+toUIMessageStreamMock.mockImplementation(fakeToUIMessageStream);
+vi.mocked(ToolLoopAgent).mockImplementation(toolLoopAgentMock);
+vi.mocked(toUIMessageStream).mockImplementation(toUIMessageStreamMock);
 vi.mock("@repo/ai/config/app", () => ({
   provider: {
     /** Supplies a fake model object because the mocked ToolLoopAgent never calls it. */
@@ -320,7 +327,7 @@ describe("nina/agent", () => {
     expect(context.learningSelection).toEqual(learningSelection);
     expect(context.userRole).toBeUndefined();
   });
-  it.live(
+  it.effect(
     "runs the ToolLoopAgent lifecycle with Nina metadata and adapter-owned tools",
     () =>
       Effect.gen(function* () {
@@ -385,7 +392,7 @@ describe("nina/agent", () => {
         ]);
       })
   );
-  it.live(
+  it.effect(
     "keeps ToolLoopAgent stream startup failures in the Effect error channel",
     () =>
       Effect.gen(function* () {
@@ -404,7 +411,7 @@ describe("nina/agent", () => {
         expect(readExitFailure(exit)).toBeInstanceOf(NinaAgentError);
       })
   );
-  it.live(
+  it.effect(
     "keeps ToolLoopAgent response failures in the Effect error channel",
     () =>
       Effect.gen(function* () {

--- a/packages/ai/nina/runtime/step.test.ts
+++ b/packages/ai/nina/runtime/step.test.ts
@@ -13,8 +13,8 @@ const externalUrlMessages = [
 ] satisfies ModelMessage[];
 
 describe("nina/runtime/step", () => {
-  it("forces Nakafa on the first page-fetch step", async () => {
-    const step = await readPreparedStep({
+  it("forces Nakafa on the first page-fetch step", () => {
+    const step = readPreparedStep({
       messages: emptyMessages,
       needsPageFetch: true,
       stepNumber: 0,
@@ -27,8 +27,8 @@ describe("nina/runtime/step", () => {
     });
   });
 
-  it("reinforces final source policy after the first page-fetch step", async () => {
-    const step = await readPreparedStep({
+  it("reinforces final source policy after the first page-fetch step", () => {
+    const step = readPreparedStep({
       messages: emptyMessages,
       needsPageFetch: true,
       stepNumber: 1,
@@ -42,7 +42,7 @@ describe("nina/runtime/step", () => {
     });
   });
 
-  it("leaves low-risk first non-page-fetch prompts to Nina's system prompt", async () => {
+  it("leaves low-risk first non-page-fetch prompts to Nina's system prompt", () => {
     const greetingMessages = [
       {
         content: "hi",
@@ -50,7 +50,7 @@ describe("nina/runtime/step", () => {
       },
     ] satisfies ModelMessage[];
 
-    const step = await readPreparedStep({
+    const step = readPreparedStep({
       messages: greetingMessages,
       needsPageFetch: false,
       stepNumber: 0,
@@ -63,8 +63,8 @@ describe("nina/runtime/step", () => {
     expect(step).not.toHaveProperty("toolChoice");
   });
 
-  it("reinforces final source policy after the first non-page-fetch step", async () => {
-    const step = await readPreparedStep({
+  it("reinforces final source policy after the first non-page-fetch step", () => {
+    const step = readPreparedStep({
       messages: emptyMessages,
       needsPageFetch: false,
       stepNumber: 1,
@@ -136,8 +136,8 @@ describe("nina/runtime/step", () => {
     });
   });
 
-  it("forces research for first-step external URL requests", async () => {
-    const step = await readPreparedStep({
+  it("forces research for first-step external URL requests", () => {
+    const step = readPreparedStep({
       messages: externalUrlMessages,
       needsPageFetch: false,
       stepNumber: 0,
@@ -150,8 +150,8 @@ describe("nina/runtime/step", () => {
     });
   });
 
-  it("keeps page fetch ahead of external URL requests", async () => {
-    const step = await readPreparedStep({
+  it("keeps page fetch ahead of external URL requests", () => {
+    const step = readPreparedStep({
       messages: externalUrlMessages,
       needsPageFetch: true,
       stepNumber: 0,
@@ -164,7 +164,7 @@ describe("nina/runtime/step", () => {
     });
   });
 
-  it("keeps prepared model messages available to later model steps", async () => {
+  it("keeps prepared model messages available to later model steps", () => {
     const messages = [
       {
         content: "Cek kabar tryout.",
@@ -176,7 +176,7 @@ describe("nina/runtime/step", () => {
       },
     ] satisfies ModelMessage[];
 
-    const step = await readPreparedStep({
+    const step = readPreparedStep({
       messages,
       needsPageFetch: false,
       stepNumber: 1,
@@ -185,7 +185,7 @@ describe("nina/runtime/step", () => {
     expect(step?.messages).toEqual(messages);
   });
 
-  it("leaves continuation tool choice to the model", async () => {
+  it("leaves continuation tool choice to the model", () => {
     const messages = [
       {
         content: [
@@ -209,7 +209,7 @@ describe("nina/runtime/step", () => {
       },
     ] satisfies ModelMessage[];
 
-    const step = await readPreparedStep({
+    const step = readPreparedStep({
       messages,
       needsPageFetch: false,
       stepNumber: 1,

--- a/packages/ai/nina/runtime/step.ts
+++ b/packages/ai/nina/runtime/step.ts
@@ -20,6 +20,9 @@ export type NinaPrepareStep = NonNullable<
   ToolLoopAgentSettings<never, NinaToolSet>["prepareStep"]
 >;
 
+type NinaPrepareStepInput = Parameters<NinaPrepareStep>[0];
+type NinaPreparedStep = Awaited<ReturnType<NinaPrepareStep>>;
+
 /**
  * Creates Nina's AI SDK step callback from verified page-fetch state.
  *
@@ -33,7 +36,7 @@ export function createNinaPrepareStep({
 }: {
   readonly instructions: string;
   readonly needsPageFetch: boolean;
-}): NinaPrepareStep {
+}): (input: NinaPrepareStepInput) => NinaPreparedStep {
   return ({ messages, stepNumber }) => {
     if (stepNumber !== firstStepNumber) {
       return {
@@ -109,7 +112,7 @@ function readToolStep({
 }: {
   readonly messages: Parameters<NinaPrepareStep>[0]["messages"];
   readonly toolName: Extract<LearningCapabilityName, RequiredStepToolName>;
-}): ReturnType<NinaPrepareStep> {
+}): NinaPreparedStep {
   return {
     activeTools: [toolName],
     messages,

--- a/packages/ai/nina/runtime/suggest.test.ts
+++ b/packages/ai/nina/runtime/suggest.test.ts
@@ -1,46 +1,42 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { suggestionGenerationTimeout } from "@repo/ai/config/timeouts";
 import { writeNinaSuggestions } from "@repo/ai/nina/runtime/suggest";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import type { ModelMessage, UIMessageStreamWriter } from "ai";
-import { Effect, Result } from "effect";
+import { streamText } from "ai";
+import { Effect, Result, Stream } from "effect";
 import { vi } from "vitest";
 
-const streamText = vi.hoisted(() => vi.fn());
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", { spy: true });
+vi.mocked(streamText).mockImplementation(streamTextMock);
+
 vi.mock("@repo/ai/config/app", () => ({
   provider: {
     languageModel: (modelId: string) => modelId,
   },
 }));
-vi.mock("ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ai")>();
-  return {
-    ...actual,
-    streamText,
-  };
-});
 const messages = [
   {
     content: "Halo Nina.",
     role: "user",
   },
 ] satisfies ModelMessage[];
-/** Creates an async iterable that emits the provided suggestion partials. */
-async function* suggestionPartials(
+/** Creates an Effect-backed async iterable that emits suggestion partials. */
+function suggestionPartials(
   chunks: readonly {
     readonly suggestions?: readonly string[];
   }[]
 ) {
-  for (const chunk of chunks) {
-    await Promise.resolve();
-    yield chunk;
-  }
+  return Stream.fromIterable(chunks).pipe(Stream.toAsyncIterable);
 }
-/** Creates an async iterable that fails while Nina reads streamed suggestions. */
-async function* failingSuggestionPartials() {
-  await Promise.resolve();
-  yield await Promise.reject(new Error("partial stream failed"));
+/** Creates an Effect-backed async iterable that fails while Nina reads it. */
+function failingSuggestionPartials() {
+  return Stream.fail(new Error("partial stream failed")).pipe(
+    Stream.toAsyncIterable
+  );
 }
 /** Captures suggestion data parts written by the Nina suggestion Module. */
 function createWriter() {
@@ -52,12 +48,12 @@ function createWriter() {
 }
 describe("nina/runtime/suggest", () => {
   beforeEach(() => {
-    streamText.mockReset();
+    streamTextMock.mockReset();
   });
-  it.live("writes final suggestions when partial chunks are empty", () =>
+  it.effect("writes final suggestions when partial chunks are empty", () =>
     Effect.gen(function* () {
       const writer = createWriter();
-      streamText.mockReturnValue({
+      streamTextMock.mockReturnValue({
         output: Promise.resolve({
           suggestions: ["Apa contoh lainnya?", "Beri latihan singkat."],
         }),
@@ -78,7 +74,7 @@ describe("nina/runtime/suggest", () => {
       );
     })
   );
-  it.live(
+  it.effect(
     "prunes tool-call transcript parts before generating suggestions",
     () =>
       Effect.gen(function* () {
@@ -119,7 +115,7 @@ describe("nina/runtime/suggest", () => {
             role: "assistant",
           },
         ] satisfies ModelMessage[];
-        streamText.mockReturnValue({
+        streamTextMock.mockReturnValue({
           output: Promise.resolve({
             suggestions: ["Beri contoh benda nyata."],
           }),
@@ -130,7 +126,7 @@ describe("nina/runtime/suggest", () => {
           messages: transcriptWithToolCall,
           writer,
         });
-        expect(streamText).toHaveBeenCalledWith(
+        expect(streamTextMock).toHaveBeenCalledWith(
           expect.objectContaining({
             messages: [
               { content: "Hitung 2 + 3.", role: "user" },
@@ -154,66 +150,70 @@ describe("nina/runtime/suggest", () => {
         );
       })
   );
-  it.live("updates the same suggestions part when final output completes", () =>
-    Effect.gen(function* () {
-      const writer = createWriter();
-      streamText.mockReturnValue({
-        output: Promise.resolve({
-          suggestions: ["Apa contoh finalnya?", "Buat latihan final."],
-        }),
-        partialOutputStream: suggestionPartials([
-          { suggestions: [] },
-          { suggestions: ["Apa langkah berikutnya?"] },
-        ]),
-      });
-      yield* writeNinaSuggestions({
-        locale: "id",
-        messages,
-        writer,
-      });
-      expect(writer.write).toHaveBeenCalledTimes(2);
-      const firstWrite = writer.write.mock.calls[0]?.[0];
-      const finalWrite = writer.write.mock.calls[1]?.[0];
-      expect(firstWrite).toEqual(
-        expect.objectContaining({
-          data: {
-            data: ["Apa langkah berikutnya?"],
-          },
-        })
-      );
-      expect(finalWrite).toEqual(
-        expect.objectContaining({
-          id: firstWrite?.id,
-          data: {
-            data: ["Apa contoh finalnya?", "Buat latihan final."],
-          },
-        })
-      );
-    })
+  it.effect(
+    "updates the same suggestions part when final output completes",
+    () =>
+      Effect.gen(function* () {
+        const writer = createWriter();
+        streamTextMock.mockReturnValue({
+          output: Promise.resolve({
+            suggestions: ["Apa contoh finalnya?", "Buat latihan final."],
+          }),
+          partialOutputStream: suggestionPartials([
+            { suggestions: [] },
+            { suggestions: ["Apa langkah berikutnya?"] },
+          ]),
+        });
+        yield* writeNinaSuggestions({
+          locale: "id",
+          messages,
+          writer,
+        });
+        expect(writer.write).toHaveBeenCalledTimes(2);
+        const firstWrite = writer.write.mock.calls[0]?.[0];
+        const finalWrite = writer.write.mock.calls[1]?.[0];
+        expect(firstWrite).toEqual(
+          expect.objectContaining({
+            data: {
+              data: ["Apa langkah berikutnya?"],
+            },
+          })
+        );
+        expect(finalWrite).toEqual(
+          expect.objectContaining({
+            id: firstWrite?.id,
+            data: {
+              data: ["Apa contoh finalnya?", "Buat latihan final."],
+            },
+          })
+        );
+      })
   );
-  it.live("skips writing when the completed suggestions object is empty", () =>
-    Effect.gen(function* () {
-      const writer = createWriter();
-      streamText.mockReturnValue({
-        output: Promise.resolve({
-          suggestions: [],
-        }),
-        partialOutputStream: suggestionPartials([{}]),
-      });
-      yield* writeNinaSuggestions({
-        locale: "id",
-        messages,
-        writer,
-      });
-      expect(writer.write).not.toHaveBeenCalled();
-    })
+  it.effect(
+    "skips writing when the completed suggestions object is empty",
+    () =>
+      Effect.gen(function* () {
+        const writer = createWriter();
+        streamTextMock.mockReturnValue({
+          output: Promise.resolve({
+            suggestions: [],
+          }),
+          partialOutputStream: suggestionPartials([{}]),
+        });
+        yield* writeNinaSuggestions({
+          locale: "id",
+          messages,
+          writer,
+        });
+        expect(writer.write).not.toHaveBeenCalled();
+      })
   );
-  it.live(
+  it.effect(
     "reports a typed failure when partial suggestion streaming fails",
     () =>
       Effect.gen(function* () {
         const writer = createWriter();
-        streamText.mockReturnValue({
+        streamTextMock.mockReturnValue({
           output: Promise.resolve({
             suggestions: ["Tidak dipakai."],
           }),
@@ -236,12 +236,12 @@ describe("nina/runtime/suggest", () => {
         });
       })
   );
-  it.live(
+  it.effect(
     "reports a typed failure when final suggestion completion fails",
     () =>
       Effect.gen(function* () {
         const writer = createWriter();
-        streamText.mockReturnValue({
+        streamTextMock.mockReturnValue({
           output: Promise.reject(new Error("completion failed")),
           partialOutputStream: suggestionPartials([{}]),
         });

--- a/packages/ai/nina/runtime/usage.test.ts
+++ b/packages/ai/nina/runtime/usage.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
+import { describe, expect, it } from "@effect/vitest";
 import { defaultModel, getModelCreditCost } from "@repo/ai/config/model";
 import { trackUsage } from "@repo/ai/nina/runtime/usage";
-import { describe, expect, it } from "@repo/testing/effect";
 import type { LanguageModelUsage } from "ai";
 import { Effect } from "effect";
 
@@ -33,7 +33,7 @@ function usageRow({
 }
 
 describe("nina/runtime/usage", () => {
-  it.live("tracks sub-agent usage and creates final metadata", () =>
+  it.effect("tracks sub-agent usage and creates final metadata", () =>
     Effect.gen(function* () {
       const usage = yield* trackUsage();
 
@@ -68,7 +68,7 @@ describe("nina/runtime/usage", () => {
     })
   );
 
-  it.live("defaults missing usage tokens to zero", () =>
+  it.effect("defaults missing usage tokens to zero", () =>
     Effect.gen(function* () {
       const usage = yield* trackUsage();
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -27,6 +27,7 @@
     "parse-domain": "^8.4.0"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/packages/ai/schema/tools.test.ts
+++ b/packages/ai/schema/tools.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "@effect/vitest";
 import {
   formatSpecialistToolTask,
   mathToolInputSchema,
@@ -7,103 +6,100 @@ import {
 } from "@repo/ai/schema/tools";
 import { asSchema } from "ai";
 import dedent from "dedent";
-import { Effect } from "effect";
+import { Predicate } from "effect";
+import { describe, expect, it } from "vitest";
 
-const readJsonSchema = Effect.fn("test.ai.schema.readJsonSchema")(function* (
-  schema: ReturnType<typeof asSchema>
-) {
-  return yield* Effect.promise(() => Promise.resolve(schema.jsonSchema));
-});
+function readJsonSchema(schema: ReturnType<typeof asSchema>) {
+  const jsonSchema = schema.jsonSchema;
+  if (Predicate.isPromiseLike(jsonSchema)) {
+    expect.fail("AI tool JSON Schema projection must remain synchronous.");
+  }
+  return jsonSchema;
+}
 
 describe("LearningCapability tool schemas", () => {
-  it.effect(
-    "uses one compact specialist input contract for every delegation tool",
-    () =>
-      Effect.gen(function* () {
-        const jsonSchemas = yield* Effect.all([
-          readJsonSchema(asSchema(nakafaToolInputSchema)),
-          readJsonSchema(asSchema(mathToolInputSchema)),
-          readJsonSchema(asSchema(researchToolInputSchema)),
-        ]);
+  it("uses one compact specialist input contract for every delegation tool", () => {
+    const jsonSchemas = [
+      readJsonSchema(asSchema(nakafaToolInputSchema)),
+      readJsonSchema(asSchema(mathToolInputSchema)),
+      readJsonSchema(asSchema(researchToolInputSchema)),
+    ];
 
-        for (const jsonSchema of jsonSchemas) {
-          expect(jsonSchema).toMatchObject({
-            properties: {
-              objective: {
-                type: "string",
-              },
-              request: {
-                type: "string",
-              },
-              requirements: {
-                type: "array",
-              },
-            },
-            type: "object",
-          });
-          expect(jsonSchema.required).toEqual(
-            expect.arrayContaining(["request", "objective"])
-          );
-          expect(jsonSchema.required).not.toContain("requirements");
-          expect(jsonSchema).not.toHaveProperty("properties.task");
-          expect(jsonSchema).not.toHaveProperty("properties.query");
-        }
-      })
-  );
-
-  it.effect("keeps each specialist-specific concern small and explicit", () =>
-    Effect.gen(function* () {
-      const [nakafaJsonSchema, mathJsonSchema, jsonSchema] = yield* Effect.all([
-        readJsonSchema(asSchema(nakafaToolInputSchema)),
-        readJsonSchema(asSchema(mathToolInputSchema)),
-        readJsonSchema(asSchema(researchToolInputSchema)),
-      ]);
-      const json = JSON.stringify(jsonSchema);
-
-      expect(nakafaJsonSchema).toMatchObject({
-        properties: {
-          deliverables: {
-            type: "array",
-          },
-        },
-        required: expect.arrayContaining(["deliverables"]),
-      });
-      expect(mathJsonSchema).toMatchObject({
-        properties: {
-          given: {
-            type: "array",
-          },
-        },
-        required: expect.arrayContaining(["given"]),
-      });
+    for (const jsonSchema of jsonSchemas) {
       expect(jsonSchema).toMatchObject({
         properties: {
-          sourceRequirements: {
+          objective: {
+            type: "string",
+          },
+          request: {
+            type: "string",
+          },
+          requirements: {
             type: "array",
           },
         },
-        required: expect.arrayContaining(["sourceRequirements"]),
         type: "object",
       });
-      expect(json).toContain("Task-relevant user request details only");
-      expect(json).toContain("Keep connective wording in the user's language");
-      expect(json).toContain("Preserve technical names and terms exactly");
-      expect(json).toContain("Do not translate this field into English");
-      expect(json).toContain("Omit unrelated, repeated, emotional");
-      expect(json).toContain("Specialist job only");
-      expect(json).toContain("Source requirements only");
-      expect(json).toContain("versions");
-      expect(JSON.stringify(mathJsonSchema)).toContain(
-        "Do not add derived formulas or solution methods"
+      expect(jsonSchema.required).toEqual(
+        expect.arrayContaining(["request", "objective"])
       );
-      expect(json).not.toContain("exact user wording");
-      expect(json).not.toContain("userRequest");
-      expect(json).toContain("Do not include final-answer wording");
-      expect(json).toContain(
-        "Do not include general answer-formatting, persona, or style rules"
-      );
-    })
-  );
+      expect(jsonSchema.required).not.toContain("requirements");
+      expect(jsonSchema).not.toHaveProperty("properties.task");
+      expect(jsonSchema).not.toHaveProperty("properties.query");
+    }
+  });
+
+  it("keeps each specialist-specific concern small and explicit", () => {
+    const [nakafaJsonSchema, mathJsonSchema, jsonSchema] = [
+      readJsonSchema(asSchema(nakafaToolInputSchema)),
+      readJsonSchema(asSchema(mathToolInputSchema)),
+      readJsonSchema(asSchema(researchToolInputSchema)),
+    ];
+    const json = JSON.stringify(jsonSchema);
+
+    expect(nakafaJsonSchema).toMatchObject({
+      properties: {
+        deliverables: {
+          type: "array",
+        },
+      },
+      required: expect.arrayContaining(["deliverables"]),
+    });
+    expect(mathJsonSchema).toMatchObject({
+      properties: {
+        given: {
+          type: "array",
+        },
+      },
+      required: expect.arrayContaining(["given"]),
+    });
+    expect(jsonSchema).toMatchObject({
+      properties: {
+        sourceRequirements: {
+          type: "array",
+        },
+      },
+      required: expect.arrayContaining(["sourceRequirements"]),
+      type: "object",
+    });
+    expect(json).toContain("Task-relevant user request details only");
+    expect(json).toContain("Keep connective wording in the user's language");
+    expect(json).toContain("Preserve technical names and terms exactly");
+    expect(json).toContain("Do not translate this field into English");
+    expect(json).toContain("Omit unrelated, repeated, emotional");
+    expect(json).toContain("Specialist job only");
+    expect(json).toContain("Source requirements only");
+    expect(json).toContain("versions");
+    expect(JSON.stringify(mathJsonSchema)).toContain(
+      "Do not add derived formulas or solution methods"
+    );
+    expect(json).not.toContain("exact user wording");
+    expect(json).not.toContain("userRequest");
+    expect(json).toContain("Do not include final-answer wording");
+    expect(json).toContain(
+      "Do not include general answer-formatting, persona, or style rules"
+    );
+  });
 
   it("renders structured specialist input into one internal Markdown task", () => {
     expect(

--- a/packages/ai/schema/tools.test.ts
+++ b/packages/ai/schema/tools.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   formatSpecialistToolTask,
   mathToolInputSchema,
@@ -6,92 +7,103 @@ import {
 } from "@repo/ai/schema/tools";
 import { asSchema } from "ai";
 import dedent from "dedent";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+
+const readJsonSchema = Effect.fn("test.ai.schema.readJsonSchema")(function* (
+  schema: ReturnType<typeof asSchema>
+) {
+  return yield* Effect.promise(() => Promise.resolve(schema.jsonSchema));
+});
 
 describe("LearningCapability tool schemas", () => {
-  it("uses one compact specialist input contract for every delegation tool", async () => {
-    const jsonSchemas = [
-      await Promise.resolve(asSchema(nakafaToolInputSchema).jsonSchema),
-      await Promise.resolve(asSchema(mathToolInputSchema).jsonSchema),
-      await Promise.resolve(asSchema(researchToolInputSchema).jsonSchema),
-    ];
+  it.effect(
+    "uses one compact specialist input contract for every delegation tool",
+    () =>
+      Effect.gen(function* () {
+        const jsonSchemas = yield* Effect.all([
+          readJsonSchema(asSchema(nakafaToolInputSchema)),
+          readJsonSchema(asSchema(mathToolInputSchema)),
+          readJsonSchema(asSchema(researchToolInputSchema)),
+        ]);
 
-    for (const jsonSchema of jsonSchemas) {
-      expect(jsonSchema).toMatchObject({
+        for (const jsonSchema of jsonSchemas) {
+          expect(jsonSchema).toMatchObject({
+            properties: {
+              objective: {
+                type: "string",
+              },
+              request: {
+                type: "string",
+              },
+              requirements: {
+                type: "array",
+              },
+            },
+            type: "object",
+          });
+          expect(jsonSchema.required).toEqual(
+            expect.arrayContaining(["request", "objective"])
+          );
+          expect(jsonSchema.required).not.toContain("requirements");
+          expect(jsonSchema).not.toHaveProperty("properties.task");
+          expect(jsonSchema).not.toHaveProperty("properties.query");
+        }
+      })
+  );
+
+  it.effect("keeps each specialist-specific concern small and explicit", () =>
+    Effect.gen(function* () {
+      const [nakafaJsonSchema, mathJsonSchema, jsonSchema] = yield* Effect.all([
+        readJsonSchema(asSchema(nakafaToolInputSchema)),
+        readJsonSchema(asSchema(mathToolInputSchema)),
+        readJsonSchema(asSchema(researchToolInputSchema)),
+      ]);
+      const json = JSON.stringify(jsonSchema);
+
+      expect(nakafaJsonSchema).toMatchObject({
         properties: {
-          objective: {
-            type: "string",
-          },
-          request: {
-            type: "string",
-          },
-          requirements: {
+          deliverables: {
             type: "array",
           },
         },
+        required: expect.arrayContaining(["deliverables"]),
+      });
+      expect(mathJsonSchema).toMatchObject({
+        properties: {
+          given: {
+            type: "array",
+          },
+        },
+        required: expect.arrayContaining(["given"]),
+      });
+      expect(jsonSchema).toMatchObject({
+        properties: {
+          sourceRequirements: {
+            type: "array",
+          },
+        },
+        required: expect.arrayContaining(["sourceRequirements"]),
         type: "object",
       });
-      expect(jsonSchema.required).toEqual(
-        expect.arrayContaining(["request", "objective"])
+      expect(json).toContain("Task-relevant user request details only");
+      expect(json).toContain("Keep connective wording in the user's language");
+      expect(json).toContain("Preserve technical names and terms exactly");
+      expect(json).toContain("Do not translate this field into English");
+      expect(json).toContain("Omit unrelated, repeated, emotional");
+      expect(json).toContain("Specialist job only");
+      expect(json).toContain("Source requirements only");
+      expect(json).toContain("versions");
+      expect(JSON.stringify(mathJsonSchema)).toContain(
+        "Do not add derived formulas or solution methods"
       );
-      expect(jsonSchema.required).not.toContain("requirements");
-      expect(jsonSchema).not.toHaveProperty("properties.task");
-      expect(jsonSchema).not.toHaveProperty("properties.query");
-    }
-  });
-
-  it("keeps each specialist-specific concern small and explicit", async () => {
-    const nakafaSchema = asSchema(nakafaToolInputSchema);
-    const mathSchema = asSchema(mathToolInputSchema);
-    const schema = asSchema(researchToolInputSchema);
-    const nakafaJsonSchema = await Promise.resolve(nakafaSchema.jsonSchema);
-    const mathJsonSchema = await Promise.resolve(mathSchema.jsonSchema);
-    const jsonSchema = await Promise.resolve(schema.jsonSchema);
-    const json = JSON.stringify(jsonSchema);
-
-    expect(nakafaJsonSchema).toMatchObject({
-      properties: {
-        deliverables: {
-          type: "array",
-        },
-      },
-      required: expect.arrayContaining(["deliverables"]),
-    });
-    expect(mathJsonSchema).toMatchObject({
-      properties: {
-        given: {
-          type: "array",
-        },
-      },
-      required: expect.arrayContaining(["given"]),
-    });
-    expect(jsonSchema).toMatchObject({
-      properties: {
-        sourceRequirements: {
-          type: "array",
-        },
-      },
-      required: expect.arrayContaining(["sourceRequirements"]),
-      type: "object",
-    });
-    expect(json).toContain("Task-relevant user request details only");
-    expect(json).toContain("Keep connective wording in the user's language");
-    expect(json).toContain("Preserve technical names and terms exactly");
-    expect(json).toContain("Do not translate this field into English");
-    expect(json).toContain("Omit unrelated, repeated, emotional");
-    expect(json).toContain("Specialist job only");
-    expect(json).toContain("Source requirements only");
-    expect(json).toContain("versions");
-    expect(JSON.stringify(mathJsonSchema)).toContain(
-      "Do not add derived formulas or solution methods"
-    );
-    expect(json).not.toContain("exact user wording");
-    expect(json).not.toContain("userRequest");
-    expect(json).toContain("Do not include final-answer wording");
-    expect(json).toContain(
-      "Do not include general answer-formatting, persona, or style rules"
-    );
-  });
+      expect(json).not.toContain("exact user wording");
+      expect(json).not.toContain("userRequest");
+      expect(json).toContain("Do not include final-answer wording");
+      expect(json).toContain(
+        "Do not include general answer-formatting, persona, or style rules"
+      );
+    })
+  );
 
   it("renders structured specialist input into one internal Markdown task", () => {
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
         specifier: ^8.4.0
         version: 8.4.0
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

Migrates the complete AI package test surface to direct official `@effect/vitest` usage through 32 small capability-owned commits. This supersedes the temporary per-file stack while preserving its commit history for review.

## Architecture

Effectful tests call `it.effect` directly. Pure deterministic tests remain ordinary Vitest. Validator promises use `Effect.promise`; synchronous JSON Schema projections stay synchronous and are explicitly asserted as such. No repository testing wrapper, raw Effect runner, global `vi`, or `it.live` is introduced.

## Scope

The patch changes AI-owned tests, adds the AI package's direct `@effect/vitest` development dependency, updates the lockfile importer, and narrows Nina's already-synchronous step callback to its truthful synchronous result type.

## Absence proof

Fresh authored-test scans under `packages/ai` report zero `@repo/testing/effect` imports, zero direct Effect runtime calls, zero `it.live`, zero raw `async` or `await`, zero raw `try/catch`, and zero Effect v3 diagnostic tokens.

## Verification

Exact head `c38922b70773840c0054ca00c84da25a87b18713` is directly based on protected main `676e2e95be14b915ee91d854bc864515ac05d454`. AI typecheck passes. All 62 AI test files and 378 tests pass at 100 percent statement, branch, function, and line coverage. Formatting, lint, Effect source parity, test policy, script typecheck and tests, boundaries, security audit, diff check, and changed-scope Doctor all pass.

## Merge gate

Merge only when this exact head remains current with protected `main`, all required checks are green, and all review findings are independently resolved. The PR will be squash-merged immediately when those conditions are satisfied.