### PR TITLE
ci(www): skip test-only Vercel production builds

### DIFF
--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -4,8 +4,19 @@ import { config, hasIsolatedTypecheck } from "@/vercel";
 
 describe("www Vercel configuration", () => {
   it("builds only affected production commits", () => {
-    expect(config.ignoreCommand).toBe(
-      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1'
+    const ignoreCommand = config.ignoreCommand ?? "";
+
+    expect(ignoreCommand).toContain(
+      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
+    );
+    expect(ignoreCommand).toContain(
+      "node ../../scripts/production-acceptance.ts vercel && exit 0"
+    );
+    expect(ignoreCommand).toContain(
+      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1'
+    );
+    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
+      ignoreCommand.indexOf("turbo query affected")
     );
     expect(config.git?.deploymentEnabled).toEqual({
       "**": false,

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -8,7 +8,7 @@ export function hasIsolatedTypecheck(vercel: "1" | undefined) {
 export const config: VercelConfig = {
   buildCommand: "pnpm run build:vercel",
   ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1',
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/scripts/production-acceptance.test.ts
+++ b/scripts/production-acceptance.test.ts
@@ -1,11 +1,16 @@
+import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, FileSystem, Schema } from "effect";
+import { Effect, FileSystem, Schema, Stream } from "effect";
 import { ChildProcess } from "effect/unstable/process";
 import {
   readProductionChanges,
   requiresProductionAcceptance,
 } from "./production-acceptance.ts";
+
+const PRODUCTION_ACCEPTANCE_SCRIPT = fileURLToPath(
+  new URL("./production-acceptance.ts", import.meta.url)
+);
 
 class GitFixtureError extends Schema.TaggedError<GitFixtureError>()(
   "GitFixtureError",
@@ -47,6 +52,116 @@ const commitAll = Effect.fn("ProductionAcceptanceTest.commitAll")(function* (
   yield* runGit(repository, ["commit", "-m", message]);
 });
 
+const makeRepository = Effect.fn("ProductionAcceptanceTest.makeRepository")(
+  function* (prefix: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const repository = yield* fileSystem.makeTempDirectoryScoped({ prefix });
+    yield* runGit(repository, ["init", "--initial-branch=main"]);
+    yield* runGit(repository, ["config", "user.name", "CI Fixture"]);
+    yield* runGit(repository, [
+      "config",
+      "user.email",
+      "ci-fixture@example.com",
+    ]);
+    yield* fileSystem.writeFileString(
+      `${repository}/example.ts`,
+      "export const example = true;\n"
+    );
+    yield* fileSystem.writeFileString(
+      `${repository}/example.test.ts`,
+      "export const testExample = true;\n"
+    );
+    yield* fileSystem.makeDirectory(`${repository}/apps/www`, {
+      recursive: true,
+    });
+    yield* commitAll(repository, "initial");
+    return repository;
+  }
+);
+
+const readGitRevision = Effect.fn("ProductionAcceptanceTest.readGitRevision")(
+  function* (repository: string, revision: string) {
+    const command = yield* ChildProcess.make("git", ["rev-parse", revision], {
+      cwd: `${repository}/apps/www`,
+    }).pipe(
+      Effect.mapError(
+        () =>
+          new GitFixtureError({
+            message: `Unable to resolve Git revision ${revision}.`,
+          })
+      )
+    );
+    const [exitCode, output] = yield* Effect.all(
+      [
+        command.exitCode,
+        command.stdout.pipe(
+          Stream.decodeText(),
+          Stream.runFold(
+            () => "",
+            (text, chunk) => text + chunk
+          )
+        ),
+      ],
+      { concurrency: 2 }
+    ).pipe(
+      Effect.mapError(
+        () =>
+          new GitFixtureError({
+            message: `Unable to read Git revision ${revision}.`,
+          })
+      )
+    );
+    if (exitCode !== 0) {
+      return yield* new GitFixtureError({
+        message: `Git could not resolve revision ${revision}.`,
+      });
+    }
+    return output.trim();
+  }
+);
+
+const runVercelDecision = Effect.fn(
+  "ProductionAcceptanceTest.runVercelDecision"
+)(function* (
+  repository: string,
+  base: string | undefined,
+  head: string | undefined
+) {
+  const runtime = yield* Effect.sync(() => ({
+    node: process.execPath,
+    path: process.env.PATH,
+  }));
+  const command = yield* ChildProcess.make(
+    runtime.node,
+    [PRODUCTION_ACCEPTANCE_SCRIPT, "vercel"],
+    {
+      cwd: `${repository}/apps/www`,
+      env: {
+        PATH: runtime.path,
+        VERCEL_GIT_COMMIT_SHA: head,
+        VERCEL_GIT_PREVIOUS_SHA: base,
+      },
+      stderr: "ignore",
+      stdout: "ignore",
+    }
+  ).pipe(
+    Effect.mapError(
+      () =>
+        new GitFixtureError({
+          message: "Unable to run the Vercel production decision.",
+        })
+    )
+  );
+  return yield* command.exitCode.pipe(
+    Effect.mapError(
+      () =>
+        new GitFixtureError({
+          message: "Unable to finish the Vercel production decision.",
+        })
+    )
+  );
+});
+
 describe("production acceptance scope", () => {
   it.each([
     { changes: [], expected: true },
@@ -79,25 +194,7 @@ describe("production acceptance scope", () => {
     () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
-        const repository = yield* fileSystem.makeTempDirectoryScoped({
-          prefix: "production-acceptance-test-",
-        });
-        yield* runGit(repository, ["init", "--initial-branch=main"]);
-        yield* runGit(repository, ["config", "user.name", "CI Fixture"]);
-        yield* runGit(repository, [
-          "config",
-          "user.email",
-          "ci-fixture@example.com",
-        ]);
-        yield* fileSystem.writeFileString(
-          `${repository}/example.ts`,
-          "export const example = true;\n"
-        );
-        yield* fileSystem.writeFileString(
-          `${repository}/example.test.ts`,
-          "export const testExample = true;\n"
-        );
-        yield* commitAll(repository, "initial");
+        const repository = yield* makeRepository("production-acceptance-test-");
 
         yield* fileSystem.writeFileString(
           `${repository}/example.test.ts`,
@@ -130,25 +227,9 @@ describe("production acceptance scope", () => {
   it.effect("ignores base-only changes after the target branch advances", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
-      const repository = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "production-acceptance-diverged-test-",
-      });
-      yield* runGit(repository, ["init", "--initial-branch=main"]);
-      yield* runGit(repository, ["config", "user.name", "CI Fixture"]);
-      yield* runGit(repository, [
-        "config",
-        "user.email",
-        "ci-fixture@example.com",
-      ]);
-      yield* fileSystem.writeFileString(
-        `${repository}/example.ts`,
-        "export const example = true;\n"
+      const repository = yield* makeRepository(
+        "production-acceptance-diverged-test-"
       );
-      yield* fileSystem.writeFileString(
-        `${repository}/example.test.ts`,
-        "export const testExample = true;\n"
-      );
-      yield* commitAll(repository, "initial");
 
       yield* runGit(repository, ["switch", "--create", "candidate"]);
       yield* fileSystem.writeFileString(
@@ -171,6 +252,37 @@ describe("production acceptance scope", () => {
       );
       expect(changes).toEqual([{ path: "example.test.ts", status: "M" }]);
       expect(requiresProductionAcceptance(changes)).toBe(false);
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+
+  it.effect("skips Vercel only for an exact test-only change", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const repository = yield* makeRepository(
+        "production-acceptance-vercel-test-"
+      );
+      const initial = yield* readGitRevision(repository, "HEAD");
+
+      yield* fileSystem.writeFileString(
+        `${repository}/example.test.ts`,
+        "export const testExample = false;\n"
+      );
+      yield* commitAll(repository, "modify test");
+      const testHead = yield* readGitRevision(repository, "HEAD");
+      expect(yield* runVercelDecision(repository, initial, testHead)).toBe(0);
+
+      yield* fileSystem.writeFileString(
+        `${repository}/example.ts`,
+        "export const example = false;\n"
+      );
+      yield* commitAll(repository, "modify source");
+      const sourceHead = yield* readGitRevision(repository, "HEAD");
+      expect(yield* runVercelDecision(repository, testHead, sourceHead)).toBe(
+        1
+      );
+      expect(yield* runVercelDecision(repository, undefined, undefined)).toBe(
+        1
+      );
     }).pipe(Effect.provide(NodeServices.layer))
   );
 });

--- a/scripts/production-acceptance.ts
+++ b/scripts/production-acceptance.ts
@@ -11,6 +11,12 @@ import { ChildProcess } from "effect/unstable/process";
 import { writeOutput } from "./output.ts";
 
 const GIT_REVISION_PATTERN = /^[0-9a-f]{40}$/u;
+const ProductionAcceptanceMode = Schema.Literals(["github", "vercel"]);
+
+interface RevisionEnvironment {
+  readonly base: string;
+  readonly head: string;
+}
 
 export interface ProductionChange {
   readonly path: string;
@@ -130,14 +136,13 @@ export function requiresProductionAcceptance(
   );
 }
 
-/** Writes the fail-closed production decision for the GitHub Actions job. */
-export const writeProductionAcceptanceDecision = Effect.fn(
-  "ProductionAcceptance.writeDecision"
-)(function* (repositoryRoot: string) {
+/** Resolves one fail-closed decision from exact revision environment values. */
+const resolveProductionAcceptance = Effect.fn(
+  "ProductionAcceptance.resolveDecision"
+)(function* (repositoryRoot: string, environment: RevisionEnvironment) {
   const config = yield* Config.all({
-    base: Config.nonEmptyString("BASE_SHA"),
-    head: Config.nonEmptyString("HEAD_SHA"),
-    output: Config.nonEmptyString("GITHUB_OUTPUT"),
+    base: Config.nonEmptyString(environment.base),
+    head: Config.nonEmptyString(environment.head),
   }).pipe(
     Effect.mapError(
       (cause) =>
@@ -163,10 +168,35 @@ export const writeProductionAcceptanceDecision = Effect.fn(
     )
   );
   const changes = yield* readProductionChanges(repositoryRoot, base, head);
-  const required = requiresProductionAcceptance(changes);
+  return {
+    changes,
+    required: requiresProductionAcceptance(changes),
+  } as const;
+});
+
+/** Writes the fail-closed production decision for the GitHub Actions job. */
+export const writeProductionAcceptanceDecision = Effect.fn(
+  "ProductionAcceptance.writeDecision"
+)(function* (repositoryRoot: string) {
+  const output = yield* Config.nonEmptyString("GITHUB_OUTPUT").pipe(
+    Effect.mapError(
+      (cause) =>
+        new ProductionAcceptanceError({
+          cause,
+          message: "Production acceptance configuration is incomplete.",
+        })
+    )
+  );
+  const { changes, required } = yield* resolveProductionAcceptance(
+    repositoryRoot,
+    {
+      base: "BASE_SHA",
+      head: "HEAD_SHA",
+    }
+  );
   const fileSystem = yield* FileSystem.FileSystem;
   yield* fileSystem
-    .writeFileString(config.output, `required=${String(required)}\n`, {
+    .writeFileString(output, `required=${String(required)}\n`, {
       flag: "a",
     })
     .pipe(
@@ -186,10 +216,52 @@ export const writeProductionAcceptanceDecision = Effect.fn(
   return required;
 });
 
+/** Resolves whether Vercel must build the exact protected-main change. */
+const resolveVercelProductionDecision = Effect.fn(
+  "ProductionAcceptance.resolveVercelDecision"
+)(function* (repositoryRoot: string) {
+  const decision = yield* resolveProductionAcceptance(repositoryRoot, {
+    base: "VERCEL_GIT_PREVIOUS_SHA",
+    head: "VERCEL_GIT_COMMIT_SHA",
+  });
+  yield* writeOutput(
+    decision.required
+      ? `Vercel production build required for ${decision.changes.length} changed paths.\n`
+      : `Vercel production build skipped for ${decision.changes.length} modified test modules.\n`
+  );
+  return decision.required;
+});
+
+/** Runs the selected production-scope adapter at the Node CLI boundary. */
+const runProductionAcceptanceMain = Effect.fn("ProductionAcceptance.runMain")(
+  function* () {
+    const modeInput = yield* Effect.sync(() => process.argv[2] ?? "github");
+    const mode = yield* Schema.decodeUnknownEffect(ProductionAcceptanceMode)(
+      modeInput
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProductionAcceptanceError({
+            cause,
+            message: "Production acceptance mode is invalid.",
+          })
+      )
+    );
+    const repositoryRoot = yield* Effect.sync(() => process.cwd());
+    if (mode === "github") {
+      yield* writeProductionAcceptanceDecision(repositoryRoot);
+      return;
+    }
+
+    const required = yield* resolveVercelProductionDecision(repositoryRoot);
+    yield* Effect.sync(() => {
+      process.exitCode = required ? 1 : 0;
+    });
+  }
+);
+
 if (import.meta.main) {
   NodeRuntime.runMain(
-    writeProductionAcceptanceDecision(process.cwd()).pipe(
-      Effect.provide(NodeServices.layer)
-    )
+    runProductionAcceptanceMain().pipe(Effect.provide(NodeServices.layer))
   );
 }


### PR DESCRIPTION
## Problem

Protected-main Effect test migrations no longer run unrelated signed GitHub Production acceptance, but Vercel still treated every test edit under `apps/www` or an internal dependency as an affected WWW build. The last three test-only merges each started a full WWW build and Convex production push.

## Shared decision

This reuses the repository-owned fail-closed production classifier instead of adding another path allowlist. A Vercel adapter reads the exact `VERCEL_GIT_PREVIOUS_SHA` and `VERCEL_GIT_COMMIT_SHA`, inspects the complete merge-base diff from the app root, and exits `0` only when every record is an in-place `M` change to an existing `*.test.ts` file.

## Fail closed

Source, configuration, manifest, workflow, dependency, addition, deletion, rename, TSX test, empty diff, invalid SHA, missing environment, invalid mode, or classifier failure continues to the existing Turbo affected-package check. If Effect dependencies are unavailable before install on a cold build cache, the Node command exits nonzero and Turbo still decides whether WWW must build.

This follows Vercel's documented ignored-build contract: exit `0` cancels and exit `1` builds. [Vercel project settings](https://vercel.com/docs/project-configuration/project-settings#ignored-build-step), [programmatic configuration](https://vercel.com/docs/project-configuration/vercel-ts#ignorecommand).

## Effect v4 design

The adapter remains native Effect RC110: named `Effect.fn` programs, `Config`, `Schema.Literals`, `Schema.decodeUnknownEffect`, `NodeRuntime`, `NodeServices`, scoped `ChildProcess`, `FileSystem`, `Stream`, and tagged expected failures. The CLI boundary alone maps the verified decision to the process exit code.

## Exact proof

Exact base `9ae9ed9e1e4162a4efe3084bbdf9fa8f799dbd68`, head `3a73bf4971a0dfcc196381802f118cd98abee9fa`, aggregate patch ID `e0d990eb044505c844e96f1b89eefdb9d89d78fd`.

Local proof: 22 script tests; end-to-end nested Vercel-root Git fixtures for test-only, source, and missing-config decisions; all 1,515 WWW tests across 209 files with 100% coverage; script and WWW typechecks; Effect source parity; test and patch policy; lint; boundaries; security audit; Doctor 100; format; exact live CLI decisions for merged backend test changes and this source/config patch.

## Release

This workflow affects protected-main production deployment selection, so the PR must pass the complete signed Production path once on its exact head. No Vercel Preview was created or requested.