### PR TITLE
test(backend): make Convex Effect boundary tests native

### DIFF
--- a/packages/backend/convex/lib/effect.test.ts
+++ b/packages/backend/convex/lib/effect.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   getUnknownErrorMessage,
   readConvexErrorData,
   runConvexActionProgram,
   runConvexProgram,
 } from "@repo/backend/convex/lib/effect";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { ConvexError } from "convex/values";
 import { Cause, Clock, Effect, Schema } from "effect";
 import { vi } from "vitest";
@@ -24,112 +24,153 @@ afterEach(() => {
 });
 
 describe("lib/effect", () => {
-  it("runs successful programs at the Convex boundary", async () => {
-    await expect(runConvexProgram(Effect.succeed("ok"))).resolves.toBe("ok");
-  });
+  it.effect("runs successful programs at the Convex boundary", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runConvexProgram(Effect.succeed("ok"))
+      );
 
-  it("does not use the Performance API while running traced programs", async () => {
-    vi.spyOn(performance, "now").mockImplementation(() => {
-      throw new Error("Performance API is unavailable");
-    });
-    const tracedProgram = Effect.fn("test.tracedProgram")(function* () {
-      return yield* Effect.succeed("ok");
-    });
+      expect(result).toBe("ok");
+    })
+  );
 
-    await expect(runConvexProgram(tracedProgram())).resolves.toBe("ok");
-  });
+  it.effect(
+    "does not use the Performance API while running traced programs",
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() => {
+          vi.spyOn(performance, "now").mockImplementation(() => {
+            throw new Error("Performance API is unavailable");
+          });
+        });
+        const tracedProgram = Effect.fn("test.tracedProgram")(function* () {
+          return yield* Effect.succeed("ok");
+        });
+        const result = yield* Effect.promise(() =>
+          runConvexProgram(tracedProgram())
+        );
 
-  it("uses a Date-backed clock inside native Convex handlers", async () => {
-    const now = 1_780_000_000_000;
-    vi.spyOn(Date, "now").mockReturnValue(now);
+        expect(result).toBe("ok");
+      })
+  );
 
-    await expect(runConvexProgram(Clock.currentTimeMillis)).resolves.toBe(now);
-    await expect(runConvexProgram(Clock.currentTimeNanos)).resolves.toBe(
-      BigInt(now) * 1_000_000n
-    );
-    await expect(
-      runConvexProgram(
-        Clock.clockWith((clock) =>
-          Effect.sync(() => [
-            clock.currentTimeMillisUnsafe(),
-            clock.currentTimeNanosUnsafe(),
-          ])
-        )
-      )
-    ).resolves.toEqual([now, BigInt(now) * 1_000_000n]);
-  });
-
-  it("rejects sleeping inside native Convex handlers", async () => {
-    await expect(runConvexProgram(Effect.sleep(1))).rejects.toThrow(
-      "Effect.sleep is not supported inside native Convex handlers."
-    );
-  });
-
-  it("does not schedule timers when native programs yield", async () => {
-    const setImmediateSpy = vi
-      .spyOn(globalThis, "setImmediate")
-      .mockImplementation(() => {
-        throw new Error("setImmediate is unavailable in native Convex");
+  it.effect("uses a Date-backed clock inside native Convex handlers", () =>
+    Effect.gen(function* () {
+      const now = 1_780_000_000_000;
+      yield* Effect.sync(() => {
+        vi.spyOn(Date, "now").mockReturnValue(now);
       });
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation(() => {
-        throw new Error("setTimeout is unavailable in native Convex");
-      });
-
-    await expect(
-      runConvexProgram(Effect.yieldNow.pipe(Effect.as("done")))
-    ).resolves.toBe("done");
-    expect(setImmediateSpy).not.toHaveBeenCalled();
-    expect(setTimeoutSpy).not.toHaveBeenCalled();
-  });
-
-  it("supports the live clock at the Node action boundary", async () => {
-    await expect(
-      runConvexActionProgram(Effect.sleep(1).pipe(Effect.as("done")))
-    ).resolves.toBe("done");
-  });
-
-  it("maps tagged Effect failures into ConvexError payloads", async () => {
-    await expect(
-      runConvexProgram(
-        Effect.fail(
-          new BoundaryFailure({
-            code: boundaryFailureCode,
-            message: "Boundary failed",
-          })
+      const milliseconds = yield* Effect.promise(() =>
+        runConvexProgram(Clock.currentTimeMillis)
+      );
+      const nanoseconds = yield* Effect.promise(() =>
+        runConvexProgram(Clock.currentTimeNanos)
+      );
+      const unsafeTimes = yield* Effect.promise(() =>
+        runConvexProgram(
+          Clock.clockWith((clock) =>
+            Effect.sync(() => [
+              clock.currentTimeMillisUnsafe(),
+              clock.currentTimeNanosUnsafe(),
+            ])
+          )
         )
+      );
+
+      expect(milliseconds).toBe(now);
+      expect(nanoseconds).toBe(BigInt(now) * 1_000_000n);
+      expect(unsafeTimes).toEqual([now, BigInt(now) * 1_000_000n]);
+    })
+  );
+
+  it.effect("rejects sleeping inside native Convex handlers", () =>
+    Effect.promise(() =>
+      expect(runConvexProgram(Effect.sleep(1))).rejects.toThrow(
+        "Effect.sleep is not supported inside native Convex handlers."
       )
-    ).rejects.toMatchObject({
-      data: {
-        code: boundaryFailureCode,
-        message: "Boundary failed",
-      },
-    });
-  });
+    )
+  );
 
-  it("preserves unexpected defects instead of turning them into domain errors", async () => {
-    await expect(runConvexProgram(Effect.die("defect"))).rejects.toThrow(
-      "defect"
-    );
-  });
+  it.effect("does not schedule timers when native programs yield", () =>
+    Effect.gen(function* () {
+      const setImmediateSpy = yield* Effect.sync(() =>
+        vi.spyOn(globalThis, "setImmediate").mockImplementation(() => {
+          throw new Error("setImmediate is unavailable in native Convex");
+        })
+      );
+      const setTimeoutSpy = yield* Effect.sync(() =>
+        vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+          throw new Error("setTimeout is unavailable in native Convex");
+        })
+      );
+      const result = yield* Effect.promise(() =>
+        runConvexProgram(Effect.yieldNow.pipe(Effect.as("done")))
+      );
 
-  it("preserves a defect when a cause also contains a tagged failure", async () => {
-    const defect = new Error("Unexpected boundary defect");
-    const cause = Cause.fromReasons([
-      Cause.makeFailReason(
-        new BoundaryFailure({
+      expect(result).toBe("done");
+      expect(setImmediateSpy).not.toHaveBeenCalled();
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("supports the live clock at the Node action boundary", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runConvexActionProgram(Effect.sleep(1).pipe(Effect.as("done")))
+      );
+
+      expect(result).toBe("done");
+    })
+  );
+
+  it.effect("maps tagged Effect failures into ConvexError payloads", () =>
+    Effect.promise(() =>
+      expect(
+        runConvexProgram(
+          Effect.fail(
+            new BoundaryFailure({
+              code: boundaryFailureCode,
+              message: "Boundary failed",
+            })
+          )
+        )
+      ).rejects.toMatchObject({
+        data: {
           code: boundaryFailureCode,
           message: "Boundary failed",
-        })
-      ),
-      Cause.makeDieReason(defect),
-    ]);
+        },
+      })
+    )
+  );
 
-    await expect(runConvexProgram(Effect.failCause(cause))).rejects.toBe(
-      defect
-    );
-  });
+  it.effect(
+    "preserves unexpected defects instead of turning them into domain errors",
+    () =>
+      Effect.promise(() =>
+        expect(runConvexProgram(Effect.die("defect"))).rejects.toThrow("defect")
+      )
+  );
+
+  it.effect(
+    "preserves a defect when a cause also contains a tagged failure",
+    () =>
+      Effect.gen(function* () {
+        const defect = new Error("Unexpected boundary defect");
+        const cause = Cause.fromReasons([
+          Cause.makeFailReason(
+            new BoundaryFailure({
+              code: boundaryFailureCode,
+              message: "Boundary failed",
+            })
+          ),
+          Cause.makeDieReason(defect),
+        ]);
+
+        yield* Effect.promise(() =>
+          expect(runConvexProgram(Effect.failCause(cause))).rejects.toBe(defect)
+        );
+      })
+  );
 
   it("normalizes unknown thrown values into messages", () => {
     expect(getUnknownErrorMessage(new Error("Exploded"))).toBe("Exploded");


### PR DESCRIPTION
## Scope

Migrate the repository-owned Convex Effect boundary test directly to the official Effect v4 Vitest integration. This checkpoint changes one existing test file and one commit.

## Native Effect v4

- Import test lifecycle and assertion APIs directly from `@effect/vitest`, with no `@repo/testing/effect` wrapper.
- Convert all eight effectful raw async cases to `it.effect`.
- Lift the external Promise boundary with `Effect.promise`.
- Keep the two pure deterministic message and payload tests on ordinary `it`.
- Retain the direct `vitest` import only for `vi` mocking APIs.

## Behavior

No production boundary behavior, dependency, configuration, schema, generated code, or lockfile changes. All 11 focused cases and their assertions are preserved.

## Exact proof

Exact base `6221077ff967a7d11f6820c7e07a55660ce4ece0`, head `70fe69b52ec91062b572ed1004886c31a47bbbf8`, patch ID `3c79f019e8e783135aad03e776ce5e259fc2e9f2`.

Local proof is green:

- focused boundary file: 1 file, 11 tests
- full backend: 348 files, 1,506 tests
- backend typecheck
- Effect source parity at `effect@4.0.0-rc.110` and vendored SHA `66114151c2b4640bf773f2b3456ce70d679422f6`
- test ownership, lint, boundaries, security audit, formatting, and diff checks

## Review

The exact diff contains no wrapper import, direct Effect runtime runner, raw async test callback, or `it.live`. Existing raw throws occur only inside mocks that prove unavailable native APIs are never called.

## Release

This is test-only. Production must remain skipped, and no Vercel Preview is requested or permitted.