### PR TITLE
test(mcp): adopt native Effect Vitest across the app

### DIFF
--- a/apps/mcp/app/route.test.ts
+++ b/apps/mcp/app/route.test.ts
@@ -1,26 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
 
 import * as route from "@/app/route";
 
 describe("MCP root route", () => {
-  it("explains the canonical and direct MCP endpoints", async () => {
-    const response = route.GET();
-    const text = await response.text();
+  it.effect("explains the canonical and direct MCP endpoints", () =>
+    Effect.gen(function* () {
+      const response = route.GET();
+      const text = yield* Effect.promise(() => response.text());
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain; charset=utf-8"
-    );
-    expect(text).toContain("https://mcp.nakafa.com is informational only");
-    expect(text).toContain(
-      "Use https://nakafa.com/mcp as the recommended MCP endpoint"
-    );
-    expect(text).toContain(
-      "Use https://mcp.nakafa.com/mcp as the direct MCP endpoint"
-    );
-    expect(text).toContain("nakafa_get_quran_reference_v2");
-    expect(text).toContain("semantic notes and signed source attribution");
-  });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe(
+        "text/plain; charset=utf-8"
+      );
+      expect(text).toContain("https://mcp.nakafa.com is informational only");
+      expect(text).toContain(
+        "Use https://nakafa.com/mcp as the recommended MCP endpoint"
+      );
+      expect(text).toContain(
+        "Use https://mcp.nakafa.com/mcp as the direct MCP endpoint"
+      );
+      expect(text).toContain("nakafa_get_quran_reference_v2");
+      expect(text).toContain("semantic notes and signed source attribution");
+    })
+  );
 
   it("does not expose root as a transport endpoint", () => {
     expect("POST" in route).toBe(false);

--- a/apps/mcp/lib/mcp/effect.test.ts
+++ b/apps/mcp/lib/mcp/effect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, type JsonSchema, Schema, Struct } from "effect";
 import {
   decodeNakafaMcpToolInput,

--- a/apps/mcp/lib/mcp/origin.test.ts
+++ b/apps/mcp/lib/mcp/origin.test.ts
@@ -1,130 +1,151 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
 import { withMcpOriginGuard } from "@/lib/mcp/origin";
 
 describe("MCP Origin helpers", () => {
-  it("allows owned, local, and configured Origins", async () => {
-    const defaultGuard = withMcpOriginGuard(() =>
-      Promise.resolve(new Response("ok", { status: 200 }))
-    );
-    const customGuard = withMcpOriginGuard(
-      () => Promise.resolve(new Response("ok", { status: 200 })),
-      "not a url, https://agent.example.com:443/"
-    );
-    const requests = [
-      defaultGuard(
-        new Request("https://mcp.nakafa.com/mcp", {
-          headers: { origin: "https://nakafa.com" },
-        })
-      ),
-      defaultGuard(
-        new Request("https://mcp.nakafa.com/mcp", {
-          headers: { origin: "https://api.nakafa.com" },
-        })
-      ),
-      defaultGuard(
-        new Request("https://mcp.nakafa.com/mcp", {
-          headers: { origin: "https://docs.nakafa.com" },
-        })
-      ),
-      defaultGuard(
-        new Request("https://mcp.nakafa.com/mcp", {
-          headers: { origin: "http://localhost:3002" },
-        })
-      ),
-      customGuard(
-        new Request("https://mcp.nakafa.com/mcp", {
-          headers: { origin: "https://agent.example.com" },
-        })
-      ),
-    ];
-    const responses = await Promise.all(requests);
-
-    expect(responses.map((response) => response.status)).toEqual([
-      200, 200, 200, 200, 200,
-    ]);
-    expect(
-      responses.map((response) =>
-        response.headers.get("access-control-allow-origin")
-      )
-    ).toEqual([
-      "https://nakafa.com",
-      "https://api.nakafa.com",
-      "https://docs.nakafa.com",
-      "http://localhost:3002",
-      "https://agent.example.com",
-    ]);
-  });
-
-  it("rejects invalid, untrusted, and insecure Origins", async () => {
-    const guarded = withMcpOriginGuard(() =>
-      Promise.resolve(new Response("ok", { status: 200 }))
-    );
-    const responses = await Promise.all(
-      ["not a url", "https://evil.example.com", "http://api.nakafa.com"].map(
-        (origin) =>
-          guarded(
-            new Request("https://mcp.nakafa.com/mcp", {
-              headers: { origin },
-            })
-          )
-      )
-    );
-
-    for (const response of responses) {
-      expect(response.status).toBe(403);
-      expect(response.headers.get("content-type")).toBe(
-        "text/plain; charset=utf-8"
+  it.effect("allows owned, local, and configured Origins", () =>
+    Effect.gen(function* () {
+      const defaultGuard = withMcpOriginGuard(() =>
+        Promise.resolve(new Response("ok", { status: 200 }))
       );
-      await expect(response.text()).resolves.toBe("Forbidden MCP Origin");
-    }
-  });
+      const customGuard = withMcpOriginGuard(
+        () => Promise.resolve(new Response("ok", { status: 200 })),
+        "not a url, https://agent.example.com:443/"
+      );
+      const requests = [
+        defaultGuard(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: { origin: "https://nakafa.com" },
+          })
+        ),
+        defaultGuard(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: { origin: "https://api.nakafa.com" },
+          })
+        ),
+        defaultGuard(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: { origin: "https://docs.nakafa.com" },
+          })
+        ),
+        defaultGuard(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: { origin: "http://localhost:3002" },
+          })
+        ),
+        customGuard(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: { origin: "https://agent.example.com" },
+          })
+        ),
+      ];
+      const responses = yield* Effect.all(
+        requests.map((request) => Effect.promise(() => request))
+      );
 
-  it("keeps server-client requests without Origin free of browser CORS headers", async () => {
-    const guarded = withMcpOriginGuard(() =>
-      Promise.resolve(new Response("ok", { status: 200 }))
-    );
-    const response = await guarded(new Request("https://mcp.nakafa.com/mcp"));
+      expect(responses.map((response) => response.status)).toEqual([
+        200, 200, 200, 200, 200,
+      ]);
+      expect(
+        responses.map((response) =>
+          response.headers.get("access-control-allow-origin")
+        )
+      ).toEqual([
+        "https://nakafa.com",
+        "https://api.nakafa.com",
+        "https://docs.nakafa.com",
+        "http://localhost:3002",
+        "https://agent.example.com",
+      ]);
+    })
+  );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("access-control-allow-origin")).toBeNull();
-    await expect(response.text()).resolves.toBe("ok");
-  });
+  it.effect("rejects invalid, untrusted, and insecure Origins", () =>
+    Effect.gen(function* () {
+      const guarded = withMcpOriginGuard(() =>
+        Promise.resolve(new Response("ok", { status: 200 }))
+      );
+      const responses = yield* Effect.all(
+        ["not a url", "https://evil.example.com", "http://api.nakafa.com"].map(
+          (origin) =>
+            Effect.promise(() =>
+              guarded(
+                new Request("https://mcp.nakafa.com/mcp", {
+                  headers: { origin },
+                })
+              )
+            )
+        )
+      );
 
-  it("echoes only supported MCP CORS request headers", async () => {
-    const guarded = withMcpOriginGuard(() =>
-      Promise.resolve(new Response("ok", { status: 200 }))
-    );
-    const response = await guarded(
-      new Request("https://mcp.nakafa.com/mcp", {
-        headers: {
-          "access-control-request-headers": [
-            "content-type",
-            "last-event-id",
-            "mcp-method",
-            "mcp-name",
-            "mcp-param-region",
-            "mcp-protocol-version",
-            "mcp-session-id",
-            "x-unsupported",
-          ].join(","),
-          origin: "https://nakafa.com",
-        },
-        method: "OPTIONS",
+      for (const response of responses) {
+        expect(response.status).toBe(403);
+        expect(response.headers.get("content-type")).toBe(
+          "text/plain; charset=utf-8"
+        );
+        const text = yield* Effect.promise(() => response.text());
+        expect(text).toBe("Forbidden MCP Origin");
+      }
+    })
+  );
+
+  it.effect(
+    "keeps server-client requests without Origin free of browser CORS headers",
+    () =>
+      Effect.gen(function* () {
+        const guarded = withMcpOriginGuard(() =>
+          Promise.resolve(new Response("ok", { status: 200 }))
+        );
+        const response = yield* Effect.promise(() =>
+          guarded(new Request("https://mcp.nakafa.com/mcp"))
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("access-control-allow-origin")).toBeNull();
+        const text = yield* Effect.promise(() => response.text());
+        expect(text).toBe("ok");
       })
-    );
-    const allowHeaders = response.headers.get("access-control-allow-headers");
+  );
 
-    expect(response.status).toBe(204);
-    expect(allowHeaders).toContain("mcp-method");
-    expect(allowHeaders).toContain("mcp-name");
-    expect(allowHeaders).toContain("mcp-param-region");
-    expect(allowHeaders).toContain("last-event-id");
-    expect(allowHeaders).not.toContain("x-unsupported");
-    expect(response.headers.get("access-control-expose-headers")).toBe(
-      "mcp-protocol-version,mcp-session-id"
-    );
-    expect(response.headers.get("vary")).toBe(
-      "Origin, Access-Control-Request-Headers"
-    );
-  });
+  it.effect("echoes only supported MCP CORS request headers", () =>
+    Effect.gen(function* () {
+      const guarded = withMcpOriginGuard(() =>
+        Promise.resolve(new Response("ok", { status: 200 }))
+      );
+      const response = yield* Effect.promise(() =>
+        guarded(
+          new Request("https://mcp.nakafa.com/mcp", {
+            headers: {
+              "access-control-request-headers": [
+                "content-type",
+                "last-event-id",
+                "mcp-method",
+                "mcp-name",
+                "mcp-param-region",
+                "mcp-protocol-version",
+                "mcp-session-id",
+                "x-unsupported",
+              ].join(","),
+              origin: "https://nakafa.com",
+            },
+            method: "OPTIONS",
+          })
+        )
+      );
+      const allowHeaders = response.headers.get("access-control-allow-headers");
+
+      expect(response.status).toBe(204);
+      expect(allowHeaders).toContain("mcp-method");
+      expect(allowHeaders).toContain("mcp-name");
+      expect(allowHeaders).toContain("mcp-param-region");
+      expect(allowHeaders).toContain("last-event-id");
+      expect(allowHeaders).not.toContain("x-unsupported");
+      expect(response.headers.get("access-control-expose-headers")).toBe(
+        "mcp-protocol-version,mcp-session-id"
+      );
+      expect(response.headers.get("vary")).toBe(
+        "Origin, Access-Control-Request-Headers"
+      );
+    })
+  );
 });

--- a/apps/mcp/lib/mcp/result.test.ts
+++ b/apps/mcp/lib/mcp/result.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   NakafaAgentDataReadError,
   NakafaAgentInputError,
 } from "@repo/contents/_lib/agent/errors";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import {
   succeedMcpReadModelError,
@@ -11,7 +11,7 @@ import {
 } from "@/lib/mcp/result";
 
 describe("MCP result helpers", () => {
-  it.live("formats structured success and actionable errors", () =>
+  it.effect("formats structured success and actionable errors", () =>
     Effect.gen(function* () {
       const success = toMcpStructuredResult({ ok: true });
       const explicitError = toMcpToolError("Missing content.", [

--- a/apps/mcp/lib/mcp/tools/content.test.ts
+++ b/apps/mcp/lib/mcp/tools/content.test.ts
@@ -1,18 +1,15 @@
-import { describe, expect, it } from "@repo/testing/effect";
-import { Effect, Schema } from "effect";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Schema } from "effect";
 import { vi } from "vitest";
 import { getNakafaContentToolResult } from "@/lib/mcp/tools/content";
 
-vi.mock("@/lib/mcp/nakafa", async () => {
-  const { Effect, Option } = await import("effect");
+const nakafaContentMock = vi.hoisted(() => ({
+  read: vi.fn(),
+}));
 
-  return {
-    nakafaContent: {
-      /** Returns no content so the tool can shape its not-found response. */
-      read: () => Effect.succeed(Option.none()),
-    },
-  };
-});
+vi.mock("@/lib/mcp/nakafa", () => ({ nakafaContent: nakafaContentMock }));
+
+nakafaContentMock.read.mockImplementation(() => Effect.succeed(Option.none()));
 
 const ToolErrorResultSchema = Schema.Struct({
   isError: Schema.Literal(true),
@@ -25,7 +22,7 @@ const ToolErrorResultSchema = Schema.Struct({
 });
 
 describe("nakafa_get_content", () => {
-  it.live("returns structured not-found errors", () =>
+  it.effect("returns structured not-found errors", () =>
     Effect.gen(function* () {
       const result = yield* getNakafaContentToolResult({
         content_ref: "https://nakafa.com/en/articles/politics/missing",

--- a/apps/mcp/lib/mcp/tools/quran.test.ts
+++ b/apps/mcp/lib/mcp/tools/quran.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { ENGLISH_APP_LOCALE_CODE } from "@nakafa/aksara-contracts/locale";
 import {
   quranReadingSourceIds,
@@ -6,58 +7,58 @@ import {
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { NakafaAgentQuranReferenceSchema } from "@repo/contents/_lib/agent/schema/quran";
 import { NakafaAgentQuranReferenceV2Schema } from "@repo/contents/_lib/agent/schema/quran/reference";
-import { describe, expect, it } from "@repo/testing/effect";
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 import { vi } from "vitest";
 import {
   getNakafaQuranReferenceToolResult,
   getNakafaQuranReferenceV2ToolResult,
 } from "@/lib/mcp/tools/quran";
 
-vi.mock("@/lib/mcp/nakafa", async () => {
-  const { Effect, Option } = await import("effect");
+const nakafaContentMock = vi.hoisted(() => ({
+  quran: vi.fn(),
+  quranV2: vi.fn(),
+}));
 
-  return {
-    nakafaContent: {
-      /** Returns deterministic Quran references for MCP result shaping tests. */
-      quran: (input: { from_verse: number; include_tafsir: boolean }) => {
-        if (input.from_verse === 999) {
-          return Effect.succeed(Option.none());
-        }
+vi.mock("@/lib/mcp/nakafa", () => ({
+  nakafaContent: nakafaContentMock,
+}));
 
-        return Effect.succeed(
-          Option.some({
-            ...readNakafaContentRefFixture("en", "quran/1", "quran"),
-            name: "Al-Faatiha",
-            revelation: "Mecca",
-            translation: "The Opening",
-            verses: [
-              {
-                arabic: "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ",
-                number: 1,
-                ...(input.include_tafsir ? { tafsir: "Tafsir" } : {}),
-                translation: "In the name of Allah.",
-              },
-              {
-                arabic: "الْحَمْدُ لِلّٰهِ رَبِّ الْعٰلَمِيْنَ",
-                number: 2,
-                ...(input.include_tafsir ? { tafsir: "Tafsir" } : {}),
-                translation: "All praise is for Allah.",
-              },
-            ],
-          })
-        );
-      },
-      /** Returns deterministic V2 Quran references for MCP result tests. */
-      quranV2: (input: { from_verse: number }) =>
-        Effect.succeed(
-          input.from_verse === 999
-            ? Option.none()
-            : Option.some(makeV2Reference())
-        ),
-    },
-  };
-});
+nakafaContentMock.quran.mockImplementation(
+  (input: { from_verse: number; include_tafsir: boolean }) => {
+    if (input.from_verse === 999) {
+      return Effect.succeed(Option.none());
+    }
+
+    return Effect.succeed(
+      Option.some({
+        ...readNakafaContentRefFixture("en", "quran/1", "quran"),
+        name: "Al-Faatiha",
+        revelation: "Mecca",
+        translation: "The Opening",
+        verses: [
+          {
+            arabic: "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ",
+            number: 1,
+            ...(input.include_tafsir ? { tafsir: "Tafsir" } : {}),
+            translation: "In the name of Allah.",
+          },
+          {
+            arabic: "الْحَمْدُ لِلّٰهِ رَبِّ الْعٰلَمِيْنَ",
+            number: 2,
+            ...(input.include_tafsir ? { tafsir: "Tafsir" } : {}),
+            translation: "All praise is for Allah.",
+          },
+        ],
+      })
+    );
+  }
+);
+
+nakafaContentMock.quranV2.mockImplementation((input: { from_verse: number }) =>
+  Effect.succeed(
+    input.from_verse === 999 ? Option.none() : Option.some(makeV2Reference())
+  )
+);
 
 const ToolErrorResultSchema = Schema.Struct({
   isError: Schema.Literal(true),
@@ -70,7 +71,7 @@ const ToolErrorResultSchema = Schema.Struct({
 });
 
 describe("nakafa_get_quran_reference", () => {
-  it.live("returns structured Quran references", () =>
+  it.effect("returns structured Quran references", () =>
     Effect.gen(function* () {
       const result = yield* getNakafaQuranReferenceToolResult({
         from_verse: 1,
@@ -92,7 +93,7 @@ describe("nakafa_get_quran_reference", () => {
     })
   );
 
-  it.live("returns structured read-model input errors", () =>
+  it.effect("returns structured read-model input errors", () =>
     Effect.gen(function* () {
       const result = yield* getNakafaQuranReferenceToolResult({
         from_verse: 1,
@@ -111,7 +112,7 @@ describe("nakafa_get_quran_reference", () => {
     })
   );
 
-  it.live("returns structured range and missing-reference errors", () =>
+  it.effect("returns structured range and missing-reference errors", () =>
     Effect.gen(function* () {
       const reversed = yield* getNakafaQuranReferenceToolResult({
         from_verse: 3,
@@ -150,7 +151,7 @@ describe("nakafa_get_quran_reference", () => {
 });
 
 describe("nakafa_get_quran_reference_v2", () => {
-  it.live("returns semantic notes and signed source access", () =>
+  it.effect("returns semantic notes and signed source access", () =>
     Effect.gen(function* () {
       const result = yield* getNakafaQuranReferenceV2ToolResult({
         from_verse: 1,
@@ -185,7 +186,7 @@ describe("nakafa_get_quran_reference_v2", () => {
     })
   );
 
-  it.live("retains structured V2 range and missing errors", () =>
+  it.effect("retains structured V2 range and missing errors", () =>
     Effect.gen(function* () {
       const reversed = yield* getNakafaQuranReferenceV2ToolResult({
         from_verse: 3,

--- a/apps/mcp/lib/mcp/tools/search.test.ts
+++ b/apps/mcp/lib/mcp/tools/search.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   NAKAFA_AGENT_DEFAULT_LIMIT,
   NAKAFA_AGENT_MAX_LIMIT,
 } from "@repo/contents/_types/agent/search";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { fetchQuery } from "convex/nextjs";
 import { Effect, Schema } from "effect";
 import { vi } from "vitest";
@@ -35,7 +35,7 @@ const ToolErrorResultSchema = Schema.Struct({
 });
 
 describe("nakafa_search_content", () => {
-  it.live(
+  it.effect(
     "decodes omitted search options with native Effect schema defaults",
     () =>
       Effect.gen(function* () {
@@ -51,7 +51,7 @@ describe("nakafa_search_content", () => {
       })
   );
 
-  it.live("returns structured read-model input errors", () =>
+  it.effect("returns structured read-model input errors", () =>
     Effect.gen(function* () {
       const result = yield* getNakafaSearchContentToolResult({
         limit: 99,
@@ -72,7 +72,7 @@ describe("nakafa_search_content", () => {
     })
   );
 
-  it.live("returns structured read-model data errors", () =>
+  it.effect("returns structured read-model data errors", () =>
     Effect.gen(function* () {
       vi.mocked(fetchQuery).mockRejectedValueOnce(new Error("Convex offline"));
 

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.17.0/nakafa-aksara-contracts-0.17.0.tgz",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@nakafa/aksara-contracts':
         specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.17.0/nakafa-aksara-contracts-0.17.0.tgz
         version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.17.0/nakafa-aksara-contracts-0.17.0.tgz(effect@4.0.0-rc.110)


### PR DESCRIPTION
## Summary

Migrates the complete MCP app test surface to direct official `@effect/vitest` usage through seven small capability-owned commits.

## Architecture

Effectful tests call `it.effect` directly. Pure deterministic tests remain ordinary Vitest. Promise boundaries use `Effect.promise`; Vitest module doubles are synchronous and explicit. No repository testing wrapper, raw Effect runner, global `vi`, or `it.live` is introduced.

## Scope

The patch changes eight MCP test modules, adds the app's direct `@effect/vitest` development dependency, and updates only the MCP lockfile importer. Production implementation is unchanged.

## Absence proof

Fresh authored-test scans under `apps/mcp` report zero `@repo/testing/effect` imports, zero direct Effect runtime calls, zero `it.live`, zero raw `async` or `await`, and zero raw `try/catch`.

## Verification

Exact head `624d9185ed6c30ffd567995233535a3be3efac93` is directly based on protected main `5b55d33535c43332c4a420c38c52e34334d3925b`. MCP typecheck passes. All 8 MCP test files and 23 tests pass at 100 percent statement, branch, function, and line coverage. Frozen install, formatting, lint, Effect source parity, test policy, script typecheck and tests, boundaries, security audit, diff check, and changed-scope Doctor all pass.

## Merge gate

Merge only when this exact head remains current with protected `main`, all required checks are green, and all review findings are independently resolved. The PR will be squash-merged immediately when those conditions are satisfied.