### PR TITLE
test(www): import Effect Vitest directly for projectile loader

### DIFF
--- a/apps/www/components/marketing/about/projectile/loader.test.ts
+++ b/apps/www/components/marketing/about/projectile/loader.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "@repo/testing/effect";
+import { describe, expect, it } from "@effect/vitest";
 import { Duration, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
 import { createElement } from "react";


### PR DESCRIPTION
## Summary

Replace the obsolete `@repo/testing/effect` pass-through import with the official `@effect/vitest` package in the projectile loader test.

## Scope

- One import line in one test file.
- No runtime, dependency, lockfile, Quran, signed-content, tryout, Convex, or Vercel Preview change.

## Verification

- Focused projectile suite: 1 file, 3 tests, 100% coverage.
- Full WWW suite: 210 files, 1,522 tests, 100% coverage.
- WWW typecheck passed with repository test environment values.
- Root lint and Effect source parity passed.
- React Doctor: 100/100.

## Migration proof

- All three effectful cases already use `it.effect` and Effect TestClock.
- No raw Effect runner, `it.live`, skipped test, or focused test.