### PR TITLE
test(www): make article navigation Effect native

### DIFF
--- a/apps/www/lib/content/article/navigation.test.ts
+++ b/apps/www/lib/content/article/navigation.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ArticleCategorySchema,
   ArticleCategoryTitleSchema,
@@ -7,7 +8,7 @@ import {
 } from "@nakafa/aksara-contracts/projection/article";
 import { RendererDomainSchema } from "@nakafa/aksara-contracts/renderer/domain";
 import { Effect, Schema } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getShellArticleNavigation,
   readArticleNavigation,
@@ -69,89 +70,113 @@ describe("article navigation", () => {
     previewConfigMock.mockReturnValue(false);
   });
 
-  it("builds navigation from every signed category page", async () => {
-    categoryReaderMock
-      .mockReturnValueOnce(
-        Effect.succeed(
-          categoryPage({
-            category: "politics",
-            done: false,
-            title: "Politics",
-          })
+  it.effect("builds navigation from every signed category page", () =>
+    Effect.gen(function* () {
+      categoryReaderMock
+        .mockReturnValueOnce(
+          Effect.succeed(
+            categoryPage({
+              category: "politics",
+              done: false,
+              title: "Politics",
+            })
+          )
         )
-      )
-      .mockReturnValueOnce(
-        Effect.succeed(
-          categoryPage({ category: "science", done: true, title: "Science" })
-        )
+        .mockReturnValueOnce(
+          Effect.succeed(
+            categoryPage({
+              category: "science",
+              done: true,
+              title: "Science",
+            })
+          )
+        );
+
+      const navigation = yield* Effect.tryPromise(() =>
+        getShellArticleNavigation("en")
       );
 
-    await expect(getShellArticleNavigation("en")).resolves.toEqual([
-      {
-        category: "politics",
-        href: "/articles/politics",
-        title: "Politics",
-      },
-      {
-        category: "science",
-        href: "/articles/science",
-        title: "Science",
-      },
-    ]);
-    expect(categoryReaderMock).toHaveBeenNthCalledWith(2, {
-      cursor: "next",
-      expectedManifestHash: manifestHash,
-      expectedReleaseId: releaseId,
-      locale: "en",
-    });
-    expect(cacheMock).toHaveBeenCalledWith("article");
-  });
+      expect(navigation).toEqual([
+        {
+          category: "politics",
+          href: "/articles/politics",
+          title: "Politics",
+        },
+        {
+          category: "science",
+          href: "/articles/science",
+          title: "Science",
+        },
+      ]);
+      expect(categoryReaderMock).toHaveBeenNthCalledWith(2, {
+        cursor: "next",
+        expectedManifestHash: manifestHash,
+        expectedReleaseId: releaseId,
+        locale: "en",
+      });
+      expect(cacheMock).toHaveBeenCalledWith("article");
+    })
+  );
 
-  it.each([
+  it.effect.each([
     { locale: "en", route: "politics", title: "Politics" },
     { locale: "id", route: "politics", title: "Politik" },
     { locale: "de", route: "politik", title: "Politik" },
   ] as const)(
     "preserves the signed $locale category route",
-    async ({ locale, route, title }) => {
+    ({ locale, route, title }) =>
+      Effect.gen(function* () {
+        categoryReaderMock.mockReturnValueOnce(
+          Effect.succeed(
+            categoryPage({ category: "politics", done: true, route, title })
+          )
+        );
+
+        const navigation = yield* Effect.tryPromise(() =>
+          getShellArticleNavigation(locale)
+        );
+
+        expect(navigation).toEqual([
+          {
+            category: "politics",
+            href: `/articles/${route}`,
+            title,
+          },
+        ]);
+      })
+  );
+
+  it.effect("rejects a stale category release without local fallback", () =>
+    Effect.gen(function* () {
       categoryReaderMock.mockReturnValueOnce(
         Effect.succeed(
-          categoryPage({ category: "politics", done: true, route, title })
+          categoryPage({
+            category: "politics",
+            done: true,
+            stale: true,
+            title: "Politics",
+          })
         )
       );
 
-      await expect(getShellArticleNavigation(locale)).resolves.toEqual([
-        {
-          category: "politics",
-          href: `/articles/${route}`,
-          title,
-        },
-      ]);
-    }
+      const error = yield* readArticleNavigation("en").pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
   );
 
-  it("rejects a stale category release without local fallback", async () => {
-    categoryReaderMock.mockReturnValueOnce(
-      Effect.succeed(
-        categoryPage({
-          category: "politics",
-          done: true,
-          stale: true,
-          title: "Politics",
-        })
-      )
-    );
+  it.effect(
+    "keeps the local Aksara preview shell independent from publication",
+    () =>
+      Effect.gen(function* () {
+        previewConfigMock.mockReturnValue(true);
 
-    await expect(
-      Effect.runPromise(readArticleNavigation("en").pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+        const navigation = yield* Effect.tryPromise(() =>
+          getShellArticleNavigation("de")
+        );
 
-  it("keeps the local Aksara preview shell independent from publication", async () => {
-    previewConfigMock.mockReturnValue(true);
-
-    await expect(getShellArticleNavigation("de")).resolves.toEqual([]);
-    expect(categoryReaderMock).not.toHaveBeenCalled();
-    expect(cacheMock).not.toHaveBeenCalled();
-  });
+        expect(navigation).toEqual([]);
+        expect(categoryReaderMock).not.toHaveBeenCalled();
+        expect(cacheMock).not.toHaveBeenCalled();
+      })
+  );
 });


### PR DESCRIPTION
## Scope

Migrate the article navigation suite directly to the official Effect v4 Vitest integration. This checkpoint changes one WWW domain test module and no production module.

## Native Effect v4

- Import Effect-aware test APIs directly from `@effect/vitest`.
- Convert all six effectful cases, including the locale matrix, to `it.effect` and `it.effect.each`.
- Yield the typed stale-release failure directly from `readArticleNavigation`.
- Lift only the existing Next.js Promise boundary from `getShellArticleNavigation` with `Effect.tryPromise`.
- Keep `vi` from Vitest only for hoisted module mocks.
- Remove every raw async test callback and direct Effect runtime runner.

## Behavior

The suite still proves multipage signed navigation, exact continuation identity, all three locale routes, stale-release rejection without fallback, cache tagging, and the local Aksara preview shell. Production navigation code, schemas, dependencies, configuration, and signed content are unchanged.

## Exact proof

Base `8d0e82a5ea902a9888ea607d37896f52d8bb0bd2`, head `f6061a99cc5cc79ccedfd3304085656e7f457f66`, patch ID `33ef8c20882aa4e75cbea173f6a4f91e02d7f7f1`.

Local proof is green:

- focused suite: 1 file, 6 tests
- complete WWW suite: 210 files, 1,519 tests
- 100% statements, branches, functions, and lines
- WWW typecheck
- formatting and repository lint
- Effect source parity at `effect@4.0.0-rc.110`
- test ownership and script suites
- package boundaries
- React Doctor 100
- security audit with zero known vulnerabilities

## Review

The final file is 182 lines and contains no repository Effect test wrapper, direct Effect runtime runner, raw async test callback, or `it.live`. The existing synchronous Schema decode remains a pure deterministic fixture construction for a known valid renderer-domain literal.

## Merge readiness

Merge only after this exact head has clean required checks, an exact-head review, zero unresolved review threads, current-main status, and clean mergeability. Production must be skipped as test-only, and no Vercel Preview is requested or allowed.