### PR TITLE
feat(quran): expand semantic Convex contracts

### DIFF
--- a/packages/backend/content/quran/bismillah.test.ts
+++ b/packages/backend/content/quran/bismillah.test.ts
@@ -1,0 +1,54 @@
+import {
+  separateQuranBismillah,
+  splitQuranBismillahPrefix,
+} from "@repo/backend/content/quran/bismillah";
+import { describe, expect, it } from "vitest";
+
+const bismillah = {
+  arabic: "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ",
+  translation: "In the Name of Allah, the Most Compassionate, Most Merciful.",
+};
+
+describe("Quran Bismillah presentation", () => {
+  it("separates Al-Baqarah verse 1 without changing its Arabic suffix", () => {
+    expect(
+      separateQuranBismillah(bismillah, [
+        {
+          arabic: `${bismillah.arabic} الٓمٓ`,
+          number: { inQuran: 8, inSurah: 1 },
+        },
+      ])
+    ).toEqual({
+      preBismillah: bismillah,
+      verses: [{ arabic: "الٓمٓ", number: { inQuran: 8, inSurah: 1 } }],
+    });
+  });
+
+  it("does not split Al-Fatihah or At-Tawbah", () => {
+    expect(
+      separateQuranBismillah(bismillah, [{ arabic: bismillah.arabic }])
+    ).toEqual({ preBismillah: null, verses: [{ arabic: bismillah.arabic }] });
+    expect(
+      separateQuranBismillah(bismillah, [{ arabic: "بَرَآءَةٌۭ مِّنَ ٱللَّهِ وَرَسُولِهِۦٓ" }])
+    ).toEqual({
+      preBismillah: null,
+      verses: [{ arabic: "بَرَآءَةٌۭ مِّنَ ٱللَّهِ وَرَسُولِهِۦٓ" }],
+    });
+  });
+
+  it("accepts source diacritic variants while preserving exact verse bytes", () => {
+    const verse = "وَٱلتِّينِ وَٱلزَّيْتُونِ";
+    expect(
+      splitQuranBismillahPrefix(
+        `بِّسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ ${verse}`,
+        bismillah.arabic
+      )
+    ).toBe(verse);
+  });
+
+  it("rejects a lookalike prefix without a source separator", () => {
+    expect(
+      splitQuranBismillahPrefix(`${bismillah.arabic}وَٱلتِّينِ`, bismillah.arabic)
+    ).toBeNull();
+  });
+});

--- a/packages/backend/content/quran/bismillah.test.ts
+++ b/packages/backend/content/quran/bismillah.test.ts
@@ -6,7 +6,19 @@ import { describe, expect, it } from "vitest";
 
 const bismillah = {
   arabic: "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ",
-  translation: "In the Name of Allah, the Most Compassionate, Most Merciful.",
+  translation: {
+    notes: [
+      {
+        number: 1,
+        referenceOffset: 20,
+        text: "A reviewed translation note.",
+      },
+    ],
+    segments: [
+      { kind: "text", offset: 0, value: "In the Name of Allah" },
+      { kind: "note", number: 1, offset: 20 },
+    ],
+  },
 };
 
 describe("Quran Bismillah presentation", () => {

--- a/packages/backend/content/quran/bismillah.ts
+++ b/packages/backend/content/quran/bismillah.ts
@@ -50,10 +50,7 @@ export function splitQuranBismillahPrefix(arabic: string, bismillah: string) {
 
 /** Projects flat Quran verses into their dedicated Bismillah presentation. */
 export function separateQuranBismillah<
-  const Bismillah extends {
-    readonly arabic: string;
-    readonly translation: string;
-  },
+  const Bismillah extends { readonly arabic: string },
   const Verse extends { readonly arabic: string },
 >(bismillah: Bismillah | null, verses: readonly Verse[]) {
   const [firstVerse, ...remainingVerses] = verses;
@@ -71,13 +68,9 @@ export function separateQuranBismillah<
 }
 
 /** Projects authenticated runtime rows while preserving every non-Arabic field. */
-export function separateQuranRuntimeBismillah(
-  bismillah: {
-    readonly arabic: string;
-    readonly translation: string;
-  } | null,
-  verses: readonly QuranRuntimeVerse[]
-) {
+export function separateQuranRuntimeBismillah<
+  const Bismillah extends { readonly arabic: string },
+>(bismillah: Bismillah | null, verses: readonly QuranRuntimeVerse[]) {
   const [firstVerse, ...remainingVerses] = verses;
   if (bismillah === null || firstVerse === undefined) {
     return { preBismillah: null, verses };

--- a/packages/backend/content/quran/bismillah.ts
+++ b/packages/backend/content/quran/bismillah.ts
@@ -1,0 +1,110 @@
+import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
+
+const unicodeMarkPattern = /^\p{Mark}$/u;
+const whitespacePrefixPattern = /^\s/u;
+
+/** Separates a signed Bismillah prefix without changing any source glyphs. */
+export function splitQuranBismillahPrefix(arabic: string, bismillah: string) {
+  const expectedLetters = baseLetters(bismillah);
+  let matchedLetters = 0;
+  let offset = 0;
+
+  while (offset < arabic.length && matchedLetters < expectedLetters.length) {
+    const codePoint = arabic.codePointAt(offset);
+    if (codePoint === undefined) {
+      return null;
+    }
+    const character = String.fromCodePoint(codePoint);
+    for (const letter of baseLetters(character)) {
+      if (letter !== expectedLetters[matchedLetters]) {
+        return null;
+      }
+      matchedLetters += 1;
+    }
+    offset += character.length;
+  }
+
+  if (matchedLetters !== expectedLetters.length) {
+    return null;
+  }
+
+  while (offset < arabic.length) {
+    const codePoint = arabic.codePointAt(offset);
+    if (codePoint === undefined) {
+      return null;
+    }
+    const character = String.fromCodePoint(codePoint);
+    if (!isUnicodeMark(character)) {
+      break;
+    }
+    offset += character.length;
+  }
+
+  const remainder = arabic.slice(offset);
+  if (remainder.length === 0 || !whitespacePrefixPattern.test(remainder)) {
+    return null;
+  }
+  const verse = remainder.trimStart();
+  return verse.length === 0 ? null : verse;
+}
+
+/** Projects flat Quran verses into their dedicated Bismillah presentation. */
+export function separateQuranBismillah<
+  const Bismillah extends {
+    readonly arabic: string;
+    readonly translation: string;
+  },
+  const Verse extends { readonly arabic: string },
+>(bismillah: Bismillah | null, verses: readonly Verse[]) {
+  const [firstVerse, ...remainingVerses] = verses;
+  if (bismillah === null || firstVerse === undefined) {
+    return { preBismillah: null, verses };
+  }
+  const arabic = splitQuranBismillahPrefix(firstVerse.arabic, bismillah.arabic);
+  if (arabic === null) {
+    return { preBismillah: null, verses };
+  }
+  return {
+    preBismillah: bismillah,
+    verses: [{ ...firstVerse, arabic }, ...remainingVerses],
+  };
+}
+
+/** Projects authenticated runtime rows while preserving every non-Arabic field. */
+export function separateQuranRuntimeBismillah(
+  bismillah: {
+    readonly arabic: string;
+    readonly translation: string;
+  } | null,
+  verses: readonly QuranRuntimeVerse[]
+) {
+  const [firstVerse, ...remainingVerses] = verses;
+  if (bismillah === null || firstVerse === undefined) {
+    return { preBismillah: null, verses };
+  }
+  const arabic = splitQuranBismillahPrefix(
+    firstVerse.text.arabic,
+    bismillah.arabic
+  );
+  if (arabic === null) {
+    return { preBismillah: null, verses };
+  }
+  return {
+    preBismillah: bismillah,
+    verses: [
+      { ...firstVerse, text: { ...firstVerse.text, arabic } },
+      ...remainingVerses,
+    ],
+  };
+}
+
+/** Removes Unicode combining marks while preserving base-letter order. */
+function baseLetters(value: string) {
+  return Array.from(value.normalize("NFD")).filter(
+    (character) => !isUnicodeMark(character)
+  );
+}
+
+function isUnicodeMark(character: string) {
+  return unicodeMarkPattern.test(character);
+}

--- a/packages/backend/convex/contentRelease/quran.test.ts
+++ b/packages/backend/convex/contentRelease/quran.test.ts
@@ -5,11 +5,150 @@ import {
   TEST_MANIFEST_HASH,
   TEST_RELEASE_ID,
 } from "@repo/backend/test/content-release";
-import { activateQuranSource } from "@repo/backend/test/quran/snapshot";
+import {
+  makeQuranAttribution,
+  makeQuranChunk,
+  makeQuranSearch,
+  makeQuranSurah,
+} from "@repo/backend/test/quran/rows";
+import {
+  activateQuranSnapshot,
+  activateQuranSource,
+} from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 
+const bismillah = "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ";
+
+function expansionRows() {
+  return [
+    makeQuranAttribution(),
+    makeQuranSurah(1),
+    makeQuranSurah(2, 2),
+    makeQuranSurah(3),
+    makeQuranChunk({
+      arabicText: bismillah,
+      firstQuranNumber: 1,
+      firstVerse: 1,
+      surahNumber: 1,
+      verseCount: 1,
+    }),
+    makeQuranChunk({
+      arabicText: `${bismillah} الٓمٓ`,
+      firstQuranNumber: 2,
+      firstVerse: 1,
+      surahNumber: 2,
+      verseCount: 2,
+    }),
+    makeQuranSearch("id", 2),
+  ];
+}
+
 describe("contentRelease/quran", () => {
+  it("registers semantic queries before consumers switch", async () => {
+    const t = convexTest(schema, convexModules);
+
+    const [surah, prose, page, passage] = await Promise.all([
+      t.query(api.contentRelease.quran.surah, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.prose, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.page, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.passage, {
+        appLocale: "id",
+        fromVerse: 1,
+        surahNumber: 2,
+      }),
+    ]);
+
+    for (const result of [surah, prose, page, passage]) {
+      expect(result).toMatchObject({ managed: false, preBismillah: null });
+    }
+    await expect(
+      t.query(api.contentRelease.quran.tafsir, {
+        appLocale: "id",
+        expectedSnapshotId: `sha256:${"0".repeat(64)}`,
+        surahNumber: 2,
+        verseNumber: 1,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_CONFLICT" },
+    });
+  });
+
+  it("preserves prior responses while semantic queries separate Bismillah", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation((ctx) => activateQuranSnapshot(ctx, expansionRows()));
+
+    const [
+      documentV2,
+      surah,
+      markdownV2,
+      prose,
+      viewV2,
+      page,
+      referenceV2,
+      passage,
+    ] = await Promise.all([
+      t.query(api.contentRelease.quran.documentV2, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.surah, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.markdownV2, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.prose, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.viewV2, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.page, {
+        appLocale: "id",
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.referenceV2, {
+        appLocale: "id",
+        fromVerse: 1,
+        surahNumber: 2,
+      }),
+      t.query(api.contentRelease.quran.passage, {
+        appLocale: "id",
+        fromVerse: 1,
+        surahNumber: 2,
+      }),
+    ]);
+
+    for (const result of [documentV2, markdownV2, viewV2]) {
+      expect(result).not.toHaveProperty("preBismillah");
+      expect(result.verses[0]?.arabic).toBe(`${bismillah} الٓمٓ`);
+    }
+    expect(referenceV2).not.toHaveProperty("preBismillah");
+    for (const result of [surah, prose, page, passage]) {
+      expect(result.preBismillah).toEqual({
+        arabic: bismillah,
+        translation: "Terjemahan teknis 1",
+      });
+    }
+    expect(surah.verses[0]?.arabic).toBe("الٓمٓ");
+    expect(prose.verses[0]?.arabic).toBe("الٓمٓ");
+    expect(page.verses[0]?.arabic).toBe("الٓمٓ");
+  });
+
   it("registers public reads and rejects a stale interpretation", async () => {
     const t = convexTest(schema, convexModules);
 

--- a/packages/backend/convex/contentRelease/quran.test.ts
+++ b/packages/backend/convex/contentRelease/quran.test.ts
@@ -31,6 +31,10 @@ function expansionRows() {
       firstQuranNumber: 1,
       firstVerse: 1,
       surahNumber: 1,
+      translationFootnotes: {
+        id: "[4] Catatan teknis Bismillah Indonesia.",
+      },
+      translationText: { id: "Terjemahan teknis 1[4]" },
       verseCount: 1,
     }),
     makeQuranChunk({
@@ -141,7 +145,19 @@ describe("contentRelease/quran", () => {
     for (const result of [surah, prose, page, passage]) {
       expect(result.preBismillah).toEqual({
         arabic: bismillah,
-        translation: "Terjemahan teknis 1",
+        translation: {
+          notes: [
+            {
+              number: 4,
+              referenceOffset: 19,
+              text: "Catatan teknis Bismillah Indonesia.",
+            },
+          ],
+          segments: [
+            { kind: "text", offset: 0, value: "Terjemahan teknis 1" },
+            { kind: "note", number: 4, offset: 19 },
+          ],
+        },
       });
     }
     expect(surah.verses[0]?.arabic).toBe("الٓمٓ");

--- a/packages/backend/convex/contentRelease/quran.ts
+++ b/packages/backend/convex/contentRelease/quran.ts
@@ -19,15 +19,14 @@ import {
 } from "@repo/backend/convex/contentRelease/quran/markdown";
 import {
   quranPassageValidator,
+  quranReferenceValidator,
   readQuranPassage,
   readQuranReference,
 } from "@repo/backend/convex/contentRelease/quran/reference";
 import {
   quranAppLocaleValidator,
-  quranReadingSourcesValidator,
   quranReferenceArgsValidator,
   quranSourceFields,
-  quranTafsirAccessValidator,
   quranTafsirAppLocaleValidator,
 } from "@repo/backend/convex/contentRelease/quran/spec";
 import {
@@ -59,17 +58,6 @@ const attributionValidator = v.object({
 const surahCatalogValidator = v.object({
   ...quranSourceFields,
   rowJson: v.array(v.string()),
-});
-
-const referenceValidator = v.object({
-  ...quranSourceFields,
-  chunkJson: v.array(v.string()),
-  fromVerse: v.number(),
-  searchJson: v.union(v.string(), v.null()),
-  sources: v.union(quranReadingSourcesValidator, v.null()),
-  surahJson: v.union(v.string(), v.null()),
-  tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
-  toVerse: v.number(),
 });
 
 /** Returns the visible signed source attribution for active Quran content. */
@@ -247,7 +235,7 @@ export const reference = query({
 /** Returns one canonical V2 localized Quran verse reference. */
 export const referenceV2 = query({
   args: quranReferenceArgsValidator.fields,
-  returns: referenceValidator,
+  returns: quranReferenceValidator,
   handler: (ctx, args) => runConvexProgram(readQuranReference(ctx, args)),
 });
 

--- a/packages/backend/convex/contentRelease/quran.ts
+++ b/packages/backend/convex/contentRelease/quran.ts
@@ -3,7 +3,9 @@ import { readQuranAttribution } from "@repo/backend/convex/contentRelease/quran/
 import { readQuranSurahs } from "@repo/backend/convex/contentRelease/quran/catalog";
 import {
   quranDocumentValidator,
+  quranSurahValidator,
   readQuranDocument,
+  readQuranSurah,
 } from "@repo/backend/convex/contentRelease/quran/document";
 import {
   quranInterpretationValidator,
@@ -11,9 +13,15 @@ import {
 } from "@repo/backend/convex/contentRelease/quran/interpretation";
 import {
   quranMarkdownValidator,
+  quranProseValidator,
   readQuranMarkdown,
+  readQuranProse,
 } from "@repo/backend/convex/contentRelease/quran/markdown";
-import { readQuranReference } from "@repo/backend/convex/contentRelease/quran/reference";
+import {
+  quranPassageValidator,
+  readQuranPassage,
+  readQuranReference,
+} from "@repo/backend/convex/contentRelease/quran/reference";
 import {
   quranAppLocaleValidator,
   quranReadingSourcesValidator,
@@ -35,7 +43,9 @@ import {
   readQuranViewV1,
 } from "@repo/backend/convex/contentRelease/quran/v1";
 import {
+  quranPageValidator,
   quranViewValidator,
+  readQuranPage,
   readQuranView,
 } from "@repo/backend/convex/contentRelease/quran/view";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -92,6 +102,14 @@ export const documentV2 = query({
     runConvexProgram(readQuranDocument(ctx, appLocale, surahNumber)),
 });
 
+/** Returns one complete signed Quran surah for product and public readers. */
+export const surah = query({
+  args: { appLocale: quranAppLocaleValidator, surahNumber: v.number() },
+  returns: quranSurahValidator,
+  handler: (ctx, { appLocale, surahNumber }) =>
+    runConvexProgram(readQuranSurah(ctx, appLocale, surahNumber)),
+});
+
 /** Returns the exact signed fields rendered by Quran markdown consumers. */
 export const markdown = query({
   args: {
@@ -120,6 +138,18 @@ export const markdownV2 = query({
     ),
 });
 
+/** Returns one signed Quran surah as semantic Markdown source fields. */
+export const prose = query({
+  args: {
+    appLocale: quranAppLocaleValidator,
+    surahNumber: v.number(),
+    verseLimit: v.optional(v.number()),
+  },
+  returns: quranProseValidator,
+  handler: (ctx, { appLocale, surahNumber, verseLimit }) =>
+    runConvexProgram(readQuranProse(ctx, appLocale, surahNumber, verseLimit)),
+});
+
 /** Returns the narrow locale-specific Quran projection used by the web UI. */
 export const view = query({
   args: { appLocale: quranAppLocaleValidator, surahNumber: v.number() },
@@ -134,6 +164,14 @@ export const viewV2 = query({
   returns: quranViewValidator,
   handler: (ctx, { appLocale, surahNumber }) =>
     runConvexProgram(readQuranView(ctx, appLocale, surahNumber)),
+});
+
+/** Returns the signed Quran page projection used by the web product. */
+export const page = query({
+  args: { appLocale: quranAppLocaleValidator, surahNumber: v.number() },
+  returns: quranPageValidator,
+  handler: (ctx, { appLocale, surahNumber }) =>
+    runConvexProgram(readQuranPage(ctx, appLocale, surahNumber)),
 });
 
 /** Returns one exact signed tafsir only after the verse is requested. */
@@ -178,6 +216,27 @@ export const interpretationV2 = query({
     ),
 });
 
+/** Returns one exact signed Tafsir entry after the verse is requested. */
+export const tafsir = query({
+  args: {
+    expectedSnapshotId: v.string(),
+    appLocale: quranTafsirAppLocaleValidator,
+    surahNumber: v.number(),
+    verseNumber: v.number(),
+  },
+  returns: quranInterpretationValidator,
+  handler: (ctx, { appLocale, expectedSnapshotId, surahNumber, verseNumber }) =>
+    runConvexProgram(
+      readQuranInterpretation(
+        ctx,
+        appLocale,
+        expectedSnapshotId,
+        surahNumber,
+        verseNumber
+      )
+    ),
+});
+
 /** Returns one bounded localized Quran verse reference. */
 export const reference = query({
   args: quranReferenceArgsValidator.fields,
@@ -190,4 +249,11 @@ export const referenceV2 = query({
   args: quranReferenceArgsValidator.fields,
   returns: referenceValidator,
   handler: (ctx, args) => runConvexProgram(readQuranReference(ctx, args)),
+});
+
+/** Returns one bounded signed Quran passage with semantic provenance. */
+export const passage = query({
+  args: quranReferenceArgsValidator.fields,
+  returns: quranPassageValidator,
+  handler: (ctx, args) => runConvexProgram(readQuranPassage(ctx, args)),
 });

--- a/packages/backend/convex/contentRelease/quran/bismillah.ts
+++ b/packages/backend/convex/contentRelease/quran/bismillah.ts
@@ -4,6 +4,7 @@ import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { quranChunkIdentity } from "@repo/backend/convex/contentRelease/quran/facts";
 import { readQuranRow } from "@repo/backend/convex/contentRelease/quran/row";
+import { quranTranslationDocumentValidator } from "@repo/backend/convex/contentRelease/quran/spec";
 import { readQuranTranslationDocument } from "@repo/backend/convex/contentRelease/quran/translation";
 import { v } from "convex/values";
 import { Effect } from "effect";
@@ -15,7 +16,7 @@ const SURAH_WITHOUT_OPENING_BISMILLAH = 9;
 /** Exact signed Bismillah presentation projected from Al-Fatihah verse 1. */
 export const quranBismillahValidator = v.object({
   arabic: v.string(),
-  translation: v.string(),
+  translation: quranTranslationDocumentValidator,
 });
 
 /** Reads one locale's canonical Bismillah from authenticated source rows. */
@@ -54,19 +55,7 @@ export const readQuranBismillah = Effect.fn(
     );
   }
   const { document } = yield* readQuranTranslationDocument(verse, appLocale);
-  const [translation] = document.segments;
-  if (
-    document.notes.length !== 0 ||
-    document.segments.length !== 1 ||
-    translation === undefined ||
-    translation.kind !== "text"
-  ) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `The signed Quran Bismillah has unsupported ${appLocale} translation notes.`
-    );
-  }
-  return { arabic: verse.text.arabic, translation: translation.value };
+  return { arabic: verse.text.arabic, translation: document };
 });
 
 /** Fails closed when a surah expected to have a Bismillah cannot be split. */

--- a/packages/backend/convex/contentRelease/quran/bismillah.ts
+++ b/packages/backend/convex/contentRelease/quran/bismillah.ts
@@ -1,0 +1,82 @@
+import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
+import { QuranChunkRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { quranChunkIdentity } from "@repo/backend/convex/contentRelease/quran/facts";
+import { readQuranRow } from "@repo/backend/convex/contentRelease/quran/row";
+import { readQuranTranslationDocument } from "@repo/backend/convex/contentRelease/quran/translation";
+import { v } from "convex/values";
+import { Effect } from "effect";
+
+const BISMILLAH_SURAH_NUMBER = 1;
+const BISMILLAH_VERSE_NUMBER = 1;
+const SURAH_WITHOUT_OPENING_BISMILLAH = 9;
+
+/** Exact signed Bismillah presentation projected from Al-Fatihah verse 1. */
+export const quranBismillahValidator = v.object({
+  arabic: v.string(),
+  translation: v.string(),
+});
+
+/** Reads one locale's canonical Bismillah from authenticated source rows. */
+export const readQuranBismillah = Effect.fn(
+  "contentRelease.readQuranBismillah"
+)(function* (
+  ctx: QueryCtx,
+  snapshotId: string,
+  appLocale: AppLocaleCode,
+  surahNumber: number,
+  fromVerse: number
+) {
+  if (
+    fromVerse !== BISMILLAH_VERSE_NUMBER ||
+    surahNumber === BISMILLAH_SURAH_NUMBER ||
+    surahNumber === SURAH_WITHOUT_OPENING_BISMILLAH
+  ) {
+    return null;
+  }
+  const row = yield* readQuranRow(
+    ctx,
+    snapshotId,
+    quranChunkIdentity(BISMILLAH_SURAH_NUMBER, BISMILLAH_VERSE_NUMBER),
+    QuranChunkRowSchema
+  );
+  const verse = row.payload.verses[0];
+  if (
+    row.payload.surahNumber !== BISMILLAH_SURAH_NUMBER ||
+    row.payload.firstVerse !== BISMILLAH_VERSE_NUMBER ||
+    verse === undefined ||
+    verse.number.inSurah !== BISMILLAH_VERSE_NUMBER
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "The signed Quran Bismillah identity is inconsistent."
+    );
+  }
+  const { document } = yield* readQuranTranslationDocument(verse, appLocale);
+  const [translation] = document.segments;
+  if (
+    document.notes.length !== 0 ||
+    document.segments.length !== 1 ||
+    translation === undefined ||
+    translation.kind !== "text"
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `The signed Quran Bismillah has unsupported ${appLocale} translation notes.`
+    );
+  }
+  return { arabic: verse.text.arabic, translation: translation.value };
+});
+
+/** Fails closed when a surah expected to have a Bismillah cannot be split. */
+export const verifyQuranBismillah = Effect.fn(
+  "contentRelease.verifyQuranBismillah"
+)(function* (expected: object | null, projected: object | null) {
+  if (expected !== null && projected === null) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "The signed Quran Bismillah prefix is inconsistent."
+    );
+  }
+});

--- a/packages/backend/convex/contentRelease/quran/document.ts
+++ b/packages/backend/convex/contentRelease/quran/document.ts
@@ -1,7 +1,13 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import {
+  quranBismillahValidator,
+  readQuranBismillah,
+  verifyQuranBismillah,
+} from "@repo/backend/convex/contentRelease/quran/bismillah";
 import { readQuranLocaleSources } from "@repo/backend/convex/contentRelease/quran/sources";
 import {
   quranAppLocaleValidator,
@@ -48,6 +54,12 @@ export const quranDocumentValidator = v.object({
   surah: v.union(quranDocumentSurahValidator, v.null()),
   tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
   verses: v.array(quranDocumentVerseValidator),
+});
+
+/** Bismillah-aware Quran document introduced before consumers switch. */
+export const quranSurahValidator = v.object({
+  ...quranDocumentValidator.fields,
+  preBismillah: v.union(quranBismillahValidator, v.null()),
 });
 
 type QuranDocument = Infer<typeof quranDocumentValidator>;
@@ -145,6 +157,36 @@ export const readQuranDocument = Effect.fn("contentRelease.readQuranDocument")(
       surah:
         loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
       verses: loaded.verses.map(({ arabic, document, number }) => ({
+        arabic,
+        number,
+        translation: document,
+      })),
+    };
+  }
+);
+
+/** Returns the Bismillah-aware Quran document without changing prior contracts. */
+export const readQuranSurah = Effect.fn("contentRelease.readQuranSurah")(
+  function* (ctx: QueryCtx, appLocale: AppLocaleCode, sourceSurah: number) {
+    const loaded = yield* loadQuranDocument(ctx, appLocale, sourceSurah);
+    const bismillah =
+      loaded.snapshotId === null
+        ? null
+        : yield* readQuranBismillah(
+            ctx,
+            loaded.snapshotId,
+            appLocale,
+            sourceSurah,
+            1
+          );
+    const projected = separateQuranBismillah(bismillah, loaded.verses);
+    yield* verifyQuranBismillah(bismillah, projected.preBismillah);
+    return {
+      ...loaded,
+      preBismillah: projected.preBismillah,
+      surah:
+        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,
         translation: document,

--- a/packages/backend/convex/contentRelease/quran/facts.ts
+++ b/packages/backend/convex/contentRelease/quran/facts.ts
@@ -22,6 +22,11 @@ export function quranSearchIdentity(
   return `search:${appLocale}:${surahNumber}`;
 }
 
+/** Derives the canonical identity for one immutable Quran chunk row. */
+export function quranChunkIdentity(surahNumber: number, firstVerse: number) {
+  return `chunk:${surahNumber}:${firstVerse}`;
+}
+
 /** Derives the immutable indexed facts stored beside one signed Quran row. */
 export function quranRowFacts(record: QuranSnapshotRow): QuranRowFacts {
   const { payload } = record;
@@ -41,7 +46,7 @@ export function quranRowFacts(record: QuranSnapshotRow): QuranRowFacts {
   if (payload.kind === "quran-chunk") {
     return {
       firstVerse: payload.firstVerse,
-      identity: `chunk:${payload.surahNumber}:${payload.firstVerse}`,
+      identity: quranChunkIdentity(payload.surahNumber, payload.firstVerse),
       kind: payload.kind,
       surahNumber: payload.surahNumber,
     };

--- a/packages/backend/convex/contentRelease/quran/markdown.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.ts
@@ -1,8 +1,14 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  quranBismillahValidator,
+  readQuranBismillah,
+  verifyQuranBismillah,
+} from "@repo/backend/convex/contentRelease/quran/bismillah";
 import { readQuranLocaleSources } from "@repo/backend/convex/contentRelease/quran/sources";
 import {
   quranAppLocaleValidator,
@@ -45,6 +51,12 @@ export const quranMarkdownValidator = v.object({
   tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
   toVerse: v.number(),
   verses: v.array(quranMarkdownVerseValidator),
+});
+
+/** Bismillah-aware Quran prose introduced before consumers switch. */
+export const quranProseValidator = v.object({
+  ...quranMarkdownValidator.fields,
+  preBismillah: v.union(quranBismillahValidator, v.null()),
 });
 
 export type QuranMarkdown = Infer<typeof quranMarkdownValidator>;
@@ -177,6 +189,46 @@ export const readQuranMarkdown = Effect.fn("contentRelease.readQuranMarkdown")(
       surah:
         loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
       verses: loaded.verses.map(({ arabic, document, number }) => ({
+        arabic,
+        number,
+        translation: document,
+      })),
+    };
+  }
+);
+
+/** Returns Bismillah-aware Quran prose without changing prior contracts. */
+export const readQuranProse = Effect.fn("contentRelease.readQuranProse")(
+  function* (
+    ctx: QueryCtx,
+    appLocale: AppLocaleCode,
+    sourceSurah: number,
+    sourceVerseLimit?: number
+  ) {
+    const loaded = yield* loadQuranMarkdown(
+      ctx,
+      appLocale,
+      sourceSurah,
+      sourceVerseLimit
+    );
+    const bismillah =
+      loaded.snapshotId === null
+        ? null
+        : yield* readQuranBismillah(
+            ctx,
+            loaded.snapshotId,
+            appLocale,
+            sourceSurah,
+            1
+          );
+    const projected = separateQuranBismillah(bismillah, loaded.verses);
+    yield* verifyQuranBismillah(bismillah, projected.preBismillah);
+    return {
+      ...loaded,
+      preBismillah: projected.preBismillah,
+      surah:
+        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,
         translation: document,

--- a/packages/backend/convex/contentRelease/quran/reference.ts
+++ b/packages/backend/convex/contentRelease/quran/reference.ts
@@ -24,17 +24,22 @@ import { readQuranSurahRow } from "@repo/backend/convex/contentRelease/quran/sur
 import { v } from "convex/values";
 import { Effect } from "effect";
 
-/** Bismillah-aware bounded passage introduced before consumers switch. */
-export const quranPassageValidator = v.object({
+/** Existing bounded reference wire contract retained during expansion. */
+export const quranReferenceValidator = v.object({
   ...quranSourceFields,
   chunkJson: v.array(v.string()),
   fromVerse: v.number(),
-  preBismillah: v.union(quranBismillahValidator, v.null()),
   searchJson: v.union(v.string(), v.null()),
   sources: v.union(quranReadingSourcesValidator, v.null()),
   surahJson: v.union(v.string(), v.null()),
   tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
   toVerse: v.number(),
+});
+
+/** Bismillah-aware bounded passage introduced before consumers switch. */
+export const quranPassageValidator = v.object({
+  ...quranReferenceValidator.fields,
+  preBismillah: v.union(quranBismillahValidator, v.null()),
 });
 
 type QuranReferenceSourceRequest = Omit<QuranReferenceArgs, "appLocale"> & {

--- a/packages/backend/convex/contentRelease/quran/reference.ts
+++ b/packages/backend/convex/contentRelease/quran/reference.ts
@@ -1,6 +1,12 @@
 import { QuranSearchRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
+import { separateQuranRuntimeBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  quranBismillahValidator,
+  readQuranBismillah,
+  verifyQuranBismillah,
+} from "@repo/backend/convex/contentRelease/quran/bismillah";
 import { readQuranChunks } from "@repo/backend/convex/contentRelease/quran/chunks";
 import { quranSearchIdentity } from "@repo/backend/convex/contentRelease/quran/facts";
 import { validateQuranReference } from "@repo/backend/convex/contentRelease/quran/input";
@@ -8,9 +14,28 @@ import { QURAN_PAGE_VERSE_LIMIT } from "@repo/backend/convex/contentRelease/qura
 import { loadQuranOwner } from "@repo/backend/convex/contentRelease/quran/owner";
 import { readQuranRow } from "@repo/backend/convex/contentRelease/quran/row";
 import { readQuranLocaleSources } from "@repo/backend/convex/contentRelease/quran/sources";
-import type { QuranReferenceArgs } from "@repo/backend/convex/contentRelease/quran/spec";
+import {
+  type QuranReferenceArgs,
+  quranReadingSourcesValidator,
+  quranSourceFields,
+  quranTafsirAccessValidator,
+} from "@repo/backend/convex/contentRelease/quran/spec";
 import { readQuranSurahRow } from "@repo/backend/convex/contentRelease/quran/surah";
+import { v } from "convex/values";
 import { Effect } from "effect";
+
+/** Bismillah-aware bounded passage introduced before consumers switch. */
+export const quranPassageValidator = v.object({
+  ...quranSourceFields,
+  chunkJson: v.array(v.string()),
+  fromVerse: v.number(),
+  preBismillah: v.union(quranBismillahValidator, v.null()),
+  searchJson: v.union(v.string(), v.null()),
+  sources: v.union(quranReadingSourcesValidator, v.null()),
+  surahJson: v.union(v.string(), v.null()),
+  tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
+  toVerse: v.number(),
+});
 
 type QuranReferenceSourceRequest = Omit<QuranReferenceArgs, "appLocale"> & {
   readonly expectedSnapshotId: null | string;
@@ -153,3 +178,72 @@ export const readQuranReference = Effect.fn(
     toVerse: loaded.input.toVerse,
   };
 });
+
+/** Returns a Bismillah-aware Quran passage without changing prior contracts. */
+export const readQuranPassage = Effect.fn("contentRelease.readQuranPassage")(
+  function* (ctx: QueryCtx, request: QuranReferenceArgs) {
+    const loaded = yield* loadQuranPassage(ctx, {
+      expectedSnapshotId: null,
+      fromVerse: request.fromVerse,
+      surahNumber: request.surahNumber,
+      toVerse: request.toVerse,
+    });
+    if (loaded.passage === null || loaded.owner.snapshotId === null) {
+      return {
+        ...loaded.owner,
+        chunkJson: [],
+        fromVerse: loaded.input.fromVerse,
+        preBismillah: null,
+        searchJson: null,
+        sources: null,
+        surahJson: null,
+        tafsirAccess: null,
+        toVerse: loaded.input.toVerse,
+      };
+    }
+    const { bismillah, localeSources, search } = yield* Effect.all(
+      {
+        bismillah: readQuranBismillah(
+          ctx,
+          loaded.owner.snapshotId,
+          request.appLocale,
+          loaded.input.surahNumber,
+          loaded.input.fromVerse
+        ),
+        localeSources: readQuranLocaleSources(
+          ctx,
+          loaded.owner.snapshotId,
+          request.appLocale
+        ),
+        search: readQuranRow(
+          ctx,
+          loaded.owner.snapshotId,
+          quranSearchIdentity(request.appLocale, loaded.input.surahNumber),
+          QuranSearchRowSchema
+        ),
+      },
+      { concurrency: "unbounded" }
+    );
+    const selectedVerses = loaded.passage.chunks.rows
+      .flatMap((chunk) => chunk.verses)
+      .filter(
+        (verse) =>
+          verse.number.inSurah >= loaded.input.fromVerse &&
+          verse.number.inSurah <= loaded.input.toVerse
+      );
+    const projected = separateQuranRuntimeBismillah(bismillah, selectedVerses);
+    yield* verifyQuranBismillah(bismillah, projected.preBismillah);
+
+    return {
+      ...loaded.owner,
+      chunkJson: loaded.passage.chunks.rowJson,
+      fromVerse: loaded.input.fromVerse,
+      preBismillah: projected.preBismillah,
+      searchJson: search.rowJson,
+      sources: localeSources.sources,
+      surahJson: loaded.passage.surah.rowJson,
+      tafsirAccess: localeSources.tafsirAccess,
+      toVerse: loaded.input.toVerse,
+    };
+  }
+);

--- a/packages/backend/convex/contentRelease/quran/view.ts
+++ b/packages/backend/convex/contentRelease/quran/view.ts
@@ -4,7 +4,13 @@ import {
   QURAN_SURAH_COUNT,
   type QuranSurahRow,
 } from "@nakafa/aksara-contracts/quran/spec";
+import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import {
+  quranBismillahValidator,
+  readQuranBismillah,
+  verifyQuranBismillah,
+} from "@repo/backend/convex/contentRelease/quran/bismillah";
 import { readQuranLocaleSources } from "@repo/backend/convex/contentRelease/quran/sources";
 import {
   quranAppLocaleValidator,
@@ -52,6 +58,12 @@ export const quranViewValidator = v.object({
   surah: v.union(quranViewSurahValidator, v.null()),
   tafsirAccess: v.union(quranTafsirAccessValidator, v.null()),
   verses: v.array(quranViewVerseValidator),
+});
+
+/** Bismillah-aware Quran page introduced before consumers switch. */
+export const quranPageValidator = v.object({
+  ...quranViewValidator.fields,
+  preBismillah: v.union(quranBismillahValidator, v.null()),
 });
 
 type QuranView = Infer<typeof quranViewValidator>;
@@ -181,6 +193,44 @@ export const readQuranView = Effect.fn("contentRelease.readQuranView")(
       surah:
         loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
       verses: loaded.verses.map(({ arabic, document, number }) => ({
+        arabic,
+        number,
+        translation: document,
+      })),
+    };
+  }
+);
+
+/** Returns the Bismillah-aware Quran page without changing prior contracts. */
+export const readQuranPage = Effect.fn("contentRelease.readQuranPage")(
+  function* (ctx: QueryCtx, appLocale: AppLocaleCode, sourceSurah: number) {
+    const loaded = yield* loadQuranView(ctx, appLocale, sourceSurah);
+    const bismillah =
+      loaded.snapshotId === null
+        ? null
+        : yield* readQuranBismillah(
+            ctx,
+            loaded.snapshotId,
+            appLocale,
+            sourceSurah,
+            1
+          );
+    const projected = separateQuranBismillah(bismillah, loaded.verses);
+    yield* verifyQuranBismillah(bismillah, projected.preBismillah);
+    return {
+      ...loaded,
+      nextSurah:
+        loaded.nextSurah === null
+          ? null
+          : projectSurah(loaded.nextSurah, appLocale),
+      preBismillah: projected.preBismillah,
+      previousSurah:
+        loaded.previousSurah === null
+          ? null
+          : projectSurah(loaded.previousSurah, appLocale),
+      surah:
+        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,
         translation: document,

--- a/packages/backend/test/quran/rows.ts
+++ b/packages/backend/test/quran/rows.ts
@@ -345,6 +345,7 @@ function makeQuranVerse(
 
 /** Creates one coherent immutable Quran chunk for protocol tests. */
 export function makeQuranChunk(input: {
+  readonly arabicText?: string;
   readonly firstQuranNumber: number;
   readonly firstVerse: number;
   readonly surahNumber: number;
@@ -354,14 +355,17 @@ export function makeQuranChunk(input: {
   readonly translationText?: Readonly<Partial<Record<AppLocaleCode, string>>>;
   readonly verseCount: number;
 }): QuranChunkRow {
-  const verses = Array.from({ length: input.verseCount }, (_, index) =>
-    makeQuranVerse(
+  const verses = Array.from({ length: input.verseCount }, (_, index) => {
+    const verse = makeQuranVerse(
       input.firstQuranNumber + index,
       input.firstVerse + index,
       input.translationFootnotes ?? {},
       input.translationText ?? {}
-    )
-  );
+    );
+    return index === 0 && input.arabicText !== undefined
+      ? { ...verse, text: { ...verse.text, arabic: input.arabicText } }
+      : verse;
+  });
   return Schema.decodeUnknownSync(QuranChunkRowSchema)({
     firstQuranNumber: input.firstQuranNumber,
     firstVerse: input.firstVerse,


### PR DESCRIPTION
## Summary

- add authenticated Bismillah extraction from the signed Al-Fatihah row
- preserve the complete typed Bismillah translation document, including reviewed notes and segments
- add byte-preserving separation so Al-Baqarah verse 1 is exactly `الٓمٓ`
- expand the semantic Convex queries `surah`, `prose`, `page`, `tafsir`, and `passage`
- preserve every predecessor and `*V2` query response unchanged during rollout

## Rollout

This is the additive expand step required before PR #390 switches consumers. It intentionally does not change any deployed consumer or remove any prior query. After this reaches production, PR #390 can switch to the semantic queries without its Next production build racing the Convex deployment.

## Verification

- `pnpm --filter @repo/backend exec vitest run content/quran convex/contentRelease/quran client/quran`: 34 files, 114 tests passed
- `pnpm --filter @repo/backend typecheck`: passed
- `pnpm lint`: passed
- compatibility coverage proves prior responses retain Bismillah inside verse 1 with no new field while semantic responses expose a typed `preBismillah`, preserve translation footnotes, and return exact `الٓمٓ`

No Vercel Preview is requested or permitted.