### PR TITLE
test(design-system): use native Effect Vitest

### DIFF
--- a/packages/design-system/lib/code-block/clipboard.test.ts
+++ b/packages/design-system/lib/code-block/clipboard.test.ts
@@ -7,7 +7,7 @@ import {
 import { Effect, Fiber } from "effect";
 
 describe("code clipboard", () => {
-  it.live("reports when the browser does not expose the Clipboard API", () =>
+  it.effect("reports when the browser does not expose the Clipboard API", () =>
     Effect.gen(function* () {
       const error = yield* writeCodeToClipboard(
         undefined,
@@ -22,7 +22,7 @@ describe("code clipboard", () => {
     })
   );
 
-  it.live("writes the exact code through the injected clipboard", () =>
+  it.effect("writes the exact code through the injected clipboard", () =>
     Effect.gen(function* () {
       const writeText = vi.fn().mockResolvedValue(undefined);
 
@@ -32,7 +32,7 @@ describe("code clipboard", () => {
     })
   );
 
-  it.live("maps clipboard failures into the typed error channel", () =>
+  it.effect("maps clipboard failures into the typed error channel", () =>
     Effect.gen(function* () {
       const cause = new Error("Clipboard permission denied.");
       const writeText = vi.fn().mockRejectedValue(cause);
@@ -51,35 +51,37 @@ describe("code clipboard", () => {
     })
   );
 
-  it.live("finishes an interrupted write before starting the next write", () =>
-    Effect.gen(function* () {
-      let finishFirstWrite: (() => void) | undefined;
-      const writeText = vi.fn((code: string) => {
-        if (code === "first") {
-          return new Promise<void>((resolve) => {
-            finishFirstWrite = resolve;
-          });
-        }
-        return Promise.resolve();
-      });
-      const first = yield* Effect.forkChild(
-        writeCodeToClipboard({ writeText }, "first")
-      );
-      yield* Effect.promise(() =>
-        vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("first"))
-      );
+  it.effect(
+    "finishes an interrupted write before starting the next write",
+    () =>
+      Effect.gen(function* () {
+        let finishFirstWrite: (() => void) | undefined;
+        const writeText = vi.fn((code: string) => {
+          if (code === "first") {
+            return new Promise<void>((resolve) => {
+              finishFirstWrite = resolve;
+            });
+          }
+          return Promise.resolve();
+        });
+        const first = yield* Effect.forkChild(
+          writeCodeToClipboard({ writeText }, "first")
+        );
+        yield* Effect.promise(() =>
+          vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("first"))
+        );
 
-      const interrupt = yield* Effect.forkChild(Fiber.interrupt(first));
-      const second = yield* Effect.forkChild(
-        writeCodeToClipboard({ writeText }, "second")
-      );
-      expect(writeText).not.toHaveBeenCalledWith("second");
+        const interrupt = yield* Effect.forkChild(Fiber.interrupt(first));
+        const second = yield* Effect.forkChild(
+          writeCodeToClipboard({ writeText }, "second")
+        );
+        expect(writeText).not.toHaveBeenCalledWith("second");
 
-      finishFirstWrite?.();
-      yield* Fiber.join(interrupt);
-      yield* Fiber.join(second);
+        finishFirstWrite?.();
+        yield* Fiber.join(interrupt);
+        yield* Fiber.join(second);
 
-      expect(writeText.mock.calls).toEqual([["first"], ["second"]]);
-    })
+        expect(writeText.mock.calls).toEqual([["first"], ["second"]]);
+      })
   );
 });

--- a/packages/design-system/lib/code-block/highlight.test.ts
+++ b/packages/design-system/lib/code-block/highlight.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 describe("code highlighting", () => {
-  it.live("uses Nakafa's defaults and preserves Shiki line boundaries", () =>
+  it.effect("uses Nakafa's defaults and preserves Shiki line boundaries", () =>
     Effect.gen(function* () {
       codeToHtmlMock.mockResolvedValue(
         '<span class="line">one</span><span class="line">two</span>'
@@ -50,7 +50,7 @@ describe("code highlighting", () => {
     })
   );
 
-  it.live("forwards an explicit supported language and theme pair", () =>
+  it.effect("forwards an explicit supported language and theme pair", () =>
     Effect.gen(function* () {
       codeToHtmlMock.mockResolvedValue("<pre>const answer = 42;</pre>");
       const themes = {
@@ -71,7 +71,7 @@ describe("code highlighting", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "applies a pre class and removes Shiki's inline background on request",
     () =>
       Effect.gen(function* () {
@@ -91,7 +91,7 @@ describe("code highlighting", () => {
       })
   );
 
-  it.live("rejects unsupported languages before invoking Shiki", () =>
+  it.effect("rejects unsupported languages before invoking Shiki", () =>
     Effect.gen(function* () {
       const error = yield* highlightCode({
         code: "example",
@@ -109,7 +109,7 @@ describe("code highlighting", () => {
     })
   );
 
-  it.live("maps Shiki rendering failures into the typed error channel", () =>
+  it.effect("maps Shiki rendering failures into the typed error channel", () =>
     Effect.gen(function* () {
       const cause = new Error("Shiki failed to load its grammar.");
       codeToHtmlMock.mockRejectedValue(cause);

--- a/packages/design-system/lib/files/download.test.ts
+++ b/packages/design-system/lib/files/download.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 });
 
 describe("browser file download", () => {
-  it.live("downloads string content and releases temporary resources", () =>
+  it.effect("downloads string content and releases temporary resources", () =>
     Effect.gen(function* () {
       const { createObjectURL, revokeObjectURL } = installUrlBoundary();
       const click = vi
@@ -61,7 +61,7 @@ describe("browser file download", () => {
     })
   );
 
-  it.live("preserves Blob content without rebuilding it", () =>
+  it.effect("preserves Blob content without rebuilding it", () =>
     Effect.gen(function* () {
       const { createObjectURL } = installUrlBoundary();
       vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
@@ -77,7 +77,7 @@ describe("browser file download", () => {
     })
   );
 
-  it.live("maps object URL failures into the typed error channel", () =>
+  it.effect("maps object URL failures into the typed error channel", () =>
     Effect.gen(function* () {
       const { createObjectURL, revokeObjectURL } = installUrlBoundary();
       const cause = new Error("Object URL unavailable.");
@@ -92,7 +92,7 @@ describe("browser file download", () => {
     })
   );
 
-  it.live("revokes the object URL when attaching the anchor fails", () =>
+  it.effect("revokes the object URL when attaching the anchor fails", () =>
     Effect.gen(function* () {
       const { revokeObjectURL } = installUrlBoundary();
       const cause = new Error("Document body unavailable.");
@@ -109,26 +109,30 @@ describe("browser file download", () => {
     })
   );
 
-  it.live("removes the anchor and revokes the URL when activation fails", () =>
-    Effect.gen(function* () {
-      const { revokeObjectURL } = installUrlBoundary();
-      const cause = new Error("Download activation blocked.");
-      const remove = vi.spyOn(Element.prototype, "remove");
-      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {
-        throw cause;
-      });
+  it.effect(
+    "removes the anchor and revokes the URL when activation fails",
+    () =>
+      Effect.gen(function* () {
+        const { revokeObjectURL } = installUrlBoundary();
+        const cause = new Error("Download activation blocked.");
+        const remove = vi.spyOn(Element.prototype, "remove");
+        vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+          () => {
+            throw cause;
+          }
+        );
 
-      const error = yield* downloadFile(DOWNLOAD).pipe(Effect.flip);
+        const error = yield* downloadFile(DOWNLOAD).pipe(Effect.flip);
 
-      expectDownloadError(error, cause);
-      expect(remove).toHaveBeenCalledOnce();
-      expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith(
-        "blob:nakafa-download"
-      );
-    })
+        expectDownloadError(error, cause);
+        expect(remove).toHaveBeenCalledOnce();
+        expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith(
+          "blob:nakafa-download"
+        );
+      })
   );
 
-  it.live("reports anchor cleanup failures and still revokes the URL", () =>
+  it.effect("reports anchor cleanup failures and still revokes the URL", () =>
     Effect.gen(function* () {
       const { revokeObjectURL } = installUrlBoundary();
       const cause = new Error("Anchor cleanup failed.");
@@ -148,7 +152,7 @@ describe("browser file download", () => {
     })
   );
 
-  it.live("reports object URL cleanup failures", () =>
+  it.effect("reports object URL cleanup failures", () =>
     Effect.gen(function* () {
       const { revokeObjectURL } = installUrlBoundary();
       const cause = new Error("Object URL cleanup failed.");

--- a/packages/design-system/lib/prompt-input/files.test.ts
+++ b/packages/design-system/lib/prompt-input/files.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
 });
 
 describe("prompt input file selection", () => {
-  it.live("keeps unconstrained and MIME-matched selections", () =>
+  it.effect("keeps unconstrained and MIME-matched selections", () =>
     Effect.gen(function* () {
       const result = yield* validatePromptInputFiles({
         currentFileCount: 0,
@@ -95,7 +95,7 @@ describe("prompt input file selection", () => {
     })
   );
 
-  it.live("matches wildcard media types and filename extensions", () =>
+  it.effect("matches wildcard media types and filename extensions", () =>
     Effect.gen(function* () {
       const result = yield* validatePromptInputFiles({
         accept: "image/*, .txt",
@@ -107,7 +107,7 @@ describe("prompt input file selection", () => {
     })
   );
 
-  it.live("rejects a selection without an accepted file type", () =>
+  it.effect("rejects a selection without an accepted file type", () =>
     Effect.gen(function* () {
       const error = yield* validatePromptInputFiles({
         accept: "image/*",
@@ -120,7 +120,7 @@ describe("prompt input file selection", () => {
     })
   );
 
-  it.live("rejects a selection whose accepted files are all oversized", () =>
+  it.effect("rejects a selection whose accepted files are all oversized", () =>
     Effect.gen(function* () {
       const error = yield* validatePromptInputFiles({
         currentFileCount: 0,
@@ -132,7 +132,7 @@ describe("prompt input file selection", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "retains valid files when only part of a selection is oversized",
     () =>
       Effect.gen(function* () {
@@ -147,7 +147,7 @@ describe("prompt input file selection", () => {
       })
   );
 
-  it.live("caps available capacity and returns a typed warning", () =>
+  it.effect("caps available capacity and returns a typed warning", () =>
     Effect.gen(function* () {
       const result = yield* validatePromptInputFiles({
         currentFileCount: 1,
@@ -163,7 +163,7 @@ describe("prompt input file selection", () => {
 });
 
 describe("prompt input attachment conversion", () => {
-  it.live("keeps remote attachments unchanged", () =>
+  it.effect("keeps remote attachments unchanged", () =>
     Effect.gen(function* () {
       const file = createPromptFile("https://nakafa.test/lesson.txt");
       const converted = yield* convertPromptInputFiles([file]);
@@ -179,7 +179,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live("converts blob attachments into data URLs", () =>
+  it.effect("converts blob attachments into data URLs", () =>
     Effect.gen(function* () {
       const { fetchAttachment, readBlob } = stubSuccessfulConversion();
       const converted = yield* convertPromptInputFiles([createPromptFile()]);
@@ -193,7 +193,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live("types attachment fetch failures", () =>
+  it.effect("types attachment fetch failures", () =>
     Effect.gen(function* () {
       const cause = new Error("Network unavailable.");
       vi.stubGlobal("fetch", vi.fn().mockRejectedValue(cause));
@@ -207,7 +207,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live("types response blob failures", () =>
+  it.effect("types response blob failures", () =>
     Effect.gen(function* () {
       const cause = new Error("Response body unavailable.");
       vi.stubGlobal(
@@ -223,7 +223,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "aborts the attachment request when blob reading is interrupted",
     () =>
       Effect.gen(function* () {
@@ -247,7 +247,7 @@ describe("prompt input attachment conversion", () => {
       })
   );
 
-  it.live("types FileReader construction failures", () =>
+  it.effect("types FileReader construction failures", () =>
     Effect.gen(function* () {
       const cause = new Error("FileReader unavailable.");
       stubSuccessfulConversion();
@@ -269,7 +269,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     [InvalidResultFileReader, ArrayBuffer],
     [FailedFileReader, DOMException],
   ])("types invalid FileReader results from %s", ([Reader, Cause]) =>
@@ -286,7 +286,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live("provides a cause when FileReader omits its error", () =>
+  it.effect("provides a cause when FileReader omits its error", () =>
     Effect.gen(function* () {
       stubSuccessfulConversion();
       vi.stubGlobal("FileReader", EmptyErrorFileReader);
@@ -302,7 +302,7 @@ describe("prompt input attachment conversion", () => {
     })
   );
 
-  it.live.each([
+  it.effect.each([
     [1, 1],
     [2, 0],
   ])(

--- a/packages/design-system/lib/prompt-input/submission.test.ts
+++ b/packages/design-system/lib/prompt-input/submission.test.ts
@@ -18,7 +18,7 @@ function createPromptFile(): PromptInputFile {
 }
 
 describe("prompt input submission", () => {
-  it.live("submits synchronously and applies success state", () =>
+  it.effect("submits synchronously and applies success state", () =>
     Effect.gen(function* () {
       const onSubmit = vi.fn();
       const onSuccess = vi.fn();
@@ -49,7 +49,7 @@ describe("prompt input submission", () => {
     })
   );
 
-  it.live("awaits asynchronous consumers before applying success state", () =>
+  it.effect("awaits asynchronous consumers before applying success state", () =>
     Effect.gen(function* () {
       const order: string[] = [];
 
@@ -70,7 +70,7 @@ describe("prompt input submission", () => {
     })
   );
 
-  it.live("types synchronous consumer failures", () =>
+  it.effect("types synchronous consumer failures", () =>
     Effect.gen(function* () {
       const cause = new Error("Submit failed immediately.");
       const onSuccess = vi.fn();
@@ -90,7 +90,7 @@ describe("prompt input submission", () => {
     })
   );
 
-  it.live("types asynchronous consumer failures", () =>
+  it.effect("types asynchronous consumer failures", () =>
     Effect.gen(function* () {
       const cause = new Error("Submit promise rejected.");
       const onSuccess = vi.fn();
@@ -108,7 +108,7 @@ describe("prompt input submission", () => {
     })
   );
 
-  it.live("types success-state failures after a successful submit", () =>
+  it.effect("types success-state failures after a successful submit", () =>
     Effect.gen(function* () {
       const cause = new Error("Completion state failed.");
       const error = yield* submitPromptInput({

--- a/packages/design-system/lib/sidebar/persistence.test.ts
+++ b/packages/design-system/lib/sidebar/persistence.test.ts
@@ -14,28 +14,30 @@ afterEach(() => {
 });
 
 describe("sidebar state persistence", () => {
-  it.live("serializes the exact state cookie through its writer service", () =>
-    Effect.gen(function* () {
-      let persistedCookie = "";
-      const recordingWriter = Layer.succeed(SidebarCookieWriter, {
-        write: (cookie) =>
-          Effect.sync(() => {
-            persistedCookie = cookie;
-          }),
-      });
+  it.effect(
+    "serializes the exact state cookie through its writer service",
+    () =>
+      Effect.gen(function* () {
+        let persistedCookie = "";
+        const recordingWriter = Layer.succeed(SidebarCookieWriter, {
+          write: (cookie) =>
+            Effect.sync(() => {
+              persistedCookie = cookie;
+            }),
+        });
 
-      yield* persistSidebarState({
-        cookieName: TEST_COOKIE_NAME,
-        open: true,
-      }).pipe(Effect.provide(recordingWriter));
+        yield* persistSidebarState({
+          cookieName: TEST_COOKIE_NAME,
+          open: true,
+        }).pipe(Effect.provide(recordingWriter));
 
-      expect(persistedCookie).toBe(
-        `${TEST_COOKIE_NAME}=true; path=/; max-age=604800`
-      );
-    })
+        expect(persistedCookie).toBe(
+          `${TEST_COOKIE_NAME}=true; path=/; max-age=604800`
+        );
+      })
   );
 
-  it.live("writes sidebar state through the browser layer", () =>
+  it.effect("writes sidebar state through the browser layer", () =>
     Effect.gen(function* () {
       yield* persistSidebarState({
         cookieName: TEST_COOKIE_NAME,
@@ -46,7 +48,7 @@ describe("sidebar state persistence", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "exposes browser write failures through the typed error channel",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Scope

- change 41 design-system effectful tests from `it.live` to `it.effect`
- keep the direct official `@effect/vitest` imports now supplied by main
- touch only six design-system test modules

## Effect v4 basis

Vendored Effect RC110 documents `it.effect` as the default scoped TestEnv runtime and reserves `it.live` for tests that require real runtime services such as the real clock or visible logging. These tests use injected browser seams, native promises, typed Effect failures, and explicit layers. None require the live Effect environment.

## Rebase result

PR #378 merged first. The rebase dropped its patch-equivalent six-file facade-import removal and retained only this PR's intended `it.live` to `it.effect` changes. There are no production, dependency, lockfile, Quran, tryout, runtime, or content changes.

## Verification

- design-system: 34 files and 335 tests passed
- design-system coverage: 100% statements, branches, functions, and lines
- design-system typecheck passed
- full repository: 15 of 15 test tasks passed
- WWW: 210 files and 1,522 tests passed with 100% coverage
- lint, test ownership, boundaries, vendored Effect RC110 parity, formatting, and diff checks passed
- Doctor correctly skipped because no WWW source changed
- no testing facade import, direct Effect runner, `it.live`, `.only`, or `.skip` remains in the six files

## Exact identity

Head: `81f6660bea9e51222b7d04cc5e2e0ae62826f35e`

Base: `7ff5a50cce55888a32611f03ae521c497fa20beb`

## Rollout

This is test-only. It creates no Vercel Preview and changes no production behavior.