### PR TITLE
test(backend): adopt direct Effect v4 Vitest for Nakafa clients

### DIFF
--- a/packages/backend/client/nakafa/decode.test.ts
+++ b/packages/backend/client/nakafa/decode.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import {
   decodeNakafaMarkdown,
@@ -10,13 +11,12 @@ import {
   NakafaAgentInputError,
 } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 const defaultLocale = ACTIVE_APP_LOCALE_CODES[0];
 
 describe("Nakafa runtime decoders", () => {
-  it.live("decodes valid agent-facing payloads", () =>
+  it.effect("decodes valid agent-facing payloads", () =>
     Effect.gen(function* () {
       expect(yield* decodeNakafaMarkdown(markdown())).toMatchObject({
         locale: "en",
@@ -48,7 +48,7 @@ describe("Nakafa runtime decoders", () => {
       });
     })
   );
-  it.live("maps invalid output and input into typed Nakafa errors", () =>
+  it.effect("maps invalid output and input into typed Nakafa errors", () =>
     Effect.gen(function* () {
       yield* expectDecodeError(
         decodeNakafaMarkdown({}),

--- a/packages/backend/client/nakafa/release.test.ts
+++ b/packages/backend/client/nakafa/release.test.ts
@@ -1,9 +1,9 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import {
   readNakafaReleasePin,
   verifyNakafaReleasePin,
 } from "@repo/backend/client/nakafa/release";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -24,7 +24,7 @@ describe("Nakafa release pin", () => {
     queryMock.mockReset();
   });
 
-  it.live("reads the complete active publication identity", () =>
+  it.effect("reads the complete active publication identity", () =>
     Effect.gen(function* () {
       queryMock.mockReturnValue(Effect.succeed(ACTIVE_RELEASE));
 
@@ -39,7 +39,7 @@ describe("Nakafa release pin", () => {
     })
   );
 
-  it.live("rejects a malformed active publication identity", () =>
+  it.effect("rejects a malformed active publication identity", () =>
     Effect.gen(function* () {
       queryMock.mockReturnValue(
         Effect.succeed({ ...ACTIVE_RELEASE, manifestHash: "not-a-hash" })
@@ -56,7 +56,7 @@ describe("Nakafa release pin", () => {
     })
   );
 
-  it.live("accepts stable active and empty publication identities", () =>
+  it.effect("accepts stable active and empty publication identities", () =>
     Effect.gen(function* () {
       for (const identity of [ACTIVE_RELEASE, null]) {
         queryMock.mockReturnValue(Effect.succeed(identity));
@@ -71,7 +71,7 @@ describe("Nakafa release pin", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     [
       "manifest hash",
       {
@@ -101,7 +101,7 @@ describe("Nakafa release pin", () => {
     })
   );
 
-  it.live("rejects activation from an empty publication", () =>
+  it.effect("rejects activation from an empty publication", () =>
     Effect.gen(function* () {
       queryMock.mockReturnValue(Effect.succeed(ACTIVE_RELEASE));
 


### PR DESCRIPTION
## Scope

Migrate two backend Nakafa client test modules directly to the official Effect v4 Vitest integration:

- runtime payload decoders
- signed release pin verification

Production code and runtime behavior are unchanged.

## Native Effect v4

- Import `@effect/vitest` directly.
- Return every effectful test through `it.effect`.
- Use `it.effect.each` for the release-pin table.
- Remove unnecessary `it.live` usage because these deterministic programs require neither wall-clock time nor live services.
- Introduce no wrapper, compatibility facade, direct Effect runner, raw async test callback, dependency, lockfile, or global Vitest change.

## Exact identity

- Base: `e03fa603b1512b22cc8451e70ec8a863a934c02d`
- Head: `bdc8cb703aad5df272830b3b7c8c763eef327ca7`
- Patch ID: `4ae8e775805bd42d1d6aab42d74554604e3a42a4`
- Commits: 2
- Files: 2

## Verification

- focused client scope: 2 files and 10 tests passed
- backend native TypeScript typecheck passed
- full backend suite: 346 files and 1,502 tests passed with `--maxWorkers=4`
- repository lint and test ownership passed
- script typecheck and 19 script tests passed
- boundaries checked 2,967 files
- Effect source parity passed at `effect@4.0.0-rc.110` and vendored source `66114151c2b4640bf773f2b3456ce70d679422f6`
- security audit found no known vulnerabilities
- changed-scope Doctor correctly skipped because no WWW source changed
- formatting, diff, wrapper-import, direct-runner, raw-async, and `it.live` scans passed

## Review focus

Verify direct official `@effect/vitest` ownership, deterministic `it.effect` semantics, supported `it.effect.each` usage, removal of unnecessary live services, and absence of behavior changes.

## Release

This is test-only. Production acceptance should be skipped. No Vercel Preview, Convex mutation, or production deployment is required. Merge only after this exact head is current with protected main, required checks and exact-head review are green, every review thread is resolved, and the worktree is clean.