### PR TITLE
feat(tryout): stage signed runtime indexes

### DIFF
--- a/packages/backend/convex/tryouts/runtime/schema.ts
+++ b/packages/backend/convex/tryouts/runtime/schema.ts
@@ -52,6 +52,8 @@ const tables = {
   ...tryoutHistorySchema,
   tryoutAttempts: defineTable({
     userId: v.id("users"),
+    tryoutBundleId: v.optional(v.id("tryoutRuntimeBundles")),
+    tryoutBundleHash: v.optional(v.string()),
     tryoutSnapshotId: v.string(),
     snapshotReleaseId: v.string(),
     setIdentity: v.string(),
@@ -85,7 +87,15 @@ const tables = {
     completedAt: v.union(v.number(), v.null()),
     endReason: v.union(attemptEndReasonValidator, v.null()),
   })
+    .index("by_scaleVersionId", {
+      fields: ["scaleVersionId"],
+      staged: true,
+    })
     .index("by_status_and_expiresAt", ["status", "expiresAt"])
+    .index("by_tryoutBundleId", {
+      fields: ["tryoutBundleId"],
+      staged: true,
+    })
     .index("by_tryoutSnapshotId", ["tryoutSnapshotId"])
     .index("by_userId_and_startedAt", ["userId", "startedAt"])
     .index("by_userId_and_status_and_expiresAt", [
@@ -242,6 +252,10 @@ const tables = {
     publishedScore: v.number(),
     finalizedAt: v.number(),
   })
+    .index("by_scaleVersionId", {
+      fields: ["scaleVersionId"],
+      staged: true,
+    })
     .index("by_tryoutAttemptId", ["tryoutAttemptId"])
     .index("by_userId_and_finalizedAt", ["userId", "finalizedAt"]),
 };


### PR DESCRIPTION
## Summary

- add optional signed runtime identifiers to existing tryout attempts without activating any writer or reader
- stage the attempt and score indexes required by the signed history migration
- keep all new indexes unqueryable until Convex completes production backfill

## Rollout

This is the expand deployment. PR #378 will only switch the indexes to active array definitions after this PR has merged, deployed through protected `main`, and the production indexes report ready.

No Vercel Preview was created.

## Verification

- `pnpm format`
- `pnpm --filter @repo/backend typecheck`
- focused tryout history reference tests
- `pnpm lint`
- `git diff --check`
- anonymous local Convex Agent Mode deployment with typechecking: `Convex functions ready!`