### PR TITLE
test(backend): adopt native Effect Vitest for learning

### DIFF
--- a/packages/backend/convex/learningPreferences/program.test.ts
+++ b/packages/backend/convex/learningPreferences/program.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { listCurriculumPrograms } from "@repo/backend/convex/learningPreferences/program";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -7,12 +8,11 @@ import {
   makeProgramSnapshotData,
   makeTechnicalProgram,
 } from "@repo/backend/test/program-snapshot";
-import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 
 describe("learningPreferences/program", () => {
-  it.live(
+  it.effect(
     "filters program kinds before enforcing the curriculum preference limit",
     () =>
       Effect.gen(function* () {
@@ -40,7 +40,7 @@ describe("learningPreferences/program", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "rejects a published preference list beyond its bounded UI contract",
     () =>
       Effect.gen(function* () {

--- a/packages/backend/convex/learningPrograms/selection.test.ts
+++ b/packages/backend/convex/learningPrograms/selection.test.ts
@@ -1,9 +1,11 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   type LearningProgram,
   LearningProgramKeySchema,
   LearningProgramSchema,
 } from "@nakafa/aksara-contracts/program/spec";
 import { api } from "@repo/backend/convex/_generated/api";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import {
   createConvexTestWithBetterAuth,
@@ -15,7 +17,6 @@ import {
   makeProgramSnapshotData,
   makeTechnicalProgram,
 } from "@repo/backend/test/program-snapshot";
-import { describe, expect, it } from "@repo/testing/effect";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 
@@ -23,7 +24,7 @@ const NOW = 1_799_020_800_000;
 const OLD_SELECTION_AT = 1_700_000_000_000;
 
 describe("learningPrograms/selection", () => {
-  it.live(
+  it.effect(
     "lists only selectable programs from the signed active snapshot",
     () =>
       Effect.gen(function* () {
@@ -48,7 +49,7 @@ describe("learningPrograms/selection", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "saves one signed selection without creating profile or plan rows",
     () =>
       Effect.gen(function* () {
@@ -115,7 +116,7 @@ describe("learningPrograms/selection", () => {
       })
   );
 
-  it.live("returns no selection after its signed program is retired", () =>
+  it.effect("returns no selection after its signed program is retired", () =>
     Effect.gen(function* () {
       const target = createConvexTestWithBetterAuth();
       const data = yield* makeProgramSnapshotData([
@@ -126,15 +127,15 @@ describe("learningPrograms/selection", () => {
         target.mutation((ctx) => seedAuthenticatedUser(ctx, { now: NOW }))
       );
       yield* Effect.promise(() =>
-        target.mutation(async (ctx) => {
-          await ctx.db.insert("learningPreferences", {
+        target.mutation((ctx) =>
+          ctx.db.insert("learningPreferences", {
             learningInterest: "school-curriculum",
             primaryProgramKey: "merdeka",
             selectionUpdatedAt: NOW,
             updatedAt: NOW,
             userId: identity.userId,
-          });
-        })
+          })
+        )
       );
       const authed = target.withIdentity({
         sessionId: identity.sessionId,
@@ -151,7 +152,7 @@ describe("learningPrograms/selection", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "refreshes the timestamp when a user explicitly reselects a program",
     () =>
       Effect.gen(function* () {
@@ -207,7 +208,7 @@ describe("learningPrograms/selection", () => {
       })
   );
 
-  it.live("rejects missing, planned, and interest-mismatched programs", () =>
+  it.effect("rejects missing, planned, and interest-mismatched programs", () =>
     Effect.gen(function* () {
       const target = createConvexTestWithBetterAuth();
       const data = yield* makeProgramSnapshotData([
@@ -253,7 +254,7 @@ describe("learningPrograms/selection", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "reports duplicate preference rows through the typed persistence contract",
     () =>
       Effect.gen(function* () {
@@ -266,16 +267,24 @@ describe("learningPrograms/selection", () => {
           target.mutation((ctx) => seedAuthenticatedUser(ctx, { now: NOW }))
         );
         yield* Effect.promise(() =>
-          target.mutation(async (ctx) => {
-            await ctx.db.insert("learningPreferences", {
-              updatedAt: NOW,
-              userId: identity.userId,
-            });
-            await ctx.db.insert("learningPreferences", {
-              updatedAt: NOW + 1,
-              userId: identity.userId,
-            });
-          })
+          target.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                yield* Effect.promise(() =>
+                  ctx.db.insert("learningPreferences", {
+                    updatedAt: NOW,
+                    userId: identity.userId,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("learningPreferences", {
+                    updatedAt: NOW + 1,
+                    userId: identity.userId,
+                  })
+                );
+              })
+            )
+          )
         );
         const authed = target.withIdentity({
           sessionId: identity.sessionId,
@@ -294,17 +303,19 @@ describe("learningPrograms/selection", () => {
       })
   );
 
-  it("fails closed when no signed program snapshot is active", async () => {
+  it.effect("fails closed when no signed program snapshot is active", () => {
     const target = convexTest(schema, convexModules);
 
-    await expect(
-      target.query(api.learningPrograms.queries.listSelectablePrograms, {
-        locale: "id",
-      })
-    ).rejects.toThrow("CONTENT_RELEASE_MISSING");
+    return Effect.promise(() =>
+      expect(
+        target.query(api.learningPrograms.queries.listSelectablePrograms, {
+          locale: "id",
+        })
+      ).rejects.toThrow("CONTENT_RELEASE_MISSING")
+    );
   });
 
-  it.live("rejects a signed program whose localized root is missing", () =>
+  it.effect("rejects a signed program whose localized root is missing", () =>
     Effect.gen(function* () {
       const target = convexTest(schema, convexModules);
       const data = yield* makeProgramSnapshotData([
@@ -312,25 +323,33 @@ describe("learningPrograms/selection", () => {
       ]);
       yield* Effect.promise(() => activateProgramSnapshot(target, data));
       yield* Effect.promise(() =>
-        target.mutation(async (ctx) => {
-          const root = await ctx.db
-            .query("curriculumRoutes")
-            .withIndex(
-              "by_snapshotId_and_appLocale_and_parentPath_and_order_and_path",
-              (index) =>
-                index
-                  .eq("snapshotId", data.snapshotId)
-                  .eq("appLocale", "id")
-                  .eq("parentPath", undefined)
-            )
-            .unique();
+        target.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const root = yield* Effect.promise(() =>
+                ctx.db
+                  .query("curriculumRoutes")
+                  .withIndex(
+                    "by_snapshotId_and_appLocale_and_parentPath_and_order_and_path",
+                    (index) =>
+                      index
+                        .eq("snapshotId", data.snapshotId)
+                        .eq("appLocale", "id")
+                        .eq("parentPath", undefined)
+                  )
+                  .unique()
+              );
 
-          if (!root) {
-            throw new Error("Expected one localized program root.");
-          }
+              if (!root) {
+                return yield* Effect.die(
+                  new Error("Expected one localized program root.")
+                );
+              }
 
-          await ctx.db.delete(root._id);
-        })
+              yield* Effect.promise(() => ctx.db.delete(root._id));
+            })
+          )
+        )
       );
 
       yield* Effect.promise(() =>


### PR DESCRIPTION
## Scope

Migrate the backend learning program test domain directly to the official Effect v4 Vitest integration. This checkpoint is limited to two existing test files and two reviewable commits.

## Native Effect v4

- Import test APIs directly from `@effect/vitest`, with no `@repo/testing/effect` wrapper.
- Replace unnecessary `it.live` cases with `it.effect`; every scenario uses explicit deterministic timestamps.
- Convert the remaining raw async test to `it.effect`.
- Model Convex Promise boundaries with `Effect.promise`.
- Compose multi-step Convex mutations as Effects through the repository's existing framework-boundary `runConvexProgram`.
- Represent impossible fixture state with the RC110 `Effect.die` API.

## Behavior

No production learning program behavior, schema, generated code, dependency, configuration, or lockfile changes. Existing assertions and all 10 focused cases are preserved.

## Exact proof

Exact base `ad76a86824a69eddf72f53506d40a7cb8c728eb2`, head `29df6d269e349ac017c13272c33b2b64cfec6b02`, aggregate patch ID `f827998014ead224934924882c04dc774ced16e6`.

Local proof is green:

- focused learning files: 2 files, 10 tests
- full backend: 348 files, 1,506 tests
- backend typecheck
- Effect source parity at `effect@4.0.0-rc.110` and vendored SHA `66114151c2b4640bf773f2b3456ce70d679422f6`
- test ownership, lint, boundaries, security audit, formatting, and diff checks

## Release

This is test-only. Production must remain skipped, and no Vercel Preview is requested or permitted.