### PR TITLE
test(www): adopt native Effect Vitest in domain libraries

### DIFF
--- a/apps/www/lib/analytics/consent/signal.test.ts
+++ b/apps/www/lib/analytics/consent/signal.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_BROWSER_SIGNAL_MECHANISM,
   ANALYTICS_CONSENT_CATEGORY,
@@ -8,7 +9,6 @@ import {
 } from "@repo/analytics/consent";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "@repo/testing/effect";
 import type { FunctionReturnType } from "convex/server";
 import { ConvexError } from "convex/values";
 import { Duration, Effect, Fiber, Option } from "effect";

--- a/apps/www/lib/analytics/consent/storage.test.ts
+++ b/apps/www/lib/analytics/consent/storage.test.ts
@@ -1,9 +1,9 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY,
   createAnonymousAnalyticsConsent,
 } from "@repo/analytics/consent";
 import { Effect, Option } from "effect";
-import { beforeEach, describe, expect, it } from "vitest";
 import {
   AnalyticsConsentStorageFailed,
   loadAnonymousAnalyticsConsent,
@@ -17,67 +17,76 @@ describe("anonymous analytics consent storage", () => {
     window.localStorage.clear();
   });
 
-  it("returns no decision before the visitor chooses", async () => {
-    const loaded = await Effect.runPromise(loadAnonymousAnalyticsConsent());
+  it.effect("returns no decision before the visitor chooses", () =>
+    Effect.gen(function* () {
+      const loaded = yield* loadAnonymousAnalyticsConsent();
 
-    expect(Option.isNone(loaded)).toBe(true);
-  });
+      expect(Option.isNone(loaded)).toBe(true);
+    })
+  );
 
-  it("persists and reloads an explicit decision", async () => {
-    await Effect.runPromise(saveAnonymousAnalyticsConsent(consent));
+  it.effect("persists and reloads an explicit decision", () =>
+    Effect.gen(function* () {
+      yield* saveAnonymousAnalyticsConsent(consent);
 
-    const loaded = await Effect.runPromise(loadAnonymousAnalyticsConsent());
+      const loaded = yield* loadAnonymousAnalyticsConsent();
 
-    expect(Option.getOrUndefined(loaded)).toEqual(consent);
-    expect(
-      window.localStorage.getItem(ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY)
-    ).toContain("granted");
-  });
+      expect(Option.getOrUndefined(loaded)).toEqual(consent);
+      expect(
+        window.localStorage.getItem(ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY)
+      ).toContain("granted");
+    })
+  );
 
-  it("fails closed for malformed persisted state", async () => {
-    window.localStorage.setItem(
-      ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY,
-      "not-json"
-    );
+  it.effect("fails closed for malformed persisted state", () =>
+    Effect.gen(function* () {
+      window.localStorage.setItem(
+        ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY,
+        "not-json"
+      );
 
-    const loaded = await Effect.runPromise(loadAnonymousAnalyticsConsent());
+      const loaded = yield* loadAnonymousAnalyticsConsent();
 
-    expect(Option.isNone(loaded)).toBe(true);
-  });
+      expect(Option.isNone(loaded)).toBe(true);
+    })
+  );
 
-  it("fails with a typed error when storage is unavailable", async () => {
-    const unavailableStorage = {
-      getItem: () => {
-        throw new Error("storage unavailable");
-      },
-      setItem: () => {
-        throw new Error("storage unavailable");
-      },
-    };
+  it.effect("fails with a typed error when storage is unavailable", () =>
+    Effect.gen(function* () {
+      const unavailableStorage = {
+        getItem: () => {
+          throw new Error("storage unavailable");
+        },
+        setItem: () => {
+          throw new Error("storage unavailable");
+        },
+      };
 
-    const readFailure = await Effect.runPromise(
-      loadAnonymousAnalyticsConsent(unavailableStorage).pipe(Effect.flip)
-    );
-    const writeFailure = await Effect.runPromise(
-      saveAnonymousAnalyticsConsent(consent, unavailableStorage).pipe(
+      const readFailure = yield* loadAnonymousAnalyticsConsent(
+        unavailableStorage
+      ).pipe(Effect.flip);
+      const writeFailure = yield* saveAnonymousAnalyticsConsent(
+        consent,
+        unavailableStorage
+      ).pipe(Effect.flip);
+
+      expect(readFailure).toBeInstanceOf(AnalyticsConsentStorageFailed);
+      expect(writeFailure).toBeInstanceOf(AnalyticsConsentStorageFailed);
+    })
+  );
+
+  it.effect("fails with a typed error when a record cannot be encoded", () =>
+    Effect.gen(function* () {
+      const invalidConsent = {
+        ...consent,
+        decidedAt: Number.POSITIVE_INFINITY,
+      };
+
+      const failure = yield* saveAnonymousAnalyticsConsent(invalidConsent).pipe(
         Effect.flip
-      )
-    );
+      );
 
-    expect(readFailure).toBeInstanceOf(AnalyticsConsentStorageFailed);
-    expect(writeFailure).toBeInstanceOf(AnalyticsConsentStorageFailed);
-  });
-
-  it("fails with a typed error when a record cannot be encoded", async () => {
-    const invalidConsent = {
-      ...consent,
-      decidedAt: Number.POSITIVE_INFINITY,
-    };
-
-    const failure = await Effect.runPromise(
-      saveAnonymousAnalyticsConsent(invalidConsent).pipe(Effect.flip)
-    );
-
-    expect(failure).toBeInstanceOf(AnalyticsConsentStorageFailed);
-  });
+      expect(failure).toBeInstanceOf(AnalyticsConsentStorageFailed);
+    })
+  );
 });

--- a/apps/www/lib/analytics/server.test.ts
+++ b/apps/www/lib/analytics/server.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
@@ -29,13 +29,9 @@ vi.mock("next/server", () => ({
 }));
 
 /** Returns the single request-time task registered with Next.js `after`. */
-function getScheduledTask() {
-  const [task] = analyticsMocks.tasks;
-  if (!task) {
-    throw new Error("Expected one scheduled analytics task.");
-  }
-  return task;
-}
+const getScheduledTask = Effect.fn("www.analytics.test.getScheduledTask")(() =>
+  Effect.fromNullishOr(analyticsMocks.tasks[0])
+);
 
 describe("request-time server exception reporting", () => {
   beforeEach(() => {
@@ -48,7 +44,7 @@ describe("request-time server exception reporting", () => {
     analyticsMocks.isServerExceptionReportingEnabled.mockReturnValue(true);
   });
 
-  it.live("does not schedule outside the production runtime", () =>
+  it.effect("does not schedule outside the production runtime", () =>
     Effect.gen(function* () {
       analyticsMocks.isServerExceptionReportingEnabled.mockReturnValue(false);
 
@@ -66,25 +62,28 @@ describe("request-time server exception reporting", () => {
     })
   );
 
-  it.live("schedules the current operational exception without identity", () =>
-    Effect.gen(function* () {
-      const error = new Error("preload failed");
-      const properties = { source: "settings" };
+  it.effect(
+    "schedules the current operational exception without identity",
+    () =>
+      Effect.gen(function* () {
+        const error = new Error("preload failed");
+        const properties = { source: "settings" };
 
-      yield* scheduleCurrentServerExceptionCapture(error, properties);
+        yield* scheduleCurrentServerExceptionCapture(error, properties);
 
-      expect(analyticsMocks.captureServerException).not.toHaveBeenCalled();
+        expect(analyticsMocks.captureServerException).not.toHaveBeenCalled();
 
-      yield* Effect.promise(() => Promise.resolve(getScheduledTask()()));
+        const task = yield* getScheduledTask();
+        yield* Effect.promise(() => Promise.resolve(task()));
 
-      expect(analyticsMocks.captureServerException).toHaveBeenCalledWith(
-        error,
-        properties
-      );
-    })
+        expect(analyticsMocks.captureServerException).toHaveBeenCalledWith(
+          error,
+          properties
+        );
+      })
   );
 
-  it.live("schedules an explicitly provided operational exception", () =>
+  it.effect("schedules an explicitly provided operational exception", () =>
     Effect.gen(function* () {
       const error = new Error("weather failed");
 
@@ -92,7 +91,8 @@ describe("request-time server exception reporting", () => {
         source: "weather-api",
       });
 
-      yield* Effect.promise(() => Promise.resolve(getScheduledTask()()));
+      const task = yield* getScheduledTask();
+      yield* Effect.promise(() => Promise.resolve(task()));
       expect(analyticsMocks.captureServerException).toHaveBeenCalledWith(
         error,
         {
@@ -102,7 +102,7 @@ describe("request-time server exception reporting", () => {
     })
   );
 
-  it.live("contains provider failures inside the request task", () =>
+  it.effect("contains provider failures inside the request task", () =>
     Effect.gen(function* () {
       analyticsMocks.captureServerException.mockReturnValue(
         Effect.fail({ cause: new Error("provider unavailable") })
@@ -115,13 +115,12 @@ describe("request-time server exception reporting", () => {
         }
       );
 
-      yield* Effect.promise(() =>
-        expect(getScheduledTask()()).resolves.toBeUndefined()
-      );
+      const task = yield* getScheduledTask();
+      yield* Effect.promise(() => expect(task()).resolves.toBeUndefined());
     })
   );
 
-  it.live("contains request scheduling failures", () =>
+  it.effect("contains request scheduling failures", () =>
     Effect.gen(function* () {
       analyticsMocks.after.mockImplementation(() => {
         throw new Error("request already closed");

--- a/apps/www/lib/auth/deletion/attempt.test.ts
+++ b/apps/www/lib/auth/deletion/attempt.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { accountDeletionRequestPhase } from "@repo/backend/convex/auth/deletion/spec";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import {
   AccountDeletionAttemptStorageFailed,
@@ -16,7 +16,7 @@ describe("account deletion attempt", () => {
     window.sessionStorage.clear();
   });
 
-  it.live("creates and reloads one tab-owned browser capability", () =>
+  it.effect("creates and reloads one tab-owned browser capability", () =>
     Effect.gen(function* () {
       const created = yield* loadOrCreateAccountDeletionAttempt(USER_ID);
       const reloaded = yield* loadOrCreateAccountDeletionAttempt(USER_ID);
@@ -30,7 +30,7 @@ describe("account deletion attempt", () => {
     })
   );
 
-  it.live("persists the irreversible phase before auth deletion", () =>
+  it.effect("persists the irreversible phase before auth deletion", () =>
     Effect.gen(function* () {
       const deletionAttempt = {
         attemptId: ATTEMPT_ID,
@@ -46,7 +46,7 @@ describe("account deletion attempt", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "rotates a persisted capability when the signed-in account changes",
     () =>
       Effect.gen(function* () {
@@ -61,7 +61,7 @@ describe("account deletion attempt", () => {
       })
   );
 
-  it.live("rotates a capability after its cancellation is proven", () =>
+  it.effect("rotates a capability after its cancellation is proven", () =>
     Effect.gen(function* () {
       const canceled = yield* loadOrCreateAccountDeletionAttempt(USER_ID);
 
@@ -73,7 +73,7 @@ describe("account deletion attempt", () => {
     })
   );
 
-  it.live("fails closed when persisted state is malformed", () =>
+  it.effect("fails closed when persisted state is malformed", () =>
     Effect.gen(function* () {
       window.sessionStorage.setItem(
         "nakafa-account-deletion-attempt",
@@ -88,7 +88,7 @@ describe("account deletion attempt", () => {
     })
   );
 
-  it.live("fails closed when session storage is unavailable", () =>
+  it.effect("fails closed when session storage is unavailable", () =>
     Effect.gen(function* () {
       const unavailableStorage = {
         getItem: () => {

--- a/apps/www/lib/auth/deletion/delete.test.ts
+++ b/apps/www/lib/auth/deletion/delete.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ACCOUNT_DELETION_ATTEMPT_HEADER,
   ACCOUNT_DELETION_PREPARATION_INCOMPLETE_CODE,
@@ -9,9 +10,9 @@ import {
   accountDeletionPreparationOutcome,
   accountDeletionRequestPhase,
 } from "@repo/backend/convex/auth/deletion/spec";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
+import { authClient } from "@/lib/auth/client";
 import { deleteCurrentAccount } from "@/lib/auth/deletion/delete";
 import {
   AccountDeletionFailed,
@@ -21,8 +22,6 @@ import {
 } from "@/lib/auth/deletion/errors";
 
 type AccountDeletionOperations = Parameters<typeof deleteCurrentAccount>[0];
-
-import { authClient } from "@/lib/auth/client";
 
 vi.mock("@/lib/auth/client", () => ({
   authClient: {
@@ -43,27 +42,32 @@ function createDeletionOperations(
       phase: accountDeletionRequestPhase.preparation,
       userId: USER_ID,
     },
-    cancelPreparation: vi.fn(
-      async () => accountDeletionCancellationOutcome.complete
+    cancelPreparation: vi.fn(() =>
+      Promise.resolve(accountDeletionCancellationOutcome.complete)
     ),
     clearAttempt: Effect.void,
     persist: vi.fn(() => Effect.void),
-    prepare: vi.fn(async () => accountDeletionPreparationOutcome.ready),
-    reconcile: vi.fn(async () => accountDeletionAttemptStatus.pending),
+    prepare: vi.fn(() =>
+      Promise.resolve(accountDeletionPreparationOutcome.ready)
+    ),
+    reconcile: vi.fn(() =>
+      Promise.resolve(accountDeletionAttemptStatus.pending)
+    ),
     ...overrides,
   };
 }
 
 function requestFailure(code: string, status = 400) {
-  return async () => ({
-    data: null,
-    error: {
-      code,
-      message: code,
-      status,
-      statusText: "ERROR",
-    },
-  });
+  return () =>
+    Promise.resolve({
+      data: null,
+      error: {
+        code,
+        message: code,
+        status,
+        statusText: "ERROR",
+      },
+    });
 }
 
 function deletionFailure(overrides: Partial<AccountDeletionOperations>) {
@@ -77,7 +81,7 @@ describe("account deletion", () => {
     vi.clearAllMocks();
   });
 
-  it.live("completes when Better Auth deletes the account", () =>
+  it.effect("completes when Better Auth deletes the account", () =>
     Effect.gen(function* () {
       vi.mocked(authClient.deleteUser).mockResolvedValue({
         data: { message: "User deleted", success: true },
@@ -97,20 +101,21 @@ describe("account deletion", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "does not clear the account for a non-terminal Better Auth response",
     () =>
       Effect.gen(function* () {
-        const cancelPreparation = vi.fn(
-          async () => accountDeletionCancellationOutcome.complete
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
         );
         const failure = yield* deleteCurrentAccount(
           createDeletionOperations({
             cancelPreparation,
-            request: async () => ({
-              data: { message: "Verification email sent", success: true },
-              error: null,
-            }),
+            request: () =>
+              Promise.resolve({
+                data: { message: "Verification email sent", success: true },
+                error: null,
+              }),
           })
         ).pipe(Effect.flip);
 
@@ -119,12 +124,12 @@ describe("account deletion", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "skips completed preparation when retrying an uncertain auth delete",
     () =>
       Effect.gen(function* () {
-        const prepare = vi.fn(
-          async () => accountDeletionPreparationOutcome.ready
+        const prepare = vi.fn(() =>
+          Promise.resolve(accountDeletionPreparationOutcome.ready)
         );
         const failure = yield* deletionFailure({
           prepare,
@@ -141,10 +146,10 @@ describe("account deletion", () => {
       })
   );
 
-  it.live("completes a retry from its durable commit receipt", () =>
+  it.effect("completes a retry from its durable commit receipt", () =>
     Effect.gen(function* () {
-      const prepare = vi.fn(
-        async () => accountDeletionPreparationOutcome.ready
+      const prepare = vi.fn(() =>
+        Promise.resolve(accountDeletionPreparationOutcome.ready)
       );
       const request = vi.fn();
 
@@ -152,8 +157,8 @@ describe("account deletion", () => {
         yield* deleteCurrentAccount(
           createDeletionOperations({
             prepare,
-            reconcile: vi.fn(
-              async () => accountDeletionAttemptStatus.committed
+            reconcile: vi.fn(() =>
+              Promise.resolve(accountDeletionAttemptStatus.committed)
             ),
             request,
             attempt: {
@@ -169,18 +174,18 @@ describe("account deletion", () => {
     })
   );
 
-  it.live("recovers when the delete response is lost after commit", () =>
+  it.effect("recovers when the delete response is lost after commit", () =>
     Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
+      const cancelPreparation = vi.fn(() =>
+        Promise.resolve(accountDeletionCancellationOutcome.complete)
       );
 
       expect(
         yield* deleteCurrentAccount(
           createDeletionOperations({
             cancelPreparation,
-            reconcile: vi.fn(
-              async () => accountDeletionAttemptStatus.committed
+            reconcile: vi.fn(() =>
+              Promise.resolve(accountDeletionAttemptStatus.committed)
             ),
             request: () => Promise.reject(new Error("response unavailable")),
           })
@@ -190,36 +195,38 @@ describe("account deletion", () => {
     })
   );
 
-  it.live("proves a lost success before accepting an unauthorized retry", () =>
-    Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
-      );
-      const reconcile = vi
-        .fn<AccountDeletionOperations["reconcile"]>()
-        .mockResolvedValueOnce(accountDeletionAttemptStatus.pending)
-        .mockResolvedValueOnce(accountDeletionAttemptStatus.committed);
+  it.effect(
+    "proves a lost success before accepting an unauthorized retry",
+    () =>
+      Effect.gen(function* () {
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
+        );
+        const reconcile = vi
+          .fn<AccountDeletionOperations["reconcile"]>()
+          .mockResolvedValueOnce(accountDeletionAttemptStatus.pending)
+          .mockResolvedValueOnce(accountDeletionAttemptStatus.committed);
 
-      expect(
-        yield* deleteCurrentAccount(
-          createDeletionOperations({
-            cancelPreparation,
-            reconcile,
-            request: requestFailure("UNAUTHORIZED", 401),
-            attempt: {
-              attemptId: ATTEMPT_ID,
-              phase: accountDeletionRequestPhase.deletion,
-              userId: USER_ID,
-            },
-          })
-        )
-      ).toBeUndefined();
-      expect(reconcile).toHaveBeenCalledTimes(2);
-      expect(cancelPreparation).not.toHaveBeenCalled();
-    })
+        expect(
+          yield* deleteCurrentAccount(
+            createDeletionOperations({
+              cancelPreparation,
+              reconcile,
+              request: requestFailure("UNAUTHORIZED", 401),
+              attempt: {
+                attemptId: ATTEMPT_ID,
+                phase: accountDeletionRequestPhase.deletion,
+                userId: USER_ID,
+              },
+            })
+          )
+        ).toBeUndefined();
+        expect(reconcile).toHaveBeenCalledTimes(2);
+        expect(cancelPreparation).not.toHaveBeenCalled();
+      })
   );
 
-  it.live("keeps a deletion retry uncertain when proof is unavailable", () =>
+  it.effect("keeps a deletion retry uncertain when proof is unavailable", () =>
     Effect.gen(function* () {
       const request = vi.fn();
       const failure = yield* deleteCurrentAccount(
@@ -243,12 +250,12 @@ describe("account deletion", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "cancels before retrying when the auth safety check is not ready",
     () =>
       Effect.gen(function* () {
-        const cancelPreparation = vi.fn(
-          async () => accountDeletionCancellationOutcome.complete
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
         );
         const clearAttempt = vi.fn();
         const failure = yield* deletionFailure({
@@ -267,10 +274,10 @@ describe("account deletion", () => {
       })
   );
 
-  it.live("rotates an attempt canceled by background recovery", () =>
+  it.effect("rotates an attempt canceled by background recovery", () =>
     Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
+      const cancelPreparation = vi.fn(() =>
+        Promise.resolve(accountDeletionCancellationOutcome.complete)
       );
       const clearAttempt = vi.fn();
       const failure = yield* deletionFailure({
@@ -294,7 +301,7 @@ describe("account deletion", () => {
     })
   );
 
-  it.live("returns a typed stale-session failure", () =>
+  it.effect("returns a typed stale-session failure", () =>
     Effect.gen(function* () {
       const failure = yield* deletionFailure({
         request: requestFailure("SESSION_EXPIRED"),
@@ -304,28 +311,30 @@ describe("account deletion", () => {
     })
   );
 
-  it.live("drains cancellation before resetting a stale-session attempt", () =>
-    Effect.gen(function* () {
-      const cancelPreparation = vi
-        .fn<AccountDeletionOperations["cancelPreparation"]>()
-        .mockResolvedValueOnce(accountDeletionCancellationOutcome.continue)
-        .mockResolvedValueOnce(accountDeletionCancellationOutcome.complete);
-      const failure = yield* deletionFailure({
-        cancelPreparation,
-        request: requestFailure("SESSION_EXPIRED"),
-      });
+  it.effect(
+    "drains cancellation before resetting a stale-session attempt",
+    () =>
+      Effect.gen(function* () {
+        const cancelPreparation = vi
+          .fn<AccountDeletionOperations["cancelPreparation"]>()
+          .mockResolvedValueOnce(accountDeletionCancellationOutcome.continue)
+          .mockResolvedValueOnce(accountDeletionCancellationOutcome.complete);
+        const failure = yield* deletionFailure({
+          cancelPreparation,
+          request: requestFailure("SESSION_EXPIRED"),
+        });
 
-      expect(failure).toBeInstanceOf(AccountDeletionSessionExpired);
-      expect(cancelPreparation).toHaveBeenCalledTimes(2);
-      expect(cancelPreparation).toHaveBeenNthCalledWith(1, ATTEMPT_ID);
-      expect(cancelPreparation).toHaveBeenNthCalledWith(2, ATTEMPT_ID);
-    })
+        expect(failure).toBeInstanceOf(AccountDeletionSessionExpired);
+        expect(cancelPreparation).toHaveBeenCalledTimes(2);
+        expect(cancelPreparation).toHaveBeenNthCalledWith(1, ATTEMPT_ID);
+        expect(cancelPreparation).toHaveBeenNthCalledWith(2, ATTEMPT_ID);
+      })
   );
 
-  it.live("leaves other delete errors to durable server recovery", () =>
+  it.effect("leaves other delete errors to durable server recovery", () =>
     Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
+      const cancelPreparation = vi.fn(() =>
+        Promise.resolve(accountDeletionCancellationOutcome.complete)
       );
       const failure = yield* deletionFailure({
         cancelPreparation,
@@ -341,12 +350,12 @@ describe("account deletion", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "returns a typed failure when an owned school needs a successor",
     () =>
       Effect.gen(function* () {
-        const cancelPreparation = vi.fn(
-          async () => accountDeletionCancellationOutcome.complete
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
         );
         const clearAttempt = vi.fn();
         const failure = yield* deletionFailure({
@@ -361,23 +370,25 @@ describe("account deletion", () => {
       })
   );
 
-  it.live("preserves the attempt when immediate cancellation also fails", () =>
-    Effect.gen(function* () {
-      const failure = yield* deletionFailure({
-        cancelPreparation: () =>
-          Promise.reject(new Error("cancellation unavailable")),
-        request: requestFailure("SESSION_EXPIRED"),
-      });
+  it.effect(
+    "preserves the attempt when immediate cancellation also fails",
+    () =>
+      Effect.gen(function* () {
+        const failure = yield* deletionFailure({
+          cancelPreparation: () =>
+            Promise.reject(new Error("cancellation unavailable")),
+          request: requestFailure("SESSION_EXPIRED"),
+        });
 
-      expect(failure).toMatchObject({
-        _tag: "AccountDeletionRequestUncertain",
-        attemptId: ATTEMPT_ID,
-        phase: accountDeletionRequestPhase.deletion,
-      });
-    })
+        expect(failure).toMatchObject({
+          _tag: "AccountDeletionRequestUncertain",
+          attemptId: ATTEMPT_ID,
+          phase: accountDeletionRequestPhase.deletion,
+        });
+      })
   );
 
-  it.live(
+  it.effect(
     "leaves uncertain transport failures to durable server recovery",
     () =>
       Effect.gen(function* () {

--- a/apps/www/lib/auth/deletion/prepare.test.ts
+++ b/apps/www/lib/auth/deletion/prepare.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   accountDeletionCancellationOutcome,
   accountDeletionPreparationOutcome,
   accountDeletionRequestPhase,
 } from "@repo/backend/convex/auth/deletion/spec";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import { AccountDeletionAttemptStorageFailed } from "@/lib/auth/deletion/attempt";
@@ -30,12 +30,14 @@ function createPreparationOperations(
       phase: accountDeletionRequestPhase.preparation,
       userId: USER_ID,
     },
-    cancelPreparation: vi.fn(
-      async () => accountDeletionCancellationOutcome.complete
+    cancelPreparation: vi.fn(() =>
+      Promise.resolve(accountDeletionCancellationOutcome.complete)
     ),
     clearAttempt: Effect.void,
     persist: vi.fn(() => Effect.void),
-    prepare: vi.fn(async () => accountDeletionPreparationOutcome.ready),
+    prepare: vi.fn(() =>
+      Promise.resolve(accountDeletionPreparationOutcome.ready)
+    ),
     ...overrides,
   };
 }
@@ -49,7 +51,7 @@ function preparationFailure(
 }
 
 describe("account deletion preparation", () => {
-  it.live(
+  it.effect(
     "drains every bounded preparation request before persisting deletion",
     () =>
       Effect.gen(function* () {
@@ -80,11 +82,11 @@ describe("account deletion preparation", () => {
       })
   );
 
-  it.live("continues the browser-persisted attempt after a page reload", () =>
+  it.effect("continues the browser-persisted attempt after a page reload", () =>
     Effect.gen(function* () {
       const persistedAttemptId = "019fa44c-02be-7cd0-a4ed-61a7af8e0621";
-      const prepare = vi.fn(
-        async () => accountDeletionPreparationOutcome.ready
+      const prepare = vi.fn(() =>
+        Promise.resolve(accountDeletionPreparationOutcome.ready)
       );
 
       yield* prepareAccountDeletion(
@@ -102,15 +104,15 @@ describe("account deletion preparation", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "cancels before deletion when its durable phase cannot be saved",
     () =>
       Effect.gen(function* () {
-        const cancelPreparation = vi.fn(
-          async () => accountDeletionCancellationOutcome.complete
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
         );
-        const prepare = vi.fn(
-          async () => accountDeletionPreparationOutcome.ready
+        const prepare = vi.fn(() =>
+          Promise.resolve(accountDeletionPreparationOutcome.ready)
         );
         const failure = yield* preparationFailure({
           cancelPreparation,
@@ -129,12 +131,12 @@ describe("account deletion preparation", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "preserves the attempt when the preparation response is uncertain",
     () =>
       Effect.gen(function* () {
-        const cancelPreparation = vi.fn(
-          async () => accountDeletionCancellationOutcome.complete
+        const cancelPreparation = vi.fn(() =>
+          Promise.resolve(accountDeletionCancellationOutcome.complete)
         );
         const failure = yield* preparationFailure({
           cancelPreparation,
@@ -151,17 +153,19 @@ describe("account deletion preparation", () => {
       })
   );
 
-  it.live("cancels when an owned school needs a successor", () =>
+  it.effect("cancels when an owned school needs a successor", () =>
     Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
+      const cancelPreparation = vi.fn(() =>
+        Promise.resolve(accountDeletionCancellationOutcome.complete)
       );
       const clearAttempt = vi.fn();
       const failure = yield* preparationFailure({
         cancelPreparation,
         clearAttempt: Effect.sync(clearAttempt),
-        prepare: vi.fn(
-          async () => accountDeletionPreparationOutcome.schoolSuccessorRequired
+        prepare: vi.fn(() =>
+          Promise.resolve(
+            accountDeletionPreparationOutcome.schoolSuccessorRequired
+          )
         ),
       });
 
@@ -171,17 +175,19 @@ describe("account deletion preparation", () => {
     })
   );
 
-  it.live("cancels a preparation that cannot safely continue", () =>
+  it.effect("cancels a preparation that cannot safely continue", () =>
     Effect.gen(function* () {
-      const cancelPreparation = vi.fn(
-        async () => accountDeletionCancellationOutcome.complete
+      const cancelPreparation = vi.fn(() =>
+        Promise.resolve(accountDeletionCancellationOutcome.complete)
       );
       const clearAttempt = vi.fn();
       const failure = yield* preparationFailure({
         cancelPreparation,
         clearAttempt: Effect.sync(clearAttempt),
-        prepare: vi.fn(
-          async () => accountDeletionPreparationOutcome.temporarilyUnavailable
+        prepare: vi.fn(() =>
+          Promise.resolve(
+            accountDeletionPreparationOutcome.temporarilyUnavailable
+          )
         ),
       });
 
@@ -191,7 +197,7 @@ describe("account deletion preparation", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "fails closed when a canceled browser capability cannot be removed",
     () =>
       Effect.gen(function* () {
@@ -201,8 +207,10 @@ describe("account deletion preparation", () => {
               code: STORAGE_FAILED_CODE,
             })
           ),
-          prepare: vi.fn(
-            async () => accountDeletionPreparationOutcome.temporarilyUnavailable
+          prepare: vi.fn(() =>
+            Promise.resolve(
+              accountDeletionPreparationOutcome.temporarilyUnavailable
+            )
           ),
         });
 

--- a/apps/www/lib/auth/identity/browser.test.ts
+++ b/apps/www/lib/auth/identity/browser.test.ts
@@ -1,9 +1,9 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ANONYMOUS_ANALYTICS_CONSENT_STORAGE_KEY } from "@repo/analytics/consent";
 import {
   disableBrowserAnalytics,
   resetBrowserAnalyticsIdentity,
 } from "@repo/analytics/posthog/browser";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import { authClient } from "@/lib/auth/client";
@@ -30,7 +30,7 @@ describe("account browser identity", () => {
     window.sessionStorage.clear();
   });
 
-  it.live("clears browser identity without stopping analytics", () =>
+  it.effect("clears browser identity without stopping analytics", () =>
     Effect.gen(function* () {
       const removePersistedAccountState = vi.fn();
       const resetAnalytics = vi.fn();
@@ -45,7 +45,7 @@ describe("account browser identity", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "clears account state while preserving the anonymous privacy choice",
     () =>
       Effect.gen(function* () {
@@ -88,34 +88,36 @@ describe("account browser identity", () => {
       })
   );
 
-  it.live("disables analytics before clearing a deleted browser identity", () =>
-    Effect.gen(function* () {
-      const denyAnonymousAnalytics = vi.fn(() => Effect.void);
-      const disableAnalytics = vi.fn(() => Effect.void);
-      const removePersistedAccountState = vi.fn();
-      const resetAnalytics = vi.fn();
+  it.effect(
+    "disables analytics before clearing a deleted browser identity",
+    () =>
+      Effect.gen(function* () {
+        const denyAnonymousAnalytics = vi.fn(() => Effect.void);
+        const disableAnalytics = vi.fn(() => Effect.void);
+        const removePersistedAccountState = vi.fn();
+        const resetAnalytics = vi.fn();
 
-      yield* clearDeletedAccountBrowserIdentity({
-        denyAnonymousAnalytics,
-        disableAnalytics,
-        removePersistedAccountState,
-        resetAnalytics,
-      });
+        yield* clearDeletedAccountBrowserIdentity({
+          denyAnonymousAnalytics,
+          disableAnalytics,
+          removePersistedAccountState,
+          resetAnalytics,
+        });
 
-      expect(disableAnalytics).toHaveBeenCalledOnce();
-      expect(denyAnonymousAnalytics).toHaveBeenCalledOnce();
-      expect(removePersistedAccountState).toHaveBeenCalledOnce();
-      expect(resetAnalytics).toHaveBeenCalledOnce();
-      expect(disableAnalytics.mock.invocationCallOrder[0]).toBeLessThan(
-        denyAnonymousAnalytics.mock.invocationCallOrder[0] ?? 0
-      );
-      expect(denyAnonymousAnalytics.mock.invocationCallOrder[0]).toBeLessThan(
-        resetAnalytics.mock.invocationCallOrder[0] ?? 0
-      );
-    })
+        expect(disableAnalytics).toHaveBeenCalledOnce();
+        expect(denyAnonymousAnalytics).toHaveBeenCalledOnce();
+        expect(removePersistedAccountState).toHaveBeenCalledOnce();
+        expect(resetAnalytics).toHaveBeenCalledOnce();
+        expect(disableAnalytics.mock.invocationCallOrder[0]).toBeLessThan(
+          denyAnonymousAnalytics.mock.invocationCallOrder[0] ?? 0
+        );
+        expect(denyAnonymousAnalytics.mock.invocationCallOrder[0]).toBeLessThan(
+          resetAnalytics.mock.invocationCallOrder[0] ?? 0
+        );
+      })
   );
 
-  it.live("denies anonymous analytics after a committed deletion", () =>
+  it.effect("denies anonymous analytics after a committed deletion", () =>
     Effect.gen(function* () {
       yield* clearDeletedAccountBrowserIdentity();
 
@@ -127,25 +129,27 @@ describe("account browser identity", () => {
     })
   );
 
-  it.live("does not fail a completed deletion when browser cleanup fails", () =>
-    Effect.gen(function* () {
-      expect(
-        yield* clearDeletedAccountBrowserIdentity({
-          denyAnonymousAnalytics: () =>
-            Effect.fail("privacy storage unavailable"),
-          disableAnalytics: () => Effect.fail("analytics queue unavailable"),
-          removePersistedAccountState: () => {
-            throw new Error("storage unavailable");
-          },
-          resetAnalytics: () => {
-            throw new Error("analytics unavailable");
-          },
-        })
-      ).toBeUndefined();
-    })
+  it.effect(
+    "does not fail a completed deletion when browser cleanup fails",
+    () =>
+      Effect.gen(function* () {
+        expect(
+          yield* clearDeletedAccountBrowserIdentity({
+            denyAnonymousAnalytics: () =>
+              Effect.fail("privacy storage unavailable"),
+            disableAnalytics: () => Effect.fail("analytics queue unavailable"),
+            removePersistedAccountState: () => {
+              throw new Error("storage unavailable");
+            },
+            resetAnalytics: () => {
+              throw new Error("analytics unavailable");
+            },
+          })
+        ).toBeUndefined();
+      })
   );
 
-  it.live("clears browser identity after successful sign-out", () =>
+  it.effect("clears browser identity after successful sign-out", () =>
     Effect.gen(function* () {
       vi.mocked(authClient.signOut).mockResolvedValue({
         data: { success: true },
@@ -175,19 +179,21 @@ describe("account browser identity", () => {
     })
   );
 
-  it.live("preserves browser identity when sign-out is rejected", () =>
+  it.effect("preserves browser identity when sign-out is rejected", () =>
     Effect.gen(function* () {
       window.localStorage.setItem("nakafa-ai", "active-account-chat");
 
-      const failure = yield* signOutAccountBrowserIdentity(async () => ({
-        data: null,
-        error: {
-          code: "SIGN_OUT_FAILED",
-          message: "Sign-out failed",
-          status: 500,
-          statusText: "INTERNAL_SERVER_ERROR",
-        },
-      })).pipe(Effect.flip);
+      const failure = yield* signOutAccountBrowserIdentity(() =>
+        Promise.resolve({
+          data: null,
+          error: {
+            code: "SIGN_OUT_FAILED",
+            message: "Sign-out failed",
+            status: 500,
+            statusText: "INTERNAL_SERVER_ERROR",
+          },
+        })
+      ).pipe(Effect.flip);
 
       expect(failure).toBeInstanceOf(AccountSignOutFailed);
       expect(window.localStorage.getItem("nakafa-ai")).toBe(
@@ -197,7 +203,7 @@ describe("account browser identity", () => {
     })
   );
 
-  it.live("preserves browser identity when sign-out cannot start", () =>
+  it.effect("preserves browser identity when sign-out cannot start", () =>
     Effect.gen(function* () {
       window.sessionStorage.setItem(
         "nakafa-forum-session:class-1",

--- a/apps/www/lib/llms/content.test.ts
+++ b/apps/www/lib/llms/content.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
 import type { Locale } from "next-intl";
 import { vi } from "vitest";

--- a/apps/www/lib/llms/routes.test.ts
+++ b/apps/www/lib/llms/routes.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
 import { vi } from "vitest";
 import {

--- a/apps/www/lib/routing/public/document.test.ts
+++ b/apps/www/lib/routing/public/document.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
 import { vi } from "vitest";
 import { resolvePublicDocumentRoute } from "@/lib/routing/public/document";

--- a/apps/www/lib/utils/system.test.ts
+++ b/apps/www/lib/utils/system.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 describe("current content reference metadata", () => {
-  it.live("reads complete metadata from the current signed reference", () =>
+  it.effect("reads complete metadata from the current signed reference", () =>
     Effect.gen(function* () {
       expect(yield* getMetadataFromSlug("en", ["quran", "1"])).toEqual({
         authors: [{ name: "Nakafa" }],
@@ -75,7 +75,7 @@ describe("current content reference metadata", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "uses translated defaults when the current reference has no row",
     () =>
       Effect.gen(function* () {
@@ -86,7 +86,7 @@ describe("current content reference metadata", () => {
       })
   );
 
-  it.live("preserves typed current-reference read failures", () =>
+  it.effect("preserves typed current-reference read failures", () =>
     Effect.gen(function* () {
       routeMocks.read.mockReturnValueOnce(
         Effect.fail(
@@ -105,7 +105,7 @@ describe("current content reference metadata", () => {
     })
   );
 
-  it.live("fills sparse current metadata from translations", () =>
+  it.effect("fills sparse current metadata from translations", () =>
     Effect.gen(function* () {
       routeMocks.read.mockReturnValueOnce(
         Effect.succeed({
@@ -120,7 +120,7 @@ describe("current content reference metadata", () => {
     })
   );
 
-  it.live("reports which translation namespace failed", () =>
+  it.effect("reports which translation namespace failed", () =>
     Effect.gen(function* () {
       mockGetTranslations.mockRejectedValueOnce(new Error("Missing Common."));
       expect(
@@ -147,11 +147,15 @@ describe("current content reference metadata", () => {
     })
   );
 
-  it("applies the content cache at the route-handler boundary", async () => {
-    await expect(
-      getCachedMetadataFromSlug("en", ["quran", "1"])
-    ).resolves.toMatchObject({ title: "Runtime title" });
-    expect(cacheMocks.tag).toHaveBeenCalledWith("content-runtime");
-    expect(cacheMocks.life).toHaveBeenCalledWith("contentRuntime");
-  });
+  it.effect("applies the content cache at the route-handler boundary", () =>
+    Effect.gen(function* () {
+      const metadata = yield* Effect.promise(() =>
+        getCachedMetadataFromSlug("en", ["quran", "1"])
+      );
+
+      expect(metadata).toMatchObject({ title: "Runtime title" });
+      expect(cacheMocks.tag).toHaveBeenCalledWith("content-runtime");
+      expect(cacheMocks.life).toHaveBeenCalledWith("contentRuntime");
+    })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate 11 existing WWW domain-library test modules to direct official `@effect/vitest`. This completes the selected analytics, consent, account-deletion, browser-identity, public-routing, LLM metadata, and system-metadata checkpoint.

## Effect v4 design

Effectful cases use `it.effect` and compose Effect values without direct runtime calls. Pure deterministic cases remain ordinary Vitest tests. The patch removes `@repo/testing/effect` from every touched module and does not add a replacement wrapper, global `vi`, or raw async test boundary.

## Small commits

The branch contains seven package-owned commits grouped by capability: consent signals, server analytics, public routing, account deletion, browser identity, metadata systems, and consent storage.

## Exact proof

Exact base `d7530eb26e55d3ebf6a625a5bf644150e1e5fe2a`, head `40a0b7b41bed1ab7a2d43fcb2ba8cdd67199af45`, aggregate patch ID `73ee02da004cf1a1cdfc77409f2561998bc4017f`.

The patch passed all 1,515 WWW tests across 209 files with 100% statements, branches, functions, and lines; WWW typecheck; lint; Effect source parity; test and patch policies; boundaries; security audit; Doctor 100; and formatting. The rebase onto current protected main preserved the exact aggregate patch ID.

## Release

All 11 paths are in-place modifications to existing `*.test.ts` files, so #407's fail-closed classifier should skip signed Production while still requiring Quality, Doctor, the scope decision, and Required. No Vercel Preview was created or requested.