### PR TITLE
test(www): make published route tests Effect native

### DIFF
--- a/apps/www/lib/content/published/projection.test.ts
+++ b/apps/www/lib/content/published/projection.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 import {
   decodePublishedArticle,
   decodePublishedPage,
@@ -16,83 +16,76 @@ const articleIdentity = {
 } satisfies Parameters<typeof decodePublishedArticle>[1];
 
 describe("published projection", () => {
-  it("decodes an exact signed article projection", async () => {
-    await expect(
-      Effect.runPromise(
-        decodePublishedArticle(testArticleProjection, articleIdentity)
-      )
-    ).resolves.toEqual(testArticleProjection);
+  it.effect("decodes an exact signed article projection", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* decodePublishedArticle(testArticleProjection, articleIdentity)
+      ).toEqual(testArticleProjection);
 
-    await expect(
-      Effect.runPromise(
-        decodePublishedArticle(testArticleProjection, {
+      expect(
+        yield* decodePublishedArticle(testArticleProjection, {
           ...articleIdentity,
           publicPath: "articles/politics/other",
         }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: testArticleProjection.appLocale,
-      publicPath: "articles/politics/other",
-    });
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        appLocale: testArticleProjection.appLocale,
+        publicPath: "articles/politics/other",
+      });
 
-    await expect(
-      Effect.runPromise(
-        decodePublishedArticle({}, articleIdentity).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...articleIdentity,
-    });
-  });
+      expect(
+        yield* decodePublishedArticle({}, articleIdentity).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...articleIdentity,
+      });
+    })
+  );
 
-  it("decodes an exact signed Page projection", async () => {
-    const identity = {
-      appLocale: testPageProjection.appLocale,
-      publicPath: testPageProjection.publicPath,
-    } satisfies Parameters<typeof decodePublishedPage>[1];
+  it.effect("decodes an exact signed Page projection", () =>
+    Effect.gen(function* () {
+      const identity = {
+        appLocale: testPageProjection.appLocale,
+        publicPath: testPageProjection.publicPath,
+      } satisfies Parameters<typeof decodePublishedPage>[1];
 
-    await expect(
-      Effect.runPromise(decodePublishedPage(testPageProjection, identity))
-    ).resolves.toEqual(testPageProjection);
-    await expect(
-      Effect.runPromise(
-        decodePublishedPage(testPageProjection, {
+      expect(yield* decodePublishedPage(testPageProjection, identity)).toEqual(
+        testPageProjection
+      );
+      expect(
+        yield* decodePublishedPage(testPageProjection, {
           ...identity,
           publicPath: "other-page",
         }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: testPageProjection.appLocale,
-      publicPath: "other-page",
-    });
-    await expect(
-      Effect.runPromise(decodePublishedPage({}, identity).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-    await expect(
-      Effect.runPromise(
-        decodePublishedPageJson(JSON.stringify(testPageProjection), identity)
-      )
-    ).resolves.toEqual(testPageProjection);
-    await expect(
-      Effect.runPromise(
-        decodePublishedPageJson("{", identity).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-    await expect(
-      Effect.runPromise(
-        decodePublishedPageJson("{}", identity).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-  });
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        appLocale: testPageProjection.appLocale,
+        publicPath: "other-page",
+      });
+      expect(
+        yield* decodePublishedPage({}, identity).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...identity,
+      });
+      expect(
+        yield* decodePublishedPageJson(
+          JSON.stringify(testPageProjection),
+          identity
+        )
+      ).toEqual(testPageProjection);
+      expect(
+        yield* decodePublishedPageJson("{", identity).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...identity,
+      });
+      expect(
+        yield* decodePublishedPageJson("{}", identity).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...identity,
+      });
+    })
+  );
 });

--- a/apps/www/lib/content/published/route.test.ts
+++ b/apps/www/lib/content/published/route.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readActiveContentRoute } from "@/lib/content/published/route";
 import { testArticleProjection } from "@/test/content-article";
 import { previewProjection } from "@/test/content-preview";
@@ -29,145 +30,155 @@ beforeEach(() => {
 });
 
 describe("published content route", () => {
-  it("skips route lookup when no content release is active", async () => {
-    await expect(
-      Effect.runPromise(
-        readActiveContentRoute({
+  it.effect("skips route lookup when no content release is active", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* readActiveContentRoute({
           activeReleaseId: null,
           appLocale: input.appLocale,
           family: input.family,
           publicPath: input.publicPath,
         })
-      )
-    ).resolves.toEqual({
-      activeReleaseId: null,
-      kind: "unmanaged",
-    });
-    expect(readQueryMock).not.toHaveBeenCalled();
-    expect(fetchQueryMock).not.toHaveBeenCalled();
-  });
-
-  it("passes unmanaged and owned absence through without projection fallback", async () => {
-    fetchQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId: input.activeReleaseId,
+      ).toEqual({
+        activeReleaseId: null,
         kind: "unmanaged",
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId: input.activeReleaseId,
-        kind: "missing",
       });
+      expect(readQueryMock).not.toHaveBeenCalled();
+      expect(fetchQueryMock).not.toHaveBeenCalled();
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input))
-    ).resolves.toEqual({
-      activeReleaseId: input.activeReleaseId,
-      kind: "unmanaged",
-    });
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input))
-    ).resolves.toEqual({
-      activeReleaseId: input.activeReleaseId,
-      kind: "missing",
-    });
-  });
+  it.effect(
+    "passes unmanaged and owned absence through without projection fallback",
+    () =>
+      Effect.gen(function* () {
+        fetchQueryMock
+          .mockResolvedValueOnce({
+            activeReleaseId: input.activeReleaseId,
+            kind: "unmanaged",
+          })
+          .mockResolvedValueOnce({
+            activeReleaseId: input.activeReleaseId,
+            kind: "missing",
+          });
 
-  it("fails when ownership changes after the caller reads active identity", async () => {
-    const nextReleaseId = ReleaseIdSchema.make("release-next");
-    fetchQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId: nextReleaseId,
-        kind: "unmanaged",
+        expect(yield* readActiveContentRoute(input)).toEqual({
+          activeReleaseId: input.activeReleaseId,
+          kind: "unmanaged",
+        });
+        expect(yield* readActiveContentRoute(input)).toEqual({
+          activeReleaseId: input.activeReleaseId,
+          kind: "missing",
+        });
       })
-      .mockResolvedValueOnce({
-        activeReleaseId: nextReleaseId,
-        kind: "missing",
-      });
+  );
 
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: "release-next",
-      expectedReleaseId: activeReleaseId,
-    });
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: "release-next",
-      expectedReleaseId: activeReleaseId,
-    });
-  });
+  it.effect(
+    "fails when ownership changes after the caller reads active identity",
+    () =>
+      Effect.gen(function* () {
+        const nextReleaseId = ReleaseIdSchema.make("release-next");
+        fetchQueryMock
+          .mockResolvedValueOnce({
+            activeReleaseId: nextReleaseId,
+            kind: "unmanaged",
+          })
+          .mockResolvedValueOnce({
+            activeReleaseId: nextReleaseId,
+            kind: "missing",
+          });
 
-  it("decodes the canonical routed projection without fetching its artifact", async () => {
-    fetchQueryMock.mockResolvedValue({
-      activeReleaseId,
-      kind: "found",
-      projectionJson: JSON.stringify(previewProjection),
-    });
+        expect(
+          yield* readActiveContentRoute(input).pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+          actualReleaseId: "release-next",
+          expectedReleaseId: activeReleaseId,
+        });
+        expect(
+          yield* readActiveContentRoute(input).pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+          actualReleaseId: "release-next",
+          expectedReleaseId: activeReleaseId,
+        });
+      })
+  );
 
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input))
-    ).resolves.toEqual({
-      activeReleaseId,
-      kind: "found",
-      projection: previewProjection,
-    });
-    expect(fetchQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: input.appLocale,
-      family: input.family,
-      publicPath: input.publicPath,
-    });
-    expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: input.appLocale,
-      family: input.family,
-      publicPath: input.publicPath,
-    });
-  });
+  it.effect(
+    "decodes the canonical routed projection without fetching its artifact",
+    () =>
+      Effect.gen(function* () {
+        fetchQueryMock.mockResolvedValue({
+          activeReleaseId,
+          kind: "found",
+          projectionJson: JSON.stringify(previewProjection),
+        });
 
-  it("surfaces malformed stored projections as typed integrity failures", async () => {
-    fetchQueryMock.mockResolvedValue({
-      activeReleaseId,
-      kind: "found",
-      projectionJson: JSON.stringify({
-        ...previewProjection,
-        publicPath: "subjects/mathematics/unrelated",
-      }),
-    });
+        expect(yield* readActiveContentRoute(input)).toEqual({
+          activeReleaseId,
+          kind: "found",
+          projection: previewProjection,
+        });
+        expect(fetchQueryMock).toHaveBeenCalledWith(expect.anything(), {
+          appLocale: input.appLocale,
+          family: input.family,
+          publicPath: input.publicPath,
+        });
+        expect(readQueryMock).toHaveBeenCalledWith(expect.anything(), {
+          appLocale: input.appLocale,
+          family: input.family,
+          publicPath: input.publicPath,
+        });
+      })
+  );
 
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: input.appLocale,
-      publicPath: input.publicPath,
-    });
+  it.effect(
+    "surfaces malformed stored projections as typed integrity failures",
+    () =>
+      Effect.gen(function* () {
+        fetchQueryMock.mockResolvedValue({
+          activeReleaseId,
+          kind: "found",
+          projectionJson: JSON.stringify({
+            ...previewProjection,
+            publicPath: "subjects/mathematics/unrelated",
+          }),
+        });
 
-    fetchQueryMock.mockResolvedValue({
-      activeReleaseId,
-      kind: "found",
-      projectionJson: JSON.stringify(testArticleProjection),
-    });
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: input.appLocale,
-      publicPath: input.publicPath,
-    });
+        expect(
+          yield* readActiveContentRoute(input).pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: input.appLocale,
+          publicPath: input.publicPath,
+        });
 
-    fetchQueryMock.mockResolvedValue({
-      activeReleaseId,
-      kind: "found",
-      projectionJson: "{",
-    });
-    await expect(
-      Effect.runPromise(readActiveContentRoute(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: input.appLocale,
-      publicPath: input.publicPath,
-    });
-  });
+        fetchQueryMock.mockResolvedValue({
+          activeReleaseId,
+          kind: "found",
+          projectionJson: JSON.stringify(testArticleProjection),
+        });
+        expect(
+          yield* readActiveContentRoute(input).pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: input.appLocale,
+          publicPath: input.publicPath,
+        });
+
+        fetchQueryMock.mockResolvedValue({
+          activeReleaseId,
+          kind: "found",
+          projectionJson: "{",
+        });
+        expect(
+          yield* readActiveContentRoute(input).pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: input.appLocale,
+          publicPath: input.publicPath,
+        });
+      })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate the published projection and active-route tests directly to the official Effect v4 Vitest integration. This checkpoint changes two related test modules in one commit.

## Native Effect v4

- Import Effect-aware test APIs directly from `@effect/vitest`.
- Convert all seven effectful cases to `it.effect`.
- Yield domain Effects directly and preserve typed failures through `Effect.flip`.
- Keep `vi` from Vitest only for mock and transform APIs.
- Add no wrapper, compatibility layer, dependency, policy allowlist, global mock, helper, service, or Layer.

## Behavior

This is test-only. Published projection decoding, route behavior, schemas, dependencies, configuration, generated code, and signed data are unchanged. Every existing assertion is preserved.

## Exact proof

Current base `9349f47eaf2bb654a80e4f1c88cbb3250017fdc1`, head `b2e3024145e4bbbc00bbc9e1eb33575ae7210cab`, patch ID `8bd018503d3614ce433468802ab16729f55b3ef4`. The rebase over CI root fix #421 preserved the exact patch.

Local proof is green:

- focused suite: 2 files, 7 tests
- WWW suite: 210 files, 1,519 tests
- 100% statements, branches, functions, and lines
- WWW typecheck, including a fresh exact-head rerun after #421
- formatting and repository lint
- Effect source parity at `effect@4.0.0-rc.110`
- test ownership and script suites
- package boundaries
- security audit

## Review

The exact files have no `@repo/testing/effect` import, direct Effect runtime runner, raw async test callback, or `it.live`.

## Merge readiness

The #421 hold is released. Merge only after this exact head has clean required checks, exact-head Codex review, zero unresolved review threads, current-main status, and clean mergeability. No Vercel Preview is requested or allowed.