### PR TITLE
test(scripts): adopt native Effect Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@changesets/cli": "^3.0.1",
     "@effect/platform-node": "catalog:",
     "@effect/tsgo": "0.36.5",
-    "@repo/testing": "workspace:*",
+    "@effect/vitest": "catalog:",
     "@repo/typescript-config": "workspace:*",
     "@turbo/gen": "2.10.11",
     "@types/node": "24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,9 @@ importers:
       '@effect/tsgo':
         specifier: 0.36.5
         version: 0.36.5
-      '@repo/testing':
-        specifier: workspace:*
-        version: link:packages/testing
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:packages/typescript-config

--- a/scripts/dependencies/policy.test.ts
+++ b/scripts/dependencies/policy.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { bumpDependencies } from "./bump.ts";
@@ -103,7 +103,7 @@ function validInput() {
 }
 
 describe("dependency policy", () => {
-  it.live("accepts the actual repository dependency policy", () =>
+  it.effect("accepts the actual repository dependency policy", () =>
     Effect.gen(function* () {
       const problems = yield* inspectDependencyPolicy(REPOSITORY_ROOT).pipe(
         Effect.provide(NodeServices.layer)
@@ -170,7 +170,7 @@ describe("dependency policy", () => {
     ).toBe(true);
   });
 
-  it.live("rejects unsafe policy before running pnpm update", () =>
+  it.effect("rejects unsafe policy before running pnpm update", () =>
     Effect.gen(function* () {
       const commands: string[][] = [];
       const errors: string[] = [];

--- a/scripts/dependencies/source.test.ts
+++ b/scripts/dependencies/source.test.ts
@@ -1,42 +1,40 @@
 import { NodeServices } from "@effect/platform-node";
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, FileSystem } from "effect";
 import { readFirstPartySourceFiles } from "./source.ts";
 
 describe("dependency source discovery", () => {
-  it.live("includes TypeScript module variants and excludes JavaScript", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const root = yield* fileSystem.makeTempDirectoryScoped({
-          prefix: "dependency-source-test-",
-        });
-        yield* fileSystem.makeDirectory(`${root}/apps/example`, {
-          recursive: true,
-        });
-        yield* fileSystem.makeDirectory(`${root}/packages/example`, {
-          recursive: true,
-        });
-        yield* fileSystem.writeFileString(
-          `${root}/apps/example/entry.mts`,
-          'import "temporary-dependency";\n'
-        );
-        yield* fileSystem.writeFileString(
-          `${root}/packages/example/worker.cts`,
-          'require("temporary-dependency");\n'
-        );
-        yield* fileSystem.writeFileString(
-          `${root}/packages/example/ignored.js`,
-          'import "temporary-dependency";\n'
-        );
+  it.effect("includes TypeScript module variants and excludes JavaScript", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "dependency-source-test-",
+      });
+      yield* fileSystem.makeDirectory(`${root}/apps/example`, {
+        recursive: true,
+      });
+      yield* fileSystem.makeDirectory(`${root}/packages/example`, {
+        recursive: true,
+      });
+      yield* fileSystem.writeFileString(
+        `${root}/apps/example/entry.mts`,
+        'import "temporary-dependency";\n'
+      );
+      yield* fileSystem.writeFileString(
+        `${root}/packages/example/worker.cts`,
+        'require("temporary-dependency");\n'
+      );
+      yield* fileSystem.writeFileString(
+        `${root}/packages/example/ignored.js`,
+        'import "temporary-dependency";\n'
+      );
 
-        const files = yield* readFirstPartySourceFiles(root);
+      const files = yield* readFirstPartySourceFiles(root);
 
-        expect(files.map(({ path }) => path).sort()).toEqual([
-          "apps/example/entry.mts",
-          "packages/example/worker.cts",
-        ]);
-      })
-    ).pipe(Effect.provide(NodeServices.layer))
+      expect(files.map(({ path }) => path).sort()).toEqual([
+        "apps/example/entry.mts",
+        "packages/example/worker.cts",
+      ]);
+    }).pipe(Effect.provide(NodeServices.layer))
   );
 });

--- a/scripts/effect-source.test.ts
+++ b/scripts/effect-source.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { NodeServices } from "@effect/platform-node";
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, FileSystem, Schema } from "effect";
 import {
   type EffectSourceConfig,
@@ -44,7 +44,7 @@ const commitAll = Effect.fn("EffectSourceTest.commitAll")(function* (
 });
 
 describe("Effect source identity", () => {
-  it.live(
+  it.effect(
     "updates linearly and remains valid after its subtree history is squashed",
     () =>
       Effect.gen(function* () {

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Result } from "effect";
 import {
   HttpClient,
@@ -41,7 +41,7 @@ function makeHttpClient(
 }
 
 describe("GitHub Action policy", () => {
-  it.live("accepts every reviewed immutable GitHub Action", () =>
+  it.effect("accepts every reviewed immutable GitHub Action", () =>
     Effect.gen(function* () {
       expect(validateGithubActionPolicy(validActionUses())).toEqual([]);
       expect(
@@ -91,7 +91,7 @@ describe("GitHub Action policy", () => {
     );
   });
 
-  it.live("reads release metadata through the Effect HTTP client", () =>
+  it.effect("reads release metadata through the Effect HTTP client", () =>
     Effect.gen(function* () {
       let observedRequest: HttpClientRequest.HttpClientRequest | undefined;
       const releaseTag = yield* fetchLatestGithubActionTag({
@@ -112,7 +112,7 @@ describe("GitHub Action policy", () => {
     })
   );
 
-  it.live("rejects unavailable GitHub release metadata", () =>
+  it.effect("rejects unavailable GitHub release metadata", () =>
     Effect.gen(function* () {
       const result = yield* fetchLatestGithubActionTag({
         repository: "actions/checkout",


### PR DESCRIPTION
## Summary

Migrates the complete repository script test surface to direct official `@effect/vitest` through four small capability-owned commits.

## Architecture

Effectful script tests use `it.effect` directly. The Effect test runtime owns each test scope, so the redundant nested `Effect.scoped` wrapper is removed. No test requires live clock behavior. The root directly owns `@effect/vitest`, while `packages/testing` continues to own and execute the shared Vitest runtime. No root Vitest dependency is added.

## Scope

Six files change: four script tests plus the root dependency declaration and root lockfile importer. Production scripts are unchanged. The root's wrapper dependency is replaced with its direct official Effect Vitest dependency.

## Absence proof

A fresh authored-test scan under `scripts` reports zero `@repo/testing/effect` imports, zero direct Effect runtime calls, zero `it.live`, zero raw `async` or `await`, and zero raw `try/catch`.

## Verification

Exact base `ebbbbf2aaf51fb2fee8c748224a4364153260e37` and head `614e63ee46fd6b0eae91a082fede9569cc7a4337`. All 4 script test files and 13 tests pass. Script typecheck, frozen install and supply-chain policy, formatting, Effect source parity, lint, test policy, boundaries, security audit, changed-scope Doctor, and diff check pass.

## Merge gate

Merge immediately when this exact head is current with protected main, required checks are green, and every review finding is independently resolved.