### PR TITLE
test(www): adopt native Effect Vitest across components

### DIFF
--- a/apps/www/components/ai/store/draft.test.ts
+++ b/apps/www/components/ai/store/draft.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe("ai/store/draft", () => {
-  it.live("saves, reads, and clears the current tab draft", () =>
+  it.effect("saves, reads, and clears the current tab draft", () =>
     Effect.gen(function* () {
       yield* saveAiDraftText("Explain this step", "learner-a");
 
@@ -27,7 +27,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "claims an anonymous draft for the account completing authentication",
     () =>
       Effect.gen(function* () {
@@ -38,7 +38,7 @@ describe("ai/store/draft", () => {
       })
   );
 
-  it.live("discards a legacy tab draft without atomic ownership", () =>
+  it.effect("discards a legacy tab draft without atomic ownership", () =>
     Effect.gen(function* () {
       window.sessionStorage.setItem("nakafa-ai-draft", "Legacy question");
 
@@ -47,7 +47,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live("writes text and ownership in one storage record", () =>
+  it.effect("writes text and ownership in one storage record", () =>
     Effect.gen(function* () {
       const setItem = vi.spyOn(Storage.prototype, "setItem");
 
@@ -61,7 +61,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live("keeps newer input entered while account ownership resolves", () =>
+  it.effect("keeps newer input entered while account ownership resolves", () =>
     Effect.gen(function* () {
       yield* saveAiDraftText("Older question", "learner-a");
 
@@ -83,7 +83,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live("keeps an intentional empty draft during account resolution", () =>
+  it.effect("keeps an intentional empty draft during account resolution", () =>
     Effect.gen(function* () {
       yield* saveAiDraftText("Older question", "learner-a");
 
@@ -98,7 +98,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live("clears a draft when another account owns it", () =>
+  it.effect("clears a draft when another account owns it", () =>
     Effect.gen(function* () {
       yield* saveAiDraftText("Private question", "learner-a");
 
@@ -107,7 +107,7 @@ describe("ai/store/draft", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "keeps draft persistence best effort when storage rejects access",
     () =>
       Effect.gen(function* () {
@@ -135,7 +135,7 @@ describe("ai/store/draft", () => {
       })
   );
 
-  it.live("does nothing when rendered without browser storage", () =>
+  it.effect("does nothing when rendered without browser storage", () =>
     Effect.gen(function* () {
       vi.stubGlobal("window", undefined);
 

--- a/apps/www/components/programs/onboarding/state.test.ts
+++ b/apps/www/components/programs/onboarding/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, Result } from "effect";
 import {
   decodeOnboardingRoleValue,
@@ -6,7 +6,7 @@ import {
 } from "@/components/programs/onboarding/state";
 
 describe("components/programs/onboarding/state", () => {
-  it.live("decodes a complete program onboarding value", () =>
+  it.effect("decodes a complete program onboarding value", () =>
     Effect.gen(function* () {
       const result = yield* decodeOnboardingValue({
         focusKey: "student-exam",
@@ -26,7 +26,7 @@ describe("components/programs/onboarding/state", () => {
       });
     })
   );
-  it.live("rejects incomplete program onboarding values", () =>
+  it.effect("rejects incomplete program onboarding values", () =>
     Effect.gen(function* () {
       const result = yield* decodeOnboardingValue({
         programKey: "snbt",
@@ -34,7 +34,7 @@ describe("components/programs/onboarding/state", () => {
       expect(Result.isFailure(result)).toBe(true);
     })
   );
-  it.live("decodes a route-owned role step value", () =>
+  it.effect("decodes a route-owned role step value", () =>
     Effect.gen(function* () {
       const role = yield* decodeOnboardingRoleValue({ role: "teacher" }).pipe(
         Effect.result

--- a/apps/www/components/programs/onboarding/submit.test.ts
+++ b/apps/www/components/programs/onboarding/submit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import {
   submitOnboardingRole,
@@ -13,7 +13,7 @@ const validValue = {
 };
 
 describe("components/programs/onboarding/submit", () => {
-  it.live("autosaves only the selected role on the role step", () =>
+  it.effect("autosaves only the selected role on the role step", () =>
     Effect.gen(function* () {
       const roleValues: unknown[] = [];
       const result = yield* submitOnboardingRole({
@@ -31,7 +31,7 @@ describe("components/programs/onboarding/submit", () => {
     })
   );
 
-  it.live("does not autosave when the role step value is invalid", () =>
+  it.effect("does not autosave when the role step value is invalid", () =>
     Effect.gen(function* () {
       const roleValues: unknown[] = [];
       const result = yield* submitOnboardingRole({
@@ -52,7 +52,7 @@ describe("components/programs/onboarding/submit", () => {
     })
   );
 
-  it.live("returns error state when role autosave fails", () =>
+  it.effect("returns error state when role autosave fails", () =>
     Effect.gen(function* () {
       const result = yield* submitOnboardingRole({
         updateRole: () => Promise.reject(new Error("Role unavailable")),
@@ -68,7 +68,7 @@ describe("components/programs/onboarding/submit", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "returns success after the Convex role and selection mutations resolve",
     () =>
       Effect.gen(function* () {
@@ -97,7 +97,7 @@ describe("components/programs/onboarding/submit", () => {
       })
   );
 
-  it.live("returns validation state without calling either mutation", () =>
+  it.effect("returns validation state without calling either mutation", () =>
     Effect.gen(function* () {
       const selectedValues: unknown[] = [];
       const roleValues: unknown[] = [];
@@ -124,22 +124,24 @@ describe("components/programs/onboarding/submit", () => {
     })
   );
 
-  it.live("returns mutation error state when the Convex selection fails", () =>
-    Effect.gen(function* () {
-      const result = yield* submitOnboardingSelection({
-        selectProgram: () => Promise.reject(new Error("Convex unavailable")),
-        updateRole: () => Promise.resolve(),
-        value: validValue,
-      });
+  it.effect(
+    "returns mutation error state when the Convex selection fails",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* submitOnboardingSelection({
+          selectProgram: () => Promise.reject(new Error("Convex unavailable")),
+          updateRole: () => Promise.resolve(),
+          value: validValue,
+        });
 
-      expect(result).toEqual({
-        messageKey: "onboarding.save-error",
-        status: "error",
-      });
-    })
+        expect(result).toEqual({
+          messageKey: "onboarding.save-error",
+          status: "error",
+        });
+      })
   );
 
-  it.live(
+  it.effect(
     "does not create a learning selection when the role mutation fails",
     () =>
       Effect.gen(function* () {

--- a/apps/www/components/school/classes/forum/conversation/input/draft.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/draft.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import { restoreForumPostInputDraft } from "./draft";
@@ -10,7 +10,7 @@ const replyTarget = {
 };
 
 describe("conversation/input/draft", () => {
-  it.live("restores the failed draft when the composer is still empty", () =>
+  it.effect("restores the failed draft when the composer is still empty", () =>
     Effect.gen(function* () {
       const restoreBody = vi.fn();
       const restoreReplyTarget = vi.fn();
@@ -31,7 +31,7 @@ describe("conversation/input/draft", () => {
     })
   );
 
-  it.live("restores a failed top-level draft without a reply target", () =>
+  it.effect("restores a failed top-level draft without a reply target", () =>
     Effect.gen(function* () {
       const restoreBody = vi.fn();
       const restoreReplyTarget = vi.fn();
@@ -52,7 +52,7 @@ describe("conversation/input/draft", () => {
     })
   );
 
-  it.live("does not overwrite newer body or reply target input", () =>
+  it.effect("does not overwrite newer body or reply target input", () =>
     Effect.gen(function* () {
       const restoreBody = vi.fn();
       const restoreReplyTarget = vi.fn();
@@ -76,7 +76,7 @@ describe("conversation/input/draft", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "does not attach a failed reply target to newer top-level input",
     () =>
       Effect.gen(function* () {

--- a/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { FileWithPreview } from "@repo/design-system/hooks/use-file-upload";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Layer, Result } from "effect";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import type { HttpClientRequest } from "effect/unstable/http/HttpClientRequest";
@@ -46,8 +46,8 @@ function makeMutations(
   overrides: Partial<SubmitForumPostInput["mutations"]> = {}
 ) {
   return {
-    createPost: vi.fn(async () => postId),
-    discardForumUploads: vi.fn(async () => null),
+    createPost: vi.fn(() => Promise.resolve(postId)),
+    discardForumUploads: vi.fn(() => Promise.resolve(null)),
     generateUploadUrl: vi.fn(),
     saveForumUpload: vi.fn(),
     ...overrides,
@@ -69,7 +69,7 @@ describe("submitForumPost", () => {
       })
     );
   });
-  it.live("creates a text-only post without upload mutations", () =>
+  it.effect("creates a text-only post without upload mutations", () =>
     Effect.gen(function* () {
       const mutations = makeMutations();
       const result = yield* runSubmit({
@@ -92,25 +92,27 @@ describe("submitForumPost", () => {
       expect(mutations.discardForumUploads).not.toHaveBeenCalled();
     })
   );
-  it.live("does not discard pending uploads when a text-only post fails", () =>
-    Effect.gen(function* () {
-      const mutations = makeMutations({
-        createPost: vi.fn(() => Promise.reject(new Error("post failed"))),
-      });
-      const result = yield* runSubmit({
-        files: [],
-        mutations,
-        post: {
-          body: "hello",
-          forumId,
-          parentId: undefined,
-        },
-      });
-      expect(Result.isFailure(result)).toBe(true);
-      expect(mutations.discardForumUploads).not.toHaveBeenCalled();
-    })
+  it.effect(
+    "does not discard pending uploads when a text-only post fails",
+    () =>
+      Effect.gen(function* () {
+        const mutations = makeMutations({
+          createPost: vi.fn(() => Promise.reject(new Error("post failed"))),
+        });
+        const result = yield* runSubmit({
+          files: [],
+          mutations,
+          post: {
+            body: "hello",
+            forumId,
+            parentId: undefined,
+          },
+        });
+        expect(Result.isFailure(result)).toBe(true);
+        expect(mutations.discardForumUploads).not.toHaveBeenCalled();
+      })
   );
-  it.live("uploads new File objects and ignores existing file metadata", () =>
+  it.effect("uploads new File objects and ignores existing file metadata", () =>
     Effect.gen(function* () {
       const uploadId =
         "upload_for_file" as Id<"schoolClassForumPendingUploads">;
@@ -128,11 +130,10 @@ describe("submitForumPost", () => {
         makeFile("fresh"),
       ] satisfies FileWithPreview[];
       const mutations = makeMutations({
-        generateUploadUrl: vi.fn(async () => ({
-          uploadId,
-          uploadUrl,
-        })),
-        saveForumUpload: vi.fn(async () => uploadId),
+        generateUploadUrl: vi.fn(() =>
+          Promise.resolve({ uploadId, uploadUrl })
+        ),
+        saveForumUpload: vi.fn(() => Promise.resolve(uploadId)),
       });
       const result = yield* runSubmit({
         files,
@@ -174,7 +175,7 @@ describe("submitForumPost", () => {
       });
     })
   );
-  it.live(
+  it.effect(
     "discards successful uploads when another attachment upload fails",
     () =>
       Effect.gen(function* () {
@@ -189,7 +190,7 @@ describe("submitForumPost", () => {
               uploadUrl,
             })
             .mockRejectedValueOnce(new Error("upload URL failed")),
-          saveForumUpload: vi.fn(async () => successfulUploadId),
+          saveForumUpload: vi.fn(() => Promise.resolve(successfulUploadId)),
         });
         const result = yield* runSubmit({
           files,
@@ -207,7 +208,7 @@ describe("submitForumPost", () => {
         });
       })
   );
-  it.live(
+  it.effect(
     "captures cleanup failures without masking storage upload errors",
     () =>
       Effect.gen(function* () {
@@ -219,11 +220,10 @@ describe("submitForumPost", () => {
         );
         const mutations = makeMutations({
           discardForumUploads: vi.fn(() => Promise.reject("cleanup failed")),
-          generateUploadUrl: vi.fn(async () => ({
-            uploadId,
-            uploadUrl,
-          })),
-          saveForumUpload: vi.fn(async () => uploadId),
+          generateUploadUrl: vi.fn(() =>
+            Promise.resolve({ uploadId, uploadUrl })
+          ),
+          saveForumUpload: vi.fn(() => Promise.resolve(uploadId)),
         });
         const result = yield* runSubmit({
           files,
@@ -252,16 +252,15 @@ describe("submitForumPost", () => {
         );
       })
   );
-  it.live("discards the pending upload when metadata save fails", () =>
+  it.effect("discards the pending upload when metadata save fails", () =>
     Effect.gen(function* () {
       const uploadId =
         "upload_metadata" as Id<"schoolClassForumPendingUploads">;
       const files = [makeFile("metadata")];
       const mutations = makeMutations({
-        generateUploadUrl: vi.fn(async () => ({
-          uploadId,
-          uploadUrl,
-        })),
+        generateUploadUrl: vi.fn(() =>
+          Promise.resolve({ uploadId, uploadUrl })
+        ),
         saveForumUpload: vi.fn(() => Promise.reject(new Error("save failed"))),
       });
       const result = yield* runSubmit({
@@ -280,18 +279,17 @@ describe("submitForumPost", () => {
       expect(mutations.createPost).not.toHaveBeenCalled();
     })
   );
-  it.live("discards uploaded attachments when creating the post fails", () =>
+  it.effect("discards uploaded attachments when creating the post fails", () =>
     Effect.gen(function* () {
       const uploadId =
         "upload_for_post" as Id<"schoolClassForumPendingUploads">;
       const files = [makeFile("attachment")];
       const mutations = makeMutations({
         createPost: vi.fn(() => Promise.reject(new Error("post failed"))),
-        generateUploadUrl: vi.fn(async () => ({
-          uploadId,
-          uploadUrl,
-        })),
-        saveForumUpload: vi.fn(async () => uploadId),
+        generateUploadUrl: vi.fn(() =>
+          Promise.resolve({ uploadId, uploadUrl })
+        ),
+        saveForumUpload: vi.fn(() => Promise.resolve(uploadId)),
       });
       const result = yield* runSubmit({
         files,

--- a/apps/www/components/shared/open-content/copy.test.ts
+++ b/apps/www/components/shared/open-content/copy.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
-import { Cause, Effect, Exit, Option } from "effect";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
 import { vi } from "vitest";
 import {
   copyOpenContent,
@@ -9,11 +10,10 @@ import {
 const SOURCE_URL =
   "https://raw.githubusercontent.com/nakafaai/aksara/revision/source.mdx";
 afterEach(() => {
-  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 describe("copyOpenContent", () => {
-  it.live("copies inline preview source without a network request", () =>
+  it.effect("copies inline preview source without a network request", () =>
     Effect.gen(function* () {
       const fetchMock = vi.fn();
       const writeClipboard = vi.fn(() => Promise.resolve());
@@ -23,7 +23,7 @@ describe("copyOpenContent", () => {
       expect(writeClipboard).toHaveBeenCalledWith("## Preview");
     })
   );
-  it.live("fetches one immutable published source only when copying", () =>
+  it.effect("fetches one immutable published source only when copying", () =>
     Effect.gen(function* () {
       const fetchMock = vi.fn(() =>
         Promise.resolve(new Response("## Published", { status: 200 }))
@@ -38,13 +38,13 @@ describe("copyOpenContent", () => {
       expect(writeClipboard).toHaveBeenCalledWith("## Published");
     })
   );
-  it.live("fails when no reviewed source exists", () =>
+  it.effect("fails when no reviewed source exists", () =>
     expectCopyFailure(
       copyOpenContent({ writeClipboard: vi.fn() }),
       "OPEN_CONTENT_SOURCE_MISSING"
     )
   );
-  it.live("models network failures", () =>
+  it.effect("models network failures", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -56,34 +56,30 @@ describe("copyOpenContent", () => {
       );
     })
   );
-  it("times out a source request that never settles", async () => {
-    vi.useFakeTimers();
-    let fetchSignal: AbortSignal | undefined;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((_input, init) => {
-        fetchSignal = init?.signal ?? undefined;
-        return new Promise<Response>(() => undefined);
-      })
-    );
-    // Vitest owns this Promise boundary so its fake clock can advance the live timeout.
-    const exitPromise = Effect.runPromiseExit(
-      copyOpenContent({ copySourceUrl: SOURCE_URL, writeClipboard: vi.fn() })
-    );
-    await vi.advanceTimersByTimeAsync(10_001);
-    const exit = await exitPromise;
-    const failure = Exit.isFailure(exit)
-      ? Cause.findErrorOption(exit.cause)
-      : Option.none();
-    expect(Option.isSome(failure)).toBe(true);
-    if (Option.isSome(failure)) {
-      expect(failure.value).toMatchObject({
-        code: "OPEN_CONTENT_SOURCE_FETCH_FAILED",
-      });
-    }
-    expect(fetchSignal?.aborted).toBe(true);
-  });
-  it.live("rejects unsuccessful source responses", () =>
+  it.effect("times out a source request that never settles", () =>
+    Effect.gen(function* () {
+      let fetchSignal: AbortSignal | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input, init) => {
+          fetchSignal = init?.signal ?? undefined;
+          return new Promise<Response>(() => undefined);
+        })
+      );
+      const fiber = yield* expectCopyFailure(
+        copyOpenContent({ copySourceUrl: SOURCE_URL, writeClipboard: vi.fn() }),
+        "OPEN_CONTENT_SOURCE_FETCH_FAILED"
+      ).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      expect(fetchSignal).toBeDefined();
+      yield* TestClock.adjust("10 seconds");
+      yield* Fiber.join(fiber);
+
+      expect(fetchSignal?.aborted).toBe(true);
+    })
+  );
+  it.effect("rejects unsuccessful source responses", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -95,7 +91,7 @@ describe("copyOpenContent", () => {
       );
     })
   );
-  it.live("models source body read failures", () =>
+  it.effect("models source body read failures", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -112,7 +108,7 @@ describe("copyOpenContent", () => {
       );
     })
   );
-  it.live("rejects empty published source", () =>
+  it.effect("rejects empty published source", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -124,7 +120,7 @@ describe("copyOpenContent", () => {
       );
     })
   );
-  it.live("waits for and models clipboard rejection", () =>
+  it.effect("waits for and models clipboard rejection", () =>
     Effect.gen(function* () {
       const writeClipboard = vi.fn(() =>
         Promise.reject(new Error("clipboard denied"))
@@ -141,16 +137,8 @@ function expectCopyFailure(
   code: OpenContentCopyError["code"]
 ) {
   return Effect.gen(function* () {
-    const exit = yield* Effect.exit(program);
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (Exit.isSuccess(exit)) {
-      return;
-    }
-    const failure = Cause.findErrorOption(exit.cause);
-    expect(Option.isSome(failure)).toBe(true);
-    if (Option.isSome(failure)) {
-      expect(failure.value).toBeInstanceOf(OpenContentCopyError);
-      expect(failure.value).toEqual(expect.objectContaining({ code }));
-    }
+    const failure = yield* Effect.flip(program);
+    expect(failure).toBeInstanceOf(OpenContentCopyError);
+    expect(failure).toEqual(expect.objectContaining({ code }));
   });
 }


### PR DESCRIPTION
## Summary

Migrates six effectful WWW component test modules from the repository wrapper to direct official `@effect/vitest`.

## Architecture

Each effectful case returns an Effect through `it.effect`. The open-content timeout case uses Effect's managed child fiber and `TestClock.adjust` instead of raw Vitest timers and a manually started runtime. External browser and Convex Promise stubs remain at their actual platform boundaries.

## Checkpoints

The branch contains four capability-owned commits for AI drafts, open-content copy, onboarding, and forum input. It is not a mechanical repository-wide commit.

## Absence proof

The six changed files contain no `@repo/testing/effect`, direct Effect runtime calls, `it.live`, raw `async` or `await`, raw `try/catch`, or Vitest fake timers.

## Verification

Exact current base `27675d683212fcf4d0bc57cabab110fa6a32ac7f` and head `ded94e821c97ab01312fd3327b47c7d2e1046e58`. The rebased aggregate patch ID is identical to the previously proved head.

On this exact base, the complete WWW suite passes 209 files and 1,526 tests at 100 percent statement, branch, function, and line coverage. WWW typecheck, Effect vendored-source parity, test ownership policy, patch policy, Ultracite, and CAS lint pass. Package boundaries, security audit, changed-scope Doctor 100, and diff checks passed for the identical patch before the unrelated browser-harness main update.

## Release gate

Squash-merge immediately when this exact head remains current with protected main and its exact-head required checks and reviews are green. No Vercel Preview is requested or permitted.