### PR TITLE
test(backend): adopt direct Effect v4 Vitest for agent boundaries

### DIFF
--- a/packages/backend/client/nakafa/markdown.test.ts
+++ b/packages/backend/client/nakafa/markdown.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { readNakafaMarkdown } from "@repo/backend/client/nakafa/markdown";
 import {
   makeMaterialContentRef,
@@ -5,7 +6,6 @@ import {
 } from "@repo/backend/test/content-material";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import type { NakafaAgentContentRef } from "@repo/contents/_lib/agent/schema/ref";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Option } from "effect";
 import { vi } from "vitest";
 
@@ -52,7 +52,7 @@ beforeEach(() => {
 });
 
 describe("readNakafaMarkdown", () => {
-  it.live.each([articleRef, materialRef])(
+  it.effect.each([articleRef, materialRef])(
     "dispatches $section through the signed public reader",
     (ref) =>
       Effect.gen(function* () {
@@ -76,7 +76,7 @@ describe("readNakafaMarkdown", () => {
       })
   );
 
-  it.live("dispatches Quran through its signed snapshot reader", () =>
+  it.effect("dispatches Quran through its signed snapshot reader", () =>
     Effect.gen(function* () {
       runtimeMocks.resolveNakafaContentRef.mockReturnValue(
         Effect.succeed(Option.some(quranRef))
@@ -98,7 +98,7 @@ describe("readNakafaMarkdown", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     Option.none(),
     Option.some(tryoutRef),
     Option.some(materialTopicRef),

--- a/packages/backend/client/nakafa/published.test.ts
+++ b/packages/backend/client/nakafa/published.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ContentTransportError } from "@repo/backend/client/content/errors";
 import { readPublishedMarkdown } from "@repo/backend/client/nakafa/published";
 import { makeMaterialProjection } from "@repo/backend/test/content-material";
 import { TEST_ARTICLE_PROJECTION } from "@repo/backend/test/content-runtime";
 import { createNakafaContentRefFromGraphProjection } from "@repo/contents/_lib/agent/refs";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Option } from "effect";
 import { vi } from "vitest";
 
@@ -26,7 +26,7 @@ beforeEach(() => {
 });
 
 describe("Nakafa signed public reader", () => {
-  it.live.each([
+  it.effect.each([
     ["articles" as const, TEST_ARTICLE_PROJECTION],
     ["material" as const, material],
   ] as const)("reads verified %s raw MDX", ([section, projection]) =>
@@ -66,7 +66,7 @@ describe("Nakafa signed public reader", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     [
       "configuration",
       () => {

--- a/packages/backend/client/nakafa/query.test.ts
+++ b/packages/backend/client/nakafa/query.test.ts
@@ -1,9 +1,9 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import type { FunctionArgs } from "convex/server";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -23,7 +23,7 @@ describe("readNakafaRuntimeQuery", () => {
   beforeEach(() => {
     runtimeMocks.runtimeQuery.mockReset();
   });
-  it.live(
+  it.effect(
     "returns generated query results from the shared Convex runtime client",
     () =>
       Effect.gen(function* () {
@@ -48,7 +48,7 @@ describe("readNakafaRuntimeQuery", () => {
         );
       })
   );
-  it.live("maps runtime client failures into Nakafa read errors", () =>
+  it.effect("maps runtime client failures into Nakafa read errors", () =>
     Effect.gen(function* () {
       const args: FunctionArgs<typeof api.contentRelease.reference.read> = {
         input: {
@@ -80,7 +80,7 @@ describe("readNakafaRuntimeQuery", () => {
       }
     })
   );
-  it.live("preserves classified runtime diagnostics", () =>
+  it.effect("preserves classified runtime diagnostics", () =>
     Effect.gen(function* () {
       const args: FunctionArgs<typeof api.contentRelease.reference.read> = {
         input: {

--- a/packages/backend/client/nakafa/ref.test.ts
+++ b/packages/backend/client/nakafa/ref.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   getContentReferenceInput,
   resolveNakafaContentRef,
@@ -6,7 +7,6 @@ import { api } from "@repo/backend/convex/_generated/api";
 import { makeMaterialProjection } from "@repo/backend/test/content-material";
 import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect, Option } from "effect";
 import { vi } from "vitest";
@@ -55,7 +55,7 @@ describe("resolveNakafaContentRef", () => {
     expect(getContentReferenceInput("not-content")).toEqual(Option.none());
   });
 
-  it.live(
+  it.effect(
     "resolves graph content IDs and resource URIs through the current seam",
     () =>
       Effect.gen(function* () {
@@ -74,7 +74,7 @@ describe("resolveNakafaContentRef", () => {
       })
   );
 
-  it.live("resolves canonical public URLs through the current seam", () =>
+  it.effect("resolves canonical public URLs through the current seam", () =>
     Effect.gen(function* () {
       const ref = yield* resolveNakafaContentRef(
         convexUrl,
@@ -96,31 +96,33 @@ describe("resolveNakafaContentRef", () => {
     })
   );
 
-  it.live("preserves citation-only references without inventing markdown", () =>
-    Effect.gen(function* () {
-      runtimeMocks.runtimeQuery.mockResolvedValueOnce({
-        ...articleRef,
-        description: "Citation-only reference.",
-        markdown_url: undefined,
-        title: "Citation-only",
-      });
+  it.effect(
+    "preserves citation-only references without inventing markdown",
+    () =>
+      Effect.gen(function* () {
+        runtimeMocks.runtimeQuery.mockResolvedValueOnce({
+          ...articleRef,
+          description: "Citation-only reference.",
+          markdown_url: undefined,
+          title: "Citation-only",
+        });
 
-      const ref = yield* resolveNakafaContentRef(
-        convexUrl,
-        articleRef.content_id
-      );
+        const ref = yield* resolveNakafaContentRef(
+          convexUrl,
+          articleRef.content_id
+        );
 
-      expect(Option.getOrUndefined(ref)).toMatchObject({
-        content_id: articleRef.content_id,
-        route: articleRef.route,
-        section: articleRef.section,
-        url: articleRef.url,
-      });
-      expect(Option.getOrUndefined(ref)).not.toHaveProperty("markdown_url");
-    })
+        expect(Option.getOrUndefined(ref)).toMatchObject({
+          content_id: articleRef.content_id,
+          route: articleRef.route,
+          section: articleRef.section,
+          url: articleRef.url,
+        });
+        expect(Option.getOrUndefined(ref)).not.toHaveProperty("markdown_url");
+      })
   );
 
-  it.live("rejects bare route refs without querying Convex", () =>
+  it.effect("rejects bare route refs without querying Convex", () =>
     Effect.gen(function* () {
       const localizedRoute = yield* resolveNakafaContentRef(
         convexUrl,

--- a/packages/backend/client/nakafa/taxonomy.test.ts
+++ b/packages/backend/client/nakafa/taxonomy.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { readNakafaTaxonomy } from "@repo/backend/client/nakafa/taxonomy";
@@ -7,7 +8,6 @@ import {
   makeQuranSurah,
 } from "@repo/backend/test/quran/rows";
 import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -37,7 +37,7 @@ beforeEach(() => {
   runtimeMocks.runtimeQuery.mockImplementation(readRuntimeFixture);
 });
 describe("readNakafaTaxonomy", () => {
-  it.live("assembles taxonomy from signed publications", () =>
+  it.effect("assembles taxonomy from signed publications", () =>
     Effect.gen(function* () {
       const taxonomy = yield* readNakafaTaxonomy(
         "https://example.convex.cloud",
@@ -81,36 +81,38 @@ describe("readNakafaTaxonomy", () => {
       ).toHaveLength(4);
     })
   );
-  it.live("fails closed when an article or material family is unmanaged", () =>
-    Effect.gen(function* () {
-      for (const family of ["article", "material"]) {
-        const target =
-          family === "article"
-            ? api.contentRelease.article.sitemapBuckets
-            : api.contentRelease.material.sitemapBuckets;
-        runtimeMocks.runtimeQuery.mockImplementation(
-          (convexUrl, query, args) => {
-            if (getFunctionName(query) === getFunctionName(target)) {
-              return Promise.resolve({ managed: false });
+  it.effect(
+    "fails closed when an article or material family is unmanaged",
+    () =>
+      Effect.gen(function* () {
+        for (const family of ["article", "material"]) {
+          const target =
+            family === "article"
+              ? api.contentRelease.article.sitemapBuckets
+              : api.contentRelease.material.sitemapBuckets;
+          runtimeMocks.runtimeQuery.mockImplementation(
+            (convexUrl, query, args) => {
+              if (getFunctionName(query) === getFunctionName(target)) {
+                return Promise.resolve({ managed: false });
+              }
+              return readRuntimeFixture(convexUrl, query, args);
             }
-            return readRuntimeFixture(convexUrl, query, args);
-          }
-        );
-        expect(
-          yield* Effect.result(
-            readNakafaTaxonomy("https://example.convex.cloud", "id")
-          )
-        ).toMatchObject({
-          _tag: "Failure",
-          failure: {
-            _tag: "NakafaAgentDataReadError",
-            message: "Unable to read signed Nakafa content inventory.",
-          },
-        });
-      }
-    })
+          );
+          expect(
+            yield* Effect.result(
+              readNakafaTaxonomy("https://example.convex.cloud", "id")
+            )
+          ).toMatchObject({
+            _tag: "Failure",
+            failure: {
+              _tag: "NakafaAgentDataReadError",
+              message: "Unable to read signed Nakafa content inventory.",
+            },
+          });
+        }
+      })
   );
-  it.live("pins every article category page to one signed release", () =>
+  it.effect("pins every article category page to one signed release", () =>
     Effect.gen(function* () {
       runtimeMocks.runtimeQuery.mockImplementation((convexUrl, query, args) => {
         if (
@@ -145,7 +147,7 @@ describe("readNakafaTaxonomy", () => {
       expect(taxonomy.articles.categories).toEqual(["politics", "science"]);
     })
   );
-  it.live("fails closed when signed article taxonomy is stale", () =>
+  it.effect("fails closed when signed article taxonomy is stale", () =>
     Effect.gen(function* () {
       runtimeMocks.runtimeQuery.mockImplementation((convexUrl, query, args) => {
         if (
@@ -169,7 +171,7 @@ describe("readNakafaTaxonomy", () => {
       });
     })
   );
-  it.live("fails closed when an article category page loses its cursor", () =>
+  it.effect("fails closed when an article category page loses its cursor", () =>
     Effect.gen(function* () {
       runtimeMocks.runtimeQuery.mockImplementation((convexUrl, query, args) => {
         if (
@@ -193,7 +195,7 @@ describe("readNakafaTaxonomy", () => {
       });
     })
   );
-  it.live(
+  it.effect(
     "fails closed when the active publication changes during assembly",
     () =>
       Effect.gen(function* () {

--- a/packages/backend/client/nakafa/verify.test.ts
+++ b/packages/backend/client/nakafa/verify.test.ts
@@ -1,9 +1,9 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { verifyNakafaContent } from "@repo/backend/client/nakafa/verify";
 import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { toRuntimeQueryError } from "@repo/backend/test/runtime-query";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
-import { beforeEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -28,7 +28,7 @@ describe("verifyNakafaContent", () => {
     runtimeMocks.runtimeQuery.mockReset();
   });
 
-  it.live("returns false without a query for unsupported references", () =>
+  it.effect("returns false without a query for unsupported references", () =>
     Effect.gen(function* () {
       const result = yield* verifyNakafaContent(convexUrl, "quran/1");
 
@@ -37,7 +37,7 @@ describe("verifyNakafaContent", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "returns false when no current signed family owns a canonical route",
     () =>
       Effect.gen(function* () {
@@ -49,7 +49,7 @@ describe("verifyNakafaContent", () => {
       })
   );
 
-  it.live("returns true when the current signed reference exists", () =>
+  it.effect("returns true when the current signed reference exists", () =>
     Effect.gen(function* () {
       runtimeMocks.runtimeQuery.mockResolvedValueOnce({
         ...quranRef,
@@ -63,7 +63,7 @@ describe("verifyNakafaContent", () => {
     })
   );
 
-  it.live("preserves typed runtime read failures", () =>
+  it.effect("preserves typed runtime read failures", () =>
     Effect.gen(function* () {
       const runtimeError = new ConvexRuntimeQueryError({
         networkCodes: ["EPIPE"],

--- a/packages/backend/convex/routes/agent/input.test.ts
+++ b/packages/backend/convex/routes/agent/input.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   hasRequestBody,
   readContentInput,
@@ -7,7 +8,6 @@ import {
   readSearchInput,
   readTaxonomyInput,
 } from "@repo/backend/convex/routes/agent/input";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 function url(path: string) {

--- a/packages/backend/convex/routes/agent/mcp/guard.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/guard.test.ts
@@ -1,14 +1,9 @@
 // @vitest-environment node
 
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { NAKAFA_MCP_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "@repo/testing/effect";
+import { Effect } from "effect";
 import { vi } from "vitest";
 
 const MCP_SECRET = "technical-mcp-edge-secret";
@@ -17,9 +12,12 @@ const ORIGINS_ENVIRONMENT = "NAKAFA_MCP_ALLOWED_ORIGINS";
 function fetchMcp(path: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
   headers.set(NAKAFA_MCP_EDGE_CONTRACT.secretHeader, MCP_SECRET);
-  return createConvexTestWithBetterAuth().fetch(
-    `${NAKAFA_MCP_EDGE_CONTRACT.originPath}${path}`,
-    { ...init, headers }
+  const test = createConvexTestWithBetterAuth();
+  return Effect.promise(() =>
+    test.fetch(`${NAKAFA_MCP_EDGE_CONTRACT.originPath}${path}`, {
+      ...init,
+      headers,
+    })
   );
 }
 
@@ -33,84 +31,94 @@ afterEach(() => {
 });
 
 describe("Nakafa MCP origin guard", () => {
-  it("rejects direct origin access before transport dispatch", async () => {
-    const response = await createConvexTestWithBetterAuth().fetch(
-      NAKAFA_MCP_EDGE_CONTRACT.originPath,
-      { method: "POST" }
-    );
+  it.effect("rejects direct origin access before transport dispatch", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const response = yield* Effect.promise(() =>
+        test.fetch(NAKAFA_MCP_EDGE_CONTRACT.originPath, { method: "POST" })
+      );
 
-    expect(response.status).toBe(403);
-    await expect(response.text()).resolves.toBe("");
-  });
+      expect(response.status).toBe(403);
+      expect(yield* Effect.promise(() => response.text())).toBe("");
+    })
+  );
 
-  it("accepts exact configured and owned browser Origins", async () => {
-    const [configured, owned] = await Promise.all([
-      fetchMcp("", {
-        headers: { origin: "https://agent.example.com" },
+  it.effect("accepts exact configured and owned browser Origins", () =>
+    Effect.gen(function* () {
+      const [configured, owned] = yield* Effect.all([
+        fetchMcp("", {
+          headers: { origin: "https://agent.example.com" },
+          method: "OPTIONS",
+        }),
+        fetchMcp("", {
+          headers: { origin: "https://nakafa.com" },
+          method: "OPTIONS",
+        }),
+      ]);
+
+      expect(configured.status).toBe(204);
+      expect(configured.headers.get("access-control-allow-origin")).toBe(
+        "https://agent.example.com"
+      );
+      expect(configured.headers.get("access-control-allow-credentials")).toBe(
+        "true"
+      );
+      expect(owned.status).toBe(204);
+    })
+  );
+
+  it.effect(
+    "rejects untrusted Origins and malformed origin configuration",
+    () =>
+      Effect.gen(function* () {
+        const untrusted = yield* fetchMcp("", {
+          headers: { origin: "https://evil.example.com" },
+          method: "OPTIONS",
+        });
+        const loopback = yield* fetchMcp("", {
+          headers: { origin: "http://localhost:3000" },
+          method: "OPTIONS",
+        });
+        vi.stubEnv(ORIGINS_ENVIRONMENT, "https://agent.example.com/path");
+        const malformed = yield* fetchMcp("", {
+          headers: { origin: "https://agent.example.com" },
+          method: "OPTIONS",
+        });
+
+        expect(untrusted.status).toBe(403);
+        expect(loopback.status).toBe(403);
+        expect(malformed.status).toBe(503);
+        for (const response of [untrusted, loopback, malformed]) {
+          expect(yield* Effect.promise(() => response.text())).toBe("");
+        }
+      })
+  );
+
+  it.effect("serves strict browser preflight metadata", () =>
+    Effect.gen(function* () {
+      const response = yield* fetchMcp("", {
+        headers: {
+          "access-control-request-headers":
+            "content-type,mcp-protocol-version,mcp-param-locale,x-ignored",
+          origin: "https://agent.example.com",
+        },
         method: "OPTIONS",
-      }),
-      fetchMcp("", {
-        headers: { origin: "https://nakafa.com" },
-        method: "OPTIONS",
-      }),
-    ]);
+      });
 
-    expect(configured.status).toBe(204);
-    expect(configured.headers.get("access-control-allow-origin")).toBe(
-      "https://agent.example.com"
-    );
-    expect(configured.headers.get("access-control-allow-credentials")).toBe(
-      "true"
-    );
-    expect(owned.status).toBe(204);
-  });
-
-  it("rejects untrusted Origins and malformed origin configuration", async () => {
-    const untrusted = await fetchMcp("", {
-      headers: { origin: "https://evil.example.com" },
-      method: "OPTIONS",
-    });
-    const loopback = await fetchMcp("", {
-      headers: { origin: "http://localhost:3000" },
-      method: "OPTIONS",
-    });
-    vi.stubEnv(ORIGINS_ENVIRONMENT, "https://agent.example.com/path");
-    const malformed = await fetchMcp("", {
-      headers: { origin: "https://agent.example.com" },
-      method: "OPTIONS",
-    });
-
-    expect(untrusted.status).toBe(403);
-    expect(loopback.status).toBe(403);
-    expect(malformed.status).toBe(503);
-    for (const response of [untrusted, loopback, malformed]) {
-      await expect(response.text()).resolves.toBe("");
-    }
-  });
-
-  it("serves strict browser preflight metadata", async () => {
-    const response = await fetchMcp("", {
-      headers: {
-        "access-control-request-headers":
-          "content-type,mcp-protocol-version,mcp-param-locale,x-ignored",
-        origin: "https://agent.example.com",
-      },
-      method: "OPTIONS",
-    });
-
-    expect(response.status).toBe(204);
-    expect(response.headers.get("access-control-allow-origin")).toBe(
-      "https://agent.example.com"
-    );
-    expect(response.headers.get("access-control-allow-methods")).toBe(
-      "GET,POST,DELETE,OPTIONS"
-    );
-    expect(response.headers.get("access-control-allow-headers")).toBe(
-      "content-type,mcp-protocol-version,mcp-param-locale"
-    );
-    expect(response.headers.get("access-control-expose-headers")).toBe(
-      "MCP-Protocol-Version,MCP-Session-ID,Retry-After"
-    );
-    expect(response.headers.get("cache-control")).toBe("no-store");
-  });
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://agent.example.com"
+      );
+      expect(response.headers.get("access-control-allow-methods")).toBe(
+        "GET,POST,DELETE,OPTIONS"
+      );
+      expect(response.headers.get("access-control-allow-headers")).toBe(
+        "content-type,mcp-protocol-version,mcp-param-locale"
+      );
+      expect(response.headers.get("access-control-expose-headers")).toBe(
+        "MCP-Protocol-Version,MCP-Session-ID,Retry-After"
+      );
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    })
+  );
 });

--- a/packages/backend/convex/routes/agent/mcp/guard.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/guard.test.ts
@@ -45,16 +45,19 @@ describe("Nakafa MCP origin guard", () => {
 
   it.effect("accepts exact configured and owned browser Origins", () =>
     Effect.gen(function* () {
-      const [configured, owned] = yield* Effect.all([
-        fetchMcp("", {
-          headers: { origin: "https://agent.example.com" },
-          method: "OPTIONS",
-        }),
-        fetchMcp("", {
-          headers: { origin: "https://nakafa.com" },
-          method: "OPTIONS",
-        }),
-      ]);
+      const [configured, owned] = yield* Effect.all(
+        [
+          fetchMcp("", {
+            headers: { origin: "https://agent.example.com" },
+            method: "OPTIONS",
+          }),
+          fetchMcp("", {
+            headers: { origin: "https://nakafa.com" },
+            method: "OPTIONS",
+          }),
+        ],
+        { concurrency: "unbounded" }
+      );
 
       expect(configured.status).toBe(204);
       expect(configured.headers.get("access-control-allow-origin")).toBe(

--- a/packages/backend/convex/routes/agent/mcp/input.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/input.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   MAX_MCP_REQUEST_BYTES,
   readMcpRequest,
 } from "@repo/backend/convex/routes/agent/mcp/input";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Effect } from "effect";
 
 /** Creates one Node request whose stream has no declared byte length. */
@@ -23,7 +23,7 @@ function streamRequest(
 }
 
 describe("MCP request input", () => {
-  it.live("accepts the exact policy ceiling and parses the body once", () =>
+  it.effect("accepts the exact policy ceiling and parses the body once", () =>
     Effect.gen(function* () {
       const source = `"${"a".repeat(MAX_MCP_REQUEST_BYTES - 2)}"`;
       const result = yield* readMcpRequest(
@@ -39,7 +39,7 @@ describe("MCP request input", () => {
     })
   );
 
-  it.live("rejects an oversized declaration without consuming the body", () =>
+  it.effect("rejects an oversized declaration without consuming the body", () =>
     Effect.gen(function* () {
       let pulls = 0;
       const request = streamRequest(
@@ -64,7 +64,7 @@ describe("MCP request input", () => {
     })
   );
 
-  it.live("stops every unbounded POST stream after the ceiling", () =>
+  it.effect("stops every unbounded POST stream after the ceiling", () =>
     Effect.gen(function* () {
       const cancelled = [false, false, false];
       const requests = ["application/json", "text/plain", undefined].map(
@@ -97,7 +97,7 @@ describe("MCP request input", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "rejects malformed framing but preserves bounded JSON parse errors",
     () =>
       Effect.gen(function* () {
@@ -128,56 +128,58 @@ describe("MCP request input", () => {
       })
   );
 
-  it.live("rejects invalid lengths, failed streams, and malformed UTF-8", () =>
-    Effect.gen(function* () {
-      const invalidLength = new Request("https://example.test/internal/mcp", {
-        body: "{}",
-        headers: {
-          "content-length": "not-a-length",
-          "content-type": "application/json",
-        },
-        method: "POST",
-      });
-      const failed = streamRequest(
-        new ReadableStream({
-          /** Fails the source on its first bounded read. */
-          pull(controller) {
-            controller.error(new Error("stream failed"));
+  it.effect(
+    "rejects invalid lengths, failed streams, and malformed UTF-8",
+    () =>
+      Effect.gen(function* () {
+        const invalidLength = new Request("https://example.test/internal/mcp", {
+          body: "{}",
+          headers: {
+            "content-length": "not-a-length",
+            "content-type": "application/json",
           },
-        })
-      );
-      const malformedUtf8 = streamRequest(
-        new ReadableStream({
-          /** Enqueues one invalid UTF-8 sequence. */
-          start(controller) {
-            controller.enqueue(new Uint8Array([0xc3, 0x28]));
-            controller.close();
-          },
-        })
-      );
-      const absent = new Request("https://example.test/internal/mcp", {
-        headers: {
-          "content-length": "1",
-          "content-type": "application/json",
-        },
-        method: "POST",
-      });
-      const results = yield* Effect.all(
-        [invalidLength, failed, malformedUtf8, absent].map((request) =>
-          readMcpRequest(request).pipe(Effect.result)
-        )
-      );
-
-      for (const result of results) {
-        expect(result).toMatchObject({
-          _tag: "Failure",
-          failure: { reason: "invalid" },
+          method: "POST",
         });
-      }
-    })
+        const failed = streamRequest(
+          new ReadableStream({
+            /** Fails the source on its first bounded read. */
+            pull(controller) {
+              controller.error(new Error("stream failed"));
+            },
+          })
+        );
+        const malformedUtf8 = streamRequest(
+          new ReadableStream({
+            /** Enqueues one invalid UTF-8 sequence. */
+            start(controller) {
+              controller.enqueue(new Uint8Array([0xc3, 0x28]));
+              controller.close();
+            },
+          })
+        );
+        const absent = new Request("https://example.test/internal/mcp", {
+          headers: {
+            "content-length": "1",
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        const results = yield* Effect.all(
+          [invalidLength, failed, malformedUtf8, absent].map((request) =>
+            readMcpRequest(request).pipe(Effect.result)
+          )
+        );
+
+        for (const result of results) {
+          expect(result).toMatchObject({
+            _tag: "Failure",
+            failure: { reason: "invalid" },
+          });
+        }
+      })
   );
 
-  it.live("preserves one explicitly empty JSON request for SDK parsing", () =>
+  it.effect("preserves one explicitly empty JSON request for SDK parsing", () =>
     Effect.gen(function* () {
       const [absent, empty] = yield* Effect.all([
         readMcpRequest(
@@ -207,7 +209,7 @@ describe("MCP request input", () => {
     })
   );
 
-  it.live("bounds unsupported media types before SDK rejection", () =>
+  it.effect("bounds unsupported media types before SDK rejection", () =>
     Effect.gen(function* () {
       const unsupported = new Request("https://example.test/internal/mcp", {
         body: "plain text",
@@ -240,7 +242,7 @@ describe("MCP request input", () => {
     })
   );
 
-  it.live("leaves bodyless methods unchanged", () =>
+  it.effect("leaves bodyless methods unchanged", () =>
     Effect.gen(function* () {
       const get = new Request("https://example.test/internal/mcp");
       const getResult = yield* readMcpRequest(get);

--- a/packages/backend/convex/routes/agent/mcp/route.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/route.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   CLIENT_CAPABILITIES_META_KEY,
   CLIENT_INFO_META_KEY,
@@ -9,39 +10,28 @@ import {
 import { NAKAFA_MCP_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { NAKAFA_MCP_PROTOCOL_VERSION } from "@repo/contents/_lib/agent/constants";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "@repo/testing/effect";
+import { Effect } from "effect";
 import { vi } from "vitest";
 
 const MCP_SECRET = "technical-mcp-edge-secret";
+const MCP_PATH = NAKAFA_MCP_EDGE_CONTRACT.originPath;
+const MCP_SECRET_ENVIRONMENT = NAKAFA_MCP_EDGE_CONTRACT.secretEnvironment;
 const MODERN_META = {
   [CLIENT_CAPABILITIES_META_KEY]: {},
-  [CLIENT_INFO_META_KEY]: {
-    name: "nakafa-test-client",
-    version: "1.0.0",
-  },
+  [CLIENT_INFO_META_KEY]: { name: "nakafa-test-client", version: "1.0.0" },
   [PROTOCOL_VERSION_META_KEY]: NAKAFA_MCP_PROTOCOL_VERSION,
 };
 type BackendTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
+const json = (response: Response) => Effect.promise(() => response.json());
+const text = (response: Response) => Effect.promise(() => response.text());
 function fetchMcp(test: BackendTest, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
   headers.set(NAKAFA_MCP_EDGE_CONTRACT.secretHeader, MCP_SECRET);
-  headers.set(
-    "x-forwarded-for",
-    headers.get("x-forwarded-for") ?? "203.0.113.21"
-  );
-  return test.fetch(NAKAFA_MCP_EDGE_CONTRACT.originPath, {
-    ...init,
-    headers,
-  });
+  const forwardedFor = headers.get("x-forwarded-for") ?? "203.0.113.21";
+  headers.set("x-forwarded-for", forwardedFor);
+  const request = { ...init, headers };
+  return Effect.promise(() => test.fetch(MCP_PATH, request));
 }
-
 function postModern(
   test: BackendTest,
   id: number,
@@ -69,432 +59,439 @@ function postModern(
     method: "POST",
   });
 }
-
-beforeEach(() => {
-  vi.stubEnv(NAKAFA_MCP_EDGE_CONTRACT.secretEnvironment, MCP_SECRET);
-});
+beforeEach(() => vi.stubEnv(MCP_SECRET_ENVIRONMENT, MCP_SECRET));
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 describe("Nakafa MCP transport", () => {
-  it("serves current discovery and the established tool surface", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const discover = await postModern(test, 1, "server/discover");
-    const discoverBody = await discover.json();
-    const tools = await postModern(test, 2, "tools/list");
-    const toolsBody = await tools.json();
-    expect(discover.status, JSON.stringify(discoverBody)).toBe(200);
-    expect(discoverBody).toMatchObject({
-      id: 1,
-      result: {
-        _meta: {
-          "io.modelcontextprotocol/serverInfo": {
-            name: "nakafa-mcp-server",
-            version: "1.0.1",
-          },
-        },
-      },
-    });
-    expect(tools.status, JSON.stringify(toolsBody)).toBe(200);
-    expect(toolsBody).toMatchObject({
-      result: {
-        tools: [
-          { name: "nakafa_search_content" },
-          { name: "nakafa_get_content" },
-          { name: "nakafa_get_taxonomy" },
-          { name: "nakafa_get_quran_reference" },
-        ],
-      },
-    });
-  });
-
-  it("preserves static resources, templates, and prompts", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const usageUri = "nakafa://usage";
-    const responses = await Promise.all([
-      postModern(test, 10, "resources/list"),
-      postModern(test, 11, "resources/templates/list"),
-      postModern(test, 12, "resources/read", { uri: usageUri }, usageUri),
-      postModern(test, 13, "prompts/list"),
-      postModern(
-        test,
-        14,
-        "prompts/get",
-        {
-          arguments: { topic: "linear equations" },
-          name: "nakafa_find_lesson",
-        },
-        "nakafa_find_lesson"
-      ),
-    ]);
-    const bodies = await Promise.all(
-      responses.map((response) => response.json())
-    );
-    expect(responses.map(({ status }) => status)).toEqual([
-      200, 200, 200, 200, 200,
-    ]);
-    expect(bodies[0]).toMatchObject({
-      result: {
-        resources: [{ uri: "nakafa://usage" }, { uri: "nakafa://taxonomy" }],
-      },
-    });
-    expect(bodies[1]).toMatchObject({
-      result: {
-        resourceTemplates: [{ uriTemplate: "nakafa://content/{contentId}" }],
-      },
-    });
-    expect(bodies[2]).toMatchObject({
-      result: {
-        contents: [
-          {
-            mimeType: "text/markdown",
-            text: expect.stringContaining("# Nakafa MCP Usage"),
-            uri: usageUri,
-          },
-        ],
-      },
-    });
-    expect(bodies[3]).toMatchObject({
-      result: {
-        prompts: [
-          { name: "nakafa_find_lesson" },
-          { name: "nakafa_answer_from_content" },
-          { name: "nakafa_quran_reference" },
-        ],
-      },
-    });
-    expect(bodies[4]).toMatchObject({
-      result: {
-        messages: [
-          {
-            content: { text: expect.stringContaining("linear equations") },
-          },
-        ],
-      },
-    });
-  });
-
-  it("renders every workflow prompt through strict argument contracts", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const responses = await Promise.all([
-      postModern(
-        test,
-        15,
-        "prompts/get",
-        {
-          arguments: {
-            content_ref: "https://nakafa.com/en/articles/math/algebra",
-            question: "What is the key idea?",
-          },
-          name: "nakafa_answer_from_content",
-        },
-        "nakafa_answer_from_content"
-      ),
-      postModern(
-        test,
-        16,
-        "prompts/get",
-        {
-          arguments: {
-            from_verse: "1",
-            locale: "id",
-            question: "Apa pesan ayat ini?",
-            surah: "1",
-            to_verse: "7",
-          },
-          name: "nakafa_quran_reference",
-        },
-        "nakafa_quran_reference"
-      ),
-      postModern(
-        test,
-        17,
-        "prompts/get",
-        {
-          arguments: { topic: "" },
-          name: "nakafa_find_lesson",
-        },
-        "nakafa_find_lesson"
-      ),
-    ]);
-    const bodies = await Promise.all(
-      responses.map((response) => response.json())
-    );
-    expect(responses.map(({ status }) => status)).toEqual([200, 200, 200]);
-    expect(bodies[0].result.messages[0].content.text).toContain(
-      "What is the key idea?"
-    );
-    expect(bodies[1].result.messages[0].content.text).toContain(
-      "Surah 1, verses 1-7"
-    );
-    expect(bodies[2]).toMatchObject({ error: { code: -32_602 }, id: 17 });
-    expect(bodies[2].jsonrpc).toBe("2.0");
-  });
-
-  it("returns typed resource failures without inventing content", async () => {
-    const missingUri = "nakafa://content/asset:en:article:missing";
-    const response = await postModern(
-      createConvexTestWithBetterAuth(),
-      18,
-      "resources/read",
-      { uri: missingUri },
-      missingUri
-    );
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      error: {
-        code: -32_602,
-        data: { uri: missingUri },
-      },
-      id: 18,
-      jsonrpc: "2.0",
-    });
-  });
-
-  it("executes tools through the shared Convex programs", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const responses = await Promise.all([
-      postModern(
-        test,
-        20,
-        "tools/call",
-        {
-          arguments: {
-            limit: 10,
-            locale: "en",
-            offset: 0,
-            queries: ["algebra"],
-          },
-          name: "nakafa_search_content",
-        },
-        "nakafa_search_content"
-      ),
-      postModern(
-        test,
-        21,
-        "tools/call",
-        {
-          arguments: {
-            content_ref: "https://nakafa.com/en/articles/missing/content",
-          },
-          name: "nakafa_get_content",
-        },
-        "nakafa_get_content"
-      ),
-      postModern(
-        test,
-        22,
-        "tools/call",
-        { arguments: { locale: "en" }, name: "nakafa_get_taxonomy" },
-        "nakafa_get_taxonomy"
-      ),
-      postModern(
-        test,
-        23,
-        "tools/call",
-        {
-          arguments: { from_verse: 1, locale: "en", surah: 1 },
-          name: "nakafa_get_quran_reference",
-        },
-        "nakafa_get_quran_reference"
-      ),
-    ]);
-    const bodies = await Promise.all(
-      responses.map((response) => response.json())
-    );
-    expect(responses.map(({ status }) => status)).toEqual([200, 200, 200, 200]);
-    expect(bodies[0]).toMatchObject({
-      result: {
-        structuredContent: {
-          count: 0,
-          has_more: false,
-          items: [],
-          limit: 10,
-          offset: 0,
-        },
-      },
-    });
-    for (const body of bodies.slice(1)) {
-      expect(body).toMatchObject({
+  it.effect("serves current discovery and the established tool surface", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const discover = yield* postModern(test, 1, "server/discover");
+      const discoverBody = yield* json(discover);
+      const tools = yield* postModern(test, 2, "tools/list");
+      const toolsBody = yield* json(tools);
+      expect(discover.status, JSON.stringify(discoverBody)).toBe(200);
+      expect(discoverBody).toMatchObject({
+        id: 1,
         result: {
-          isError: true,
-          structuredContent: {
-            error: {
-              message: expect.any(String),
-              suggestions: [expect.any(String)],
+          _meta: {
+            "io.modelcontextprotocol/serverInfo": {
+              name: "nakafa-mcp-server",
+              version: "1.0.1",
             },
           },
         },
       });
-    }
-  });
-
-  it("rejects the predecessor 2025 initialize handshake", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const body = JSON.stringify({
-      id: 30,
-      jsonrpc: "2.0",
-      method: "initialize",
-      params: {
-        capabilities: {},
-        clientInfo: { name: "predecessor-test", version: "1.0.0" },
-        protocolVersion: MCP_PREDECESSOR_PROTOCOL_VERSION,
-      },
-    });
-    const request = (headers: HeadersInit) =>
-      fetchMcp(test, {
-        body,
-        headers: {
-          accept: "application/json, text/event-stream",
-          "content-type": "application/json",
-          ...headers,
+      expect(tools.status, JSON.stringify(toolsBody)).toBe(200);
+      expect(toolsBody).toMatchObject({
+        result: {
+          tools: [
+            { name: "nakafa_search_content" },
+            { name: "nakafa_get_content" },
+            { name: "nakafa_get_taxonomy" },
+            { name: "nakafa_get_quran_reference" },
+          ],
         },
-        method: "POST",
       });
-    const [missingHeader, predecessorHeader] = await Promise.all([
-      request({}),
-      request({
-        "mcp-method": "initialize",
-        "mcp-protocol-version": MCP_PREDECESSOR_PROTOCOL_VERSION,
-      }),
-    ]);
-    expect(missingHeader.status).toBe(400);
-    await expect(missingHeader.json()).resolves.toMatchObject({
-      error: { code: -32_020 },
-      id: 30,
-      jsonrpc: "2.0",
-    });
-    expect(predecessorHeader.status).toBe(400);
-    await expect(predecessorHeader.json()).resolves.toMatchObject({
-      error: { code: -32_022 },
-      id: 30,
-      jsonrpc: "2.0",
-    });
-  });
-
-  it("rejects modern traffic that omits its protocol header", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const post = (body: Readonly<Record<string, unknown>>) =>
-      fetchMcp(test, {
-        body: JSON.stringify(body),
-        headers: {
-          accept: "application/json, text/event-stream",
-          "content-type": "application/json",
-          "mcp-method": "server/discover",
+    })
+  );
+  it.effect("preserves static resources, templates, and prompts", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const usageUri = "nakafa://usage";
+      const responses = yield* Effect.all([
+        postModern(test, 10, "resources/list"),
+        postModern(test, 11, "resources/templates/list"),
+        postModern(test, 12, "resources/read", { uri: usageUri }, usageUri),
+        postModern(test, 13, "prompts/list"),
+        postModern(
+          test,
+          14,
+          "prompts/get",
+          {
+            arguments: { topic: "linear equations" },
+            name: "nakafa_find_lesson",
+          },
+          "nakafa_find_lesson"
+        ),
+      ]);
+      const bodies = yield* Effect.all(responses.map(json));
+      expect(responses.every(({ status }) => status === 200)).toBe(true);
+      expect(bodies[0]).toMatchObject({
+        result: {
+          resources: [{ uri: "nakafa://usage" }, { uri: "nakafa://taxonomy" }],
         },
-        method: "POST",
       });
-    const [response, notification] = await Promise.all([
-      post({
+      expect(bodies[1]).toMatchObject({
+        result: {
+          resourceTemplates: [{ uriTemplate: "nakafa://content/{contentId}" }],
+        },
+      });
+      expect(bodies[2]).toMatchObject({
+        result: {
+          contents: [
+            {
+              mimeType: "text/markdown",
+              text: expect.stringContaining("# Nakafa MCP Usage"),
+              uri: usageUri,
+            },
+          ],
+        },
+      });
+      expect(bodies[3]).toMatchObject({
+        result: {
+          prompts: [
+            { name: "nakafa_find_lesson" },
+            { name: "nakafa_answer_from_content" },
+            { name: "nakafa_quran_reference" },
+          ],
+        },
+      });
+      expect(bodies[4]).toMatchObject({
+        result: {
+          messages: [
+            {
+              content: { text: expect.stringContaining("linear equations") },
+            },
+          ],
+        },
+      });
+    })
+  );
+  it.effect(
+    "renders every workflow prompt through strict argument contracts",
+    () =>
+      Effect.gen(function* () {
+        const test = createConvexTestWithBetterAuth();
+        const responses = yield* Effect.all([
+          postModern(
+            test,
+            15,
+            "prompts/get",
+            {
+              arguments: {
+                content_ref: "https://nakafa.com/en/articles/math/algebra",
+                question: "What is the key idea?",
+              },
+              name: "nakafa_answer_from_content",
+            },
+            "nakafa_answer_from_content"
+          ),
+          postModern(
+            test,
+            16,
+            "prompts/get",
+            {
+              arguments: {
+                from_verse: "1",
+                locale: "id",
+                question: "Apa pesan ayat ini?",
+                surah: "1",
+                to_verse: "7",
+              },
+              name: "nakafa_quran_reference",
+            },
+            "nakafa_quran_reference"
+          ),
+          postModern(
+            test,
+            17,
+            "prompts/get",
+            {
+              arguments: { topic: "" },
+              name: "nakafa_find_lesson",
+            },
+            "nakafa_find_lesson"
+          ),
+        ]);
+        const bodies = yield* Effect.all(responses.map(json));
+        expect(responses.map(({ status }) => status)).toEqual([200, 200, 200]);
+        expect(bodies[0].result.messages[0].content.text).toContain(
+          "What is the key idea?"
+        );
+        expect(bodies[1].result.messages[0].content.text).toContain(
+          "Surah 1, verses 1-7"
+        );
+        expect(bodies[2]).toMatchObject({ error: { code: -32_602 }, id: 17 });
+        expect(bodies[2].jsonrpc).toBe("2.0");
+      })
+  );
+  it.effect("returns typed resource failures without inventing content", () =>
+    Effect.gen(function* () {
+      const missingUri = "nakafa://content/asset:en:article:missing";
+      const response = yield* postModern(
+        createConvexTestWithBetterAuth(),
+        18,
+        "resources/read",
+        { uri: missingUri },
+        missingUri
+      );
+      expect(response.status).toBe(200);
+      expect(yield* json(response)).toMatchObject({
+        error: {
+          code: -32_602,
+          data: { uri: missingUri },
+        },
+        id: 18,
+        jsonrpc: "2.0",
+      });
+    })
+  );
+  it.effect("executes tools through the shared Convex programs", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const responses = yield* Effect.all([
+        postModern(
+          test,
+          20,
+          "tools/call",
+          {
+            arguments: {
+              limit: 10,
+              locale: "en",
+              offset: 0,
+              queries: ["algebra"],
+            },
+            name: "nakafa_search_content",
+          },
+          "nakafa_search_content"
+        ),
+        postModern(
+          test,
+          21,
+          "tools/call",
+          {
+            arguments: {
+              content_ref: "https://nakafa.com/en/articles/missing/content",
+            },
+            name: "nakafa_get_content",
+          },
+          "nakafa_get_content"
+        ),
+        postModern(
+          test,
+          22,
+          "tools/call",
+          { arguments: { locale: "en" }, name: "nakafa_get_taxonomy" },
+          "nakafa_get_taxonomy"
+        ),
+        postModern(
+          test,
+          23,
+          "tools/call",
+          {
+            arguments: { from_verse: 1, locale: "en", surah: 1 },
+            name: "nakafa_get_quran_reference",
+          },
+          "nakafa_get_quran_reference"
+        ),
+      ]);
+      const bodies = yield* Effect.all(responses.map(json));
+      expect(responses.every(({ status }) => status === 200)).toBe(true);
+      expect(bodies[0]).toMatchObject({
+        result: {
+          structuredContent: {
+            count: 0,
+            has_more: false,
+            items: [],
+            limit: 10,
+            offset: 0,
+          },
+        },
+      });
+      for (const body of bodies.slice(1)) {
+        expect(body).toMatchObject({
+          result: {
+            isError: true,
+            structuredContent: {
+              error: {
+                message: expect.any(String),
+                suggestions: [expect.any(String)],
+              },
+            },
+          },
+        });
+      }
+    })
+  );
+  it.effect("rejects the predecessor 2025 initialize handshake", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const body = JSON.stringify({
+        id: 30,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "predecessor-test", version: "1.0.0" },
+          protocolVersion: MCP_PREDECESSOR_PROTOCOL_VERSION,
+        },
+      });
+      const request = (headers: HeadersInit) =>
+        fetchMcp(test, {
+          body,
+          headers: {
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
+            ...headers,
+          },
+          method: "POST",
+        });
+      const [missingHeader, predecessorHeader] = yield* Effect.all([
+        request({}),
+        request({
+          "mcp-method": "initialize",
+          "mcp-protocol-version": MCP_PREDECESSOR_PROTOCOL_VERSION,
+        }),
+      ]);
+      expect(missingHeader.status).toBe(400);
+      expect(yield* json(missingHeader)).toMatchObject({
+        error: { code: -32_020 },
+        id: 30,
+        jsonrpc: "2.0",
+      });
+      expect(predecessorHeader.status).toBe(400);
+      expect(yield* json(predecessorHeader)).toMatchObject({
+        error: { code: -32_022 },
+        id: 30,
+        jsonrpc: "2.0",
+      });
+    })
+  );
+  it.effect("rejects modern traffic that omits its protocol header", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const post = (body: Readonly<Record<string, unknown>>) =>
+        fetchMcp(test, {
+          body: JSON.stringify(body),
+          headers: {
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
+            "mcp-method": "server/discover",
+          },
+          method: "POST",
+        });
+      const [response, notification] = yield* Effect.all([
+        post({
+          id: 31,
+          jsonrpc: "2.0",
+          method: "server/discover",
+          params: { _meta: MODERN_META },
+        }),
+        post({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: { _meta: MODERN_META },
+        }),
+      ]);
+      expect(response.status).toBe(400);
+      expect(yield* json(response)).toMatchObject({
+        error: {
+          code: -32_020,
+          data: { request_id: expect.any(String) },
+        },
         id: 31,
         jsonrpc: "2.0",
-        method: "server/discover",
-        params: { _meta: MODERN_META },
-      }),
-      post({
+      });
+      expect(notification.status).toBe(400);
+      expect(yield* text(notification)).toBe("");
+    })
+  );
+  it.effect("preserves SDK parse and method failures", () =>
+    Effect.gen(function* () {
+      const test = createConvexTestWithBetterAuth();
+      const [malformed, get] = yield* Effect.all([
+        fetchMcp(test, {
+          body: "{",
+          headers: {
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
+          },
+          method: "POST",
+        }),
+        fetchMcp(test),
+      ]);
+      expect(malformed.status).toBe(400);
+      expect(yield* json(malformed)).toMatchObject({
+        error: { code: -32_700 },
         jsonrpc: "2.0",
-        method: "notifications/initialized",
-        params: { _meta: MODERN_META },
-      }),
-    ]);
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
-      error: {
-        code: -32_020,
-        data: { request_id: expect.any(String) },
-      },
-      id: 31,
-      jsonrpc: "2.0",
-    });
-    expect(notification.status).toBe(400);
-    await expect(notification.text()).resolves.toBe("");
-  });
-
-  it("preserves SDK parse and method failures", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const [malformed, get] = await Promise.all([
-      fetchMcp(test, {
-        body: "{",
-        headers: {
-          accept: "application/json, text/event-stream",
-          "content-type": "application/json",
-        },
-        method: "POST",
-      }),
-      fetchMcp(test),
-    ]);
-    expect(malformed.status).toBe(400);
-    await expect(malformed.json()).resolves.toMatchObject({
-      error: { code: -32_700 },
-      jsonrpc: "2.0",
-    });
-    expect(get.status).toBe(405);
-  });
-
-  it("rejects oversized declared and streaming bodies before SDK parsing", async () => {
-    const test = createConvexTestWithBetterAuth();
-    const notification = JSON.stringify({
-      jsonrpc: "2.0",
-      method: "notifications/initialized",
-      padding: "x".repeat(65_537),
-    });
-    const declared = await fetchMcp(test, {
-      headers: {
-        "content-length": "65537",
-        "content-type": "application/json",
-      },
-      method: "POST",
-    });
-    const streamed = await fetchMcp(test, {
-      body: notification,
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    });
-    for (const response of [declared, streamed]) {
-      expect(response.status).toBe(413);
-      await expect(response.text()).resolves.toBe("");
-    }
-  });
-  it("charges rejected bodies and keeps transport failures bodyless", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
-    const test = createConvexTestWithBetterAuth();
-    const notificationBody = JSON.stringify({
-      jsonrpc: "2.0",
-      method: "notifications/initialized",
-    });
-    const allowed = await Promise.all(
-      Array.from({ length: 29 }, (_, index) =>
-        postModern(test, 100 + index, "server/discover")
-      )
-    );
-    const rejected = await fetchMcp(test, {
-      headers: {
-        "content-length": "65537",
-        "content-type": "application/json",
-      },
-      method: "POST",
-    });
-    const throttled = await fetchMcp(test, {
-      body: notificationBody,
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    });
-    const unavailable = await fetchMcp(test, {
-      body: notificationBody,
-      headers: {
-        "content-type": "application/json",
-        "x-forwarded-for": "",
-      },
-      method: "POST",
-    });
-    expect(allowed.every(({ status }) => status === 200)).toBe(true);
-    expect(rejected.status).toBe(413);
-    expect([throttled.status, unavailable.status]).toEqual([429, 503]);
-    expect(throttled.headers.get("content-type")).toBeNull();
-    expect(throttled.headers.get("retry-after")).toBe("1");
-    for (const response of [throttled, unavailable]) {
-      await expect(response.text()).resolves.toBe("");
-    }
-  });
+      });
+      expect(get.status).toBe(405);
+    })
+  );
+  it.effect(
+    "rejects oversized declared and streaming bodies before SDK parsing",
+    () =>
+      Effect.gen(function* () {
+        const test = createConvexTestWithBetterAuth();
+        const notification = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          padding: "x".repeat(65_537),
+        });
+        const declared = yield* fetchMcp(test, {
+          headers: {
+            "content-length": "65537",
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        const streamed = yield* fetchMcp(test, {
+          body: notification,
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        for (const response of [declared, streamed]) {
+          expect(response.status).toBe(413);
+          expect(yield* text(response)).toBe("");
+        }
+      })
+  );
+  it.effect(
+    "charges rejected bodies and keeps transport failures bodyless",
+    () =>
+      Effect.gen(function* () {
+        vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+        const test = createConvexTestWithBetterAuth();
+        const notificationBody = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        const allowed = yield* Effect.all(
+          Array.from({ length: 29 }, (_, index) =>
+            postModern(test, 100 + index, "server/discover")
+          )
+        );
+        const rejected = yield* fetchMcp(test, {
+          headers: {
+            "content-length": "65537",
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        const throttled = yield* fetchMcp(test, {
+          body: notificationBody,
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        const unavailable = yield* fetchMcp(test, {
+          body: notificationBody,
+          headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": "",
+          },
+          method: "POST",
+        });
+        expect(allowed.every(({ status }) => status === 200)).toBe(true);
+        expect(rejected.status).toBe(413);
+        expect([throttled.status, unavailable.status]).toEqual([429, 503]);
+        expect(throttled.headers.get("content-type")).toBeNull();
+        expect(throttled.headers.get("retry-after")).toBe("1");
+        for (const response of [throttled, unavailable]) {
+          expect(yield* text(response)).toBe("");
+        }
+      })
+  );
 });

--- a/packages/backend/convex/routes/agent/mcp/route.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/route.test.ts
@@ -24,6 +24,9 @@ const MODERN_META = {
 type BackendTest = ReturnType<typeof createConvexTestWithBetterAuth>;
 const json = (response: Response) => Effect.promise(() => response.json());
 const text = (response: Response) => Effect.promise(() => response.text());
+const allConcurrently = <const A extends Iterable<Effect.All.EffectAny>>(
+  effects: A
+) => Effect.all(effects, { concurrency: "unbounded" });
 function fetchMcp(test: BackendTest, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
   headers.set(NAKAFA_MCP_EDGE_CONTRACT.secretHeader, MCP_SECRET);
@@ -101,7 +104,7 @@ describe("Nakafa MCP transport", () => {
     Effect.gen(function* () {
       const test = createConvexTestWithBetterAuth();
       const usageUri = "nakafa://usage";
-      const responses = yield* Effect.all([
+      const responses = yield* allConcurrently([
         postModern(test, 10, "resources/list"),
         postModern(test, 11, "resources/templates/list"),
         postModern(test, 12, "resources/read", { uri: usageUri }, usageUri),
@@ -117,7 +120,7 @@ describe("Nakafa MCP transport", () => {
           "nakafa_find_lesson"
         ),
       ]);
-      const bodies = yield* Effect.all(responses.map(json));
+      const bodies = yield* allConcurrently(responses.map(json));
       expect(responses.every(({ status }) => status === 200)).toBe(true);
       expect(bodies[0]).toMatchObject({
         result: {
@@ -165,7 +168,7 @@ describe("Nakafa MCP transport", () => {
     () =>
       Effect.gen(function* () {
         const test = createConvexTestWithBetterAuth();
-        const responses = yield* Effect.all([
+        const responses = yield* allConcurrently([
           postModern(
             test,
             15,
@@ -206,7 +209,7 @@ describe("Nakafa MCP transport", () => {
             "nakafa_find_lesson"
           ),
         ]);
-        const bodies = yield* Effect.all(responses.map(json));
+        const bodies = yield* allConcurrently(responses.map(json));
         expect(responses.map(({ status }) => status)).toEqual([200, 200, 200]);
         expect(bodies[0].result.messages[0].content.text).toContain(
           "What is the key idea?"
@@ -242,7 +245,7 @@ describe("Nakafa MCP transport", () => {
   it.effect("executes tools through the shared Convex programs", () =>
     Effect.gen(function* () {
       const test = createConvexTestWithBetterAuth();
-      const responses = yield* Effect.all([
+      const responses = yield* allConcurrently([
         postModern(
           test,
           20,
@@ -288,7 +291,7 @@ describe("Nakafa MCP transport", () => {
           "nakafa_get_quran_reference"
         ),
       ]);
-      const bodies = yield* Effect.all(responses.map(json));
+      const bodies = yield* allConcurrently(responses.map(json));
       expect(responses.every(({ status }) => status === 200)).toBe(true);
       expect(bodies[0]).toMatchObject({
         result: {
@@ -339,7 +342,7 @@ describe("Nakafa MCP transport", () => {
           },
           method: "POST",
         });
-      const [missingHeader, predecessorHeader] = yield* Effect.all([
+      const [missingHeader, predecessorHeader] = yield* allConcurrently([
         request({}),
         request({
           "mcp-method": "initialize",
@@ -373,7 +376,7 @@ describe("Nakafa MCP transport", () => {
           },
           method: "POST",
         });
-      const [response, notification] = yield* Effect.all([
+      const [response, notification] = yield* allConcurrently([
         post({
           id: 31,
           jsonrpc: "2.0",
@@ -402,7 +405,7 @@ describe("Nakafa MCP transport", () => {
   it.effect("preserves SDK parse and method failures", () =>
     Effect.gen(function* () {
       const test = createConvexTestWithBetterAuth();
-      const [malformed, get] = yield* Effect.all([
+      const [malformed, get] = yield* allConcurrently([
         fetchMcp(test, {
           body: "{",
           headers: {
@@ -459,7 +462,7 @@ describe("Nakafa MCP transport", () => {
           jsonrpc: "2.0",
           method: "notifications/initialized",
         });
-        const allowed = yield* Effect.all(
+        const allowed = yield* allConcurrently(
           Array.from({ length: 29 }, (_, index) =>
             postModern(test, 100 + index, "server/discover")
           )

--- a/packages/backend/convex/routes/agent/response.test.ts
+++ b/packages/backend/convex/routes/agent/response.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { logInternalFailure } from "@repo/backend/convex/routes/agent/response";
-import { describe, expect, it } from "@repo/testing/effect";
 import { Cause, Effect, Logger } from "effect";
 
 describe("agent responses", () => {

--- a/packages/backend/convex/routes/agent/security.test.ts
+++ b/packages/backend/convex/routes/agent/security.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { NAKAFA_API_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { hasValidEdgeSecret } from "@repo/backend/convex/routes/agent/security";
-import { afterEach, describe, expect, it } from "@repo/testing/effect";
 import { Effect, Result } from "effect";
 import { vi } from "vitest";
 


### PR DESCRIPTION
## Summary

- migrate 12 backend Nakafa client and agent transport test modules from the one-line `@repo/testing/effect` facade to direct `@effect/vitest`
- run effectful cases with `it.effect`, including table-driven `it.effect.each`
- lift Promise-returning framework boundaries with `Effect.promise`
- remove unjustified `it.live` usage where no live clock or test-service override is required

## Effect v4 basis

This follows the official [Effect v4 Vitest API](https://www.effect.website/docs/v4/api/vitest) and the repository-owned vendored source at `effect@4.0.0-rc.110`, SHA `66114151c2b4640bf773f2b3456ce70d679422f6`.

Vendored v4 source confirms that `Effect.all` defaults to concurrency `1`. The MCP tests previously used `Promise.all`, so the migration preserves their concurrent request and rate-limit coverage with an explicitly typed local `allConcurrently` helper using `{ concurrency: "unbounded" }`.

## Scope

- 12 test-only files
- 8 small commits grouped by owning capability
- no production source, package manifest, lockfile, configuration, Quran, tryout runtime, content runtime, or migration change
- no shared Vitest wrapper, global `vi`, raw Effect runner, or Vercel Preview
- test and assertion counts are unchanged

## Verification

Exact head `e9050178f77893aca0e9695761216247379c6d41` on base `af9fcb349df5bd4fb4d482603e46fbeb14931057`:

- focused cohort: 12 files, 61 tests passed
- full backend: 349 files, 1,513 tests passed
- backend typecheck passed
- root lint passed, including Effect source parity, test ownership, Ultracite, and CAS lint
- script typecheck and tests: 4 files, 19 tests passed
- Turborepo boundaries: 2,975 files, no issues
- security audit: no known vulnerabilities
- diff check clean; every touched file is 500 lines or fewer

## Test boundary

The only retained raw `async` callbacks are Vitest `importOriginal` module factories, which are framework mocking boundaries rather than Effect programs. Mocked Promise APIs still return Promises because that is the production interface being substituted.

## Release

This is a test-only checkpoint. Production acceptance should classify it as non-production and skip deployment. It is ready for exact-head CI and review, then immediate protected squash merge when `Required`, `Doctor`, mergeability, and review threads are green.