### PR TITLE
test(www): make LLMS inventory Effect native

### DIFF
--- a/apps/www/lib/llms/material-pages.test.ts
+++ b/apps/www/lib/llms/material-pages.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readMaterialLlmsInventory } from "@/lib/llms/material-pages";
 
 const mockReadPublishedBuckets = vi.hoisted(() => vi.fn());
@@ -21,14 +22,14 @@ beforeEach(() => {
 });
 
 describe("material LLMS pages", () => {
-  it("projects the signed material inventory", async () => {
-    await expect(
-      Effect.runPromise(readMaterialLlmsInventory("en"))
-    ).resolves.toEqual({
-      activeReleaseId: "release-material",
-      buckets: ["abc"],
-      pageCount: 1,
-      routeCount: 1,
-    });
-  });
+  it.effect("projects the signed material inventory", () =>
+    Effect.gen(function* () {
+      expect(yield* readMaterialLlmsInventory("en")).toEqual({
+        activeReleaseId: "release-material",
+        buckets: ["abc"],
+        pageCount: 1,
+        routeCount: 1,
+      });
+    })
+  );
 });

--- a/apps/www/lib/llms/site.test.ts
+++ b/apps/www/lib/llms/site.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { buildSiteLlmsEntries } from "@/lib/llms/entries";
 import { readSiteLlmsEntries } from "@/lib/llms/site";
 import { testPageProjection } from "@/test/content-page";
@@ -22,10 +23,12 @@ beforeEach(() => {
 });
 
 describe("site llms entries", () => {
-  it("reads site routes from the active signed Page catalog", async () => {
-    await expect(Effect.runPromise(readSiteLlmsEntries("en"))).resolves.toEqual(
-      buildSiteLlmsEntries("en", [testPageProjection])
-    );
-    expect(catalogMock).toHaveBeenCalledOnce();
-  });
+  it.effect("reads site routes from the active signed Page catalog", () =>
+    Effect.gen(function* () {
+      expect(yield* readSiteLlmsEntries("en")).toEqual(
+        buildSiteLlmsEntries("en", [testPageProjection])
+      );
+      expect(catalogMock).toHaveBeenCalledOnce();
+    })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate two existing WWW LLMS inventory tests directly to the official Effect v4 Vitest integration. This checkpoint changes two closely related test modules in one commit.

## Native Effect v4

- Import test APIs directly from `@effect/vitest`.
- Convert both effectful cases to `it.effect`.
- Compose the signed catalog Effects directly inside `Effect.gen`.
- Keep `vi` imported from Vitest only for transform and mock APIs.
- Add no wrapper, compatibility layer, dependency, policy allowlist, global mock, helper, or service abstraction.

## Behavior

This is test-only. Production LLMS inventory behavior, signed catalogs, dependencies, configuration, and generated code are unchanged. Both existing behavioral cases and assertions are preserved.

## Exact proof

Base `a24bbac609aef711e86029cbe1629e28d66c8504`, head `5aea5360d2036daa3a374b94ec2dc92bfb38d58f`, patch ID `5f661c7b033ab14f7f91a294b65206f12a661bf9`.

Local proof is green:

- focused LLMS inventory suite: 2 files, 2 tests
- WWW suite: 210 files, 1,519 tests, 100% statements, branches, functions, and lines
- WWW typecheck
- formatting and repository lint
- Effect source parity at `effect@4.0.0-rc.110`
- test ownership policy
- package boundaries
- security audit
- diff and migration scans

## Review

The exact files have no `@repo/testing/effect` import, direct Effect runtime runner, raw async test callback, or `it.live`.

## Merge readiness

The branch is based on current Nakafa main. Merge only after this exact head has clean required checks, review, threads, and strict-base status.