### PR TITLE
test(backend): adopt direct Effect v4 Vitest for MCP

### DIFF
--- a/packages/backend/agent/mcp/manifest.test.ts
+++ b/packages/backend/agent/mcp/manifest.test.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from "node:url";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { describe, expect, it } from "@effect/vitest";
 import { NAKAFA_MCP_REGISTRY_MANIFEST } from "@repo/backend/agent/mcp/manifest";
 import { NAKAFA_MCP_SERVER_VERSION } from "@repo/contents/_lib/agent/constants";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, FileSystem } from "effect";
 
 const repositoryManifestUrl = new URL(

--- a/packages/backend/agent/mcp/result.test.ts
+++ b/packages/backend/agent/mcp/result.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   mcpToolOutputSchema,
   runMcpTool,
@@ -5,43 +6,47 @@ import {
 } from "@repo/backend/agent/mcp/result";
 import { toMcpObjectSchema } from "@repo/backend/agent/mcp/schema";
 import { NakafaAgentInputError } from "@repo/contents/_lib/agent/errors";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
 
 describe("Nakafa MCP tool results", () => {
-  it("preserves successful structured content", async () => {
-    const result = await runMcpTool(
-      Effect.succeed({ status: "ok" as const }),
-      "request-success"
-    );
+  it.effect("preserves successful structured content", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runMcpTool(Effect.succeed({ status: "ok" as const }), "request-success")
+      );
 
-    expect(result).toEqual({
-      content: [{ text: '{"status":"ok"}', type: "text" }],
-      structuredContent: { status: "ok" },
-    });
-  });
+      expect(result).toEqual({
+        content: [{ text: '{"status":"ok"}', type: "text" }],
+        structuredContent: { status: "ok" },
+      });
+    })
+  );
 
-  it("maps expected input failures to the established error shape", async () => {
-    const result = await runMcpTool(
-      Effect.fail(
-        new NakafaAgentInputError({
-          cause: "Use one of the published locale values.",
-          message: "Invalid tool arguments.",
-        })
-      ),
-      "request-input"
-    );
+  it.effect("maps expected input failures to the established error shape", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runMcpTool(
+          Effect.fail(
+            new NakafaAgentInputError({
+              cause: "Use one of the published locale values.",
+              message: "Invalid tool arguments.",
+            })
+          ),
+          "request-input"
+        )
+      );
 
-    expect(result).toMatchObject({
-      isError: true,
-      structuredContent: {
-        error: {
-          message: "Invalid tool arguments.",
-          suggestions: ["Use one of the published locale values."],
+      expect(result).toMatchObject({
+        isError: true,
+        structuredContent: {
+          error: {
+            message: "Invalid tool arguments.",
+            suggestions: ["Use one of the published locale values."],
+          },
         },
-      },
-    });
-  });
+      });
+    })
+  );
 
   it("builds non-empty actionable error guidance", () => {
     expect(
@@ -57,17 +62,15 @@ describe("Nakafa MCP tool results", () => {
     });
   });
 
-  it("advertises success and error structured content", async () => {
+  it("advertises success and error structured content", () => {
     const schema = toMcpObjectSchema(
       mcpToolOutputSchema(Schema.Struct({ status: Schema.Literal("ok") }))
     );
     const error = {
       error: { message: "Unavailable.", suggestions: ["Retry later."] },
     };
-    const [successValidation, errorValidation] = await Promise.all([
-      schema["~standard"].validate({ status: "ok" }),
-      schema["~standard"].validate(error),
-    ]);
+    const successValidation = schema["~standard"].validate({ status: "ok" });
+    const errorValidation = schema["~standard"].validate(error);
 
     expect(successValidation).toMatchObject({ value: { status: "ok" } });
     expect(errorValidation).toMatchObject({ value: error });

--- a/packages/backend/agent/mcp/schema.test.ts
+++ b/packages/backend/agent/mcp/schema.test.ts
@@ -1,6 +1,6 @@
 import { toMcpObjectSchema } from "@repo/backend/agent/mcp/schema";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
 
 describe("MCP object schemas", () => {
   it("keeps input and output schemas object-rooted", () => {


### PR DESCRIPTION
## Scope

Migrate three backend MCP test modules directly to the official Effect v4 Vitest integration:

- registry manifest filesystem behavior
- MCP callback result behavior
- deterministic MCP object-schema behavior

Production code and runtime behavior are unchanged.

## Native Effect v4

- Import `@effect/vitest` directly for effectful tests.
- Return filesystem programs through `it.effect`.
- Re-enter the Effect test graph with `Effect.promise` when testing the public Promise returned by the real MCP callback boundary.
- Keep synchronous schema and error-shape assertions on ordinary Vitest.
- Remove two raw async test callbacks and one unnecessary Promise aggregation.
- Introduce no wrapper, compatibility facade, direct test runner, `it.live`, global Vitest mock, dependency, or lockfile change.

The production `runMcpTool` runner remains intentionally at the MCP server callback boundary, exactly where the repository Effect policy permits runtime execution.

## Exact identity

- Base: `2fae54fec31b7cd630a56933b613fa5b9504695a`
- Head: `f8461febbd78f3049145b080382c0384785a5e12`
- Patch ID: `ba9c9da33a9d7e97f9c3bcea877d15a7521f6018`
- Commits: 3
- Files: 3

## Verification

- focused MCP scope: 3 files and 6 tests passed
- backend native TypeScript typecheck passed
- full backend suite with bounded local workers: 346 files and 1,502 tests passed
- two default-parallel local runs hit rotating 5-second timeouts in four untouched Convex suites under machine contention; all four affected suites passed immediately in isolation
- repository lint, test ownership, script typecheck and 19 script tests passed
- boundaries checked 2,967 files
- Effect source parity passed at `effect@4.0.0-rc.110` and vendored source `66114151c2b4640bf773f2b3456ce70d679422f6`
- security audit found no known vulnerabilities
- changed-scope Doctor correctly skipped because no WWW source changed
- formatting, direct-runner, wrapper-import, raw-async, `it.live`, diff, and patch scans passed

## Review focus

Verify the official `@effect/vitest` imports, the `Effect.promise` bridge at the public MCP Promise boundary, ordinary Vitest for synchronous Standard Schema validation, preservation of the callback-boundary runner, and absence of behavior changes.

## Release

This is test-only. Production acceptance should be skipped. No Vercel Preview, Convex mutation, or production deployment is required. Merge only after this exact head remains current with protected main, exact-head CI and review are green, every review thread is resolved, and the worktree is clean.