### PR TITLE
fix(ci): admit independent main runs

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -10,8 +10,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: Agent-Friendly Docs-${{ github.ref }}
-  cancel-in-progress: true
+  # Pull request heads supersede their own predecessor runs. Protected-main
+  # runs use the immutable commit SHA so a later independent merge cannot
+  # cancel an already-admitted production acceptance.
+  group: Agent-Friendly Docs-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   production-scope:
@@ -29,28 +32,28 @@ jobs:
           REQUIRED: ${{ env.TRUSTED_CONTENT_ENVIRONMENT }}
         run: echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
 
-      - if: github.event_name == 'pull_request' && env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+      - if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup toolchain
-        if: github.event_name == 'pull_request' && env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           cache: true
           install: false
 
       - name: Install dependencies
-        if: github.event_name == 'pull_request' && env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Classify production acceptance
-        if: github.event_name == 'pull_request' && env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         id: classify
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: pnpm ci:production-acceptance
 
   quality:
@@ -89,7 +92,7 @@ jobs:
     # same-repository candidates with production-relevant changes. In-place
     # test-only candidates retain Quality while Production is skipped.
     needs: production-scope
-    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih' && needs.production-scope.outputs.required == 'true')
+    if: needs.production-scope.outputs.required == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih'))
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -52,8 +52,8 @@ jobs:
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         id: classify
         env:
-          BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: pnpm ci:production-acceptance
 
   quality:


### PR DESCRIPTION
## Root cause

Every protected-main push shared `Agent-Friendly Docs-refs/heads/main` with `cancel-in-progress: true`. Rapid independent merges therefore cancelled valid 22-minute Production acceptance runs and made Required red even when tests had not failed. The existing production classifier was used only for pull requests, so exact test-only main commits still started the full signed Production job.

## Change

- Keep pull request supersession keyed by the pull request ref.
- Key protected-main workflow runs by immutable commit SHA so a later merge cannot cancel an admitted run.
- Run the existing fail-closed Effect-native production classifier for trusted main pushes using the push before and head revisions.
- Skip Production for exact in-place `.test.ts` edits on main while retaining Quality and Required.
- Keep Production mandatory for source, workflow, added, deleted, renamed, empty, or unclassifiable changes.

## Verification

- Workflow YAML decoded and inspected successfully.
- `pnpm exec tsc --version`: `Version 7.0.2+effect-tsgo.0.36.5`.
- Focused production acceptance and GitHub Action policy tests: 13 passed.
- `pnpm typecheck:scripts`: passed.
- `pnpm lint`: passed, including Effect source parity, repository test ownership, Ultracite, and CAS lint.
- `git diff --check`: passed.

No dependency, lockfile, application runtime, Vercel, Convex, or Quran code changes. No Preview deployment requested.