### PR TITLE
test(backend): adopt native Effect Vitest for auth

### DIFF
--- a/packages/backend/convex/auth/deletion/recovery.test.ts
+++ b/packages/backend/convex/auth/deletion/recovery.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ACCOUNT_DELETION_RECONCILIATION_DELAY_MS,
   ACCOUNT_DELETION_RECOVERY_SWEEP_BATCH_SIZE,
@@ -9,7 +10,6 @@ import {
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
-import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -18,15 +18,15 @@ const NOW = Date.UTC(2026, 6, 28, 11, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
 
 describe("auth/deletion/recovery", () => {
-  it.live("cancels preparation while the auth user still exists", () =>
+  it.effect("cancels preparation while the auth user still exists", () =>
     Effect.gen(function* () {
-      const cancel = vi.fn(async () => false);
-      const finalize = vi.fn(async () => undefined);
+      const cancel = vi.fn(() => Promise.resolve(false));
+      const finalize = vi.fn(() => Promise.resolve());
 
       yield* recoverAccountDeletionProgram({
-        authUserExists: vi.fn(async () => true),
+        authUserExists: vi.fn(() => Promise.resolve(true)),
         cancel,
-        continueCommit: vi.fn(async () => false),
+        continueCommit: vi.fn(() => Promise.resolve(false)),
         finalize,
       });
 
@@ -35,15 +35,15 @@ describe("auth/deletion/recovery", () => {
     })
   );
 
-  it.live("finalizes preparation after the auth user is gone", () =>
+  it.effect("finalizes preparation after the auth user is gone", () =>
     Effect.gen(function* () {
-      const cancel = vi.fn(async () => false);
-      const finalize = vi.fn(async () => undefined);
+      const cancel = vi.fn(() => Promise.resolve(false));
+      const finalize = vi.fn(() => Promise.resolve());
 
       yield* recoverAccountDeletionProgram({
-        authUserExists: vi.fn(async () => false),
+        authUserExists: vi.fn(() => Promise.resolve(false)),
         cancel,
-        continueCommit: vi.fn(async () => false),
+        continueCommit: vi.fn(() => Promise.resolve(false)),
         finalize,
       });
 
@@ -52,15 +52,15 @@ describe("auth/deletion/recovery", () => {
     })
   );
 
-  it.live("keeps failed recovery typed for the durable sweep to retry", () =>
+  it.effect("keeps failed recovery typed for the durable sweep to retry", () =>
     Effect.gen(function* () {
       const failure = yield* recoverAccountDeletionProgram({
         authUserExists: vi.fn(() =>
           Promise.reject(new Error("auth unavailable"))
         ),
-        cancel: vi.fn(async () => false),
-        continueCommit: vi.fn(async () => false),
-        finalize: vi.fn(async () => undefined),
+        cancel: vi.fn(() => Promise.resolve(false)),
+        continueCommit: vi.fn(() => Promise.resolve(false)),
+        finalize: vi.fn(() => Promise.resolve()),
       }).pipe(Effect.flip);
 
       expect(failure).toMatchObject({
@@ -71,27 +71,27 @@ describe("auth/deletion/recovery", () => {
     })
   );
 
-  it.live("delegates exactly one bounded cancellation batch", () =>
+  it.effect("delegates exactly one bounded cancellation batch", () =>
     Effect.gen(function* () {
-      const cancel = vi.fn(async () => true);
+      const cancel = vi.fn(() => Promise.resolve(true));
 
       yield* recoverAccountDeletionProgram({
-        authUserExists: vi.fn(async () => true),
+        authUserExists: vi.fn(() => Promise.resolve(true)),
         cancel,
-        continueCommit: vi.fn(async () => false),
-        finalize: vi.fn(async () => undefined),
+        continueCommit: vi.fn(() => Promise.resolve(false)),
+        finalize: vi.fn(() => Promise.resolve()),
       });
 
       expect(cancel).toHaveBeenCalledOnce();
     })
   );
 
-  it.live("continues a claimed deletion without reopening cancellation", () =>
+  it.effect("continues a claimed deletion without reopening cancellation", () =>
     Effect.gen(function* () {
-      const authUserExists = vi.fn(async () => true);
-      const cancel = vi.fn(async () => false);
-      const continueCommit = vi.fn(async () => true);
-      const finalize = vi.fn(async () => undefined);
+      const authUserExists = vi.fn(() => Promise.resolve(true));
+      const cancel = vi.fn(() => Promise.resolve(false));
+      const continueCommit = vi.fn(() => Promise.resolve(true));
+      const finalize = vi.fn(() => Promise.resolve());
 
       yield* recoverAccountDeletionProgram({
         authUserExists,

--- a/packages/backend/convex/auth/deletion/recovery.test.ts
+++ b/packages/backend/convex/auth/deletion/recovery.test.ts
@@ -107,182 +107,215 @@ describe("auth/deletion/recovery", () => {
     })
   );
 
-  it("claims only due preparations before scheduling recovery", async () => {
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, convexModules);
-    const seeded = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "due-recovery-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "due-recovery-owner@example.com",
-        name: "Due Recovery Owner",
-        plan: "free",
-      });
-      const dueId = await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: ATTEMPT_ID,
-        authId: "due-recovery-owner",
-        recoveryAt: NOW - 1,
-        recoveryGeneration: 2,
-        userId,
-      });
-      const futureId = await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: "019fa44c-02be-7cd0-a4ed-61a7af8e0621",
-        authId: "future-recovery-owner",
-        recoveryAt: NOW + 1,
-        recoveryGeneration: 0,
-        userId,
-      });
+  it.effect("claims only due preparations before scheduling recovery", () =>
+    Effect.gen(function* () {
+      vi.setSystemTime(NOW);
+      const t = convexTest(schema, convexModules);
+      const seeded = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const userId = await ctx.db.insert("users", {
+            authId: "due-recovery-owner",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "due-recovery-owner@example.com",
+            name: "Due Recovery Owner",
+            plan: "free",
+          });
+          const dueId = await ctx.db.insert("accountDeletionPreparations", {
+            attemptId: ATTEMPT_ID,
+            authId: "due-recovery-owner",
+            recoveryAt: NOW - 1,
+            recoveryGeneration: 2,
+            userId,
+          });
+          const futureId = await ctx.db.insert("accountDeletionPreparations", {
+            attemptId: "019fa44c-02be-7cd0-a4ed-61a7af8e0621",
+            authId: "future-recovery-owner",
+            recoveryAt: NOW + 1,
+            recoveryGeneration: 0,
+            userId,
+          });
 
-      return { dueId, futureId };
-    });
-    const scheduleRecovery = vi.fn(async () => undefined);
+          return { dueId, futureId };
+        })
+      );
+      const scheduleRecovery = vi.fn(() => Promise.resolve());
 
-    const hasMore = await t.mutation((ctx) =>
-      runConvexProgram(
-        sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
-      )
-    );
-    const state = await t.query(async (ctx) => ({
-      due: await ctx.db.get("accountDeletionPreparations", seeded.dueId),
-      future: await ctx.db.get("accountDeletionPreparations", seeded.futureId),
-    }));
-
-    expect(hasMore).toBe(false);
-    expect(state.due).toMatchObject({
-      recoveryAt: NOW + ACCOUNT_DELETION_RECONCILIATION_DELAY_MS,
-      recoveryGeneration: 3,
-    });
-    expect(state.future).toMatchObject({
-      recoveryAt: NOW + 1,
-      recoveryGeneration: 0,
-    });
-    expect(scheduleRecovery).toHaveBeenCalledExactlyOnceWith(
-      expect.any(Object),
-      "due-recovery-owner",
-      {
-        attemptId: ATTEMPT_ID,
-        preparationId: seeded.dueId,
-        recoveryGeneration: 3,
-      }
-    );
-  });
-
-  it("clears an invalid recovery lease without scheduling it", async () => {
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, convexModules);
-    const preparationId = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "finalized-recovery-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "finalized-recovery-owner@example.com",
-        name: "Finalized Recovery Owner",
-        plan: "free",
-      });
-
-      return ctx.db.insert("accountDeletionPreparations", {
-        authId: "finalized-recovery-owner",
-        finalizedAt: NOW - 10,
-        recoveryAt: NOW - 1,
-        recoveryGeneration: 0,
-        userId,
-      });
-    });
-    const scheduleRecovery = vi.fn(async () => undefined);
-
-    await t.mutation((ctx) =>
-      runConvexProgram(
-        sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
-      )
-    );
-    const preparation = await t.query((ctx) =>
-      ctx.db.get("accountDeletionPreparations", preparationId)
-    );
-
-    expect(preparation).not.toHaveProperty("recoveryAt");
-    expect(scheduleRecovery).not.toHaveBeenCalled();
-  });
-
-  it("rolls back the lease when scheduling fails", async () => {
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, convexModules);
-    const preparationId = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "failed-schedule-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "failed-schedule-owner@example.com",
-        name: "Failed Schedule Owner",
-        plan: "free",
-      });
-
-      return ctx.db.insert("accountDeletionPreparations", {
-        attemptId: ATTEMPT_ID,
-        authId: "failed-schedule-owner",
-        recoveryAt: NOW - 1,
-        recoveryGeneration: 0,
-        userId,
-      });
-    });
-
-    await expect(
-      t.mutation((ctx) =>
-        runConvexProgram(
-          sweepAccountDeletionRecoveryProgram(ctx, () =>
-            Promise.reject(new Error("scheduler unavailable"))
+      const hasMore = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
           )
         )
-      )
-    ).rejects.toThrow("scheduler unavailable");
+      );
+      const state = yield* Effect.promise(() =>
+        t.query(async (ctx) => ({
+          due: await ctx.db.get("accountDeletionPreparations", seeded.dueId),
+          future: await ctx.db.get(
+            "accountDeletionPreparations",
+            seeded.futureId
+          ),
+        }))
+      );
 
-    const preparation = await t.query((ctx) =>
-      ctx.db.get("accountDeletionPreparations", preparationId)
-    );
-
-    expect(preparation).toMatchObject({
-      recoveryAt: NOW - 1,
-      recoveryGeneration: 0,
-    });
-  });
-
-  it("requests another page after one full recovery batch", async () => {
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, convexModules);
-    await t.mutation(async (ctx) => {
-      for (
-        let index = 0;
-        index < ACCOUNT_DELETION_RECOVERY_SWEEP_BATCH_SIZE;
-        index += 1
-      ) {
-        const userId = await ctx.db.insert("users", {
-          authId: `batch-recovery-owner-${index}`,
-          credits: 0,
-          creditsResetAt: 0,
-          email: `batch-recovery-owner-${index}@example.com`,
-          name: `Batch Recovery Owner ${index}`,
-          plan: "free",
-        });
-        await ctx.db.insert("accountDeletionPreparations", {
+      expect(hasMore).toBe(false);
+      expect(state.due).toMatchObject({
+        recoveryAt: NOW + ACCOUNT_DELETION_RECONCILIATION_DELAY_MS,
+        recoveryGeneration: 3,
+      });
+      expect(state.future).toMatchObject({
+        recoveryAt: NOW + 1,
+        recoveryGeneration: 0,
+      });
+      expect(scheduleRecovery).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Object),
+        "due-recovery-owner",
+        {
           attemptId: ATTEMPT_ID,
-          authId: `batch-recovery-owner-${index}`,
-          recoveryAt: NOW - 1,
-          recoveryGeneration: 0,
-          userId,
-        });
-      }
-    });
-    const scheduleRecovery = vi.fn(async () => undefined);
+          preparationId: seeded.dueId,
+          recoveryGeneration: 3,
+        }
+      );
+    })
+  );
 
-    const hasMore = await t.mutation((ctx) =>
-      runConvexProgram(
-        sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
-      )
-    );
+  it.effect("clears an invalid recovery lease without scheduling it", () =>
+    Effect.gen(function* () {
+      vi.setSystemTime(NOW);
+      const t = convexTest(schema, convexModules);
+      const preparationId = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const userId = await ctx.db.insert("users", {
+            authId: "finalized-recovery-owner",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "finalized-recovery-owner@example.com",
+            name: "Finalized Recovery Owner",
+            plan: "free",
+          });
 
-    expect(hasMore).toBe(true);
-    expect(scheduleRecovery).toHaveBeenCalledTimes(
-      ACCOUNT_DELETION_RECOVERY_SWEEP_BATCH_SIZE
-    );
-  });
+          return ctx.db.insert("accountDeletionPreparations", {
+            authId: "finalized-recovery-owner",
+            finalizedAt: NOW - 10,
+            recoveryAt: NOW - 1,
+            recoveryGeneration: 0,
+            userId,
+          });
+        })
+      );
+      const scheduleRecovery = vi.fn(() => Promise.resolve());
+
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
+          )
+        )
+      );
+      const preparation = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          ctx.db.get("accountDeletionPreparations", preparationId)
+        )
+      );
+
+      expect(preparation).not.toHaveProperty("recoveryAt");
+      expect(scheduleRecovery).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("rolls back the lease when scheduling fails", () =>
+    Effect.gen(function* () {
+      vi.setSystemTime(NOW);
+      const t = convexTest(schema, convexModules);
+      const preparationId = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const userId = await ctx.db.insert("users", {
+            authId: "failed-schedule-owner",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "failed-schedule-owner@example.com",
+            name: "Failed Schedule Owner",
+            plan: "free",
+          });
+
+          return ctx.db.insert("accountDeletionPreparations", {
+            attemptId: ATTEMPT_ID,
+            authId: "failed-schedule-owner",
+            recoveryAt: NOW - 1,
+            recoveryGeneration: 0,
+            userId,
+          });
+        })
+      );
+
+      yield* Effect.promise(() =>
+        expect(
+          t.mutation((ctx) =>
+            runConvexProgram(
+              sweepAccountDeletionRecoveryProgram(ctx, () =>
+                Promise.reject(new Error("scheduler unavailable"))
+              )
+            )
+          )
+        ).rejects.toThrow("scheduler unavailable")
+      );
+
+      const preparation = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          ctx.db.get("accountDeletionPreparations", preparationId)
+        )
+      );
+
+      expect(preparation).toMatchObject({
+        recoveryAt: NOW - 1,
+        recoveryGeneration: 0,
+      });
+    })
+  );
+
+  it.effect("requests another page after one full recovery batch", () =>
+    Effect.gen(function* () {
+      vi.setSystemTime(NOW);
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          for (
+            let index = 0;
+            index < ACCOUNT_DELETION_RECOVERY_SWEEP_BATCH_SIZE;
+            index += 1
+          ) {
+            const userId = await ctx.db.insert("users", {
+              authId: `batch-recovery-owner-${index}`,
+              credits: 0,
+              creditsResetAt: 0,
+              email: `batch-recovery-owner-${index}@example.com`,
+              name: `Batch Recovery Owner ${index}`,
+              plan: "free",
+            });
+            await ctx.db.insert("accountDeletionPreparations", {
+              attemptId: ATTEMPT_ID,
+              authId: `batch-recovery-owner-${index}`,
+              recoveryAt: NOW - 1,
+              recoveryGeneration: 0,
+              userId,
+            });
+          }
+        })
+      );
+      const scheduleRecovery = vi.fn(() => Promise.resolve());
+
+      const hasMore = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            sweepAccountDeletionRecoveryProgram(ctx, scheduleRecovery)
+          )
+        )
+      );
+
+      expect(hasMore).toBe(true);
+      expect(scheduleRecovery).toHaveBeenCalledTimes(
+        ACCOUNT_DELETION_RECOVERY_SWEEP_BATCH_SIZE
+      );
+    })
+  );
 });

--- a/packages/backend/convex/auth/deletion/verification.test.ts
+++ b/packages/backend/convex/auth/deletion/verification.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { components, internal } from "@repo/backend/convex/_generated/api";
 import { ACCOUNT_DELETION_TRANSACTION_BATCH_SIZE } from "@repo/backend/convex/auth/deletion/constants";
 import { createDeletedUserTombstone } from "@repo/backend/convex/auth/deletion/tombstone";
 import { drainDeletedUserVerificationsProgram } from "@repo/backend/convex/auth/deletion/verification";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "@repo/testing/effect";
-import { Effect, Result, Schema } from "effect";
+import { Effect, Schema } from "effect";
 import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 21, 0, 0);
@@ -18,7 +18,7 @@ const decodeVerificationPage = Schema.decodeUnknownSync(
   })
 );
 describe("auth/deletion/verification", () => {
-  it.live(
+  it.effect(
     "resumes from the last committed verification page after an action retry",
     () =>
       Effect.gen(function* () {
@@ -51,12 +51,11 @@ describe("auth/deletion/verification", () => {
         const interrupted = yield* drainDeletedUserVerificationsProgram(
           operations
         ).pipe(Effect.result);
-        expect(Result.isFailure(interrupted)).toBe(true);
-        if (Result.isSuccess(interrupted)) {
-          throw new Error("Expected verification cleanup to be interrupted.");
-        }
-        expect(interrupted.failure).toMatchObject({
-          _tag: "UserCleanupError",
+        expect(interrupted).toMatchObject({
+          _tag: "Failure",
+          failure: {
+            _tag: "UserCleanupError",
+          },
         });
         expect(durableCursor).toBe("verification-cursor-1");
         expect(

--- a/packages/backend/convex/auth/deletion/verification.test.ts
+++ b/packages/backend/convex/auth/deletion/verification.test.ts
@@ -69,124 +69,144 @@ describe("auth/deletion/verification", () => {
         expect(durableCursor).toBeNull();
       })
   );
-  it("drains direct tokens and OAuth-link state across bounded pages", async () => {
-    const t = createConvexTestWithBetterAuth();
-    const authUser = await t.mutation(components.betterAuth.adapter.create, {
-      input: {
-        model: "user",
-        data: {
-          createdAt: NOW,
-          email: "verification-owner@example.com",
-          emailVerified: true,
-          name: "Verification owner",
-          updatedAt: NOW,
-        },
-      },
-      select: ["_id"],
-    });
-    const unrelatedValues = Array.from(
-      { length: ACCOUNT_DELETION_TRANSACTION_BATCH_SIZE + 1 },
-      (_, index) => `unrelated-${index}`
-    );
-    for (const [index, value] of unrelatedValues.entries()) {
-      await t.mutation(components.betterAuth.adapter.create, {
-        input: {
-          model: "verification",
-          data: {
-            createdAt: NOW + index,
-            expiresAt: NOW + 60_000,
-            identifier: `unrelated-${index}`,
-            updatedAt: NOW + index,
-            value,
-          },
-        },
-      });
-    }
-    await t.mutation(components.betterAuth.adapter.create, {
-      input: {
-        model: "verification",
-        data: {
-          createdAt: NOW + 100,
-          expiresAt: NOW + 60_000,
-          identifier: "reset-password:token",
-          updatedAt: NOW + 100,
-          value: authUser._id,
-        },
-      },
-    });
-    await t.mutation(components.betterAuth.adapter.create, {
-      input: {
-        model: "verification",
-        data: {
-          createdAt: NOW + 101,
-          expiresAt: NOW + 60_000,
-          identifier: "oauth-link-state",
-          updatedAt: NOW + 101,
-          value: JSON.stringify({
-            callbackURL: "https://nakafa.com/id",
-            codeVerifier: "verifier",
-            expiresAt: NOW + 60_000,
-            link: {
-              email: "verification-owner@example.com",
-              userId: authUser._id,
+  it.effect(
+    "drains direct tokens and OAuth-link state across bounded pages",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const authUser = yield* Effect.promise(() =>
+          t.mutation(components.betterAuth.adapter.create, {
+            input: {
+              model: "user",
+              data: {
+                createdAt: NOW,
+                email: "verification-owner@example.com",
+                emailVerified: true,
+                name: "Verification owner",
+                updatedAt: NOW,
+              },
             },
-          }),
-        },
-      },
-    });
-    const substringValue = `unrelated-${authUser._id}`;
-    await t.mutation(components.betterAuth.adapter.create, {
-      input: {
-        model: "verification",
-        data: {
-          createdAt: NOW + 102,
-          expiresAt: NOW + 60_000,
-          identifier: "unrelated-substring",
-          updatedAt: NOW + 102,
-          value: substringValue,
-        },
-      },
-    });
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await ctx.db.insert("users", {
-        authId: authUser._id,
-        credits: 0,
-        creditsResetAt: NOW,
-        email: "verification-owner@example.com",
-        name: "Verification owner",
-        plan: "free",
-      });
-      await ctx.db.patch(
-        "users",
-        insertedUserId,
-        createDeletedUserTombstone(insertedUserId, NOW)
-      );
-      return insertedUserId;
-    });
-    await t.action(
-      internal.auth.deletion.verification.drainDeletedUserVerifications,
-      {
-        authId: authUser._id,
-        userId,
-      }
-    );
-    const state = await t.query(async (ctx) => ({
-      remaining: decodeVerificationPage(
-        await ctx.runQuery(components.betterAuth.adapter.findMany, {
-          model: "verification",
-          paginationOpts: {
-            cursor: null,
-            numItems: 100,
-          },
-          select: ["value"],
-        })
-      ),
-      user: await ctx.db.get("users", userId),
-    }));
-    expect(state.remaining.page.map((row) => row.value)).toEqual([
-      ...unrelatedValues,
-      substringValue,
-    ]);
-    expect(state.user).not.toHaveProperty("authVerificationCleanupCursor");
-  });
+            select: ["_id"],
+          })
+        );
+        const unrelatedValues = Array.from(
+          { length: ACCOUNT_DELETION_TRANSACTION_BATCH_SIZE + 1 },
+          (_, index) => `unrelated-${index}`
+        );
+        for (const [index, value] of unrelatedValues.entries()) {
+          yield* Effect.promise(() =>
+            t.mutation(components.betterAuth.adapter.create, {
+              input: {
+                model: "verification",
+                data: {
+                  createdAt: NOW + index,
+                  expiresAt: NOW + 60_000,
+                  identifier: `unrelated-${index}`,
+                  updatedAt: NOW + index,
+                  value,
+                },
+              },
+            })
+          );
+        }
+        yield* Effect.promise(() =>
+          t.mutation(components.betterAuth.adapter.create, {
+            input: {
+              model: "verification",
+              data: {
+                createdAt: NOW + 100,
+                expiresAt: NOW + 60_000,
+                identifier: "reset-password:token",
+                updatedAt: NOW + 100,
+                value: authUser._id,
+              },
+            },
+          })
+        );
+        yield* Effect.promise(() =>
+          t.mutation(components.betterAuth.adapter.create, {
+            input: {
+              model: "verification",
+              data: {
+                createdAt: NOW + 101,
+                expiresAt: NOW + 60_000,
+                identifier: "oauth-link-state",
+                updatedAt: NOW + 101,
+                value: JSON.stringify({
+                  callbackURL: "https://nakafa.com/id",
+                  codeVerifier: "verifier",
+                  expiresAt: NOW + 60_000,
+                  link: {
+                    email: "verification-owner@example.com",
+                    userId: authUser._id,
+                  },
+                }),
+              },
+            },
+          })
+        );
+        const substringValue = `unrelated-${authUser._id}`;
+        yield* Effect.promise(() =>
+          t.mutation(components.betterAuth.adapter.create, {
+            input: {
+              model: "verification",
+              data: {
+                createdAt: NOW + 102,
+                expiresAt: NOW + 60_000,
+                identifier: "unrelated-substring",
+                updatedAt: NOW + 102,
+                value: substringValue,
+              },
+            },
+          })
+        );
+        const userId = yield* Effect.promise(() =>
+          t.mutation(async (ctx) => {
+            const insertedUserId = await ctx.db.insert("users", {
+              authId: authUser._id,
+              credits: 0,
+              creditsResetAt: NOW,
+              email: "verification-owner@example.com",
+              name: "Verification owner",
+              plan: "free",
+            });
+            await ctx.db.patch(
+              "users",
+              insertedUserId,
+              createDeletedUserTombstone(insertedUserId, NOW)
+            );
+            return insertedUserId;
+          })
+        );
+        yield* Effect.promise(() =>
+          t.action(
+            internal.auth.deletion.verification.drainDeletedUserVerifications,
+            {
+              authId: authUser._id,
+              userId,
+            }
+          )
+        );
+        const state = yield* Effect.promise(() =>
+          t.query(async (ctx) => ({
+            remaining: decodeVerificationPage(
+              await ctx.runQuery(components.betterAuth.adapter.findMany, {
+                model: "verification",
+                paginationOpts: {
+                  cursor: null,
+                  numItems: 100,
+                },
+                select: ["value"],
+              })
+            ),
+            user: await ctx.db.get("users", userId),
+          }))
+        );
+        expect(state.remaining.page.map((row) => row.value)).toEqual([
+          ...unrelatedValues,
+          substringValue,
+        ]);
+        expect(state.user).not.toHaveProperty("authVerificationCleanupCursor");
+      })
+  );
 });

--- a/packages/backend/convex/auth/runtime.test.ts
+++ b/packages/backend/convex/auth/runtime.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ACCOUNT_DELETION_PREPARATION_INCOMPLETE_CODE,
   ACCOUNT_DELETION_REQUIRES_SCHOOL_MEMBER_CODE,
@@ -5,15 +6,14 @@ import {
 } from "@repo/backend/convex/auth/deletion/constants";
 import { accountDeletionPreparationOutcome } from "@repo/backend/convex/auth/deletion/spec";
 import { verifyAccountDeletionPreparation } from "@repo/backend/convex/auth/runtime";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
 describe("auth/runtime", () => {
-  it.live("accepts one ready preparation step", () =>
+  it.effect("accepts one ready preparation step", () =>
     Effect.gen(function* () {
-      const prepare = vi.fn(
-        async () => accountDeletionPreparationOutcome.ready
+      const prepare = vi.fn(() =>
+        Promise.resolve(accountDeletionPreparationOutcome.ready)
       );
 
       expect(yield* verifyAccountDeletionPreparation(prepare)).toBeUndefined();
@@ -21,7 +21,7 @@ describe("auth/runtime", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     {
       code: ACCOUNT_DELETION_PREPARATION_INCOMPLETE_CODE,
       outcome: accountDeletionPreparationOutcome.continue,
@@ -39,7 +39,7 @@ describe("auth/runtime", () => {
     },
   ])("maps $outcome without draining another step", (testCase) =>
     Effect.gen(function* () {
-      const prepare = vi.fn(async () => testCase.outcome);
+      const prepare = vi.fn(() => Promise.resolve(testCase.outcome));
       const failure = yield* verifyAccountDeletionPreparation(prepare).pipe(
         Effect.flip
       );
@@ -55,7 +55,7 @@ describe("auth/runtime", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "maps adapter failures without retrying inside the auth request",
     () =>
       Effect.gen(function* () {

--- a/packages/backend/convex/auth/username/availability.test.ts
+++ b/packages/backend/convex/auth/username/availability.test.ts
@@ -1,13 +1,13 @@
+import { describe, expect, it } from "@effect/vitest";
 import { resolveUniqueGeneratedUsername } from "@repo/backend/convex/auth/username/availability";
 import {
   createGoogleUsernameFields,
   usernameOptions,
 } from "@repo/backend/convex/auth/username/policy";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 describe("auth/username availability", () => {
-  it.live("keeps the generated username when it is already unique", () =>
+  it.effect("keeps the generated username when it is already unique", () =>
     Effect.gen(function* () {
       const fields = createGoogleUsernameFields({
         email: "student@gmail.com",
@@ -25,7 +25,7 @@ describe("auth/username availability", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "creates another generated username when the first one already exists",
     () =>
       Effect.gen(function* () {
@@ -52,7 +52,7 @@ describe("auth/username availability", () => {
       })
   );
 
-  it.live("keeps trying generated usernames until it finds a free one", () =>
+  it.effect("keeps trying generated usernames until it finds a free one", () =>
     Effect.gen(function* () {
       const fields = createGoogleUsernameFields({
         email: "student@gmail.com",

--- a/packages/backend/convex/auth/username/request.test.ts
+++ b/packages/backend/convex/auth/username/request.test.ts
@@ -1,19 +1,21 @@
+import { describe, expect, it } from "@effect/vitest";
 import { rejectReservedUsername } from "@repo/backend/convex/auth/username/request";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Exit } from "effect";
 
 describe("auth/username request", () => {
-  it.live("rejects user-provided usernames from the generated namespace", () =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        rejectReservedUsername({ username: "g_student_ng64hohj4t2h3" })
-      );
+  it.effect(
+    "rejects user-provided usernames from the generated namespace",
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          rejectReservedUsername({ username: "g_student_ng64hohj4t2h3" })
+        );
 
-      expect(Exit.isFailure(exit)).toBe(true);
-    })
+        expect(Exit.isFailure(exit)).toBe(true);
+      })
   );
 
-  it.live(
+  it.effect(
     "allows user-provided usernames outside the generated namespace",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Scope

Migrate five backend authentication test modules to direct official `@effect/vitest`: deletion recovery, deletion verification, auth runtime, username availability, and username requests.

## Effect v4 design

Effectful cases return Effects through `it.effect`. Scoped runtime setup and typed failure assertions stay inside Effect composition. The patch removes `@repo/testing/effect`, direct Effect runtime calls, live-clock tests, and raw async test callbacks from every touched module. It adds no wrapper, global `vi`, or production compatibility path.

## Small commits

The branch contains three package-owned commits: auth policies, deletion recovery, and the Convex auth harness boundary.

## Exact proof

Exact base `36f501cdd5828707bc186ddb39dabe03fb5df620`, head `e87b298866e994bba09101d12f2908692c36cacd`, aggregate patch ID `ef25ada912ebc7452286f7c0cd203b1d80f30aa9`.

The exact current-base focused suite passes 21 of 21 tests. Backend typecheck passes. The unchanged aggregate patch previously passed all 1,518 backend tests, lint, boundaries, and security audit. The exact diff passes `git diff --check` and contains no wrapper import, direct Effect runner, `it.live`, or raw async test callback.

## Release

All five paths are in-place modifications to existing `*.test.ts` files, so signed Production should be skipped while Quality, Doctor, Production Scope, and Required remain mandatory. No Vercel Preview was created or requested.