### PR TITLE
test(backend): adopt Effect Vitest for forum attachments

### DIFF
--- a/packages/backend/convex/classes/forums/attachments/route.test.ts
+++ b/packages/backend/convex/classes/forums/attachments/route.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
@@ -12,17 +13,11 @@ import {
   insertSchool,
   insertSchoolMembership,
 } from "@repo/backend/convex/classes/test.helpers";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "@repo/testing/effect";
 import { Effect, Schema } from "effect";
 import { vi } from "vitest";
 
@@ -30,69 +25,77 @@ const NOW = Date.UTC(2026, 4, 29, 15, 0, 0);
 const LEASE_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
 const polarSecretName = "POLAR_WEBHOOK_SECRET";
 const uploadTokenSuffixPattern = /[^/]+$/;
+
 /** Seeds one authenticated teacher and an open forum for HTTP upload tests. */
-async function seedOpenForum(ctx: MutationCtx) {
-  const user = await seedAuthenticatedUser(ctx, {
-    now: NOW,
-    suffix: "forum-upload-route",
-  });
-  const schoolId = await insertSchool(ctx, {
-    now: NOW,
-    userId: user.userId,
-  });
-  const classId = await insertClass(ctx, {
-    now: NOW,
-    schoolId,
-    userId: user.userId,
-  });
-  await insertSchoolMembership(ctx, {
-    now: NOW,
-    role: "teacher",
-    schoolId,
-    userId: user.userId,
-  });
-  await insertClassMembership(ctx, {
-    now: NOW,
-    role: "teacher",
-    classId,
-    schoolId,
-    userId: user.userId,
-  });
-  const forumId = await ctx.db.insert("schoolClassForums", {
-    body: "Attachment forum body",
-    classId,
-    createdBy: user.userId,
-    isPinned: false,
-    lastPostAt: NOW,
-    lastPostBy: user.userId,
-    nextPostSequence: 1,
-    postCount: 0,
-    reactionCounts: [],
-    schoolId,
-    status: "open",
-    tag: "general",
-    title: "Attachment forum",
-    updatedAt: NOW,
-  });
-  return { ...user, forumId };
-}
-/** Creates one pending upload through the same authenticated mutation as WWW. */
-async function createPendingUpload() {
+const seedOpenForum = Effect.fn("test.forumAttachments.seedOpenForum")(
+  (ctx: MutationCtx) =>
+    Effect.promise(async () => {
+      const user = await seedAuthenticatedUser(ctx, {
+        now: NOW,
+        suffix: "forum-upload-route",
+      });
+      const schoolId = await insertSchool(ctx, {
+        now: NOW,
+        userId: user.userId,
+      });
+      const classId = await insertClass(ctx, {
+        now: NOW,
+        schoolId,
+        userId: user.userId,
+      });
+      await insertSchoolMembership(ctx, {
+        now: NOW,
+        role: "teacher",
+        schoolId,
+        userId: user.userId,
+      });
+      await insertClassMembership(ctx, {
+        now: NOW,
+        role: "teacher",
+        classId,
+        schoolId,
+        userId: user.userId,
+      });
+      const forumId = await ctx.db.insert("schoolClassForums", {
+        body: "Attachment forum body",
+        classId,
+        createdBy: user.userId,
+        isPinned: false,
+        lastPostAt: NOW,
+        lastPostBy: user.userId,
+        nextPostSequence: 1,
+        postCount: 0,
+        reactionCounts: [],
+        schoolId,
+        status: "open",
+        tag: "general",
+        title: "Attachment forum",
+        updatedAt: NOW,
+      });
+      return { ...user, forumId };
+    })
+);
+
+const createPendingUpload = Effect.fn(
+  "test.forumAttachments.createPendingUpload"
+)(function* () {
   const t = createConvexTestWithBetterAuth();
-  const seeded = await t.mutation(seedOpenForum);
+  const seeded = yield* Effect.promise(() =>
+    t.mutation((ctx) => runConvexProgram(seedOpenForum(ctx)))
+  );
   const owner = t.withIdentity({
     sessionId: seeded.sessionId,
     subject: seeded.authUserId,
   });
-  const upload = await owner.mutation(
-    api.classes.forums.mutations.uploads.generateUploadUrl,
-    { forumId: seeded.forumId }
+  const upload = yield* Effect.promise(() =>
+    owner.mutation(api.classes.forums.mutations.uploads.generateUploadUrl, {
+      forumId: seeded.forumId,
+    })
   );
   const capability = new URL(upload.uploadUrl);
-  const uploadToken = capability.pathname.split("/").at(-1);
-  if (!uploadToken) {
-    throw new Error("Expected a token in the upload capability path.");
-  }
+  const uploadToken = yield* Schema.decodeUnknownEffect(Schema.NonEmptyString)(
+    capability.pathname.split("/").at(-1)
+  );
   return {
     capabilityPath: capability.pathname,
     owner,
@@ -101,43 +104,44 @@ async function createPendingUpload() {
     uploadId: upload.uploadId,
     uploadToken,
   };
-}
-/** Claims one pending capability as the internal HTTP adapter. */
-async function claimPendingUpload(
-  pendingUpload: Awaited<ReturnType<typeof createPendingUpload>>,
-  leaseId = LEASE_ID
-) {
-  return await pendingUpload.t.mutation(
-    internal.classes.forums.attachments.upload.claim,
-    {
+});
+
+type PendingUpload = Effect.Success<ReturnType<typeof createPendingUpload>>;
+
+const claimPendingUpload = Effect.fn(
+  "test.forumAttachments.claimPendingUpload"
+)(function* (pendingUpload: PendingUpload, leaseId = LEASE_ID) {
+  return yield* Effect.promise(() =>
+    pendingUpload.t.mutation(internal.classes.forums.attachments.upload.claim, {
       leaseId,
       uploadId: pendingUpload.uploadId,
       uploadToken: pendingUpload.uploadToken,
-    }
+    })
   );
-}
-/** Asserts response bytes and the capability URL remain private. */
+});
+
 function expectPrivate(response: Response) {
   expect(response.headers.get("cache-control")).toBe("private, no-store");
   expect(response.headers.get("x-content-type-options")).toBe("nosniff");
 }
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
-  process.env[polarSecretName] = "technical-webhook-secret";
+  vi.stubEnv(polarSecretName, "technical-webhook-secret");
 });
 afterEach(() => {
   vi.useRealTimers();
-  delete process.env[polarSecretName];
+  vi.unstubAllEnvs();
 });
+
 describe("classes/forums/attachments/route", () => {
-  it.live(
+  it.effect(
     "stores, binds, and finalizes an attachment through the browser protocol",
     () =>
       Effect.gen(function* () {
-        const { capabilityPath, owner, t, uploadId } = yield* Effect.promise(
-          () => createPendingUpload()
-        );
+        const { capabilityPath, owner, t, uploadId } =
+          yield* createPendingUpload();
         const response = yield* Effect.promise(() =>
           t.fetch(capabilityPath, {
             body: "hello",
@@ -162,27 +166,18 @@ describe("classes/forums/attachments/route", () => {
             ctx.db.get("schoolClassForumPendingUploads", uploadId)
           )
         );
-        if (!boundUpload?.storageId) {
-          throw new Error(
-            "Expected the HTTP action to bind its stored object."
-          );
-        }
-        const storageId = boundUpload.storageId;
+        const storageId = yield* Effect.fromNullishOr(boundUpload?.storageId);
         expect(body.storageId).toBe(storageId);
-        yield* Effect.promise(() =>
-          expect(
-            owner.mutation(
-              api.classes.forums.mutations.uploads.saveForumUpload,
-              {
-                name: "notes.txt",
-                size: 5,
-                storageId,
-                type: "text/plain",
-                uploadId,
-              }
-            )
-          ).resolves.toBe(uploadId)
+        const savedUploadId = yield* Effect.promise(() =>
+          owner.mutation(api.classes.forums.mutations.uploads.saveForumUpload, {
+            name: "notes.txt",
+            size: 5,
+            storageId,
+            type: "text/plain",
+            uploadId,
+          })
         );
+        expect(savedUploadId).toBe(uploadId);
         const state = yield* Effect.promise(() =>
           t.query(async (ctx) => {
             const pendingUpload = await ctx.db.get(
@@ -206,240 +201,298 @@ describe("classes/forums/attachments/route", () => {
         expect(state.storageMetadata).toMatchObject({ size: 5 });
       })
   );
-  it("rejects a wrong capability before consuming a hostile body", async () => {
-    const { capabilityPath, t } = await createPendingUpload();
-    const wrongPath = capabilityPath.replace(
-      uploadTokenSuffixPattern,
-      "wrong-token"
-    );
-    let pulls = 0;
-    const body = new ReadableStream<Uint8Array>(
-      {
-        /** Records any attempt to consume a body before capability rejection. */
-        pull(controller) {
-          pulls += 1;
-          controller.error(new Error("Unauthorized body was consumed."));
+  it.effect("rejects a wrong capability before consuming a hostile body", () =>
+    Effect.gen(function* () {
+      const { capabilityPath, t } = yield* createPendingUpload();
+      const wrongPath = capabilityPath.replace(
+        uploadTokenSuffixPattern,
+        "wrong-token"
+      );
+      let pulls = 0;
+      const body = new ReadableStream<Uint8Array>(
+        {
+          pull(controller) {
+            pulls += 1;
+            controller.error(new Error("Unauthorized body was consumed."));
+          },
         },
-      },
-      { highWaterMark: 0 }
-    );
-    const request = {
-      body,
-      duplex: "half",
-      headers: { "content-type": "text/plain" },
-      method: "POST",
-    } satisfies RequestInit & {
-      readonly duplex: "half";
-    };
-    const response = await t.fetch(wrongPath, request);
-    expect(response.status).toBe(404);
-    expectPrivate(response);
-    expect(pulls).toBe(0);
-    await expect(response.json()).resolves.toEqual({
-      code: "FORUM_ATTACHMENT_UPLOAD_NOT_FOUND",
-    });
-  });
-  it("rejects a concurrent request before consuming its hostile body", async () => {
-    const pendingUpload = await createPendingUpload();
-    const { capabilityPath, t, uploadId } = pendingUpload;
-    await expect(claimPendingUpload(pendingUpload)).resolves.toBe(true);
-    let pulls = 0;
-    const body = new ReadableStream<Uint8Array>(
-      {
-        /** Records any attempt to consume a concurrently leased body. */
-        pull(controller) {
-          pulls += 1;
-          controller.error(new Error("Leased capability body was consumed."));
-        },
-      },
-      { highWaterMark: 0 }
-    );
-    const request = {
-      body,
-      duplex: "half",
-      headers: { "content-type": "text/plain" },
-      method: "POST",
-    } satisfies RequestInit & {
-      readonly duplex: "half";
-    };
-    const response = await t.fetch(capabilityPath, request);
-    expect(response.status).toBe(404);
-    expectPrivate(response);
-    expect(pulls).toBe(0);
-    await expect(
-      t.query((ctx) => ctx.db.get("schoolClassForumPendingUploads", uploadId))
-    ).resolves.toMatchObject({
-      uploadLease: {
-        expiresAt: NOW + FORUM_PENDING_UPLOAD_LEASE_MS,
-        id: LEASE_ID,
-      },
-    });
-  });
-  it("reclaims an interrupted upload after its lease expires", async () => {
-    const pendingUpload = await createPendingUpload();
-    const { capabilityPath, t, uploadId } = pendingUpload;
-    await expect(claimPendingUpload(pendingUpload)).resolves.toBe(true);
-    vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_LEASE_MS);
-    const response = await t.fetch(capabilityPath, {
-      body: "hello",
-      headers: { "content-type": "text/plain" },
-      method: "POST",
-    });
-    expect(response.status).toBe(200);
-    expectPrivate(response);
-    const upload = await t.query((ctx) =>
-      ctx.db.get("schoolClassForumPendingUploads", uploadId)
-    );
-    expect(upload).toMatchObject({ size: 5 });
-    expect(upload).not.toHaveProperty("uploadLease");
-  });
-  it("rejects an expired capability before consuming the request body", async () => {
-    const { capabilityPath, t, uploadId } = await createPendingUpload();
-    vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_EXPIRATION_MS);
-    let pulls = 0;
-    const body = new ReadableStream<Uint8Array>(
-      {
-        /** Records any attempt to consume a body after capability expiry. */
-        pull(controller) {
-          pulls += 1;
-          controller.error(new Error("Expired capability body was consumed."));
-        },
-      },
-      { highWaterMark: 0 }
-    );
-    const request = {
-      body,
-      duplex: "half",
-      headers: { "content-type": "text/plain" },
-      method: "POST",
-    } satisfies RequestInit & {
-      readonly duplex: "half";
-    };
-    const response = await t.fetch(capabilityPath, request);
-    expect(response.status).toBe(404);
-    expectPrivate(response);
-    expect(pulls).toBe(0);
-    await expect(response.json()).resolves.toEqual({
-      code: "FORUM_ATTACHMENT_UPLOAD_NOT_FOUND",
-    });
-    await expect(
-      t.query((ctx) => ctx.db.get("schoolClassForumPendingUploads", uploadId))
-    ).resolves.not.toBeNull();
-  });
-  it("rejects an oversized upload without binding storage", async () => {
-    const { capabilityPath, t, uploadId } = await createPendingUpload();
-    const response = await t.fetch(capabilityPath, {
-      body: "hello",
-      headers: {
-        "content-length": String(MAX_FORUM_ATTACHMENT_BYTES + 1),
-        "content-type": "text/plain",
-      },
-      method: "POST",
-    });
-    expect(response.status).toBe(413);
-    expectPrivate(response);
-    await expect(response.json()).resolves.toEqual({
-      code: "FORUM_ATTACHMENT_UPLOAD_INVALID",
-    });
-    await expect(
-      t.query(async (ctx) => {
-        const upload = await ctx.db.get(
-          "schoolClassForumPendingUploads",
-          uploadId
+        { highWaterMark: 0 }
+      );
+      const request = {
+        body,
+        duplex: "half",
+        headers: { "content-type": "text/plain" },
+        method: "POST",
+      } satisfies RequestInit & {
+        readonly duplex: "half";
+      };
+      const response = yield* Effect.promise(() => t.fetch(wrongPath, request));
+      expect(response.status).toBe(404);
+      expectPrivate(response);
+      expect(pulls).toBe(0);
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        code: "FORUM_ATTACHMENT_UPLOAD_NOT_FOUND",
+      });
+    })
+  );
+
+  it.effect(
+    "rejects a concurrent request before consuming its hostile body",
+    () =>
+      Effect.gen(function* () {
+        const pendingUpload = yield* createPendingUpload();
+        const { capabilityPath, t, uploadId } = pendingUpload;
+        expect(yield* claimPendingUpload(pendingUpload)).toBe(true);
+        let pulls = 0;
+        const body = new ReadableStream<Uint8Array>(
+          {
+            pull(controller) {
+              pulls += 1;
+              controller.error(
+                new Error("Leased capability body was consumed.")
+              );
+            },
+          },
+          { highWaterMark: 0 }
         );
-        return {
-          storageId: upload?.storageId ?? null,
-          uploadLease: upload?.uploadLease,
+        const request = {
+          body,
+          duplex: "half",
+          headers: { "content-type": "text/plain" },
+          method: "POST",
+        } satisfies RequestInit & {
+          readonly duplex: "half";
         };
+        const response = yield* Effect.promise(() =>
+          t.fetch(capabilityPath, request)
+        );
+        expect(response.status).toBe(404);
+        expectPrivate(response);
+        expect(pulls).toBe(0);
+        const upload = yield* Effect.promise(() =>
+          t.query((ctx) =>
+            ctx.db.get("schoolClassForumPendingUploads", uploadId)
+          )
+        );
+        expect(upload).toMatchObject({
+          uploadLease: {
+            expiresAt: NOW + FORUM_PENDING_UPLOAD_LEASE_MS,
+            id: LEASE_ID,
+          },
+        });
       })
-    ).resolves.toEqual({
-      storageId: null,
-      uploadLease: undefined,
-    });
-  });
-  it("binds a server-created object for an active upload capability", async () => {
-    const pendingUpload = await createPendingUpload();
-    const { t, uploadId, uploadToken } = pendingUpload;
-    await expect(claimPendingUpload(pendingUpload)).resolves.toBe(true);
-    const storageId = await t.run((ctx) =>
-      ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
-    );
-    await expect(
-      t.query((ctx) => ctx.db.system.get("_storage", storageId))
-    ).resolves.toMatchObject({ size: 5 });
-    await expect(
-      t.mutation(internal.classes.forums.attachments.upload.settle, {
-        contentType: "text/plain",
-        leaseId: LEASE_ID,
-        size: 5,
-        storageId,
-        uploadId,
-        uploadToken,
+  );
+
+  it.effect("reclaims an interrupted upload after its lease expires", () =>
+    Effect.gen(function* () {
+      const pendingUpload = yield* createPendingUpload();
+      const { capabilityPath, t, uploadId } = pendingUpload;
+      expect(yield* claimPendingUpload(pendingUpload)).toBe(true);
+      vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_LEASE_MS);
+      const response = yield* Effect.promise(() =>
+        t.fetch(capabilityPath, {
+          body: "hello",
+          headers: { "content-type": "text/plain" },
+          method: "POST",
+        })
+      );
+      expect(response.status).toBe(200);
+      expectPrivate(response);
+      const upload = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.get("schoolClassForumPendingUploads", uploadId))
+      );
+      expect(upload).toMatchObject({ size: 5 });
+      expect(upload).not.toHaveProperty("uploadLease");
+    })
+  );
+
+  it.effect(
+    "rejects an expired capability before consuming the request body",
+    () =>
+      Effect.gen(function* () {
+        const { capabilityPath, t, uploadId } = yield* createPendingUpload();
+        vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_EXPIRATION_MS);
+        let pulls = 0;
+        const body = new ReadableStream<Uint8Array>(
+          {
+            pull(controller) {
+              pulls += 1;
+              controller.error(
+                new Error("Expired capability body was consumed.")
+              );
+            },
+          },
+          { highWaterMark: 0 }
+        );
+        const request = {
+          body,
+          duplex: "half",
+          headers: { "content-type": "text/plain" },
+          method: "POST",
+        } satisfies RequestInit & {
+          readonly duplex: "half";
+        };
+        const response = yield* Effect.promise(() =>
+          t.fetch(capabilityPath, request)
+        );
+        expect(response.status).toBe(404);
+        expectPrivate(response);
+        expect(pulls).toBe(0);
+        expect(yield* Effect.promise(() => response.json())).toEqual({
+          code: "FORUM_ATTACHMENT_UPLOAD_NOT_FOUND",
+        });
+        expect(
+          yield* Effect.promise(() =>
+            t.query((ctx) =>
+              ctx.db.get("schoolClassForumPendingUploads", uploadId)
+            )
+          )
+        ).not.toBeNull();
       })
-    ).resolves.toBe("accepted");
-  });
-  it("removes a newly stored object when deletion wins the settlement race", async () => {
-    const pendingUpload = await createPendingUpload();
-    const { seeded, t, uploadId, uploadToken } = pendingUpload;
-    await expect(claimPendingUpload(pendingUpload)).resolves.toBe(true);
-    const storageId = await t.run((ctx) =>
-      ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
-    );
-    await t.mutation((ctx) =>
-      ctx.db.patch("users", seeded.userId, { deletionPreparedAt: NOW })
-    );
-    await expect(
-      t.mutation(internal.classes.forums.attachments.upload.settle, {
-        contentType: "text/plain",
-        leaseId: LEASE_ID,
-        size: 5,
-        storageId,
-        uploadId,
-        uploadToken,
+  );
+
+  it.effect("rejects an oversized upload without binding storage", () =>
+    Effect.gen(function* () {
+      const { capabilityPath, t, uploadId } = yield* createPendingUpload();
+      const response = yield* Effect.promise(() =>
+        t.fetch(capabilityPath, {
+          body: "hello",
+          headers: {
+            "content-length": String(MAX_FORUM_ATTACHMENT_BYTES + 1),
+            "content-type": "text/plain",
+          },
+          method: "POST",
+        })
+      );
+      expect(response.status).toBe(413);
+      expectPrivate(response);
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        code: "FORUM_ATTACHMENT_UPLOAD_INVALID",
+      });
+      const upload = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.get("schoolClassForumPendingUploads", uploadId))
+      );
+      expect({
+        storageId: upload?.storageId ?? null,
+        uploadLease: upload?.uploadLease,
+      }).toEqual({
+        storageId: null,
+        uploadLease: undefined,
+      });
+    })
+  );
+
+  it.effect(
+    "binds a server-created object for an active upload capability",
+    () =>
+      Effect.gen(function* () {
+        const pendingUpload = yield* createPendingUpload();
+        const { t, uploadId, uploadToken } = pendingUpload;
+        expect(yield* claimPendingUpload(pendingUpload)).toBe(true);
+        const storageId = yield* Effect.promise(() =>
+          t.run((ctx) =>
+            ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
+          )
+        );
+        const storageMetadata = yield* Effect.promise(() =>
+          t.query((ctx) => ctx.db.system.get("_storage", storageId))
+        );
+        expect(storageMetadata).toMatchObject({ size: 5 });
+        const settlement = yield* Effect.promise(() =>
+          t.mutation(internal.classes.forums.attachments.upload.settle, {
+            contentType: "text/plain",
+            leaseId: LEASE_ID,
+            size: 5,
+            storageId,
+            uploadId,
+            uploadToken,
+          })
+        );
+        expect(settlement).toBe("accepted");
       })
-    ).resolves.toBe("discarded");
-    await expect(
-      t.query(async (ctx) => ({
-        pendingUpload: await ctx.db.get(
-          "schoolClassForumPendingUploads",
-          uploadId
-        ),
-        storageMetadata: await ctx.db.system.get("_storage", storageId),
-      }))
-    ).resolves.toEqual({
-      pendingUpload: null,
-      storageMetadata: null,
-    });
-  });
-  it("removes a server-created object when settlement reaches its deadline", async () => {
-    const pendingUpload = await createPendingUpload();
-    const { t, uploadId, uploadToken } = pendingUpload;
-    await expect(claimPendingUpload(pendingUpload)).resolves.toBe(true);
-    const storageId = await t.run((ctx) =>
-      ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
-    );
-    vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_EXPIRATION_MS);
-    await expect(
-      t.mutation(internal.classes.forums.attachments.upload.settle, {
-        contentType: "text/plain",
-        leaseId: LEASE_ID,
-        size: 5,
-        storageId,
-        uploadId,
-        uploadToken,
+  );
+
+  it.effect(
+    "removes a newly stored object when deletion wins the settlement race",
+    () =>
+      Effect.gen(function* () {
+        const pendingUpload = yield* createPendingUpload();
+        const { seeded, t, uploadId, uploadToken } = pendingUpload;
+        expect(yield* claimPendingUpload(pendingUpload)).toBe(true);
+        const storageId = yield* Effect.promise(() =>
+          t.run((ctx) =>
+            ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
+          )
+        );
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            ctx.db.patch("users", seeded.userId, { deletionPreparedAt: NOW })
+          )
+        );
+        const settlement = yield* Effect.promise(() =>
+          t.mutation(internal.classes.forums.attachments.upload.settle, {
+            contentType: "text/plain",
+            leaseId: LEASE_ID,
+            size: 5,
+            storageId,
+            uploadId,
+            uploadToken,
+          })
+        );
+        expect(settlement).toBe("discarded");
+        const state = yield* Effect.promise(() =>
+          t.query(async (ctx) => ({
+            pendingUpload: await ctx.db.get(
+              "schoolClassForumPendingUploads",
+              uploadId
+            ),
+            storageMetadata: await ctx.db.system.get("_storage", storageId),
+          }))
+        );
+        expect(state).toEqual({
+          pendingUpload: null,
+          storageMetadata: null,
+        });
       })
-    ).resolves.toBe("rejected");
-    await expect(
-      t.query(async (ctx) => ({
-        pendingUpload: await ctx.db.get(
-          "schoolClassForumPendingUploads",
-          uploadId
-        ),
-        storageMetadata: await ctx.db.system.get("_storage", storageId),
-      }))
-    ).resolves.toEqual({
-      pendingUpload: null,
-      storageMetadata: null,
-    });
-  });
+  );
+
+  it.effect(
+    "removes a server-created object when settlement reaches its deadline",
+    () =>
+      Effect.gen(function* () {
+        const pendingUpload = yield* createPendingUpload();
+        const { t, uploadId, uploadToken } = pendingUpload;
+        expect(yield* claimPendingUpload(pendingUpload)).toBe(true);
+        const storageId = yield* Effect.promise(() =>
+          t.run((ctx) =>
+            ctx.storage.store(new Blob(["hello"], { type: "text/plain" }))
+          )
+        );
+        vi.setSystemTime(NOW + FORUM_PENDING_UPLOAD_EXPIRATION_MS);
+        const settlement = yield* Effect.promise(() =>
+          t.mutation(internal.classes.forums.attachments.upload.settle, {
+            contentType: "text/plain",
+            leaseId: LEASE_ID,
+            size: 5,
+            storageId,
+            uploadId,
+            uploadToken,
+          })
+        );
+        expect(settlement).toBe("rejected");
+        const state = yield* Effect.promise(() =>
+          t.query(async (ctx) => ({
+            pendingUpload: await ctx.db.get(
+              "schoolClassForumPendingUploads",
+              uploadId
+            ),
+            storageMetadata: await ctx.db.system.get("_storage", storageId),
+          }))
+        );
+        expect(state).toEqual({
+          pendingUpload: null,
+          storageMetadata: null,
+        });
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- Import the official `@effect/vitest` API directly for the forum attachment HTTP tests.
- Run all nine effectful cases through `it.effect`.
- Model shared setup and capability claims as named `Effect.fn` programs.

## Effect v4 basis

- Matches the repository-pinned Effect `4.0.0-rc.110` vendored source.
- Uses `Effect.promise` only at Convex and platform Promise boundaries.
- Uses `Effect.fromNullishOr` to preserve the branded Convex storage ID while failing natively on an absent binding.
- Decodes the upload capability token with `Schema.NonEmptyString`.

## Scope

- One backend test file only.
- No production source, dependency, lockfile, Quran, signed-content, tryout-runtime, Convex deployment, or Vercel Preview change.

## Verification

- Focused test: 1 file, 9 tests passed.
- Full backend: 349 files, 1,513 tests passed.
- Backend typecheck passed.
- Root lint and Effect source parity passed.
- Boundaries passed for 2,974 files across 19 packages.
- Changed-scope Doctor found no changed React source.

## Migration proof

- No `@repo/testing/effect` import.
- No `it.live`.
- No raw `Effect.runPromise`, `Effect.runSync`, or `Effect.runPromiseExit`.
- No skipped or focused tests.