### PR TITLE
test(www): use native Effect Vitest for indexes

### DIFF
--- a/apps/www/lib/llms/content-listing.test.ts
+++ b/apps/www/lib/llms/content-listing.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { getContentListingLlmsEntries } from "@/lib/llms/content-listing";
 
 const mockReadPublishedCategoryArticles = vi.hoisted(() => vi.fn());
@@ -63,103 +64,107 @@ beforeEach(() => {
 });
 
 describe("llms content listing", () => {
-  it("builds one bounded signed article listing", async () => {
-    const entries = await Effect.runPromise(
-      getContentListingLlmsEntries({
+  it.effect("builds one bounded signed article listing", () =>
+    Effect.gen(function* () {
+      const entries = yield* getContentListingLlmsEntries({
         locale: "en",
         route: "articles/politics",
-      })
-    );
+      });
 
-    expect(entries?.map((entry) => entry.route)).toEqual([
-      "/articles/politics/dynastic-politics-asian-values",
-      "/articles/politics/regional-elections-turmoil",
-    ]);
-    expect(mockReadPublishedCategoryArticles).toHaveBeenCalledWith(
-      "en",
-      "politics",
-      100,
-      activeReleaseId
-    );
-  });
+      expect(entries?.map((entry) => entry.route)).toEqual([
+        "/articles/politics/dynastic-politics-asian-values",
+        "/articles/politics/regional-elections-turmoil",
+      ]);
+      expect(mockReadPublishedCategoryArticles).toHaveBeenCalledWith(
+        "en",
+        "politics",
+        100,
+        activeReleaseId
+      );
+    })
+  );
 
-  it("uses the published owner for an active article category", async () => {
-    mockReadPublishedCategoryArticles.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId,
-        articles: [
-          {
-            authors: [{ name: "Shifna Zihdatal Haq" }],
-            category: "politics",
-            categoryTitle: "Politics",
-            datePublished: "2024-10-27",
-            description:
-              "The political anomaly in Indonesia as it prepares for the 2024 Regional Elections.",
-            official: true,
-            publicPath: "articles/politics/regional-elections-turmoil",
-            route: {
+  it.effect("uses the published owner for an active article category", () =>
+    Effect.gen(function* () {
+      mockReadPublishedCategoryArticles.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId,
+          articles: [
+            {
+              authors: [{ name: "Shifna Zihdatal Haq" }],
               category: "politics",
-              slug: "regional-elections-turmoil",
+              categoryTitle: "Politics",
+              datePublished: "2024-10-27",
+              description:
+                "The political anomaly in Indonesia as it prepares for the 2024 Regional Elections.",
+              official: true,
+              publicPath: "articles/politics/regional-elections-turmoil",
+              route: {
+                category: "politics",
+                slug: "regional-elections-turmoil",
+              },
+              title:
+                "Political Turmoil Ahead of Regional Elections: Politics in Chaos, The People Cry Out",
             },
-            title:
-              "Political Turmoil Ahead of Regional Elections: Politics in Chaos, The People Cry Out",
-          },
-        ],
-      })
-    );
-
-    await expect(
-      Effect.runPromise(
-        getContentListingLlmsEntries({
-          locale: "en",
-          route: "articles/politics",
+          ],
         })
-      )
-    ).resolves.toEqual([
-      expect.objectContaining({
-        route: "/articles/politics/regional-elections-turmoil",
-        title:
-          "Political Turmoil Ahead of Regional Elections: Politics in Chaos, The People Cry Out",
-      }),
-    ]);
-    expect(mockReadPublishedCategoryArticles).toHaveBeenCalledWith(
-      "en",
-      "politics",
-      100,
-      activeReleaseId
-    );
-  });
+      );
 
-  it("rejects unsupported listing routes without catalog reads", async () => {
-    const routes = [
-      "articles",
-      "articles/Invalid_Category",
-      "articles/politics/extra",
-      "curriculum/merdeka/class-10/mathematics/integral",
-    ];
+      const entries = yield* getContentListingLlmsEntries({
+        locale: "en",
+        route: "articles/politics",
+      });
 
-    for (const route of routes) {
-      await expect(
-        Effect.runPromise(getContentListingLlmsEntries({ locale: "en", route }))
-      ).resolves.toBeNull();
-    }
-    expect(mockReadPublishedCategoryArticles).not.toHaveBeenCalled();
-    expect(mockReadPublishedArticleCategory).not.toHaveBeenCalled();
-  });
+      expect(entries).toEqual([
+        expect.objectContaining({
+          route: "/articles/politics/regional-elections-turmoil",
+          title:
+            "Political Turmoil Ahead of Regional Elections: Politics in Chaos, The People Cry Out",
+        }),
+      ]);
+      expect(mockReadPublishedCategoryArticles).toHaveBeenCalledWith(
+        "en",
+        "politics",
+        100,
+        activeReleaseId
+      );
+    })
+  );
 
-  it("rejects a valid route segment absent from the signed catalog", async () => {
-    mockReadPublishedArticleCategory.mockReturnValue(
-      Effect.succeed(Option.none())
-    );
+  it.effect("rejects unsupported listing routes without catalog reads", () =>
+    Effect.gen(function* () {
+      const routes = [
+        "articles",
+        "articles/Invalid_Category",
+        "articles/politics/extra",
+        "curriculum/merdeka/class-10/mathematics/integral",
+      ];
 
-    await expect(
-      Effect.runPromise(
-        getContentListingLlmsEntries({
+      const entries = yield* Effect.forEach(routes, (route) =>
+        getContentListingLlmsEntries({ locale: "en", route })
+      );
+
+      expect(entries).toEqual([null, null, null, null]);
+      expect(mockReadPublishedCategoryArticles).not.toHaveBeenCalled();
+      expect(mockReadPublishedArticleCategory).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "rejects a valid route segment absent from the signed catalog",
+    () =>
+      Effect.gen(function* () {
+        mockReadPublishedArticleCategory.mockReturnValue(
+          Effect.succeed(Option.none())
+        );
+
+        const entries = yield* getContentListingLlmsEntries({
           locale: "de",
           route: "articles/fehlend",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(mockReadPublishedCategoryArticles).not.toHaveBeenCalled();
-  });
+        });
+
+        expect(entries).toBeNull();
+        expect(mockReadPublishedCategoryArticles).not.toHaveBeenCalled();
+      })
+  );
 });

--- a/apps/www/lib/llms/section.test.ts
+++ b/apps/www/lib/llms/section.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import type { LlmsEntry } from "@/lib/llms/entries";
 import {
@@ -60,69 +61,86 @@ beforeEach(() => {
 });
 
 describe("llms section indexes", () => {
-  it("reads signed article partitions without source discovery", async () => {
-    await expect(
-      Effect.runPromise(
-        getLlmsSectionPages({ locale: "en", section: "articles" })
-      )
-    ).resolves.toEqual({
-      pageCount: 3,
-      routeCount: 250,
-    });
-    expect(mockReadQuranInventory).not.toHaveBeenCalled();
-  });
+  it.effect("reads signed article partitions without source discovery", () =>
+    Effect.gen(function* () {
+      const pages = yield* getLlmsSectionPages({
+        locale: "en",
+        section: "articles",
+      });
 
-  it("reads signed material counts without source discovery", async () => {
-    await expect(
-      Effect.runPromise(
-        getLlmsSectionPages({ locale: "en", section: "material" })
-      )
-    ).resolves.toEqual({
-      pageCount: 1,
-      routeCount: 100,
-    });
-    expect(mockReadPublishedArticleBuckets).not.toHaveBeenCalled();
-  });
+      expect(pages).toEqual({
+        pageCount: 3,
+        routeCount: 250,
+      });
+      expect(mockReadQuranInventory).not.toHaveBeenCalled();
+    })
+  );
 
-  it("uses signed material partitions", async () => {
-    mockReadMaterialInventory.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-material",
-        buckets: ["000", "abc"],
+  it.effect("reads signed material counts without source discovery", () =>
+    Effect.gen(function* () {
+      const pages = yield* getLlmsSectionPages({
+        locale: "en",
+        section: "material",
+      });
+
+      expect(pages).toEqual({
+        pageCount: 1,
+        routeCount: 100,
+      });
+      expect(mockReadPublishedArticleBuckets).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("uses signed material partitions", () =>
+    Effect.gen(function* () {
+      mockReadMaterialInventory.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-material",
+          buckets: ["000", "abc"],
+          pageCount: 2,
+          routeCount: 42,
+        })
+      );
+
+      const pages = yield* getLlmsSectionPages({
+        locale: "en",
+        section: "material",
+      });
+
+      expect(pages).toEqual({
         pageCount: 2,
         routeCount: 42,
+      });
+      expect(mockReadQuranInventory).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "reads the signed Quran inventory and handles an empty release",
+    () =>
+      Effect.gen(function* () {
+        const published = yield* getLlmsSectionPages({
+          locale: "en",
+          section: "quran",
+        });
+        expect(published).toEqual({
+          pageCount: 1,
+          routeCount: 114,
+        });
+
+        mockReadQuranInventory.mockReturnValueOnce(
+          Effect.succeed({ pageCount: 0, routeCount: 0 })
+        );
+        const empty = yield* getLlmsSectionPages({
+          locale: "id",
+          section: "quran",
+        });
+        expect(empty).toEqual({
+          pageCount: 0,
+          routeCount: 0,
+        });
       })
-    );
-
-    await expect(
-      Effect.runPromise(
-        getLlmsSectionPages({ locale: "en", section: "material" })
-      )
-    ).resolves.toEqual({
-      pageCount: 2,
-      routeCount: 42,
-    });
-    expect(mockReadQuranInventory).not.toHaveBeenCalled();
-  });
-
-  it("reads the signed Quran inventory and handles an empty release", async () => {
-    await expect(
-      Effect.runPromise(getLlmsSectionPages({ locale: "en", section: "quran" }))
-    ).resolves.toEqual({
-      pageCount: 1,
-      routeCount: 114,
-    });
-
-    mockReadQuranInventory.mockReturnValueOnce(
-      Effect.succeed({ pageCount: 0, routeCount: 0 })
-    );
-    await expect(
-      Effect.runPromise(getLlmsSectionPages({ locale: "id", section: "quran" }))
-    ).resolves.toEqual({
-      pageCount: 0,
-      routeCount: 0,
-    });
-  });
+  );
 
   it("renders empty, single, and multi-page navigation", () => {
     const empty = buildLlmsSectionPageMapText({

--- a/apps/www/lib/utils/seo/translations.test.ts
+++ b/apps/www/lib/utils/seo/translations.test.ts
@@ -1,5 +1,6 @@
-import { Cause, Effect, Exit, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { vi } from "vitest";
 import {
   fetchSEOTranslationsNamespace,
   SEOTranslationLoadError,
@@ -15,23 +16,24 @@ describe("fetchSEOTranslationsNamespace", () => {
   beforeEach(() => {
     mockGetTranslations.mockReset();
   });
-  it("preserves thrown Error messages in the typed failure channel", async () => {
-    mockGetTranslations.mockRejectedValue(new Error("dictionary unavailable"));
-    const exit = await Effect.runPromiseExit(
-      fetchSEOTranslationsNamespace("en", "SEO")
-    );
-    const failure = Exit.isFailure(exit)
-      ? Cause.findErrorOption(exit.cause)
-      : Option.none();
-    expect(Option.isSome(failure)).toBe(true);
-    if (Option.isSome(failure)) {
-      expect(failure.value).toBeInstanceOf(SEOTranslationLoadError);
-      expect(failure.value).toMatchObject({
-        _tag: "SEOTranslationLoadError",
-        locale: "en",
-        message: "Failed to load SEO translations: dictionary unavailable",
-        namespace: "SEO",
-      });
-    }
-  });
+  it.effect(
+    "preserves thrown Error messages in the typed failure channel",
+    () =>
+      Effect.gen(function* () {
+        mockGetTranslations.mockRejectedValue(
+          new Error("dictionary unavailable")
+        );
+        const failure = yield* fetchSEOTranslationsNamespace("en", "SEO").pipe(
+          Effect.flip
+        );
+
+        expect(failure).toBeInstanceOf(SEOTranslationLoadError);
+        expect(failure).toMatchObject({
+          _tag: "SEOTranslationLoadError",
+          locale: "en",
+          message: "Failed to load SEO translations: dictionary unavailable",
+          namespace: "SEO",
+        });
+      })
+  );
 });

--- a/apps/www/scripts/indexing/manifest.test.ts
+++ b/apps/www/scripts/indexing/manifest.test.ts
@@ -1,5 +1,6 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const sitemapMocks = vi.hoisted(() => ({
   getSitemapEntries: vi.fn(),
@@ -19,63 +20,65 @@ afterEach(() => {
 });
 
 describe("forEachSiteIndexUrlBatch", () => {
-  it("streams canonical sitemap URLs through bounded batches", async () => {
-    sitemapMocks.readSitemapPageDescriptors.mockReturnValue(
-      Effect.succeed([{ id: "public_id_0" }, { id: "public_en_0" }])
-    );
-    sitemapMocks.getSitemapEntries
-      .mockReturnValueOnce(
-        Effect.succeed([
-          { url: "https://nakafa.com/id/home" },
-          { url: "https://nakafa.com/id/search" },
-        ])
-      )
-      .mockReturnValueOnce(
-        Effect.succeed([{ url: "https://nakafa.com/en/home" }])
+  it.effect("streams canonical sitemap URLs through bounded batches", () =>
+    Effect.gen(function* () {
+      sitemapMocks.readSitemapPageDescriptors.mockReturnValue(
+        Effect.succeed([{ id: "public_id_0" }, { id: "public_en_0" }])
       );
-    const { forEachSiteIndexUrlBatch } = await import(
-      "@/scripts/indexing/manifest"
-    );
-    const batches: string[][] = [];
+      sitemapMocks.getSitemapEntries
+        .mockReturnValueOnce(
+          Effect.succeed([
+            { url: "https://nakafa.com/id/home" },
+            { url: "https://nakafa.com/id/search" },
+          ])
+        )
+        .mockReturnValueOnce(
+          Effect.succeed([{ url: "https://nakafa.com/en/home" }])
+        );
+      const { forEachSiteIndexUrlBatch } = yield* Effect.promise(
+        () => import("@/scripts/indexing/manifest")
+      );
+      const batches: string[][] = [];
 
-    const summary = await Effect.runPromise(
-      forEachSiteIndexUrlBatch(
+      const summary = yield* forEachSiteIndexUrlBatch(
         (batch) =>
           Effect.sync(() => {
             batches.push([...batch.urls]);
           }),
         { batchSize: 2 }
-      )
-    );
+      );
 
-    expect(summary).toEqual({
-      batchCount: 2,
-      canonicalUrlCount: 3,
-    });
-    expect(batches).toEqual([
-      ["https://nakafa.com/id/home", "https://nakafa.com/id/search"],
-      ["https://nakafa.com/en/home"],
-    ]);
-  });
+      expect(summary).toEqual({
+        batchCount: 2,
+        canonicalUrlCount: 3,
+      });
+      expect(batches).toEqual([
+        ["https://nakafa.com/id/home", "https://nakafa.com/id/search"],
+        ["https://nakafa.com/en/home"],
+      ]);
+    })
+  );
 
-  it("returns an empty summary without invoking the batch processor", async () => {
-    sitemapMocks.readSitemapPageDescriptors.mockReturnValue(
-      Effect.succeed([{ id: "public_id_0" }])
-    );
-    sitemapMocks.getSitemapEntries.mockReturnValueOnce(Effect.succeed([]));
-    const { forEachSiteIndexUrlBatch } = await import(
-      "@/scripts/indexing/manifest"
-    );
-    const processBatch = vi.fn(() => Effect.void);
+  it.effect(
+    "returns an empty summary without invoking the batch processor",
+    () =>
+      Effect.gen(function* () {
+        sitemapMocks.readSitemapPageDescriptors.mockReturnValue(
+          Effect.succeed([{ id: "public_id_0" }])
+        );
+        sitemapMocks.getSitemapEntries.mockReturnValueOnce(Effect.succeed([]));
+        const { forEachSiteIndexUrlBatch } = yield* Effect.promise(
+          () => import("@/scripts/indexing/manifest")
+        );
+        const processBatch = vi.fn(() => Effect.void);
 
-    const summary = await Effect.runPromise(
-      forEachSiteIndexUrlBatch(processBatch)
-    );
+        const summary = yield* forEachSiteIndexUrlBatch(processBatch);
 
-    expect(summary).toEqual({
-      batchCount: 0,
-      canonicalUrlCount: 0,
-    });
-    expect(processBatch).not.toHaveBeenCalled();
-  });
+        expect(summary).toEqual({
+          batchCount: 0,
+          canonicalUrlCount: 0,
+        });
+        expect(processBatch).not.toHaveBeenCalled();
+      })
+  );
 });


### PR DESCRIPTION
## Scope

- migrate four WWW indexing and LLM test modules to direct `@effect/vitest`
- replace 12 direct Effect runtime boundaries with 11 native `it.effect` cases
- keep rendering-only deterministic assertions on ordinary Vitest
- retain direct Vitest `vi` imports only for transform-time hoisted module mocks

## Architecture

Effectful tests now return their Effects directly to the official Effect v4 Vitest integration. No repository testing facade, compatibility wrapper, production source, dependency, lockfile, backend, Convex, Quran, or content-runtime file changes.

## Verification

- focused LLM tests: 10 of 10 passed
- full WWW suite: 210 files and 1,520 tests passed with 100% statement, branch, function, and line coverage
- WWW typecheck passed
- full repository tests: 15 of 15 tasks passed
- root lint, boundaries, Effect source parity, testing ownership, and diff checks passed
- forbidden-pattern scan found no testing facade import, `it.live`, direct Effect runner, `.only`, or `.skip` in the four changed files

Exact head: `9de42e354bddaf88a842732292015ffa7a351d5a`
Exact base: `0edfc323cca3f29d5d9127f3d9cd11fdcf9824f0`

## Rollout

This is a test-only checkpoint. It creates no Vercel Preview and changes no production behavior. Merge requires this exact head to remain current-base clean with required checks and review threads green.