### PR TITLE
refactor(quran): remove meaning rollout bridge

### DIFF
--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -1,13 +1,11 @@
 // @vitest-environment node
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
-import { api } from "@repo/backend/convex/_generated/api";
 import {
   encodeTestQuranRow,
   makeQuranLocaleSources,
   makeQuranSurah,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
-import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -64,7 +62,7 @@ describe("published Quran content", () => {
     expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
   });
   it("reads the locale-specific signed markdown through the Effect boundary", async () => {
-    useProjectionFixture(api.contentRelease.quran.prose, markdownResult());
+    runtimeQueryMock.mockResolvedValue(markdownResult());
     await expect(
       Effect.runPromise(readPublishedQuranMarkdown("id", 1, 80))
     ).resolves.toMatchObject({
@@ -84,10 +82,7 @@ describe("published Quran content", () => {
     expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
   });
   it("reads the complete signed markdown when no verse limit is requested", async () => {
-    useProjectionFixture(
-      api.contentRelease.quran.prose,
-      legacyMarkdownResult()
-    );
+    runtimeQueryMock.mockResolvedValue(markdownResult());
     await expect(
       Effect.runPromise(readPublishedQuranMarkdown("id", 1))
     ).resolves.toMatchObject({
@@ -112,7 +107,7 @@ describe("published Quran content", () => {
     });
   });
   it("caches the locale-specific Quran web projection", async () => {
-    useProjectionFixture(api.contentRelease.quran.page, viewResult());
+    runtimeQueryMock.mockResolvedValue(viewResult());
     await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
       appLocale: "id",
       nextSurah: {
@@ -152,11 +147,8 @@ describe("published Quran content", () => {
     expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
     expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
   });
-  it("aligns the final surah and its previous neighbor", async () => {
-    useProjectionFixture(
-      api.contentRelease.quran.page,
-      legacyFinalViewResult()
-    );
+  it("preserves the final surah and its previous neighbor", async () => {
+    runtimeQueryMock.mockResolvedValue(finalViewResult());
     await expect(getPublishedQuranView("id", 114)).resolves.toMatchObject({
       nextSurah: null,
       previousSurah: {
@@ -173,66 +165,6 @@ describe("published Quran content", () => {
       },
     });
   });
-  it("retries a predecessor view when the signed release switches", async () => {
-    const otherSnapshotId = Sha256HashSchema.make(`sha256:${"d".repeat(64)}`);
-    let catalogReads = 0;
-    runtimeQueryMock.mockImplementation((query: FunctionReference<"query">) => {
-      if (
-        getFunctionName(query) ===
-        getFunctionName(api.contentRelease.quran.page)
-      ) {
-        return Promise.resolve(legacyViewResult());
-      }
-      if (
-        getFunctionName(query) ===
-        getFunctionName(api.contentRelease.quran.surahs)
-      ) {
-        catalogReads += 1;
-        return Promise.resolve(
-          catalogResult(
-            catalogReads === 1 ? otherSnapshotId : source.snapshotId
-          )
-        );
-      }
-      return Promise.reject(new Error("Unhandled Quran publication query."));
-    });
-
-    await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
-      surah: {
-        name: {
-          meaning: { appLocale: "en", text: "Technical meaning 1" },
-        },
-      },
-    });
-    expect(catalogReads).toBe(2);
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(4);
-  });
-  it("fails closed after a persistent predecessor snapshot race", async () => {
-    const otherSnapshotId = Sha256HashSchema.make(`sha256:${"d".repeat(64)}`);
-    runtimeQueryMock.mockImplementation((query: FunctionReference<"query">) => {
-      if (
-        getFunctionName(query) ===
-        getFunctionName(api.contentRelease.quran.prose)
-      ) {
-        return Promise.resolve(legacyMarkdownResult());
-      }
-      if (
-        getFunctionName(query) ===
-        getFunctionName(api.contentRelease.quran.surahs)
-      ) {
-        return Promise.resolve(catalogResult(otherSnapshotId));
-      }
-      return Promise.reject(new Error("Unhandled Quran publication query."));
-    });
-
-    await expect(
-      Effect.runPromise(Effect.result(readPublishedQuranMarkdown("id", 1)))
-    ).resolves.toMatchObject({
-      _tag: "Failure",
-      failure: { _tag: "QuranSnapshotChangedError" },
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(6);
-  });
 });
 /** Builds the complete signed metadata catalog response. */
 function catalogResult(snapshotId = source.snapshotId) {
@@ -245,24 +177,6 @@ function catalogResult(snapshotId = source.snapshotId) {
   };
 }
 
-/** Routes one projection and its canonical catalog through the runtime mock. */
-function useProjectionFixture(
-  projection: FunctionReference<"query">,
-  result: unknown
-) {
-  runtimeQueryMock.mockImplementation((query: FunctionReference<"query">) => {
-    if (
-      getFunctionName(query) ===
-      getFunctionName(api.contentRelease.quran.surahs)
-    ) {
-      return Promise.resolve(catalogResult());
-    }
-    if (getFunctionName(query) === getFunctionName(projection)) {
-      return Promise.resolve(result);
-    }
-    return Promise.reject(new Error("Unhandled Quran publication query."));
-  });
-}
 /** Builds one narrow locale-specific Quran web response. */
 function viewResult() {
   return {
@@ -270,7 +184,6 @@ function viewResult() {
     appLocale: "id",
     nextSurah: {
       name: {
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "Technical meaning 2" },
         transliteration: "Technical Surah 2",
       },
@@ -280,7 +193,6 @@ function viewResult() {
     previousSurah: null,
     surah: {
       name: {
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         transliteration: "Technical Surah 1",
       },
@@ -311,30 +223,8 @@ function viewResult() {
   };
 }
 
-/** Simulates the deployed predecessor view during the rollout switch. */
-function legacyViewResult() {
-  const result = viewResult();
-  return {
-    ...result,
-    nextSurah: {
-      ...result.nextSurah,
-      name: {
-        meaning: result.nextSurah.name.meaning,
-        transliteration: result.nextSurah.name.transliteration,
-      },
-    },
-    surah: {
-      ...result.surah,
-      name: {
-        meaning: result.surah.name.meaning,
-        transliteration: result.surah.name.transliteration,
-      },
-    },
-  };
-}
-
-/** Simulates the final deployed predecessor view with no next neighbor. */
-function legacyFinalViewResult() {
+/** Builds the final Quran web response with no next neighbor. */
+function finalViewResult() {
   const result = viewResult();
   const previousSurah = makeQuranSurah(113);
   const surah = makeQuranSurah(114);
@@ -344,7 +234,7 @@ function legacyFinalViewResult() {
     previousSurah: {
       ...previousSurah,
       name: {
-        meaning: null,
+        sourceMeaning: previousSurah.name.meaning,
         transliteration: previousSurah.name.transliteration,
       },
       numberOfVerses: 1,
@@ -352,7 +242,7 @@ function legacyFinalViewResult() {
     surah: {
       ...surah,
       name: {
-        meaning: null,
+        sourceMeaning: surah.name.meaning,
         transliteration: surah.name.transliteration,
       },
       numberOfVerses: 1,
@@ -367,7 +257,6 @@ function markdownResult() {
     sources: makeQuranLocaleSources("id"),
     surah: {
       name: {
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         transliteration: "Technical Surah 1",
       },
@@ -387,20 +276,5 @@ function markdownResult() {
         },
       },
     ],
-  };
-}
-
-/** Simulates the deployed predecessor Markdown during the rollout switch. */
-function legacyMarkdownResult() {
-  const result = markdownResult();
-  return {
-    ...result,
-    surah: {
-      ...result.surah,
-      name: {
-        meaning: result.surah.name.meaning,
-        transliteration: result.surah.name.transliteration,
-      },
-    },
   };
 }

--- a/apps/www/lib/content/quran/publication.ts
+++ b/apps/www/lib/content/quran/publication.ts
@@ -1,10 +1,7 @@
 import "server-only";
 
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
-import {
-  completePublishedQuranSurah,
-  decodePublishedQuranCatalog,
-} from "@repo/backend/client/quran/catalog";
+import { decodePublishedQuranCatalog } from "@repo/backend/client/quran/catalog";
 import { decodePublishedQuranMarkdown } from "@repo/backend/client/quran/markdown";
 import { decodePublishedQuranSource } from "@repo/backend/client/quran/publication";
 import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
@@ -33,9 +30,9 @@ export const readPublishedQuranCatalog = Effect.fn(
   return yield* decodePublishedQuranCatalog(result);
 });
 
-/** Reads one Quran markdown projection and its predecessor-only catalog. */
-const readPublishedQuranMarkdownAttempt = Effect.fn(
-  "NakafaQuran.readPublishedMarkdownAttempt"
+/** Reads one complete signed Quran markdown projection. */
+export const readPublishedQuranMarkdown = Effect.fn(
+  "NakafaQuran.readPublishedMarkdown"
 )(function* (locale: Locale, surahNumber: number, verseLimit?: number) {
   const appLocale = AppLocaleSchema.make(locale);
   const result = yield* readRuntimeQuery(
@@ -44,90 +41,25 @@ const readPublishedQuranMarkdownAttempt = Effect.fn(
       ? { appLocale, surahNumber }
       : { appLocale, surahNumber, verseLimit }
   );
-  const markdown = yield* decodePublishedQuranMarkdown(result, {
+  return yield* decodePublishedQuranMarkdown(result, {
     appLocale,
     surahNumber,
     verseLimit,
   });
-  const catalog =
-    markdown.surah.name.meaning === null
-      ? yield* readPublishedQuranCatalog()
-      : null;
-  const surah = yield* completePublishedQuranSurah(markdown.surah, catalog, {
-    operation: "markdown",
-    snapshotId: markdown.snapshotId,
-  });
-  return { ...markdown, surah };
 });
 
-/** Retries only the release-switch race while predecessor reads remain live. */
-export const readPublishedQuranMarkdown = Effect.fn(
-  "NakafaQuran.readPublishedMarkdown"
-)(function* (locale: Locale, surahNumber: number, verseLimit?: number) {
-  return yield* readPublishedQuranMarkdownAttempt(
-    locale,
-    surahNumber,
-    verseLimit
-  ).pipe(
-    Effect.retry({
-      times: 2,
-      while: (error) => error._tag === "QuranSnapshotChangedError",
-    })
-  );
-});
-
-/** Reads one Quran view projection and its predecessor-only catalog. */
-const readPublishedQuranViewAttempt = Effect.fn(
-  "NakafaQuran.readPublishedViewAttempt"
-)(function* (locale: Locale, surahNumber: number) {
-  const appLocale = AppLocaleSchema.make(locale);
-  const result = yield* readRuntimeQuery(api.contentRelease.quran.page, {
-    appLocale,
-    surahNumber,
-  });
-  const view = yield* decodePublishedQuranView(result, {
-    appLocale,
-    surahNumber,
-  });
-  const needsCatalog = [view.surah, view.previousSurah, view.nextSurah].some(
-    (surah) => surah?.name.meaning === null
-  );
-  const catalog = needsCatalog ? yield* readPublishedQuranCatalog() : null;
-  const surah = yield* completePublishedQuranSurah(view.surah, catalog, {
-    operation: "view",
-    snapshotId: view.snapshotId,
-  });
-  const previousSurah =
-    view.previousSurah === null
-      ? null
-      : yield* completePublishedQuranSurah(view.previousSurah, catalog, {
-          operation: "view",
-          snapshotId: view.snapshotId,
-        });
-  const nextSurah =
-    view.nextSurah === null
-      ? null
-      : yield* completePublishedQuranSurah(view.nextSurah, catalog, {
-          operation: "view",
-          snapshotId: view.snapshotId,
-        });
-  return {
-    ...view,
-    nextSurah,
-    previousSurah,
-    surah,
-  };
-});
-
-/** Reads one race-safe locale-specific signed Quran web projection. */
+/** Reads one complete signed Quran web projection. */
 const readPublishedQuranView = Effect.fn("NakafaQuran.readPublishedView")(
   function* (locale: Locale, surahNumber: number) {
-    return yield* readPublishedQuranViewAttempt(locale, surahNumber).pipe(
-      Effect.retry({
-        times: 2,
-        while: (error) => error._tag === "QuranSnapshotChangedError",
-      })
-    );
+    const appLocale = AppLocaleSchema.make(locale);
+    const result = yield* readRuntimeQuery(api.contentRelease.quran.page, {
+      appLocale,
+      surahNumber,
+    });
+    return yield* decodePublishedQuranView(result, {
+      appLocale,
+      surahNumber,
+    });
   }
 );
 

--- a/packages/backend/agent/content.ts
+++ b/packages/backend/agent/content.ts
@@ -2,7 +2,6 @@ import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { decodeAgentOutput } from "@repo/backend/agent/decode";
 import { readAgentQuery } from "@repo/backend/agent/query";
 import { getAgentContentReferenceInput } from "@repo/backend/agent/ref";
-import { completePublishedQuranSurah } from "@repo/backend/client/quran/catalog";
 import {
   decodePublishedQuranMarkdown,
   renderQuranReadingSourcesMarkdown,
@@ -175,10 +174,7 @@ const renderQuranMarkdown = Effect.fn("agent.renderQuranMarkdown")(function* (
     appLocale: ref.locale,
     surahNumber: source.surahNumber,
   }).pipe(Effect.mapError(contentReadError));
-  const surah = yield* completePublishedQuranSurah(publication.surah, null, {
-    operation: "markdown",
-    snapshotId: publication.snapshotId,
-  }).pipe(Effect.mapError(contentReadError));
+  const surah = publication.surah;
   const title = surah.name.transliteration;
   const meaning = surah.name.meaning;
   const description = meaning.text;

--- a/packages/backend/client/nakafa/decode.ts
+++ b/packages/backend/client/nakafa/decode.ts
@@ -1,7 +1,4 @@
-import type {
-  QuranPublicationError,
-  QuranSnapshotChangedError,
-} from "@repo/backend/client/quran/publication";
+import type { QuranPublicationError } from "@repo/backend/client/quran/publication";
 import {
   getUnknownErrorMessage,
   NakafaAgentDataReadError,
@@ -13,9 +10,7 @@ import { NakafaAgentMarkdownSchema } from "@repo/contents/_lib/agent/schema/read
 import { NakafaAgentTaxonomySchema } from "@repo/contents/_lib/agent/schema/taxonomy";
 import { Effect, Schema } from "effect";
 /** Maps signed Quran contract failures into the public agent read boundary. */
-export function toNakafaQuranDataReadError(
-  error: QuranPublicationError | QuranSnapshotChangedError
-) {
+export function toNakafaQuranDataReadError(error: QuranPublicationError) {
   return new NakafaAgentDataReadError({
     cause: error.reason,
     message: `Unable to read signed Nakafa Quran ${error.operation}.`,

--- a/packages/backend/client/nakafa/quran.test.ts
+++ b/packages/backend/client/nakafa/quran.test.ts
@@ -183,87 +183,6 @@ describe("Quran Nakafa reader", () => {
         expect(runtimeMocks.runtimeQuery).toHaveBeenCalledTimes(1);
       })
   );
-  it.live("retries predecessor Markdown across a signed release switch", () =>
-    Effect.gen(function* () {
-      const otherSnapshotId = Sha256HashSchema.make(`sha256:${"d".repeat(64)}`);
-      let catalogReads = 0;
-      runtimeMocks.runtimeQuery.mockImplementation(
-        (
-          _url: string,
-          query: FunctionReference<"query">,
-          args: Record<string, unknown>
-        ) => {
-          if (
-            getFunctionName(query) ===
-            getFunctionName(api.contentRelease.quran.prose)
-          ) {
-            return Promise.resolve(legacyMarkdownResult(args));
-          }
-          if (
-            getFunctionName(query) ===
-            getFunctionName(api.contentRelease.quran.surahs)
-          ) {
-            catalogReads += 1;
-            return Promise.resolve(
-              catalogResult(
-                catalogReads === 1 ? otherSnapshotId : source.snapshotId
-              )
-            );
-          }
-          return Promise.reject(new Error("Unhandled Quran query fixture."));
-        }
-      );
-
-      const markdown = yield* readQuranMarkdown(
-        convexUrl,
-        readNakafaContentRefFixture("id", "quran/1", "quran")
-      );
-      expect(Option.getOrUndefined(markdown)?.description).toBe("The Opening");
-      expect(catalogReads).toBe(2);
-      expect(runtimeMocks.runtimeQuery).toHaveBeenCalledTimes(4);
-    })
-  );
-  it.live("maps a persistent signed release switch to the agent boundary", () =>
-    Effect.gen(function* () {
-      const otherSnapshotId = Sha256HashSchema.make(`sha256:${"d".repeat(64)}`);
-      runtimeMocks.runtimeQuery.mockImplementation(
-        (
-          _url: string,
-          query: FunctionReference<"query">,
-          args: Record<string, unknown>
-        ) => {
-          if (
-            getFunctionName(query) ===
-            getFunctionName(api.contentRelease.quran.prose)
-          ) {
-            return Promise.resolve(legacyMarkdownResult(args));
-          }
-          if (
-            getFunctionName(query) ===
-            getFunctionName(api.contentRelease.quran.surahs)
-          ) {
-            return Promise.resolve(catalogResult(otherSnapshotId));
-          }
-          return Promise.reject(new Error("Unhandled Quran query fixture."));
-        }
-      );
-
-      const result = yield* Effect.result(
-        readQuranMarkdown(
-          convexUrl,
-          readNakafaContentRefFixture("id", "quran/1", "quran")
-        )
-      );
-      expect(result).toMatchObject({
-        _tag: "Failure",
-        failure: {
-          _tag: "NakafaAgentDataReadError",
-          cause: "Signed Quran release changed while reading its projection.",
-        },
-      });
-      expect(runtimeMocks.runtimeQuery).toHaveBeenCalledTimes(6);
-    })
-  );
   it.live("rejects non-Quran routes and reads source names directly", () =>
     Effect.gen(function* () {
       const missing = yield* readQuranMarkdown(
@@ -295,11 +214,6 @@ function readRuntimeFixture(
   ) {
     return Promise.resolve(markdownResult(args));
   }
-  if (
-    getFunctionName(query) === getFunctionName(api.contentRelease.quran.surahs)
-  ) {
-    return Promise.resolve(catalogResult());
-  }
   return Promise.reject(new Error("Unhandled Quran query fixture."));
 }
 
@@ -328,7 +242,6 @@ function markdownResult(args: Record<string, unknown>) {
     sources: makeQuranLocaleSources(appLocale),
     surah: {
       name: {
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "The Opening" },
         transliteration: "Al-Fatihah",
       },
@@ -345,32 +258,6 @@ function markdownResult(args: Record<string, unknown>) {
         translation: translationDocument(appLocale),
       },
     ],
-  };
-}
-
-/** Builds the stable signed catalog used across the projection switch. */
-function catalogResult(snapshotId = source.snapshotId) {
-  return {
-    ...source,
-    snapshotId,
-    rowJson: Array.from({ length: 114 }, (_, index) =>
-      encodeTestQuranRow(snapshotId, surahRow(index + 1))
-    ),
-  };
-}
-
-/** Simulates the deployed predecessor Markdown before the successor field. */
-function legacyMarkdownResult(args: Record<string, unknown>) {
-  const result = markdownResult(args);
-  return {
-    ...result,
-    surah: {
-      ...result.surah,
-      name: {
-        meaning: result.surah.name.meaning,
-        transliteration: result.surah.name.transliteration,
-      },
-    },
   };
 }
 

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -6,10 +6,6 @@ import {
 } from "@repo/backend/client/nakafa/decode";
 import { readNakafaRuntimeQuery } from "@repo/backend/client/nakafa/query";
 import {
-  completePublishedQuranSurah,
-  decodePublishedQuranCatalog,
-} from "@repo/backend/client/quran/catalog";
-import {
   decodePublishedQuranMarkdown,
   renderQuranReadingSourcesMarkdown,
   renderQuranTafsirAccessMarkdown,
@@ -85,7 +81,7 @@ function referenceArgs(input: ParsedQuranReferenceOptions) {
   };
 }
 
-/** Reads one expanded projection, consulting the catalog only for its predecessor. */
+/** Reads one complete signed Quran markdown projection. */
 const readQuranMarkdownPublication = Effect.fn(
   "NakafaQuran.readMarkdownPublication"
 )(function* (
@@ -98,23 +94,10 @@ const readQuranMarkdownPublication = Effect.fn(
     api.contentRelease.quran.prose,
     { appLocale, surahNumber }
   );
-  const publication = yield* decodePublishedQuranMarkdown(result, {
+  return yield* decodePublishedQuranMarkdown(result, {
     appLocale,
     surahNumber,
   });
-  const catalog =
-    publication.surah.name.meaning === null
-      ? yield* readNakafaRuntimeQuery(
-          convexUrl,
-          api.contentRelease.quran.surahs,
-          {}
-        ).pipe(Effect.flatMap(decodePublishedQuranCatalog))
-      : null;
-  const surah = yield* completePublishedQuranSurah(publication.surah, catalog, {
-    operation: "markdown",
-    snapshotId: publication.snapshotId,
-  });
-  return { ...publication, surah };
 });
 
 /** Renders one signed Quran surah as full agent markdown. */
@@ -130,16 +113,9 @@ export const readQuranMarkdown = Effect.fn("NakafaQuran.readMarkdown")(
       ref.locale,
       surahNumber
     ).pipe(
-      Effect.retry({
-        times: 2,
-        while: (error) => error._tag === "QuranSnapshotChangedError",
-      }),
-      Effect.catchTags({
-        QuranPublicationError: (error) =>
-          Effect.fail(toNakafaQuranDataReadError(error)),
-        QuranSnapshotChangedError: (error) =>
-          Effect.fail(toNakafaQuranDataReadError(error)),
-      })
+      Effect.catchTag("QuranPublicationError", (error) =>
+        Effect.fail(toNakafaQuranDataReadError(error))
+      )
     );
     const surah = publication.surah;
     const title = getSurahName(surah);

--- a/packages/backend/client/quran/catalog.test.ts
+++ b/packages/backend/client/quran/catalog.test.ts
@@ -4,10 +4,8 @@ import {
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
 import {
-  completePublishedQuranSurah,
   decodePublishedQuranCatalog,
   decodePublishedQuranSurah,
-  selectPublishedQuranSurah,
 } from "@repo/backend/client/quran/catalog";
 import { QuranPublicationError } from "@repo/backend/client/quran/publication";
 import {
@@ -44,13 +42,6 @@ describe("signed Quran catalog decoder", () => {
         text: "Technical meaning 1",
       });
       expect(catalog.surahs.at(-1)?.number).toBe(114);
-      expect(
-        yield* selectPublishedQuranSurah(catalog, {
-          operation: "view",
-          snapshotId: source.snapshotId,
-          surahNumber: 1,
-        })
-      ).toEqual(catalog.surahs[0]);
     })
   );
 
@@ -77,37 +68,11 @@ describe("signed Quran catalog decoder", () => {
     })
   );
 
-  it.live("rejects cross-snapshot projection metadata", () =>
+  it.live("normalizes the required source meaning", () =>
     Effect.gen(function* () {
-      const catalog = yield* decodePublishedQuranCatalog(
-        catalogResult((index) =>
-          encodeTestQuranRow(source.snapshotId, makeQuranSurah(index + 1))
-        )
-      );
-      const selected = yield* Effect.result(
-        selectPublishedQuranSurah(catalog, {
-          operation: "markdown",
-          snapshotId: Sha256HashSchema.make(`sha256:${"d".repeat(64)}`),
-          surahNumber: 1,
-        })
-      );
-
-      expect(selected).toMatchObject({
-        _tag: "Failure",
-        failure: {
-          _tag: "QuranSnapshotChangedError",
-          operation: "markdown",
-        },
-      });
-    })
-  );
-
-  it.live("normalizes the expanded meaning and detects its predecessor", () =>
-    Effect.gen(function* () {
-      const expanded = yield* decodePublishedQuranSurah(
+      const decoded = yield* decodePublishedQuranSurah(
         {
           name: {
-            meaning: null,
             sourceMeaning: { appLocale: "en", text: "The Opening" },
             transliteration: "Al-Fatihah",
           },
@@ -115,29 +80,20 @@ describe("signed Quran catalog decoder", () => {
         },
         "view"
       );
-      const predecessor = yield* decodePublishedQuranSurah(
-        {
-          name: { meaning: null, transliteration: "Al-Fatihah" },
-          number: 1,
-        },
-        "view"
-      );
 
-      expect(expanded.name).toEqual({
+      expect(decoded.name).toEqual({
         meaning: { appLocale: "en", text: "The Opening" },
         transliteration: "Al-Fatihah",
       });
-      expect(predecessor.name.meaning).toBeNull();
     })
   );
 
-  it.live("fails closed for an invalid expanded meaning", () =>
+  it.live("fails closed for an invalid source meaning", () =>
     Effect.gen(function* () {
       const decoded = yield* Effect.result(
         decodePublishedQuranSurah(
           {
             name: {
-              meaning: null,
               sourceMeaning: { appLocale: "id", text: "Pembukaan" },
               transliteration: "Al-Fatihah",
             },
@@ -153,81 +109,6 @@ describe("signed Quran catalog decoder", () => {
           _tag: "QuranPublicationError",
           operation: "view",
           reason: "Signed Quran source meaning is invalid.",
-        },
-      });
-    })
-  );
-
-  it.live("completes only predecessor projections from the same catalog", () =>
-    Effect.gen(function* () {
-      const catalog = yield* decodePublishedQuranCatalog(
-        catalogResult((index) =>
-          encodeTestQuranRow(source.snapshotId, makeQuranSurah(index + 1))
-        )
-      );
-      const expanded = yield* completePublishedQuranSurah(
-        {
-          name: {
-            meaning: makeQuranSurah(1).name.meaning,
-            transliteration: "Al-Fatihah",
-          },
-          number: 1,
-        },
-        null,
-        { operation: "view", snapshotId: source.snapshotId }
-      );
-      const predecessor = yield* completePublishedQuranSurah(
-        {
-          name: { meaning: null, transliteration: "Al-Fatihah" },
-          number: 1,
-        },
-        catalog,
-        { operation: "view", snapshotId: source.snapshotId }
-      );
-      const missing = yield* Effect.result(
-        completePublishedQuranSurah(
-          {
-            name: { meaning: null, transliteration: "Al-Fatihah" },
-            number: 1,
-          },
-          null,
-          { operation: "view", snapshotId: source.snapshotId }
-        )
-      );
-
-      expect(expanded.name.meaning.text).toBe("Technical meaning 1");
-      expect(predecessor.name.meaning.text).toBe("Technical meaning 1");
-      expect(missing).toMatchObject({
-        _tag: "Failure",
-        failure: {
-          _tag: "QuranPublicationError",
-          reason: "Signed Quran source meaning is missing.",
-        },
-      });
-    })
-  );
-
-  it.live("rejects a projection outside the signed catalog", () =>
-    Effect.gen(function* () {
-      const catalog = yield* decodePublishedQuranCatalog(
-        catalogResult((index) =>
-          encodeTestQuranRow(source.snapshotId, makeQuranSurah(index + 1))
-        )
-      );
-      const selected = yield* Effect.result(
-        selectPublishedQuranSurah(catalog, {
-          operation: "view",
-          snapshotId: source.snapshotId,
-          surahNumber: 115,
-        })
-      );
-
-      expect(selected).toMatchObject({
-        _tag: "Failure",
-        failure: {
-          _tag: "QuranPublicationError",
-          operation: "view",
-          reason: "Signed Quran projection has no matching catalog surah.",
         },
       });
     })

--- a/packages/backend/client/quran/catalog.ts
+++ b/packages/backend/client/quran/catalog.ts
@@ -7,7 +7,6 @@ import {
   decodePublishedQuranSource,
   type PublishedQuranSource,
   type QuranPublicationOperation,
-  QuranSnapshotChangedError,
   quranPublicationError,
 } from "@repo/backend/client/quran/publication";
 import { decodeQuranSurahRow } from "@repo/backend/client/quran/rows";
@@ -24,24 +23,15 @@ export type PublishedQuranCatalog = PublishedQuranSource & {
   readonly surahs: readonly QuranSurahRow[];
 };
 
-interface QuranSurahProjection {
-  readonly name: {
-    readonly meaning: QuranSurahRow["name"]["meaning"] | null;
-    readonly transliteration: string;
-  };
-  readonly number: number;
-}
-
 interface QuranSurahTransportProjection {
   readonly name: {
-    readonly meaning: unknown;
-    readonly sourceMeaning?: unknown;
+    readonly sourceMeaning: unknown;
     readonly transliteration: string;
   };
   readonly number: number;
 }
 
-/** Normalizes the expanded transport field into the canonical meaning shape. */
+/** Normalizes the source transport field into the canonical meaning shape. */
 export const decodePublishedQuranSurah = Effect.fn(
   "NakafaQuran.decodePublishedSurah"
 )(function* <Surah extends QuranSurahTransportProjection>(
@@ -49,9 +39,6 @@ export const decodePublishedQuranSurah = Effect.fn(
   operation: QuranPublicationOperation
 ) {
   const { sourceMeaning, ...name } = projection.name;
-  if (sourceMeaning === undefined) {
-    return { ...projection, name: { ...name, meaning: null } };
-  }
   const meaning = yield* Schema.decodeUnknownEffect(
     QuranSurahRowSchema.fields.name.fields.meaning
   )(sourceMeaning).pipe(
@@ -63,86 +50,6 @@ export const decodePublishedQuranSurah = Effect.fn(
     )
   );
   return { ...projection, name: { ...name, meaning } };
-});
-
-/** Selects one surah from the exact signed snapshot used by a projection. */
-export const selectPublishedQuranSurah = Effect.fn(
-  "NakafaQuran.selectPublishedSurah"
-)(function* (
-  catalog: PublishedQuranCatalog,
-  expected: {
-    readonly operation: QuranPublicationOperation;
-    readonly snapshotId: PublishedQuranSource["snapshotId"];
-    readonly surahNumber: number;
-  }
-) {
-  if (catalog.snapshotId !== expected.snapshotId) {
-    return yield* new QuranSnapshotChangedError({
-      catalogSnapshotId: catalog.snapshotId,
-      operation: expected.operation,
-      projectionSnapshotId: expected.snapshotId,
-      reason: "Signed Quran release changed while reading its projection.",
-    });
-  }
-  const surah = catalog.surahs[expected.surahNumber - 1];
-  if (surah?.number !== expected.surahNumber) {
-    return yield* quranPublicationError(
-      expected.operation,
-      "Signed Quran projection has no matching catalog surah."
-    );
-  }
-  return surah;
-});
-
-/** Completes a predecessor projection only when its successor field is absent. */
-export const completePublishedQuranSurah = Effect.fn(
-  "NakafaQuran.completePublishedSurah"
-)(function* <Surah extends QuranSurahProjection>(
-  projection: Surah,
-  catalog: PublishedQuranCatalog | null,
-  expected: {
-    readonly operation: QuranPublicationOperation;
-    readonly snapshotId: PublishedQuranSource["snapshotId"];
-  }
-) {
-  const { name: projectionName, ...surah } = projection;
-  const { meaning, ...name } = projectionName;
-  if (meaning !== null) {
-    return {
-      ...surah,
-      name: { ...name, meaning },
-    };
-  }
-  if (catalog === null) {
-    return yield* quranPublicationError(
-      expected.operation,
-      "Signed Quran source meaning is missing."
-    );
-  }
-  return yield* alignPublishedQuranSurah(catalog, projection, expected);
-});
-
-/** Aligns projected metadata with its canonical row from the same snapshot. */
-export const alignPublishedQuranSurah = Effect.fn(
-  "NakafaQuran.alignPublishedSurah"
-)(function* <Surah extends QuranSurahProjection>(
-  catalog: PublishedQuranCatalog,
-  projection: Surah,
-  expected: {
-    readonly operation: QuranPublicationOperation;
-    readonly snapshotId: PublishedQuranSource["snapshotId"];
-  }
-) {
-  const source = yield* selectPublishedQuranSurah(catalog, {
-    ...expected,
-    surahNumber: projection.number,
-  });
-  const { name: projectionName, ...surah } = projection;
-  const { meaning: _meaning, ...name } = projectionName;
-  return {
-    ...surah,
-    name: { ...name, meaning: source.name.meaning },
-  };
 });
 
 /** Decodes the complete active signed Quran metadata catalog. */

--- a/packages/backend/client/quran/document.test.ts
+++ b/packages/backend/client/quran/document.test.ts
@@ -97,7 +97,6 @@ function documentResult(): QuranDocumentResult {
       kind: "quran-surah",
       name: {
         arabic: "الفاتحة",
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "The Opening" },
         transliteration: "Al-Fatihah",
       },

--- a/packages/backend/client/quran/markdown.test.ts
+++ b/packages/backend/client/quran/markdown.test.ts
@@ -171,7 +171,6 @@ function markdownResult(
     tafsirAccess: makeQuranTafsirProjection("en"),
     surah: {
       name: {
-        meaning: "The Opening",
         sourceMeaning: { appLocale: "en", text: "The Opening" },
         transliteration: "Al-Fatihah",
       },

--- a/packages/backend/client/quran/publication.ts
+++ b/packages/backend/client/quran/publication.ts
@@ -28,17 +28,6 @@ export class QuranPublicationError extends Schema.TaggedError<QuranPublicationEr
   }
 ) {}
 
-/** A projection and its predecessor catalog were read across a release switch. */
-export class QuranSnapshotChangedError extends Schema.TaggedError<QuranSnapshotChangedError>()(
-  "QuranSnapshotChangedError",
-  {
-    catalogSnapshotId: Sha256HashSchema,
-    operation: QuranPublicationOperationSchema,
-    projectionSnapshotId: Sha256HashSchema,
-    reason: Schema.String,
-  }
-) {}
-
 /** Creates one domain failure for malformed or inactive signed Quran data. */
 export function quranPublicationError(
   operation: QuranPublicationOperation,

--- a/packages/backend/client/quran/view.test.ts
+++ b/packages/backend/client/quran/view.test.ts
@@ -19,7 +19,6 @@ const source = {
 };
 const surah = {
   name: {
-    meaning: "The Opening",
     sourceMeaning: { appLocale: "en" as const, text: "The Opening" },
     transliteration: "Al-Fatihah",
   },

--- a/packages/backend/convex/contentRelease/quran/document.test.ts
+++ b/packages/backend/convex/contentRelease/quran/document.test.ts
@@ -69,7 +69,6 @@ describe("contentRelease/quran/document", () => {
       kind: "quran-surah",
       name: {
         arabic: "سورة 1",
-        meaning: null,
         sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         transliteration: "Technical Surah 1",
       },
@@ -103,7 +102,6 @@ describe("contentRelease/quran/document", () => {
       sources: makeQuranLocaleSources("de"),
       surah: {
         name: {
-          meaning: null,
           sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         },
       },

--- a/packages/backend/convex/contentRelease/quran/document.ts
+++ b/packages/backend/convex/contentRelease/quran/document.ts
@@ -30,8 +30,7 @@ const quranDocumentSurahValidator = v.object({
   kind: v.literal("quran-surah"),
   name: v.object({
     arabic: v.string(),
-    meaning: v.union(v.string(), v.null()),
-    sourceMeaning: v.optional(quranSurahMeaningValidator),
+    sourceMeaning: quranSurahMeaningValidator,
     transliteration: v.string(),
   }),
   number: v.number(),
@@ -63,18 +62,11 @@ type QuranDocument = Infer<typeof quranDocumentValidator>;
 type QuranDocumentSurah = NonNullable<QuranDocument["surah"]>;
 
 /** Projects complete public surah metadata without signed envelope fields. */
-function projectSurah(
-  surah: QuranSurahRow,
-  appLocale: AppLocaleCode
-): QuranDocumentSurah {
+function projectSurah(surah: QuranSurahRow): QuranDocumentSurah {
   return {
     kind: surah.kind,
     name: {
       arabic: surah.name.arabic,
-      meaning:
-        surah.name.meaning.appLocale === appLocale
-          ? surah.name.meaning.text
-          : null,
       sourceMeaning: surah.name.meaning,
       transliteration: surah.name.transliteration,
     },
@@ -165,8 +157,7 @@ export const readQuranDocument = Effect.fn("contentRelease.readQuranDocument")(
     return {
       ...document,
       preBismillah: projected.preBismillah,
-      surah:
-        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      surah: loaded.surah === null ? null : projectSurah(loaded.surah),
       verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,

--- a/packages/backend/convex/contentRelease/quran/markdown.test.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.test.ts
@@ -50,7 +50,6 @@ describe("contentRelease/quran/markdown", () => {
 
     expect(markdown.surah).toEqual({
       name: {
-        meaning: "Technical meaning 1",
         sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         transliteration: "Technical Surah 1",
       },
@@ -120,7 +119,6 @@ describe("contentRelease/quran/markdown", () => {
     expect(markdown.toVerse).toBe(80);
     expect(markdown.verses).toHaveLength(80);
     expect(markdown.preBismillah?.arabic).toBe(bismillah);
-    expect(markdown.surah?.name.meaning).toBeNull();
     expect(markdown.surah?.name.sourceMeaning).toEqual({
       appLocale: "en",
       text: "Technical meaning 2",

--- a/packages/backend/convex/contentRelease/quran/markdown.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.ts
@@ -29,8 +29,7 @@ import { Effect } from "effect";
 
 const quranMarkdownSurahValidator = v.object({
   name: v.object({
-    meaning: v.union(v.string(), v.null()),
-    sourceMeaning: v.optional(quranSurahMeaningValidator),
+    sourceMeaning: quranSurahMeaningValidator,
     transliteration: v.string(),
   }),
   number: v.number(),
@@ -60,16 +59,9 @@ export type QuranMarkdown = Infer<typeof quranMarkdownValidator>;
 type QuranMarkdownSurah = NonNullable<QuranMarkdown["surah"]>;
 
 /** Projects only metadata rendered by Quran markdown consumers. */
-function projectSurah(
-  surah: QuranSurahRow,
-  appLocale: AppLocaleCode
-): QuranMarkdownSurah {
+function projectSurah(surah: QuranSurahRow): QuranMarkdownSurah {
   return {
     name: {
-      meaning:
-        surah.name.meaning.appLocale === appLocale
-          ? surah.name.meaning.text
-          : null,
       sourceMeaning: surah.name.meaning,
       transliteration: surah.name.transliteration,
     },
@@ -197,8 +189,7 @@ export const readQuranMarkdown = Effect.fn("contentRelease.readQuranMarkdown")(
     return {
       ...markdown,
       preBismillah: projected.preBismillah,
-      surah:
-        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      surah: loaded.surah === null ? null : projectSurah(loaded.surah),
       verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,

--- a/packages/backend/convex/contentRelease/quran/view.test.ts
+++ b/packages/backend/convex/contentRelease/quran/view.test.ts
@@ -116,7 +116,6 @@ describe("contentRelease/quran/view", () => {
 
     expect(english.nextSurah).toEqual({
       name: {
-        meaning: "Technical meaning 2",
         sourceMeaning: { appLocale: "en", text: "Technical meaning 2" },
         transliteration: "Technical Surah 2",
       },
@@ -126,7 +125,6 @@ describe("contentRelease/quran/view", () => {
     expect(english.previousSurah).toBeNull();
     expect(english.surah).toEqual({
       name: {
-        meaning: "Technical meaning 1",
         sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
         transliteration: "Technical Surah 1",
       },
@@ -175,12 +173,10 @@ describe("contentRelease/quran/view", () => {
     ]);
     expect(indonesian.sources).toEqual(makeQuranLocaleSources("id"));
     expect(indonesian.tafsirAccess).toEqual(makeQuranTafsirProjection("id"));
-    expect(indonesian.nextSurah?.name.meaning).toBeNull();
     expect(indonesian.nextSurah?.name.sourceMeaning).toEqual({
       appLocale: "en",
       text: "Technical meaning 2",
     });
-    expect(indonesian.surah?.name.meaning).toBeNull();
     expect(indonesian.surah?.name.sourceMeaning).toEqual({
       appLocale: "en",
       text: "Technical meaning 1",

--- a/packages/backend/convex/contentRelease/quran/view.ts
+++ b/packages/backend/convex/contentRelease/quran/view.ts
@@ -30,8 +30,7 @@ import { type Infer, v } from "convex/values";
 import { Effect } from "effect";
 
 const quranViewNameValidator = v.object({
-  meaning: v.union(v.string(), v.null()),
-  sourceMeaning: v.optional(quranSurahMeaningValidator),
+  sourceMeaning: quranSurahMeaningValidator,
   transliteration: v.string(),
 });
 
@@ -79,16 +78,9 @@ const readNeighbor = Effect.fn("contentRelease.readQuranNeighbor")(function* (
 });
 
 /** Projects only the signed surah metadata needed by the Quran page. */
-function projectSurah(
-  surah: QuranSurahRow,
-  appLocale: AppLocaleCode
-): QuranViewSurah {
+function projectSurah(surah: QuranSurahRow): QuranViewSurah {
   return {
     name: {
-      meaning:
-        surah.name.meaning.appLocale === appLocale
-          ? surah.name.meaning.text
-          : null,
       sourceMeaning: surah.name.meaning,
       transliteration: surah.name.transliteration,
     },
@@ -194,16 +186,13 @@ export const readQuranView = Effect.fn("contentRelease.readQuranView")(
     return {
       ...view,
       nextSurah:
-        loaded.nextSurah === null
-          ? null
-          : projectSurah(loaded.nextSurah, appLocale),
+        loaded.nextSurah === null ? null : projectSurah(loaded.nextSurah),
       previousSurah:
         loaded.previousSurah === null
           ? null
-          : projectSurah(loaded.previousSurah, appLocale),
+          : projectSurah(loaded.previousSurah),
       preBismillah: projected.preBismillah,
-      surah:
-        loaded.surah === null ? null : projectSurah(loaded.surah, appLocale),
+      surah: loaded.surah === null ? null : projectSurah(loaded.surah),
       verses: projected.verses.map(({ arabic, document, number }) => ({
         arabic,
         number,


### PR DESCRIPTION
## Outcome

Completes the Quran meaning contract rollout after #429 was merged and verified in production.

- Requires the signed locale-aware `sourceMeaning` field in Convex Quran views, documents, and markdown.
- Decodes that transport provenance once into the canonical schema-derived `name.meaning` reader contract.
- Deletes the legacy nullable `meaning` field, catalog fallback, snapshot retry, compatibility error, and their obsolete tests.
- Preserves the existing Quran UI and styling unchanged.

## Rollout evidence

- #429 exact head passed all required checks and was merged at 2026-08-27 22:22 UTC.
- Matching Vercel production deployment `dpl_FqNokgFXrwz6D3SJrjs29fxitC3n` was READY and live on `nakafa.com` before this PR was opened.
- Convex production expand deployment was completed before this contraction.
- The migration-owned observation window began at the #429 merge and continues until this PR merges. From 22:22 through 23:09 UTC, production served Quran traffic in all three locales from the expanded deployment with no Vercel runtime errors.
- The Quran page reader is `server-only`; repository-wide caller tracing found no browser bundle or documented external client for `contentRelease.quran.page` or `contentRelease.quran.prose`.
- Live Indonesian, English, and German Quran pages showed their localized surah meaning, preserved Bismillah and verse numbering, and emitted no browser errors.
- Indonesian embedded tafsir opened successfully. English and German correctly expose the official external editions because their current terms do not permit embedding.

## Local verification

- Backend typecheck
- Web typecheck
- Backend suite: 349 files, 1508 tests
- Web suite: 210 files, 1520 tests, 100% coverage
- Focused Quran backend and web tests
- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- React Doctor changed scope: 100/100
- `git diff --check`

The local Next production compilation completed. Secret-backed prerendering is covered by protected exact-head CI because the local `CONTENT_RUNTIME_TOKEN` is stale and the protected `NAKAFA_API_EDGE_SECRET` is unavailable outside CI.
