### PR TITLE
test(api): adopt direct Effect v4 Vitest

### DIFF
--- a/apps/api/app/contents/[locale]/articles/[...slug]/route.test.ts
+++ b/apps/api/app/contents/[locale]/articles/[...slug]/route.test.ts
@@ -1,5 +1,8 @@
+import { it as effectIt } from "@effect/vitest";
+import { logError } from "@repo/utilities/logging/effect";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getArticleApiContentPage } from "@/lib/content/runtime";
 import * as route from "./route";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -9,25 +12,16 @@ const loggingMocks = vi.hoisted(() => ({
   logError: vi.fn(),
 }));
 
-vi.mock("@repo/utilities/logging/effect", async () => {
-  const { Effect } = await import("effect");
-
-  return {
-    logError: (...args: unknown[]) => {
-      loggingMocks.logError(...args);
-      return Effect.void;
-    },
-  };
+vi.mock("@repo/utilities/logging/effect", { spy: true });
+vi.mocked(logError).mockImplementation((error, context) => {
+  loggingMocks.logError(error, context);
+  return Effect.void;
 });
 
-vi.mock("@/lib/content/runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/content/runtime")>();
-
-  return {
-    ...actual,
-    getArticleApiContentPage: runtimeMocks.getArticleApiContentPage,
-  };
-});
+vi.mock("@/lib/content/runtime", { spy: true });
+vi.mocked(getArticleApiContentPage).mockImplementation(
+  runtimeMocks.getArticleApiContentPage
+);
 
 const articleRow = {
   description: "Political dynasty article.",
@@ -46,157 +40,196 @@ describe("article content API route", () => {
     expect(route.dynamic).toBe("force-dynamic");
   });
 
-  it("returns the pagination envelope for default article requests", async () => {
-    const page = {
-      continueCursor: "",
-      isDone: true,
-      page: [articleRow],
-    };
+  effectIt.effect(
+    "returns the pagination envelope for default article requests",
+    () =>
+      Effect.gen(function* () {
+        const page = {
+          continueCursor: "",
+          isDone: true,
+          page: [articleRow],
+        };
 
-    runtimeMocks.getArticleApiContentPage.mockReturnValue(Effect.succeed(page));
+        runtimeMocks.getArticleApiContentPage.mockReturnValue(
+          Effect.succeed(page)
+        );
 
-    const response = await route.GET(
-      new Request("http://localhost/contents/en/articles/politics"),
-      {
-        params: Promise.resolve({
+        const response = yield* Effect.promise(() =>
+          route.GET(
+            new Request("http://localhost/contents/en/articles/politics"),
+            {
+              params: Promise.resolve({
+                locale: "en",
+                slug: ["politics"],
+              }),
+            }
+          )
+        );
+
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual(page);
+        expect(runtimeMocks.getArticleApiContentPage).toHaveBeenCalledWith({
+          appLocale: "en",
+          cursor: null,
+          limit: 100,
+          prefix: "articles/politics",
+        });
+      })
+  );
+
+  effectIt.effect(
+    "returns the pagination envelope for explicit article pagination",
+    () =>
+      Effect.gen(function* () {
+        const page = {
+          continueCursor: "next-cursor",
+          isDone: false,
+          page: [articleRow],
+        };
+
+        runtimeMocks.getArticleApiContentPage.mockReturnValue(
+          Effect.succeed(page)
+        );
+
+        const response = yield* Effect.promise(() =>
+          route.GET(
+            new Request(
+              "http://localhost/contents/en/articles/politics?cursor=page-1&limit=1"
+            ),
+            {
+              params: Promise.resolve({
+                locale: "en",
+                slug: ["politics"],
+              }),
+            }
+          )
+        );
+
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual(page);
+        expect(runtimeMocks.getArticleApiContentPage).toHaveBeenCalledWith({
+          appLocale: "en",
+          cursor: "page-1",
+          limit: 1,
+          prefix: "articles/politics",
+        });
+      })
+  );
+
+  effectIt.effect("rejects invalid locales before reading Convex", () =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request("http://localhost/contents/fr/articles/politics"),
+          {
+            params: Promise.resolve({
+              locale: "fr",
+              slug: ["politics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(400);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Invalid locale. Supported locales: en, id, de.",
+      });
+      expect(runtimeMocks.getArticleApiContentPage).not.toHaveBeenCalled();
+    })
+  );
+
+  effectIt.effect("rejects invalid pagination before reading Convex", () =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request(
+            "http://localhost/contents/en/articles/politics?limit=101"
+          ),
+          {
+            params: Promise.resolve({
+              locale: "en",
+              slug: ["politics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(400);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Invalid pagination. Limit must be between 1 and 100.",
+      });
+      expect(runtimeMocks.getArticleApiContentPage).not.toHaveBeenCalled();
+    })
+  );
+
+  effectIt.effect("logs Convex read failures and returns an API error", () =>
+    Effect.gen(function* () {
+      const readError = new Error("Convex unavailable");
+      runtimeMocks.getArticleApiContentPage.mockReturnValue(
+        Effect.fail(readError)
+      );
+
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request("http://localhost/contents/en/articles/politics"),
+          {
+            params: Promise.resolve({
+              locale: "en",
+              slug: ["politics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(500);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Failed to fetch contents.",
+      });
+      expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
+        service: "api-contents",
+        locale: "en",
+        basePath: "politics",
+        slugLength: 1,
+        message: "Failed to fetch contents.",
+      });
+    })
+  );
+
+  effectIt.effect(
+    "logs root article prefix failures with a readable base path",
+    () =>
+      Effect.gen(function* () {
+        const readError = new Error("Convex unavailable");
+        runtimeMocks.getArticleApiContentPage.mockReturnValue(
+          Effect.fail(readError)
+        );
+
+        const response = yield* Effect.promise(() =>
+          route.GET(new Request("http://localhost/contents/en/articles"), {
+            params: Promise.resolve({
+              locale: "en",
+              slug: [],
+            }),
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({
+          error: "Failed to fetch contents.",
+        });
+        expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
+          service: "api-contents",
           locale: "en",
-          slug: ["politics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(page);
-    expect(runtimeMocks.getArticleApiContentPage).toHaveBeenCalledWith({
-      appLocale: "en",
-      cursor: null,
-      limit: 100,
-      prefix: "articles/politics",
-    });
-  });
-
-  it("returns the pagination envelope for explicit article pagination", async () => {
-    const page = {
-      continueCursor: "next-cursor",
-      isDone: false,
-      page: [articleRow],
-    };
-
-    runtimeMocks.getArticleApiContentPage.mockReturnValue(Effect.succeed(page));
-
-    const response = await route.GET(
-      new Request(
-        "http://localhost/contents/en/articles/politics?cursor=page-1&limit=1"
-      ),
-      {
-        params: Promise.resolve({
-          locale: "en",
-          slug: ["politics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(page);
-    expect(runtimeMocks.getArticleApiContentPage).toHaveBeenCalledWith({
-      appLocale: "en",
-      cursor: "page-1",
-      limit: 1,
-      prefix: "articles/politics",
-    });
-  });
-
-  it("rejects invalid locales before reading Convex", async () => {
-    const response = await route.GET(
-      new Request("http://localhost/contents/fr/articles/politics"),
-      {
-        params: Promise.resolve({
-          locale: "fr",
-          slug: ["politics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid locale. Supported locales: en, id, de.",
-    });
-    expect(runtimeMocks.getArticleApiContentPage).not.toHaveBeenCalled();
-  });
-
-  it("rejects invalid pagination before reading Convex", async () => {
-    const response = await route.GET(
-      new Request("http://localhost/contents/en/articles/politics?limit=101"),
-      {
-        params: Promise.resolve({
-          locale: "en",
-          slug: ["politics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid pagination. Limit must be between 1 and 100.",
-    });
-    expect(runtimeMocks.getArticleApiContentPage).not.toHaveBeenCalled();
-  });
-
-  it("logs Convex read failures and returns an API error", async () => {
-    const readError = new Error("Convex unavailable");
-    runtimeMocks.getArticleApiContentPage.mockReturnValue(
-      Effect.fail(readError)
-    );
-
-    const response = await route.GET(
-      new Request("http://localhost/contents/en/articles/politics"),
-      {
-        params: Promise.resolve({
-          locale: "en",
-          slug: ["politics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: "Failed to fetch contents.",
-    });
-    expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
-      service: "api-contents",
-      locale: "en",
-      basePath: "politics",
-      slugLength: 1,
-      message: "Failed to fetch contents.",
-    });
-  });
-
-  it("logs root article prefix failures with a readable base path", async () => {
-    const readError = new Error("Convex unavailable");
-    runtimeMocks.getArticleApiContentPage.mockReturnValue(
-      Effect.fail(readError)
-    );
-
-    const response = await route.GET(
-      new Request("http://localhost/contents/en/articles"),
-      {
-        params: Promise.resolve({
-          locale: "en",
-          slug: [],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: "Failed to fetch contents.",
-    });
-    expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
-      service: "api-contents",
-      locale: "en",
-      basePath: "/",
-      slugLength: 0,
-      message: "Failed to fetch contents.",
-    });
-  });
+          basePath: "/",
+          slugLength: 0,
+          message: "Failed to fetch contents.",
+        });
+      })
+  );
 });

--- a/apps/api/app/contents/[locale]/material/[...slug]/route.test.ts
+++ b/apps/api/app/contents/[locale]/material/[...slug]/route.test.ts
@@ -1,5 +1,8 @@
+import { it as effectIt } from "@effect/vitest";
+import { logError } from "@repo/utilities/logging/effect";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getMaterialApiContentPage } from "@/lib/content/runtime";
 import * as route from "./route";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -9,25 +12,16 @@ const loggingMocks = vi.hoisted(() => ({
   logError: vi.fn(),
 }));
 
-vi.mock("@repo/utilities/logging/effect", async () => {
-  const { Effect } = await import("effect");
-
-  return {
-    logError: (...args: unknown[]) => {
-      loggingMocks.logError(...args);
-      return Effect.void;
-    },
-  };
+vi.mock("@repo/utilities/logging/effect", { spy: true });
+vi.mocked(logError).mockImplementation((error, context) => {
+  loggingMocks.logError(error, context);
+  return Effect.void;
 });
 
-vi.mock("@/lib/content/runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/content/runtime")>();
-
-  return {
-    ...actual,
-    getMaterialApiContentPage: runtimeMocks.getMaterialApiContentPage,
-  };
-});
+vi.mock("@/lib/content/runtime", { spy: true });
+vi.mocked(getMaterialApiContentPage).mockImplementation(
+  runtimeMocks.getMaterialApiContentPage
+);
 
 const materialRow = {
   description: "Logarithm lesson.",
@@ -47,163 +41,202 @@ describe("material content API route", () => {
     expect(route.dynamic).toBe("force-dynamic");
   });
 
-  it("returns the pagination envelope for default material requests", async () => {
-    const page = {
-      continueCursor: "",
-      isDone: true,
-      page: [materialRow],
-    };
+  effectIt.effect(
+    "returns the pagination envelope for default material requests",
+    () =>
+      Effect.gen(function* () {
+        const page = {
+          continueCursor: "",
+          isDone: true,
+          page: [materialRow],
+        };
 
-    runtimeMocks.getMaterialApiContentPage.mockReturnValue(
-      Effect.succeed(page)
-    );
+        runtimeMocks.getMaterialApiContentPage.mockReturnValue(
+          Effect.succeed(page)
+        );
 
-    const response = await route.GET(
-      new Request("http://localhost/contents/id/material/lesson/mathematics"),
-      {
-        params: Promise.resolve({
+        const response = yield* Effect.promise(() =>
+          route.GET(
+            new Request(
+              "http://localhost/contents/id/material/lesson/mathematics"
+            ),
+            {
+              params: Promise.resolve({
+                locale: "id",
+                slug: ["lesson", "mathematics"],
+              }),
+            }
+          )
+        );
+
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual(page);
+        expect(runtimeMocks.getMaterialApiContentPage).toHaveBeenCalledWith({
+          appLocale: "id",
+          cursor: null,
+          limit: 100,
+          prefix: "material/lesson/mathematics",
+        });
+      })
+  );
+
+  effectIt.effect(
+    "returns the pagination envelope for explicit material pagination",
+    () =>
+      Effect.gen(function* () {
+        const page = {
+          continueCursor: "next-cursor",
+          isDone: false,
+          page: [materialRow],
+        };
+
+        runtimeMocks.getMaterialApiContentPage.mockReturnValue(
+          Effect.succeed(page)
+        );
+
+        const response = yield* Effect.promise(() =>
+          route.GET(
+            new Request(
+              "http://localhost/contents/id/material/lesson/mathematics?cursor=page-1&limit=1"
+            ),
+            {
+              params: Promise.resolve({
+                locale: "id",
+                slug: ["lesson", "mathematics"],
+              }),
+            }
+          )
+        );
+
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual(page);
+        expect(runtimeMocks.getMaterialApiContentPage).toHaveBeenCalledWith({
+          appLocale: "id",
+          cursor: "page-1",
+          limit: 1,
+          prefix: "material/lesson/mathematics",
+        });
+      })
+  );
+
+  effectIt.effect("rejects invalid locales before reading Convex", () =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request(
+            "http://localhost/contents/fr/material/lesson/mathematics"
+          ),
+          {
+            params: Promise.resolve({
+              locale: "fr",
+              slug: ["lesson", "mathematics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(400);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Invalid locale. Supported locales: en, id, de.",
+      });
+      expect(runtimeMocks.getMaterialApiContentPage).not.toHaveBeenCalled();
+    })
+  );
+
+  effectIt.effect("rejects invalid pagination before reading Convex", () =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request(
+            "http://localhost/contents/id/material/lesson/mathematics?limit=0"
+          ),
+          {
+            params: Promise.resolve({
+              locale: "id",
+              slug: ["lesson", "mathematics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(400);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Invalid pagination. Limit must be between 1 and 100.",
+      });
+      expect(runtimeMocks.getMaterialApiContentPage).not.toHaveBeenCalled();
+    })
+  );
+
+  effectIt.effect("logs Convex read failures and returns an API error", () =>
+    Effect.gen(function* () {
+      const readError = new Error("Convex unavailable");
+      runtimeMocks.getMaterialApiContentPage.mockReturnValue(
+        Effect.fail(readError)
+      );
+
+      const response = yield* Effect.promise(() =>
+        route.GET(
+          new Request(
+            "http://localhost/contents/id/material/lesson/mathematics"
+          ),
+          {
+            params: Promise.resolve({
+              locale: "id",
+              slug: ["lesson", "mathematics"],
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(500);
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({
+        error: "Failed to fetch contents.",
+      });
+      expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
+        service: "api-contents",
+        locale: "id",
+        basePath: "lesson/mathematics",
+        slugLength: 2,
+        message: "Failed to fetch contents.",
+      });
+    })
+  );
+
+  effectIt.effect(
+    "logs root material prefix failures with a readable base path",
+    () =>
+      Effect.gen(function* () {
+        const readError = new Error("Convex unavailable");
+        runtimeMocks.getMaterialApiContentPage.mockReturnValue(
+          Effect.fail(readError)
+        );
+
+        const response = yield* Effect.promise(() =>
+          route.GET(new Request("http://localhost/contents/id/material"), {
+            params: Promise.resolve({
+              locale: "id",
+              slug: [],
+            }),
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({
+          error: "Failed to fetch contents.",
+        });
+        expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
+          service: "api-contents",
           locale: "id",
-          slug: ["lesson", "mathematics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(page);
-    expect(runtimeMocks.getMaterialApiContentPage).toHaveBeenCalledWith({
-      appLocale: "id",
-      cursor: null,
-      limit: 100,
-      prefix: "material/lesson/mathematics",
-    });
-  });
-
-  it("returns the pagination envelope for explicit material pagination", async () => {
-    const page = {
-      continueCursor: "next-cursor",
-      isDone: false,
-      page: [materialRow],
-    };
-
-    runtimeMocks.getMaterialApiContentPage.mockReturnValue(
-      Effect.succeed(page)
-    );
-
-    const response = await route.GET(
-      new Request(
-        "http://localhost/contents/id/material/lesson/mathematics?cursor=page-1&limit=1"
-      ),
-      {
-        params: Promise.resolve({
-          locale: "id",
-          slug: ["lesson", "mathematics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(page);
-    expect(runtimeMocks.getMaterialApiContentPage).toHaveBeenCalledWith({
-      appLocale: "id",
-      cursor: "page-1",
-      limit: 1,
-      prefix: "material/lesson/mathematics",
-    });
-  });
-
-  it("rejects invalid locales before reading Convex", async () => {
-    const response = await route.GET(
-      new Request("http://localhost/contents/fr/material/lesson/mathematics"),
-      {
-        params: Promise.resolve({
-          locale: "fr",
-          slug: ["lesson", "mathematics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid locale. Supported locales: en, id, de.",
-    });
-    expect(runtimeMocks.getMaterialApiContentPage).not.toHaveBeenCalled();
-  });
-
-  it("rejects invalid pagination before reading Convex", async () => {
-    const response = await route.GET(
-      new Request(
-        "http://localhost/contents/id/material/lesson/mathematics?limit=0"
-      ),
-      {
-        params: Promise.resolve({
-          locale: "id",
-          slug: ["lesson", "mathematics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid pagination. Limit must be between 1 and 100.",
-    });
-    expect(runtimeMocks.getMaterialApiContentPage).not.toHaveBeenCalled();
-  });
-
-  it("logs Convex read failures and returns an API error", async () => {
-    const readError = new Error("Convex unavailable");
-    runtimeMocks.getMaterialApiContentPage.mockReturnValue(
-      Effect.fail(readError)
-    );
-
-    const response = await route.GET(
-      new Request("http://localhost/contents/id/material/lesson/mathematics"),
-      {
-        params: Promise.resolve({
-          locale: "id",
-          slug: ["lesson", "mathematics"],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: "Failed to fetch contents.",
-    });
-    expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
-      service: "api-contents",
-      locale: "id",
-      basePath: "lesson/mathematics",
-      slugLength: 2,
-      message: "Failed to fetch contents.",
-    });
-  });
-
-  it("logs root material prefix failures with a readable base path", async () => {
-    const readError = new Error("Convex unavailable");
-    runtimeMocks.getMaterialApiContentPage.mockReturnValue(
-      Effect.fail(readError)
-    );
-
-    const response = await route.GET(
-      new Request("http://localhost/contents/id/material"),
-      {
-        params: Promise.resolve({
-          locale: "id",
-          slug: [],
-        }),
-      }
-    );
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: "Failed to fetch contents.",
-    });
-    expect(loggingMocks.logError).toHaveBeenCalledWith(readError, {
-      service: "api-contents",
-      locale: "id",
-      basePath: "/",
-      slugLength: 0,
-      message: "Failed to fetch contents.",
-    });
-  });
+          basePath: "/",
+          slugLength: 0,
+          message: "Failed to fetch contents.",
+        });
+      })
+  );
 });

--- a/apps/api/app/contents/graph/[contentId]/route.test.ts
+++ b/apps/api/app/contents/graph/[contentId]/route.test.ts
@@ -1,22 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
 import { GET } from "./route";
 
 describe("retired content graph API route", () => {
-  it("returns an explicit successor instead of changing the legacy schema", async () => {
-    const contentId = "asset:en:article:politics:article:example";
-    const response = await GET(
-      new Request(`http://localhost/contents/graph/${contentId}`),
-      { params: Promise.resolve({ contentId }) }
-    );
-    const successor = `/contents/reference/${encodeURIComponent(contentId)}`;
+  it.effect(
+    "returns an explicit successor instead of changing the legacy schema",
+    () =>
+      Effect.gen(function* () {
+        const contentId = "asset:en:article:politics:article:example";
+        const response = yield* Effect.promise(() =>
+          GET(new Request(`http://localhost/contents/graph/${contentId}`), {
+            params: Promise.resolve({ contentId }),
+          })
+        );
+        const successor = `/contents/reference/${encodeURIComponent(contentId)}`;
 
-    expect(response.status).toBe(410);
-    expect(response.headers.get("Link")).toBe(
-      `<${successor}>; rel="successor-version"`
-    );
-    expect(await response.json()).toEqual({
-      error: "The legacy content graph contract has been retired.",
-      successor,
-    });
-  });
+        expect(response.status).toBe(410);
+        expect(response.headers.get("Link")).toBe(
+          `<${successor}>; rel="successor-version"`
+        );
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({
+          error: "The legacy content graph contract has been retired.",
+          successor,
+        });
+      })
+  );
 });

--- a/apps/api/lib/content/published.test.ts
+++ b/apps/api/lib/content/published.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { makeMaterialProjection } from "@repo/backend/test/content-material";
 import { TEST_PAGE_PROJECTION } from "@repo/backend/test/content-page";
 import { testLocalizedArticleProjection } from "@repo/backend/test/content-runtime";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 import {
@@ -36,7 +36,7 @@ describe("published API content", () => {
     readPublicContentBatchMock.mockReset();
   });
 
-  it.live("maps a signed material into the established partner item", () =>
+  it.effect("maps a signed material into the established partner item", () =>
     Effect.gen(function* () {
       readPublicContentBatchMock.mockReturnValue(
         Effect.succeed([
@@ -78,7 +78,7 @@ describe("published API content", () => {
     })
   );
 
-  it.live.each(["en", "id", "de"] as const)(
+  it.effect.each(["en", "id", "de"] as const)(
     "accepts current article and material projections for %s",
     (appLocale) =>
       Effect.gen(function* () {
@@ -126,7 +126,7 @@ describe("published API content", () => {
       })
   );
 
-  it.live("omits absent optional metadata", () =>
+  it.effect("omits absent optional metadata", () =>
     Effect.gen(function* () {
       readPublicContentBatchMock.mockReturnValue(
         Effect.succeed([
@@ -150,7 +150,7 @@ describe("published API content", () => {
     })
   );
 
-  it.live("normalizes an authenticated legacy projection once", () =>
+  it.effect("normalizes an authenticated legacy projection once", () =>
     Effect.gen(function* () {
       const legacyProjection = {
         ...baseProjection,
@@ -182,7 +182,7 @@ describe("published API content", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "maps signed-read and current-identity failures to one typed error",
     () =>
       Effect.gen(function* () {
@@ -217,7 +217,7 @@ describe("published API content", () => {
       })
   );
 
-  it.live("rejects a signed page from the article and material API", () =>
+  it.effect("rejects a signed page from the article and material API", () =>
     Effect.gen(function* () {
       readPublicContentBatchMock.mockReturnValue(
         Effect.succeed([
@@ -240,7 +240,7 @@ describe("published API content", () => {
     })
   );
 
-  it.live("rejects a response that loses its ordered batch item", () =>
+  it.effect("rejects a response that loses its ordered batch item", () =>
     Effect.gen(function* () {
       readPublicContentBatchMock.mockReturnValue(Effect.succeed([]));
 

--- a/apps/api/lib/content/runtime.test.ts
+++ b/apps/api/lib/content/runtime.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
-import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
-import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
-import { Effect, Fiber } from "effect";
+import { NetworkRetryCodeSchema } from "@repo/backend/client/network";
+import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
+import { Effect, Fiber, Schema } from "effect";
 import { vi } from "vitest";
 import {
   getApiContentReferenceByContentId,
@@ -19,14 +19,33 @@ const runtimeClientMocks = vi.hoisted(() => ({
 const publishedContentMocks = vi.hoisted(() => ({
   readPublishedApiItems: vi.fn(),
 }));
-vi.mock("@repo/backend/client/runtime", async (importOriginal) => ({
-  ...(await importOriginal()),
-  readConvexRuntimeQuery: (url: string, query: unknown, args: unknown) =>
-    Effect.tryPromise({
-      catch: toRuntimeQueryError,
-      try: () => runtimeClientMocks.runtimeQuery(url, query, args),
-    }),
+
+class RuntimeQueryFixtureError extends Schema.TaggedError<RuntimeQueryFixtureError>()(
+  "ConvexRuntimeQueryError",
+  {
+    networkCodes: Schema.Array(NetworkRetryCodeSchema),
+    query: Schema.String,
+    reason: Schema.Literals(["client", "query", "transport"]),
+  }
+) {}
+
+vi.mock("@repo/backend/client/runtime", () => ({
+  readConvexRuntimeQuery: vi.fn(),
 }));
+vi.mocked(readConvexRuntimeQuery).mockImplementation(
+  (url: string, query: unknown, args: unknown) =>
+    Effect.tryPromise({
+      catch: (cause) =>
+        cause instanceof RuntimeQueryFixtureError
+          ? cause
+          : new RuntimeQueryFixtureError({
+              networkCodes: [],
+              query: "test-runtime-query",
+              reason: "query",
+            }),
+      try: () => runtimeClientMocks.runtimeQuery(url, query, args),
+    })
+);
 vi.mock("@/lib/content/published", () => publishedContentMocks);
 describe("API content runtime", () => {
   afterEach(() => {
@@ -56,7 +75,7 @@ describe("API content runtime", () => {
     );
     expect(parseApiContentId("en/articles/a")).toBeNull();
   });
-  it.live.each([
+  it.effect.each([
     {
       args: {
         appLocale: "en" as const,
@@ -114,7 +133,7 @@ describe("API content runtime", () => {
       );
     })
   );
-  it.live(
+  it.effect(
     "chunks by eight and runs at most four batch reads concurrently",
     () =>
       Effect.gen(function* () {
@@ -191,7 +210,7 @@ describe("API content runtime", () => {
         expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledTimes(2);
       })
   );
-  it.live.each([{ releaseId: "release-after" }, null])(
+  it.effect.each([{ releaseId: "release-after" }, null])(
     "rejects a page when its signed release changes or disappears",
     (active) =>
       Effect.gen(function* () {
@@ -214,7 +233,7 @@ describe("API content runtime", () => {
         );
       })
   );
-  it.live("maps signed hydration failures into the API runtime error", () =>
+  it.effect("maps signed hydration failures into the API runtime error", () =>
     Effect.gen(function* () {
       runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
         activeReleaseId: "release-test",
@@ -224,7 +243,7 @@ describe("API content runtime", () => {
       });
       publishedContentMocks.readPublishedApiItems.mockReturnValue(
         Effect.fail(
-          new ConvexRuntimeQueryError({
+          new RuntimeQueryFixtureError({
             networkCodes: [],
             query: "contentRuntime/batch",
             reason: "query",
@@ -242,7 +261,7 @@ describe("API content runtime", () => {
       );
     })
   );
-  it.live("reads one current reference by stable graph content ID", () =>
+  it.effect("reads one current reference by stable graph content ID", () =>
     Effect.gen(function* () {
       const row = { contentId: "asset:en:article:politics:article:a" };
       runtimeClientMocks.runtimeQuery.mockResolvedValueOnce(row);
@@ -256,10 +275,10 @@ describe("API content runtime", () => {
       );
     })
   );
-  it.live("wraps runtime query failures with query context", () =>
+  it.effect("wraps runtime query failures with query context", () =>
     Effect.gen(function* () {
       runtimeClientMocks.runtimeQuery.mockRejectedValueOnce(
-        new ConvexRuntimeQueryError({
+        new RuntimeQueryFixtureError({
           networkCodes: [],
           query: "contentRelease/article:apiPage",
           reason: "transport",

--- a/apps/api/lib/content/runtime.test.ts
+++ b/apps/api/lib/content/runtime.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from "@effect/vitest";
+import { it as effectIt } from "@effect/vitest";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
-import { NetworkRetryCodeSchema } from "@repo/backend/client/network";
-import { readConvexRuntimeQuery } from "@repo/backend/client/runtime";
-import { Effect, Fiber, Schema } from "effect";
-import { vi } from "vitest";
+import * as convexRuntime from "@repo/backend/client/runtime";
+import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
+import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
+import { Effect, Fiber } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getApiContentReferenceByContentId,
   getArticleApiContentPage,
@@ -20,29 +21,10 @@ const publishedContentMocks = vi.hoisted(() => ({
   readPublishedApiItems: vi.fn(),
 }));
 
-class RuntimeQueryFixtureError extends Schema.TaggedError<RuntimeQueryFixtureError>()(
-  "ConvexRuntimeQueryError",
-  {
-    networkCodes: Schema.Array(NetworkRetryCodeSchema),
-    query: Schema.String,
-    reason: Schema.Literals(["client", "query", "transport"]),
-  }
-) {}
-
-vi.mock("@repo/backend/client/runtime", () => ({
-  readConvexRuntimeQuery: vi.fn(),
-}));
-vi.mocked(readConvexRuntimeQuery).mockImplementation(
+vi.spyOn(convexRuntime, "readConvexRuntimeQuery").mockImplementation(
   (url: string, query: unknown, args: unknown) =>
     Effect.tryPromise({
-      catch: (cause) =>
-        cause instanceof RuntimeQueryFixtureError
-          ? cause
-          : new RuntimeQueryFixtureError({
-              networkCodes: [],
-              query: "test-runtime-query",
-              reason: "query",
-            }),
+      catch: toRuntimeQueryError,
       try: () => runtimeClientMocks.runtimeQuery(url, query, args),
     })
 );
@@ -75,7 +57,7 @@ describe("API content runtime", () => {
     );
     expect(parseApiContentId("en/articles/a")).toBeNull();
   });
-  it.effect.each([
+  effectIt.effect.each([
     {
       args: {
         appLocale: "en" as const,
@@ -133,7 +115,7 @@ describe("API content runtime", () => {
       );
     })
   );
-  it.effect(
+  effectIt.effect(
     "chunks by eight and runs at most four batch reads concurrently",
     () =>
       Effect.gen(function* () {
@@ -210,7 +192,7 @@ describe("API content runtime", () => {
         expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledTimes(2);
       })
   );
-  it.effect.each([{ releaseId: "release-after" }, null])(
+  effectIt.effect.each([{ releaseId: "release-after" }, null])(
     "rejects a page when its signed release changes or disappears",
     (active) =>
       Effect.gen(function* () {
@@ -233,52 +215,56 @@ describe("API content runtime", () => {
         );
       })
   );
-  it.effect("maps signed hydration failures into the API runtime error", () =>
-    Effect.gen(function* () {
-      runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
-        activeReleaseId: "release-test",
-        continueCursor: "",
-        isDone: true,
-        page: [{ appLocale: "en", publicPath: "articles/politics/test" }],
-      });
-      publishedContentMocks.readPublishedApiItems.mockReturnValue(
-        Effect.fail(
-          new RuntimeQueryFixtureError({
-            networkCodes: [],
-            query: "contentRuntime/batch",
-            reason: "query",
-          })
-        )
-      );
-      const failure = yield* getArticleApiContentPage({
-        appLocale: "en",
-        cursor: null,
-        limit: 10,
-        prefix: "articles/politics",
-      }).pipe(Effect.flip);
-      expect(failure.message).toContain(
-        "Unable to read signed content for the public API."
-      );
-    })
+  effectIt.effect(
+    "maps signed hydration failures into the API runtime error",
+    () =>
+      Effect.gen(function* () {
+        runtimeClientMocks.runtimeQuery.mockResolvedValueOnce({
+          activeReleaseId: "release-test",
+          continueCursor: "",
+          isDone: true,
+          page: [{ appLocale: "en", publicPath: "articles/politics/test" }],
+        });
+        publishedContentMocks.readPublishedApiItems.mockReturnValue(
+          Effect.fail(
+            new ConvexRuntimeQueryError({
+              networkCodes: [],
+              query: "contentRuntime/batch",
+              reason: "query",
+            })
+          )
+        );
+        const failure = yield* getArticleApiContentPage({
+          appLocale: "en",
+          cursor: null,
+          limit: 10,
+          prefix: "articles/politics",
+        }).pipe(Effect.flip);
+        expect(failure.message).toContain(
+          "Unable to read signed content for the public API."
+        );
+      })
   );
-  it.effect("reads one current reference by stable graph content ID", () =>
-    Effect.gen(function* () {
-      const row = { contentId: "asset:en:article:politics:article:a" };
-      runtimeClientMocks.runtimeQuery.mockResolvedValueOnce(row);
-      expect(
-        yield* getApiContentReferenceByContentId({ contentId: row.contentId })
-      ).toEqual(row);
-      expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
-        "https://test.convex.cloud",
-        expect.anything(),
-        { input: { contentId: row.contentId, kind: "content" } }
-      );
-    })
+  effectIt.effect(
+    "reads one current reference by stable graph content ID",
+    () =>
+      Effect.gen(function* () {
+        const row = { contentId: "asset:en:article:politics:article:a" };
+        runtimeClientMocks.runtimeQuery.mockResolvedValueOnce(row);
+        expect(
+          yield* getApiContentReferenceByContentId({ contentId: row.contentId })
+        ).toEqual(row);
+        expect(runtimeClientMocks.runtimeQuery).toHaveBeenCalledWith(
+          "https://test.convex.cloud",
+          expect.anything(),
+          { input: { contentId: row.contentId, kind: "content" } }
+        );
+      })
   );
-  it.effect("wraps runtime query failures with query context", () =>
+  effectIt.effect("wraps runtime query failures with query context", () =>
     Effect.gen(function* () {
       runtimeClientMocks.runtimeQuery.mockRejectedValueOnce(
-        new RuntimeQueryFixtureError({
+        new ConvexRuntimeQueryError({
           networkCodes: [],
           query: "contentRelease/article:apiPage",
           reason: "transport",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/react": "19.2.18",

--- a/apps/api/proxy.test.ts
+++ b/apps/api/proxy.test.ts
@@ -1,7 +1,9 @@
+import { it as effectIt } from "@effect/vitest";
 import {
   NAKAFA_API_EDGE_CONTRACT,
   NAKAFA_EDGE_RELEASE_SHA_HEADER,
 } from "@repo/backend/agent/edge";
+import { Effect } from "effect";
 import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server.js";
 import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
@@ -15,48 +17,59 @@ function requestProxy(pathname: string, headers?: HeadersInit) {
 
 describe("proxy middleware", () => {
   describe("authentication", () => {
-    it("should reject request without Authorization header", async () => {
-      const request = new NextRequest(
-        "http://localhost:3000/contents/en/articles"
-      );
+    effectIt.effect("should reject request without Authorization header", () =>
+      Effect.gen(function* () {
+        const request = new NextRequest(
+          "http://localhost:3000/contents/en/articles"
+        );
 
-      const response = proxy(request);
+        const response = proxy(request);
 
-      expect(response.status).toBe(401);
-      expect(await response.json()).toEqual({ error: "Unauthorized" });
-    });
+        expect(response.status).toBe(401);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({ error: "Unauthorized" });
+      })
+    );
 
-    it("should reject request with invalid Authorization format", async () => {
-      const request = new NextRequest(
-        "http://localhost:3000/contents/en/articles",
-        {
-          headers: {
-            Authorization: "InvalidFormat",
-          },
-        }
-      );
+    effectIt.effect(
+      "should reject request with invalid Authorization format",
+      () =>
+        Effect.gen(function* () {
+          const request = new NextRequest(
+            "http://localhost:3000/contents/en/articles",
+            {
+              headers: {
+                Authorization: "InvalidFormat",
+              },
+            }
+          );
 
-      const response = proxy(request);
+          const response = proxy(request);
 
-      expect(response.status).toBe(401);
-      expect(await response.json()).toEqual({ error: "Unauthorized" });
-    });
+          expect(response.status).toBe(401);
+          const body = yield* Effect.promise(() => response.json());
+          expect(body).toEqual({ error: "Unauthorized" });
+        })
+    );
 
-    it("should reject request with wrong API key", async () => {
-      const request = new NextRequest(
-        "http://localhost:3000/contents/en/articles",
-        {
-          headers: {
-            Authorization: "Bearer wrong-api-key",
-          },
-        }
-      );
+    effectIt.effect("should reject request with wrong API key", () =>
+      Effect.gen(function* () {
+        const request = new NextRequest(
+          "http://localhost:3000/contents/en/articles",
+          {
+            headers: {
+              Authorization: "Bearer wrong-api-key",
+            },
+          }
+        );
 
-      const response = proxy(request);
+        const response = proxy(request);
 
-      expect(response.status).toBe(401);
-      expect(await response.json()).toEqual({ error: "Unauthorized" });
-    });
+        expect(response.status).toBe(401);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({ error: "Unauthorized" });
+      })
+    );
 
     it("should allow request with correct API key", () => {
       const request = new NextRequest(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../../packages/testing


### PR DESCRIPTION
## Scope

Migrate the API package's public content boundaries directly to the official Effect v4 Vitest integration. The checkpoint covers the retired graph route, proxy response decoding, content runtime, published content mapping, and article and material route tests. Production code and runtime behavior are unchanged.

## Native Effect v4

- Add `@effect/vitest` as an explicit API workspace development dependency.
- Run effectful cases through `it.effect` and `it.effect.each`.
- Keep deterministic parser, configuration, and synchronous middleware cases on ordinary Vitest.
- Replace repository wrapper imports and unnecessary `it.live` usage.
- Keep framework Promise boundaries inside the Effect test graph.
- Reuse the backend-owned `ConvexRuntimeQueryError` contract through a Vitest spy instead of duplicating its Schema.

## Architecture

The API workspace now owns its direct testing dependency while `@repo/testing` continues to own shared Vitest configuration. No test wrapper or compatibility facade is introduced. Effectful cases stay interruptible in the official runner, while Vitest transform and spy APIs remain explicit framework boundaries.

## Behavior

All existing assertions remain: public pagination and hydration, bounded batching, release coherence, typed error mapping, retired-route successor metadata, API authentication responses, proxy rewrites, and article and material route failures.

## Exact proof

Base `bbf583e0cb9591260ff8143980c31eac94519bca`, head `a9416ae30565b248c943fbff30ebe079f20824f5`, patch ID `105f8b4e4e8810422c1622157be1013f3a03e468`.

Local proof is green on the exact current base:

- focused migration set: 6 files, 47 tests
- complete API suite: 7 files, 51 tests
- 100% statements, branches, functions, and lines
- API native TypeScript typecheck
- repository lint and test ownership policy
- script tests: 4 files, 19 tests
- package boundaries across 2,974 files
- Effect source parity at `effect@4.0.0-rc.110`
- security audit with zero known vulnerabilities
- changed-scope Doctor correctly skipped because no WWW source changed
- patch identity and diff checks
- patch identity preserved across the merged tryout-index and MCP-observer checkpoints

## Release

This is a test-only code change, but the explicit API workspace dependency updates `apps/api/package.json` and the lockfile, so the repository correctly runs full Production acceptance. Vercel Preview is prohibited and has not been created.

## Merge readiness

Merge only after this exact head remains current with protected main, Required, Quality, Doctor, scope, and Production checks are green, the exact patch review is clean, all review threads are resolved, and the worktree is clean.
