### PR TITLE
test(www): make article routing Effect native

### DIFF
--- a/apps/www/lib/content/article/decode.test.ts
+++ b/apps/www/lib/content/article/decode.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { canonicalizeArticleProjection } from "@nakafa/aksara-contracts/projection/article";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 import {
   decodeArticleJson,
   isArticleCounterpart,
@@ -21,28 +21,32 @@ const identity = {
 };
 
 describe("published article decoding", () => {
-  it("decodes one canonical article projection", async () => {
-    await expect(
-      Effect.runPromise(
-        decodeArticleJson(
-          canonicalizeArticleProjection(testArticleProjection),
-          identity
-        )
-      )
-    ).resolves.toEqual(testArticleProjection);
-  });
+  it.effect("decodes one canonical article projection", () =>
+    Effect.gen(function* () {
+      const projection = yield* decodeArticleJson(
+        canonicalizeArticleProjection(testArticleProjection),
+        identity
+      );
 
-  it.each([
+      expect(projection).toEqual(testArticleProjection);
+    })
+  );
+
+  it.effect.each([
     ["invalid JSON", "{"],
     ["invalid projection", "{}"],
-  ])("preserves %s in the typed error channel", async (_label, source) => {
-    await expect(
-      Effect.runPromise(decodeArticleJson(source, identity).pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-  });
+  ])("preserves %s in the typed error channel", ([, source]) =>
+    Effect.gen(function* () {
+      const error = yield* decodeArticleJson(source, identity).pipe(
+        Effect.flip
+      );
+
+      expect(error).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...identity,
+      });
+    })
+  );
 
   it("compares stable locale counterparts", () => {
     expect(
@@ -56,43 +60,38 @@ describe("published article decoding", () => {
     ).toBe(false);
   });
 
-  it("accepts only identical projections from one active release", async () => {
-    const activeReleaseId = ReleaseIdSchema.make("release-active");
-    const catalog = { activeReleaseId, projection: testArticleProjection };
+  it.effect("accepts only identical projections from one active release", () =>
+    Effect.gen(function* () {
+      const activeReleaseId = ReleaseIdSchema.make("release-active");
+      const catalog = { activeReleaseId, projection: testArticleProjection };
 
-    await expect(
-      Effect.runPromise(verifyArticlePublication(catalog, catalog))
-    ).resolves.toBeUndefined();
+      const verified = yield* verifyArticlePublication(catalog, catalog);
+      expect(verified).toBeUndefined();
 
-    await expect(
-      Effect.runPromise(
-        verifyArticlePublication(catalog, {
-          activeReleaseId: ReleaseIdSchema.make("release-next"),
-          projection: testArticleProjection,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: "release-next",
-      expectedReleaseId: activeReleaseId,
-    });
+      const releaseError = yield* verifyArticlePublication(catalog, {
+        activeReleaseId: ReleaseIdSchema.make("release-next"),
+        projection: testArticleProjection,
+      }).pipe(Effect.flip);
+      expect(releaseError).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: "release-next",
+        expectedReleaseId: activeReleaseId,
+      });
 
-    await expect(
-      Effect.runPromise(
-        verifyArticlePublication(catalog, {
-          activeReleaseId,
-          projection: {
-            ...testArticleProjection,
-            metadata: {
-              ...testArticleProjection.metadata,
-              title: "Different title",
-            },
+      const projectionError = yield* verifyArticlePublication(catalog, {
+        activeReleaseId,
+        projection: {
+          ...testArticleProjection,
+          metadata: {
+            ...testArticleProjection.metadata,
+            title: "Different title",
           },
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      ...identity,
-    });
-  });
+        },
+      }).pipe(Effect.flip);
+      expect(projectionError).toMatchObject({
+        _tag: "PublishedProjectionError",
+        ...identity,
+      });
+    })
+  );
 });

--- a/apps/www/lib/content/article/route.test.ts
+++ b/apps/www/lib/content/article/route.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { canonicalizeArticleProjection } from "@nakafa/aksara-contracts/projection/article";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedArticleRoute,
   readPublishedArticleRoute,
@@ -63,86 +64,92 @@ beforeEach(() => {
 });
 
 describe("published article route", () => {
-  it.each([
+  it.effect.each([
     testArticleProjection,
     testArticleIdProjection,
     testArticleDeProjection,
   ])(
     "decodes one complete $appLocale route and reciprocal locale set",
-    async (projection) => {
-      runtimeQueryMock.mockResolvedValueOnce(
-        foundModel({
-          projectionJson: canonicalizeArticleProjection(projection),
-        })
-      );
+    (projection) =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce(
+          foundModel({
+            projectionJson: canonicalizeArticleProjection(projection),
+          })
+        );
 
-      await expect(
-        getPublishedArticleRoute(projection.appLocale, projection.publicPath)
-      ).resolves.toEqual({
-        activeReleaseId,
-        alternates: [
-          testArticleProjection,
-          testArticleIdProjection,
-          testArticleDeProjection,
-        ],
-        projection,
-      });
-      expect(cacheMock).toHaveBeenCalledWith("article");
-    }
+        const route = yield* Effect.tryPromise(() =>
+          getPublishedArticleRoute(projection.appLocale, projection.publicPath)
+        );
+        expect(route).toEqual({
+          activeReleaseId,
+          alternates: [
+            testArticleProjection,
+            testArticleIdProjection,
+            testArticleDeProjection,
+          ],
+          projection,
+        });
+        expect(cacheMock).toHaveBeenCalledWith("article");
+      })
   );
 
-  it("pins a route read to the expected active release", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
+  it.effect("pins a route read to the expected active release", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      getPublishedArticleRoute(
-        "en",
-        testArticleProjection.publicPath,
-        activeReleaseId
-      )
-    ).resolves.toMatchObject({ activeReleaseId });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
-    );
-  });
-
-  it("preserves an active release mismatch for pinned callers", async () => {
-    const expectedReleaseId = ReleaseIdSchema.make("release-previous");
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
-
-    await expect(
-      Effect.runPromise(
-        readPublishedArticleRoute(
+      const route = yield* Effect.tryPromise(() =>
+        getPublishedArticleRoute(
           "en",
           testArticleProjection.publicPath,
-          expectedReleaseId
-        ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: activeReleaseId,
-      expectedReleaseId,
-    });
-  });
+          activeReleaseId
+        )
+      );
+      expect(route).toMatchObject({ activeReleaseId });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
+      );
+    })
+  );
 
-  it("preserves a signed missing-route tombstone", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(
-      foundModel({ alternateJson: [], projectionJson: null })
-    );
+  it.effect("preserves an active release mismatch for pinned callers", () =>
+    Effect.gen(function* () {
+      const expectedReleaseId = ReleaseIdSchema.make("release-previous");
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      Effect.runPromise(
-        readPublishedArticleRoute("en", testArticleProjection.publicPath)
-      )
-    ).resolves.toEqual({
-      activeReleaseId,
-      alternates: [],
-      projection: null,
-    });
-  });
+      const error = yield* readPublishedArticleRoute(
+        "en",
+        testArticleProjection.publicPath,
+        expectedReleaseId
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: activeReleaseId,
+        expectedReleaseId,
+      });
+    })
+  );
 
-  it.each([
+  it.effect("preserves a signed missing-route tombstone", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(
+        foundModel({ alternateJson: [], projectionJson: null })
+      );
+
+      const route = yield* readPublishedArticleRoute(
+        "en",
+        testArticleProjection.publicPath
+      );
+      expect(route).toEqual({
+        activeReleaseId,
+        alternates: [],
+        projection: null,
+      });
+    })
+  );
+
+  it.effect.each([
     ["active locales", foundModel({ activeAppLocales: ["id", "en", "de"] })],
     ["missing release", foundModel({ activeReleaseId: null })],
     [
@@ -179,15 +186,15 @@ describe("published article route", () => {
     ],
     ["projection JSON", foundModel({ projectionJson: "{}" })],
     ["alternate JSON", foundModel({ alternateJson: ["{}"] })],
-  ])("rejects an invalid %s", async (_label, result) => {
-    runtimeQueryMock.mockResolvedValueOnce(result);
+  ])("rejects an invalid %s", ([, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(result);
 
-    await expect(
-      Effect.runPromise(
-        readPublishedArticleRoute("en", testArticleProjection.publicPath).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      const error = yield* readPublishedArticleRoute(
+        "en",
+        testArticleProjection.publicPath
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });

--- a/apps/www/lib/content/article/sitemap.test.ts
+++ b/apps/www/lib/content/article/sitemap.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   readPublishedArticleBuckets,
   readPublishedArticleSitemap,
@@ -23,77 +24,90 @@ describe("published article sitemap", () => {
     runtimeQueryMock.mockReset();
   });
 
-  it("reads bucket discovery and one exact route partition", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
+  it.effect("reads bucket discovery and one exact route partition", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          articleCount: 1,
+          buckets: ["abc"],
+          managed: true,
+        })
+        .mockResolvedValueOnce({
+          routes: [
+            {
+              lastModified: "2026-07-23",
+              publicPath: "articles/politics/article",
+            },
+          ],
+        });
+
+      const buckets = yield* readPublishedArticleBuckets("en");
+      expect(buckets).toEqual({
         activeReleaseId,
         articleCount: 1,
         buckets: ["abc"],
-        managed: true,
-      })
-      .mockResolvedValueOnce({
-        routes: [
-          {
-            lastModified: "2026-07-23",
-            publicPath: "articles/politics/article",
-          },
-        ],
+      });
+      const sitemap = yield* readPublishedArticleSitemap("en", "abc");
+      expect(sitemap).toMatchObject({
+        routes: [{ publicPath: "articles/politics/article" }],
+      });
+      expect(runtimeQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+        appLocale: "en",
+      });
+      expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+        appLocale: "en",
+        bucket: "abc",
+      });
+    })
+  );
+
+  it.effect("rejects an unmanaged article sitemap inventory", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce({
+        activeReleaseId: null,
+        articleCount: 0,
+        buckets: [],
+        managed: false,
       });
 
-    await expect(
-      Effect.runPromise(readPublishedArticleBuckets("en"))
-    ).resolves.toEqual({
-      activeReleaseId,
-      articleCount: 1,
-      buckets: ["abc"],
-    });
-    await expect(
-      Effect.runPromise(readPublishedArticleSitemap("en", "abc"))
-    ).resolves.toMatchObject({
-      routes: [{ publicPath: "articles/politics/article" }],
-    });
-    expect(runtimeQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
-      appLocale: "en",
-    });
-    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
-      appLocale: "en",
-      bucket: "abc",
-    });
-  });
+      const error = yield* readPublishedArticleBuckets("en").pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-  it("rejects an unmanaged article sitemap inventory", async () => {
-    runtimeQueryMock.mockResolvedValueOnce({
-      activeReleaseId: null,
-      articleCount: 0,
-      buckets: [],
-      managed: false,
-    });
+  it.effect(
+    "preserves runtime query failures in the Effect error channel",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockRejectedValueOnce(
+          new Error("sitemap unavailable")
+        );
 
-    await expect(
-      Effect.runPromise(readPublishedArticleBuckets("en").pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+        const error = yield* readPublishedArticleBuckets("id").pipe(
+          Effect.flip
+        );
+        expect(error).toMatchObject({
+          _tag: "TestRuntimeQueryError",
+          message: "Error: sitemap unavailable",
+        });
+      })
+  );
 
-  it("preserves runtime query failures in the Effect error channel", async () => {
-    runtimeQueryMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
+  it.effect("rejects a sitemap inventory from another signed release", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce({
+        activeReleaseId: "release-next",
+        articleCount: 1,
+        buckets: ["abc"],
+        managed: true,
+      });
 
-    await expect(
-      Effect.runPromise(readPublishedArticleBuckets("id"))
-    ).rejects.toThrow("sitemap unavailable");
-  });
-
-  it("rejects a sitemap inventory from another signed release", async () => {
-    runtimeQueryMock.mockResolvedValueOnce({
-      activeReleaseId: "release-next",
-      articleCount: 1,
-      buckets: ["abc"],
-      managed: true,
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedArticleBuckets("de", activeReleaseId).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedReleaseMismatchError" });
-  });
+      const error = yield* readPublishedArticleBuckets(
+        "de",
+        activeReleaseId
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedReleaseMismatchError" });
+    })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate the article projection decoder, signed route, and sitemap tests directly to the official Effect v4 Vitest integration. This checkpoint changes three domain-owned WWW test modules and no production module.

## Native Effect v4

- Import Effect-aware test APIs directly from `@effect/vitest`.
- Convert every effectful case and parameterized effectful case to `it.effect` and `it.effect.each`.
- Yield domain Effects and typed failures directly without `Effect.runPromise`.
- Use `Effect.tryPromise` only where the test deliberately exercises the framework Promise adapter.
- Keep the deterministic counterpart comparison on ordinary Vitest semantics.
- Keep `vi` from Vitest only for module mock APIs.

## Behavior

All existing route, locale, release pin, tombstone, sitemap, and projection assertions are preserved. The runtime rejection assertion is stronger: it now verifies the typed `TestRuntimeQueryError` in the Effect error channel instead of observing a FiberFailure through a Promise runner. Production code, runtime queries, schemas, dependencies, configuration, and signed content are unchanged.

## Exact proof

Base `6036050f9b74f9b68c8a8895ded49e35a563c870`, head `93ab34df42d217fb62b291bf3b0e3d2cd2554ea4`, patch ID `688171f5e686f82094e4b6ea8cb470e9a0e01ffa`.

Local proof is green:

- focused cohort: 3 files, 23 tests
- complete WWW suite: 210 files, 1,519 tests
- 100% statements, branches, functions, and lines
- WWW typecheck
- formatting and repository lint
- Effect source parity at `effect@4.0.0-rc.110`
- test ownership and script suites
- package boundaries
- React Doctor 100
- security audit with zero known vulnerabilities

## Review

All three files are below 300 lines. They contain no repository Effect test wrapper, direct Effect runtime runner, raw async test callback, or `it.live`. The two retained `async` callbacks are Vitest module-transform factories required by `vi.mock`.

## Merge readiness

Merge only after this exact head has clean required checks, an exact-head Codex review, zero unresolved review threads, current-main status, and clean mergeability. No Vercel Preview is requested or allowed.