### PR TITLE
test(www): make published identity Effect native

### DIFF
--- a/apps/www/lib/content/published/active.test.ts
+++ b/apps/www/lib/content/published/active.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ReleaseIdSchema,
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readActiveContentIdentity } from "@/lib/content/published/active";
 import { createTestRuntimeQuery } from "@/test/runtime-query";
 
@@ -23,25 +24,27 @@ beforeEach(() => {
 });
 
 describe("published active identity", () => {
-  it("reads the exact active release without another state interpretation", async () => {
-    const identity = {
-      manifestHash: Sha256HashSchema.make(`sha256:${"a".repeat(64)}`),
-      releaseId: ReleaseIdSchema.make("release-active"),
-      sequence: 3,
-    };
-    fetchQueryMock.mockResolvedValue(identity);
+  it.effect(
+    "reads the exact active release without another state interpretation",
+    () =>
+      Effect.gen(function* () {
+        const identity = {
+          manifestHash: Sha256HashSchema.make(`sha256:${"a".repeat(64)}`),
+          releaseId: ReleaseIdSchema.make("release-active"),
+          sequence: 3,
+        };
+        fetchQueryMock.mockResolvedValue(identity);
 
-    await expect(
-      Effect.runPromise(readActiveContentIdentity())
-    ).resolves.toEqual(identity);
-    expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {});
-  });
+        expect(yield* readActiveContentIdentity()).toEqual(identity);
+        expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {});
+      })
+  );
 
-  it("preserves the absence of an active release", async () => {
-    fetchQueryMock.mockResolvedValue(null);
+  it.effect("preserves the absence of an active release", () =>
+    Effect.gen(function* () {
+      fetchQueryMock.mockResolvedValue(null);
 
-    await expect(
-      Effect.runPromise(readActiveContentIdentity())
-    ).resolves.toBeNull();
-  });
+      expect(yield* readActiveContentIdentity()).toBeNull();
+    })
+  );
 });

--- a/apps/www/lib/content/published/origin.test.ts
+++ b/apps/www/lib/content/published/origin.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
 
 const identity = {
@@ -9,28 +9,27 @@ const identity = {
 } as const;
 
 describe("content/published/origin", () => {
-  it("treats omitted and null revisions as absent", async () => {
-    await expect(
-      Effect.runPromise(decodeSourceRevision(undefined, identity))
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(decodeSourceRevision(null, identity))
-    ).resolves.toBeNull();
-  });
+  it.effect("treats omitted and null revisions as absent", () =>
+    Effect.gen(function* () {
+      expect(yield* decodeSourceRevision(undefined, identity)).toBeNull();
+      expect(yield* decodeSourceRevision(null, identity)).toBeNull();
+    })
+  );
 
-  it("decodes exact Git provenance", async () => {
-    const revision = "a".repeat(40);
+  it.effect("decodes exact Git provenance", () =>
+    Effect.gen(function* () {
+      const revision = "a".repeat(40);
 
-    await expect(
-      Effect.runPromise(decodeSourceRevision(revision, identity))
-    ).resolves.toBe(revision);
-  });
+      expect(yield* decodeSourceRevision(revision, identity)).toBe(revision);
+    })
+  );
 
-  it("rejects malformed Git provenance", async () => {
-    await expect(
-      Effect.runPromise(
-        decodeSourceRevision("not-a-commit", identity).pipe(Effect.flip)
+  it.effect("rejects malformed Git provenance", () =>
+    decodeSourceRevision("not-a-commit", identity).pipe(
+      Effect.flip,
+      Effect.map((error) =>
+        expect(error).toMatchObject({ _tag: "PublishedProjectionError" })
       )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+    )
+  );
 });

--- a/apps/www/lib/content/published/release.test.ts
+++ b/apps/www/lib/content/published/release.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import type { PublishedProjectionIdentity } from "@/lib/content/published/errors";
 import {
   decodeContentReleasePin,
@@ -28,62 +29,66 @@ beforeEach(() => {
 });
 
 describe("content release pin", () => {
-  it.each([
+  it.effect.each([
     ["active release", activeReleaseId],
     ["no active release", null],
-  ])("decodes %s", async (_label, actual) => {
-    await expect(
-      Effect.runPromise(decodeContentReleasePin(actual, undefined, identity))
-    ).resolves.toBe(actual);
-  });
+  ])("decodes %s", ([, actual]) =>
+    Effect.gen(function* () {
+      expect(yield* decodeContentReleasePin(actual, undefined, identity)).toBe(
+        actual
+      );
+    })
+  );
 
-  it("maps malformed release data to the material projection failure", async () => {
-    await expect(
-      Effect.runPromise(
-        decodeContentReleasePin("invalid release", undefined, identity).pipe(
-          Effect.flip
+  it.effect(
+    "maps malformed release data to the material projection failure",
+    () =>
+      decodeContentReleasePin("invalid release", undefined, identity).pipe(
+        Effect.flip,
+        Effect.map((error) =>
+          expect(error).toMatchObject({
+            _tag: "PublishedProjectionError",
+            ...identity,
+          })
         )
       )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-  });
+  );
 
-  it("rejects a changed active release", async () => {
-    await expect(
-      Effect.runPromise(
-        decodeContentReleasePin(nextReleaseId, activeReleaseId, identity).pipe(
-          Effect.flip
-        )
+  it.effect("rejects a changed active release", () =>
+    decodeContentReleasePin(nextReleaseId, activeReleaseId, identity).pipe(
+      Effect.flip,
+      Effect.map((error) =>
+        expect(error).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+          actualReleaseId: nextReleaseId,
+          expectedReleaseId: activeReleaseId,
+        })
       )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: nextReleaseId,
-      expectedReleaseId: activeReleaseId,
-    });
-  });
+    )
+  );
 
-  it("rechecks the latest active release identity", async () => {
-    readActiveContentIdentityMock.mockReturnValueOnce(
-      Effect.succeed({
-        manifestHash: `sha256:${"a".repeat(64)}`,
-        releaseId: activeReleaseId,
-        sequence: 3,
-      })
-    );
+  it.effect("rechecks the latest active release identity", () =>
+    Effect.gen(function* () {
+      readActiveContentIdentityMock.mockReturnValueOnce(
+        Effect.succeed({
+          manifestHash: `sha256:${"a".repeat(64)}`,
+          releaseId: activeReleaseId,
+          sequence: 3,
+        })
+      );
 
-    await expect(
-      Effect.runPromise(verifyContentReleasePin(activeReleaseId, identity))
-    ).resolves.toBe(activeReleaseId);
-    expect(readActiveContentIdentityMock).toHaveBeenCalledOnce();
-  });
+      expect(yield* verifyContentReleasePin(activeReleaseId, identity)).toBe(
+        activeReleaseId
+      );
+      expect(readActiveContentIdentityMock).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("preserves an absent active release identity", async () => {
-    readActiveContentIdentityMock.mockReturnValueOnce(Effect.succeed(null));
+  it.effect("preserves an absent active release identity", () =>
+    Effect.gen(function* () {
+      readActiveContentIdentityMock.mockReturnValueOnce(Effect.succeed(null));
 
-    await expect(
-      Effect.runPromise(verifyContentReleasePin(null, identity))
-    ).resolves.toBeNull();
-  });
+      expect(yield* verifyContentReleasePin(null, identity)).toBeNull();
+    })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate three related WWW published-identity tests directly to the official Effect v4 Vitest integration. This checkpoint changes the active release, source revision, and release pin test modules in one commit.

## Native Effect v4

- Import test APIs directly from `@effect/vitest`.
- Convert all 11 effectful cases to `it.effect` or `it.effect.each`.
- Use the official single-row tuple callback for the release pin table.
- Compose typed failures directly through `Effect.flip`.
- Keep `vi` imported from Vitest only for transform and mock APIs.
- Add no wrapper, compatibility layer, dependency, policy allowlist, global mock, helper, or service abstraction.

## Behavior

This is test-only. Production published-content identity behavior, schemas, dependencies, configuration, generated code, and signed data are unchanged. Every existing behavioral case and assertion is preserved.

## Exact proof

Base `8d0e1b15eabbab4599664a8ee8fbfc0366253f76`, head `49886d75887a5bec21380e296284048c4570b799`, patch ID `d1075842eb614bdb0d2d166bee7dcb85c6677506`.

Local proof is green:

- focused published-identity suite: 3 files, 11 tests
- WWW suite: 210 files, 1,519 tests, 100% statements, branches, functions, and lines
- WWW typecheck
- formatting and repository lint
- Effect source parity at `effect@4.0.0-rc.110`
- test ownership policy
- package boundaries
- security audit
- diff and migration scans

## Review

The exact files have no `@repo/testing/effect` import, direct Effect runtime runner, raw async test callback, or `it.live`.

## Merge readiness

The branch is based on current Nakafa main. Merge only after this exact head has clean required checks, review, threads, and strict-base status.