### PR TITLE
test(backend): adopt native Effect Vitest for emails

### DIFF
--- a/packages/backend/convex/emails/deletion.test.ts
+++ b/packages/backend/convex/emails/deletion.test.ts
@@ -62,8 +62,8 @@ describe("emails/deletion", () => {
                 );
 
                 if (!user) {
-                  return yield* Effect.dieMessage(
-                    "Expected the welcome email owner."
+                  return yield* Effect.die(
+                    new Error("Expected the welcome email owner.")
                   );
                 }
 

--- a/packages/backend/convex/emails/deletion.test.ts
+++ b/packages/backend/convex/emails/deletion.test.ts
@@ -1,11 +1,11 @@
 import { Resend } from "@convex-dev/resend";
 import resendTest from "@convex-dev/resend/test";
+import { describe, expect, it } from "@effect/vitest";
 import { components } from "@repo/backend/convex/_generated/api";
 import { cancelPendingWelcomeEmail } from "@repo/backend/convex/emails/deletion";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
-import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -17,53 +17,77 @@ const testResend = new Resend(components.resend, {
 });
 
 describe("emails/deletion", () => {
-  it("cancels the component delivery and clears its app-owned handle", async () => {
-    const t = convexTest(schema, convexModules);
-    resendTest.register(t);
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "welcome-email-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "delivered@resend.dev",
-        name: "Welcome Email Owner",
-        plan: "free",
+  it.effect(
+    "cancels the component delivery and clears its app-owned handle",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        resendTest.register(t);
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            ctx.db.insert("users", {
+              authId: "welcome-email-owner",
+              credits: 0,
+              creditsResetAt: 0,
+              email: "delivered@resend.dev",
+              name: "Welcome Email Owner",
+              plan: "free",
+            })
+          )
+        );
+        const emailId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            testResend.sendEmail(ctx, {
+              from: "Nakafa <nakafa@notifications.nakafa.com>",
+              subject: "Welcome",
+              text: "Welcome",
+              to: "delivered@resend.dev",
+            })
+          )
+        );
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            ctx.db.patch("users", userId, {
+              welcomeEmailId: emailId,
+            })
+          )
+        );
+
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const user = yield* Effect.promise(() =>
+                  ctx.db.get("users", userId)
+                );
+
+                if (!user) {
+                  return yield* Effect.dieMessage(
+                    "Expected the welcome email owner."
+                  );
+                }
+
+                yield* cancelPendingWelcomeEmail(ctx, user);
+              })
+            )
+          )
+        );
+
+        const user = yield* Effect.promise(() =>
+          t.query((ctx) => ctx.db.get("users", userId))
+        );
+        const status = yield* Effect.promise(() =>
+          t.query(components.resend.lib.getStatus, {
+            emailId,
+          })
+        );
+
+        expect(status).toMatchObject({ status: "cancelled" });
+        expect(user).not.toHaveProperty("welcomeEmailId");
       })
-    );
-    const emailId = await t.mutation((ctx) =>
-      testResend.sendEmail(ctx, {
-        from: "Nakafa <nakafa@notifications.nakafa.com>",
-        subject: "Welcome",
-        text: "Welcome",
-        to: "delivered@resend.dev",
-      })
-    );
-    await t.mutation((ctx) =>
-      ctx.db.patch("users", userId, {
-        welcomeEmailId: emailId,
-      })
-    );
+  );
 
-    await t.mutation(async (ctx) => {
-      const user = await ctx.db.get("users", userId);
-
-      if (!user) {
-        throw new Error("Expected the welcome email owner.");
-      }
-
-      await runConvexProgram(cancelPendingWelcomeEmail(ctx, user));
-    });
-
-    const user = await t.query((ctx) => ctx.db.get("users", userId));
-    await expect(
-      t.query(components.resend.lib.getStatus, {
-        emailId,
-      })
-    ).resolves.toMatchObject({ status: "cancelled" });
-    expect(user).not.toHaveProperty("welcomeEmailId");
-  });
-
-  it.live.each(["waiting", "queued"] as const)(
+  it.effect.each(["waiting", "queued"] as const)(
     "cancels and clears a %s welcome email",
     (status) =>
       Effect.gen(function* () {
@@ -90,7 +114,7 @@ describe("emails/deletion", () => {
       })
   );
 
-  it.live.each([null, "sent", "delivered", "cancelled"] as const)(
+  it.effect.each([null, "sent", "delivered", "cancelled"] as const)(
     "clears a non-cancellable %s welcome email without failing deletion",
     (status) =>
       Effect.gen(function* () {

--- a/packages/backend/convex/emails/welcome.test.ts
+++ b/packages/backend/convex/emails/welcome.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { canonicalizePublicPageProjection } from "@nakafa/aksara-contracts/projection/page";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -11,7 +12,6 @@ import {
   TEST_PAGE_PROJECTION_JSON,
 } from "@repo/backend/test/content-page";
 import { TEST_ARTICLE_PROJECTION_JSON } from "@repo/backend/test/content-runtime";
-import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -25,23 +25,21 @@ function pageJson(pageKey: string, publicPath: string) {
 }
 
 /** Inserts one welcome-email recipient fixture. */
-function insertWelcomeUser(
-  ctx: MutationCtx,
-  suffix: string,
-  deletionPreparedAt?: number
-) {
-  return Effect.promise(() =>
-    ctx.db.insert("users", {
-      authId: `${suffix}-welcome-owner`,
-      credits: 0,
-      creditsResetAt: 0,
-      deletionPreparedAt,
-      email: `${suffix}@example.com`,
-      name: `${suffix} Welcome Owner`,
-      plan: "free",
-    })
-  );
-}
+const insertWelcomeUser = Effect.fn("test.emails.welcome.insertUser")(
+  function* (ctx: MutationCtx, suffix: string, deletionPreparedAt?: number) {
+    return yield* Effect.promise(() =>
+      ctx.db.insert("users", {
+        authId: `${suffix}-welcome-owner`,
+        credits: 0,
+        creditsResetAt: 0,
+        deletionPreparedAt,
+        email: `${suffix}@example.com`,
+        name: `${suffix} Welcome Owner`,
+        plan: "free",
+      })
+    );
+  }
+);
 
 describe("emails/welcome", () => {
   it.effect(


### PR DESCRIPTION
## Scope

Migrate the backend email test domain directly to the official Effect v4 Vitest integration. This is intentionally limited to two existing test files and three reviewable commits.

## Native Effect v4

- Import `describe`, `expect`, and `it` from `@effect/vitest`, with no `@repo/testing/effect` wrapper.
- Run the Convex component scenario through `it.effect` and model its Promise boundaries with `Effect.promise`.
- Replace unnecessary `it.live` cases with `it.effect`.
- Name the effectful welcome-user fixture with `Effect.fn`.
- Use RC110 `Effect.die` for the impossible fixture defect. The Effect-patched compiler rejects the removed v3 `Effect.dieMessage` API.

Pure deterministic helpers remain ordinary TypeScript because they perform no IO and cannot fail.

## Behavior

No production email behavior, schema, dependency, generated code, configuration, or lockfile changes. Existing assertions and all seven tests in each file are preserved.

## Exact proof

Exact base `aa7fef358c845cb7b0d60f3db85a47043a8fe6c1`, head `74d9972d8c51eabb3e4cdf8319766ad23cd6e35a`, aggregate patch ID `e37b247fcdb03bdddbd0d9b76724c7bedc006b73`. The patch ID is unchanged across both required protected-main rebases after #413 and #390 merged.

Local proof is green:

- focused email files: 2 files, 14 tests
- full backend: 348 files, 1,506 tests
- backend typecheck
- Effect source parity at `effect@4.0.0-rc.110` and vendored SHA `66114151c2b4640bf773f2b3456ce70d679422f6`
- test ownership, lint, boundaries, security audit, formatting, and diff checks

## Release

This is test-only and must pass exact-head Quality, Doctor, Production Scope, Required, and review. Production must remain skipped. No Vercel Preview was created or requested.