### PR TITLE
test(www): use native Effect Vitest for chat

### DIFF
--- a/apps/www/app/api/chat/context.test.ts
+++ b/apps/www/app/api/chat/context.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import type { NinaContextSnapshot } from "@repo/ai/nina/memory/pack";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { resolveNinaLearningSession } from "@/app/api/chat/context";
 import { previewProjection, previewSourcePath } from "@/test/content-preview";
 
@@ -81,332 +82,353 @@ describe("app/api/chat/context", () => {
     mocks.materialContext.mockReturnValue(Effect.succeed(null));
   });
 
-  it("opens an unverified off-page turn as canonical when no pinned context exists", async () => {
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        rawContext: "not-a-client-context",
-        slug: "/chat",
-        url: "https://nakafa.com/en/chat",
-        verified: false,
-      })
-    );
+  it.effect(
+    "opens an unverified off-page turn as canonical when no pinned context exists",
+    () =>
+      Effect.gen(function* () {
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          rawContext: "not-a-client-context",
+          slug: "/chat",
+          url: "https://nakafa.com/en/chat",
+          verified: false,
+        });
 
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        locale: "en",
-        slug: "chat",
-        url: "https://nakafa.com/en/chat",
-        verified: false,
-      },
-      source: "current-page",
-      tools: {
-        allowPageFetch: false,
-        evidenceScope: "general-learning",
-      },
-    });
-    expect(session.context.transition).toEqual({
-      reason: "page-context",
-      toContextKey: "canonical:chat",
-    });
-  });
-
-  it("builds canonical learning identity for a retained source try-out", async () => {
-    const slug = "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge";
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        rawContext: {},
-        slug: `/${slug}`,
-        url: `https://nakafa.com/en/${slug}`,
-        verified: true,
-      })
-    );
-
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        slug,
-        verified: true,
-      },
-      source: "current-page",
-    });
-    expect(session.context.snapshot.learning.sourcePath).toBeUndefined();
-    expect(session.context.snapshot.placement).toBeUndefined();
-  });
-
-  it("reuses stored Nina context when an existing chat continues off a verified learning page", async () => {
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        pinnedContext,
-        rawContext: {},
-        slug: "/chat/chat_existing",
-        url: "https://nakafa.com/en/chat/chat_existing",
-        verified: false,
-      })
-    );
-
-    expect(session.context.snapshot).toMatchObject({
-      capturedAt: "2026-06-22T00:00:00.000Z",
-      learning: pinnedContext.learning,
-      source: "pinned-chat",
-      tools: {
-        allowPageFetch: true,
-        evidenceScope: "verified-page",
-      },
-    });
-    expect(session.context.transition).toEqual({
-      reason: "same-context",
-      toContextKey:
-        "canonical:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-    });
-  });
-
-  it("preserves pinned placement when replaying an existing chat off-page", async () => {
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        pinnedContext: pinnedPlacementContext,
-        rawContext: {},
-        slug: "/chat/chat_existing",
-        url: "https://nakafa.com/en/chat/chat_existing",
-        verified: false,
-      })
-    );
-
-    expect(session.context.snapshot).toMatchObject({
-      capturedAt: "2026-06-22T00:00:00.000Z",
-      learning: pinnedContext.learning,
-      placement: pinnedPlacementContext.placement,
-      source: "pinned-chat",
-    });
-    expect(session.context.transition).toEqual({
-      reason: "same-context",
-      toContextKey:
-        "placement:merdeka:class-10-chemistry-basic-chemistry-laws:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-    });
-  });
-
-  it("keeps verified material placement when the browser context hint validates", async () => {
-    mocks.materialContext.mockReturnValueOnce(
-      Effect.succeed({
-        context: {
-          nodeKey: "class-10-chemistry-basic-chemistry-laws",
-          programKey: "merdeka",
-        },
-        href: "/en/curriculum/merdeka/class-10/chemistry#basic-laws-of-chemistry",
-        label: "Basic Laws of Chemistry",
-      })
-    );
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        rawContext: {
-          materialContextHint:
-            "merdeka~class-10-chemistry-basic-chemistry-laws",
-        },
-        slug: "/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-        url: "https://nakafa.com/en/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-        verified: true,
-      })
-    );
-
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        materialKey: "lesson.chemistry.basic-chemistry-laws",
-        section: "subject-lesson",
-        sourcePath:
-          "material/lesson/chemistry/basic-chemistry-laws/chemistry-law-applications",
-        title: "Law Applications",
-        verified: true,
-      },
-      placement: {
-        mode: "placement",
-        nodeKey: "class-10-chemistry-basic-chemistry-laws",
-        parentHref:
-          "/en/curriculum/merdeka/class-10/chemistry#basic-laws-of-chemistry",
-        parentTitle: "Basic Laws of Chemistry",
-        programKey: "merdeka",
-      },
-      source: "current-page",
-      tools: {
-        allowPageFetch: true,
-        evidenceScope: "verified-page",
-      },
-    });
-    expect(session.context.transition).toEqual({
-      reason: "page-context",
-      toContextKey:
-        "placement:merdeka:class-10-chemistry-basic-chemistry-laws:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-    });
-  });
-
-  it("drops a stale material context hint instead of inventing placement", async () => {
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-06-22T00:00:00.000Z",
-        locale: "en",
-        rawContext: {
-          materialContextHint: "merdeka~stale-node",
-        },
-        slug: "/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-        url: "https://nakafa.com/en/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-        verified: true,
-      })
-    );
-
-    expect(session.context.snapshot.placement).toBeUndefined();
-    expect(session.context.transition).toEqual({
-      reason: "page-context",
-      toContextKey:
-        "canonical:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
-    });
-  });
-
-  it("uses active material and program projections instead of stale static rows", async () => {
-    mocks.materialRoute.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        projection: {
-          contentKey:
-            "material/lesson/mathematics/function-composition-inverse-function/function-concept",
-          graph: {
-            assetId: "asset:en:material:function-concept",
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            locale: "en",
+            slug: "chat",
+            url: "https://nakafa.com/en/chat",
+            verified: false,
           },
-          kind: "subject-lesson",
-          materialKey:
-            "lesson.mathematics.function-composition-inverse-function",
-          metadata: { title: "Function Concept" },
-        },
-        sourcePath:
-          "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx",
+          source: "current-page",
+          tools: {
+            allowPageFetch: false,
+            evidenceScope: "general-learning",
+          },
+        });
+        expect(session.context.transition).toEqual({
+          reason: "page-context",
+          toContextKey: "canonical:chat",
+        });
       })
-    );
-    mocks.materialContext.mockReturnValueOnce(
-      Effect.succeed({
-        context: {
-          nodeKey: "cambridge-function-concept",
-          programKey: "cambridge-international",
-        },
-        href: "/en/curriculum/cambridge-international/mathematics#functions",
-        label: "Functions",
+  );
+
+  it.effect(
+    "builds canonical learning identity for a retained source try-out",
+    () =>
+      Effect.gen(function* () {
+        const slug = "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge";
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          rawContext: {},
+          slug: `/${slug}`,
+          url: `https://nakafa.com/en/${slug}`,
+          verified: true,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            slug,
+            verified: true,
+          },
+          source: "current-page",
+        });
+        expect(session.context.snapshot.learning.sourcePath).toBeUndefined();
+        expect(session.context.snapshot.placement).toBeUndefined();
       })
-    );
+  );
 
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-07-26T00:00:00.000Z",
-        locale: "en",
-        rawContext: {
-          materialContextHint:
-            "cambridge-international~cambridge-function-concept",
-        },
-        slug: "/subjects/mathematics/function-composition-inverse-function/function-concept",
-        url: "https://nakafa.com/en/subjects/mathematics/function-composition-inverse-function/function-concept",
-        verified: true,
+  it.effect(
+    "reuses stored Nina context when an existing chat continues off a verified learning page",
+    () =>
+      Effect.gen(function* () {
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          pinnedContext,
+          rawContext: {},
+          slug: "/chat/chat_existing",
+          url: "https://nakafa.com/en/chat/chat_existing",
+          verified: false,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          learning: pinnedContext.learning,
+          source: "pinned-chat",
+          tools: {
+            allowPageFetch: true,
+            evidenceScope: "verified-page",
+          },
+        });
+        expect(session.context.transition).toEqual({
+          reason: "same-context",
+          toContextKey:
+            "canonical:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+        });
       })
-    );
+  );
 
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        assetId: "asset:en:material:function-concept",
-        contentId: "asset:en:material:function-concept",
-        materialKey: "lesson.mathematics.function-composition-inverse-function",
-        sourcePath:
-          "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx",
-        title: "Function Concept",
-      },
-      placement: {
-        nodeKey: "cambridge-function-concept",
-        parentTitle: "Functions",
-        programKey: "cambridge-international",
-      },
-    });
-  });
+  it.effect(
+    "preserves pinned placement when replaying an existing chat off-page",
+    () =>
+      Effect.gen(function* () {
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          pinnedContext: pinnedPlacementContext,
+          rawContext: {},
+          slug: "/chat/chat_existing",
+          url: "https://nakafa.com/en/chat/chat_existing",
+          verified: false,
+        });
 
-  it("uses signed material identity for placement after a route rename", async () => {
-    const renamedPath =
-      "subjects/mathematics/function-composition-inverse-function/renamed-function-concept";
-    mocks.materialRoute.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        projection: {
-          ...previewProjection,
-          publicPath: renamedPath,
-        },
-        sourcePath: previewSourcePath,
+        expect(session.context.snapshot).toMatchObject({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          learning: pinnedContext.learning,
+          placement: pinnedPlacementContext.placement,
+          source: "pinned-chat",
+        });
+        expect(session.context.transition).toEqual({
+          reason: "same-context",
+          toContextKey:
+            "placement:merdeka:class-10-chemistry-basic-chemistry-laws:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+        });
       })
-    );
-    mocks.materialContext.mockReturnValueOnce(
-      Effect.succeed({
-        context: {
-          nodeKey: "class-11-mathematics-function-composition-inverse-function",
-          programKey: "merdeka",
-        },
-        href: "/en/curriculum/merdeka/class-11/mathematics#functions",
-        label: "Functions",
+  );
+
+  it.effect(
+    "keeps verified material placement when the browser context hint validates",
+    () =>
+      Effect.gen(function* () {
+        mocks.materialContext.mockReturnValueOnce(
+          Effect.succeed({
+            context: {
+              nodeKey: "class-10-chemistry-basic-chemistry-laws",
+              programKey: "merdeka",
+            },
+            href: "/en/curriculum/merdeka/class-10/chemistry#basic-laws-of-chemistry",
+            label: "Basic Laws of Chemistry",
+          })
+        );
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          rawContext: {
+            materialContextHint:
+              "merdeka~class-10-chemistry-basic-chemistry-laws",
+          },
+          slug: "/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+          url: "https://nakafa.com/en/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+          verified: true,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            materialKey: "lesson.chemistry.basic-chemistry-laws",
+            section: "subject-lesson",
+            sourcePath:
+              "material/lesson/chemistry/basic-chemistry-laws/chemistry-law-applications",
+            title: "Law Applications",
+            verified: true,
+          },
+          placement: {
+            mode: "placement",
+            nodeKey: "class-10-chemistry-basic-chemistry-laws",
+            parentHref:
+              "/en/curriculum/merdeka/class-10/chemistry#basic-laws-of-chemistry",
+            parentTitle: "Basic Laws of Chemistry",
+            programKey: "merdeka",
+          },
+          source: "current-page",
+          tools: {
+            allowPageFetch: true,
+            evidenceScope: "verified-page",
+          },
+        });
+        expect(session.context.transition).toEqual({
+          reason: "page-context",
+          toContextKey:
+            "placement:merdeka:class-10-chemistry-basic-chemistry-laws:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+        });
       })
-    );
+  );
 
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-07-28T00:00:00.000Z",
-        locale: "en",
-        rawContext: {
-          materialContextHint:
-            "merdeka~class-11-mathematics-function-composition-inverse-function",
-        },
-        slug: `/${renamedPath}`,
-        url: `https://nakafa.com/en/${renamedPath}`,
-        verified: true,
+  it.effect(
+    "drops a stale material context hint instead of inventing placement",
+    () =>
+      Effect.gen(function* () {
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-06-22T00:00:00.000Z",
+          locale: "en",
+          rawContext: {
+            materialContextHint: "merdeka~stale-node",
+          },
+          slug: "/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+          url: "https://nakafa.com/en/subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+          verified: true,
+        });
+
+        expect(session.context.snapshot.placement).toBeUndefined();
+        expect(session.context.transition).toEqual({
+          reason: "page-context",
+          toContextKey:
+            "canonical:subjects/chemistry/basic-chemistry-laws/chemistry-law-applications",
+        });
       })
-    );
+  );
 
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        contentId: previewProjection.graph.assetId,
-        slug: renamedPath,
-      },
-      placement: {
-        nodeKey: "class-11-mathematics-function-composition-inverse-function",
-        programKey: "merdeka",
-      },
-    });
-  });
+  it.effect(
+    "uses active material and program projections instead of stale static rows",
+    () =>
+      Effect.gen(function* () {
+        mocks.materialRoute.mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            projection: {
+              contentKey:
+                "material/lesson/mathematics/function-composition-inverse-function/function-concept",
+              graph: {
+                assetId: "asset:en:material:function-concept",
+              },
+              kind: "subject-lesson",
+              materialKey:
+                "lesson.mathematics.function-composition-inverse-function",
+              metadata: { title: "Function Concept" },
+            },
+            sourcePath:
+              "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx",
+          })
+        );
+        mocks.materialContext.mockReturnValueOnce(
+          Effect.succeed({
+            context: {
+              nodeKey: "cambridge-function-concept",
+              programKey: "cambridge-international",
+            },
+            href: "/en/curriculum/cambridge-international/mathematics#functions",
+            label: "Functions",
+          })
+        );
 
-  it("keeps active material canonical when no placement hint exists", async () => {
-    mocks.materialRoute.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        projection: previewProjection,
-        sourcePath: previewSourcePath,
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-07-26T00:00:00.000Z",
+          locale: "en",
+          rawContext: {
+            materialContextHint:
+              "cambridge-international~cambridge-function-concept",
+          },
+          slug: "/subjects/mathematics/function-composition-inverse-function/function-concept",
+          url: "https://nakafa.com/en/subjects/mathematics/function-composition-inverse-function/function-concept",
+          verified: true,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            assetId: "asset:en:material:function-concept",
+            contentId: "asset:en:material:function-concept",
+            materialKey:
+              "lesson.mathematics.function-composition-inverse-function",
+            sourcePath:
+              "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx",
+            title: "Function Concept",
+          },
+          placement: {
+            nodeKey: "cambridge-function-concept",
+            parentTitle: "Functions",
+            programKey: "cambridge-international",
+          },
+        });
       })
-    );
+  );
 
-    const session = await Effect.runPromise(
-      resolveNinaLearningSession({
-        capturedAt: "2026-07-26T00:00:00.000Z",
-        locale: "en",
-        rawContext: {},
-        slug: `/${previewProjection.publicPath}`,
-        url: `https://nakafa.com/en/${previewProjection.publicPath}`,
-        verified: true,
+  it.effect(
+    "uses signed material identity for placement after a route rename",
+    () =>
+      Effect.gen(function* () {
+        const renamedPath =
+          "subjects/mathematics/function-composition-inverse-function/renamed-function-concept";
+        mocks.materialRoute.mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            projection: {
+              ...previewProjection,
+              publicPath: renamedPath,
+            },
+            sourcePath: previewSourcePath,
+          })
+        );
+        mocks.materialContext.mockReturnValueOnce(
+          Effect.succeed({
+            context: {
+              nodeKey:
+                "class-11-mathematics-function-composition-inverse-function",
+              programKey: "merdeka",
+            },
+            href: "/en/curriculum/merdeka/class-11/mathematics#functions",
+            label: "Functions",
+          })
+        );
+
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-07-28T00:00:00.000Z",
+          locale: "en",
+          rawContext: {
+            materialContextHint:
+              "merdeka~class-11-mathematics-function-composition-inverse-function",
+          },
+          slug: `/${renamedPath}`,
+          url: `https://nakafa.com/en/${renamedPath}`,
+          verified: true,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            contentId: previewProjection.graph.assetId,
+            slug: renamedPath,
+          },
+          placement: {
+            nodeKey:
+              "class-11-mathematics-function-composition-inverse-function",
+            programKey: "merdeka",
+          },
+        });
       })
-    );
+  );
 
-    expect(session.context.snapshot).toMatchObject({
-      learning: {
-        contentId: previewProjection.graph.assetId,
-        sourcePath: previewSourcePath,
-      },
-      source: "current-page",
-    });
-    expect(session.context.snapshot.placement).toBeUndefined();
-    expect(mocks.materialContext).not.toHaveBeenCalled();
-  });
+  it.effect(
+    "keeps active material canonical when no placement hint exists",
+    () =>
+      Effect.gen(function* () {
+        mocks.materialRoute.mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            projection: previewProjection,
+            sourcePath: previewSourcePath,
+          })
+        );
+
+        const session = yield* resolveNinaLearningSession({
+          capturedAt: "2026-07-26T00:00:00.000Z",
+          locale: "en",
+          rawContext: {},
+          slug: `/${previewProjection.publicPath}`,
+          url: `https://nakafa.com/en/${previewProjection.publicPath}`,
+          verified: true,
+        });
+
+        expect(session.context.snapshot).toMatchObject({
+          learning: {
+            contentId: previewProjection.graph.assetId,
+            sourcePath: previewSourcePath,
+          },
+          source: "current-page",
+        });
+        expect(session.context.snapshot.placement).toBeUndefined();
+        expect(mocks.materialContext).not.toHaveBeenCalled();
+      })
+  );
 });

--- a/apps/www/app/api/chat/persistence.test.ts
+++ b/apps/www/app/api/chat/persistence.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ModelIdSchema } from "@repo/ai/config/model";
 import type {
   NinaContextSnapshot,
@@ -6,7 +7,7 @@ import type {
 } from "@repo/ai/nina/memory/pack";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import {
   createChatWithMessage,
@@ -77,23 +78,21 @@ function withNinaContext() {
 }
 
 /** Returns one typed chat ID through the public persistence path. */
-async function savedChatId() {
+const savedChatId = Effect.fn("ChatPersistenceTest.savedChatId")(function* () {
   mocks.fetchMutation.mockResolvedValueOnce({ chatId: "chat_existing" });
 
-  const chatId = await Effect.runPromise(
-    createChatWithMessage({
-      message,
-      modelId,
-      ...withNinaContext(),
-      token: "session-token",
-    })
-  );
+  const chatId = yield* createChatWithMessage({
+    message,
+    modelId,
+    ...withNinaContext(),
+    token: "session-token",
+  });
 
   vi.clearAllMocks();
   mocks.mapUIMessagePartsToDBParts.mockReturnValue([]);
 
   return chatId;
-}
+});
 
 describe("app/api/chat/persistence", () => {
   beforeEach(() => {
@@ -106,301 +105,324 @@ describe("app/api/chat/persistence", () => {
     mocks.mapUIMessagePartsToDBParts.mockReturnValue([]);
   });
 
-  it("passes the selected model when creating a chat with the first user message", async () => {
-    mocks.fetchMutation.mockResolvedValue({ chatId: "chat_new" });
+  it.effect(
+    "passes the selected model when creating a chat with the first user message",
+    () =>
+      Effect.gen(function* () {
+        mocks.fetchMutation.mockResolvedValue({ chatId: "chat_new" });
 
-    const chatId = await Effect.runPromise(
-      createChatWithMessage({
-        message,
-        modelId,
-        ...withNinaContext(),
-        token: "session-token",
-      })
-    );
-
-    expect(chatId).toBe("chat_new");
-    expect(mocks.fetchMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        message: {
-          identifier: "message-1",
+        const chatId = yield* createChatWithMessage({
+          message,
           modelId,
-          ninaContextSnapshot,
-          ninaContextTransition,
-          role: "user",
-        },
-        parts: [],
-        type: "study",
-      },
-      { token: "session-token" }
-    );
-  });
+          ...withNinaContext(),
+          token: "session-token",
+        });
 
-  it("maps chat creation failures into the mutation error contract", async () => {
-    const cause = new Error("mutation unavailable");
-    mocks.fetchMutation.mockRejectedValueOnce(cause);
-
-    const error = await Effect.runPromise(
-      createChatWithMessage({
-        message,
-        modelId,
-        ...withNinaContext(),
-        token: "session-token",
-      }).pipe(Effect.flip)
-    );
-
-    expect(error).toBeInstanceOf(ChatMutationError);
-    expect(error).toMatchObject({
-      cause,
-      operation: "create-chat",
-    });
-  });
-
-  it("passes the selected model when saving a message to an existing chat", async () => {
-    const chatId = await savedChatId();
-    mocks.fetchQuery.mockResolvedValue(null);
-
-    const result = await Effect.runPromise(
-      saveChatMessage({
-        chatId,
-        message,
-        modelId,
-        ...withNinaContext(),
-        token: "session-token",
+        expect(chatId).toBe("chat_new");
+        expect(mocks.fetchMutation).toHaveBeenCalledWith(
+          expect.anything(),
+          {
+            message: {
+              identifier: "message-1",
+              modelId,
+              ninaContextSnapshot,
+              ninaContextTransition,
+              role: "user",
+            },
+            parts: [],
+            type: "study",
+          },
+          { token: "session-token" }
+        );
       })
-    );
+  );
 
-    expect(result).toBe(chatId);
-    expect(mocks.fetchMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        message: {
+  it.effect(
+    "maps chat creation failures into the mutation error contract",
+    () =>
+      Effect.gen(function* () {
+        const cause = new Error("mutation unavailable");
+        mocks.fetchMutation.mockRejectedValueOnce(cause);
+
+        const error = yield* createChatWithMessage({
+          message,
+          modelId,
+          ...withNinaContext(),
+          token: "session-token",
+        }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(ChatMutationError);
+        expect(error).toMatchObject({
+          cause,
+          operation: "create-chat",
+        });
+      })
+  );
+
+  it.effect(
+    "passes the selected model when saving a message to an existing chat",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+        mocks.fetchQuery.mockResolvedValue(null);
+
+        const result = yield* saveChatMessage({
           chatId,
-          identifier: "message-1",
+          message,
           modelId,
-          ninaContextSnapshot,
-          ninaContextTransition,
-          role: "user",
-        },
-        parts: [],
-      },
-      { token: "session-token" }
-    );
-  });
+          ...withNinaContext(),
+          token: "session-token",
+        });
 
-  it("maps message save failures into the mutation error contract", async () => {
-    const chatId = await savedChatId();
-    const cause = new Error("mutation unavailable");
-    mocks.fetchMutation.mockRejectedValueOnce(cause);
+        expect(result).toBe(chatId);
+        expect(mocks.fetchMutation).toHaveBeenCalledWith(
+          expect.anything(),
+          {
+            message: {
+              chatId,
+              identifier: "message-1",
+              modelId,
+              ninaContextSnapshot,
+              ninaContextTransition,
+              role: "user",
+            },
+            parts: [],
+          },
+          { token: "session-token" }
+        );
+      })
+  );
 
-    const error = await Effect.runPromise(
-      saveChatMessage({
+  it.effect("maps message save failures into the mutation error contract", () =>
+    Effect.gen(function* () {
+      const chatId = yield* savedChatId();
+      const cause = new Error("mutation unavailable");
+      mocks.fetchMutation.mockRejectedValueOnce(cause);
+
+      const error = yield* saveChatMessage({
         chatId,
         message,
         modelId,
         ...withNinaContext(),
         token: "session-token",
-      }).pipe(Effect.flip)
-    );
+      }).pipe(Effect.flip);
 
-    expect(error).toBeInstanceOf(ChatMutationError);
-    expect(error).toMatchObject({
-      cause,
-      operation: "save-message",
-    });
-  });
+      expect(error).toBeInstanceOf(ChatMutationError);
+      expect(error).toMatchObject({
+        cause,
+        operation: "save-message",
+      });
+    })
+  );
 
-  it("loads the newest stored Nina context for pinned-chat continuation", async () => {
-    const chatId = await savedChatId();
-    mocks.fetchQuery.mockResolvedValue(ninaContextSnapshot);
+  it.effect(
+    "loads the newest stored Nina context for pinned-chat continuation",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+        mocks.fetchQuery.mockResolvedValue(ninaContextSnapshot);
 
-    const result = await Effect.runPromise(
-      loadPinnedNinaContext({
-        chatId,
-        messageIdentifier: message.id,
-        token: "session-token",
-      })
-    );
-
-    expect(result).toEqual(ninaContextSnapshot);
-    expect(mocks.fetchQuery).toHaveBeenCalledWith(
-      expect.anything(),
-      { chatId, messageIdentifier: message.id },
-      { token: "session-token" }
-    );
-  });
-
-  it("ignores missing pinned Nina context instead of inventing chat context", async () => {
-    const chatId = await savedChatId();
-    mocks.fetchQuery.mockResolvedValue(null);
-
-    const result = await Effect.runPromise(
-      loadPinnedNinaContext({
-        chatId,
-        messageIdentifier: message.id,
-        token: "session-token",
-      })
-    );
-
-    expect(result).toBeUndefined();
-  });
-
-  it("maps pinned-context failures into the query error contract", async () => {
-    const chatId = await savedChatId();
-    const cause = new Error("query unavailable");
-    mocks.fetchQuery.mockRejectedValueOnce(cause);
-
-    const error = await Effect.runPromise(
-      loadPinnedNinaContext({
-        chatId,
-        messageIdentifier: message.id,
-        token: "session-token",
-      }).pipe(Effect.flip)
-    );
-
-    expect(error).toBeInstanceOf(ChatQueryError);
-    expect(error).toMatchObject({
-      cause,
-      operation: "load-context",
-    });
-  });
-
-  it("saves an existing chat rewrite through one atomic Convex mutation", async () => {
-    const chatId = await savedChatId();
-
-    await Effect.runPromise(
-      saveChatMessage({
-        chatId,
-        message,
-        modelId,
-        ...withNinaContext(),
-        token: "session-token",
-      })
-    );
-
-    expect(mocks.fetchQuery).not.toHaveBeenCalled();
-    expect(mocks.fetchMutation).toHaveBeenCalledTimes(1);
-    expect(mocks.fetchMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        message: expect.objectContaining({
+        const result = yield* loadPinnedNinaContext({
           chatId,
-          modelId,
-        }),
-      }),
-      { token: "session-token" }
-    );
-  });
+          messageIdentifier: message.id,
+          token: "session-token",
+        });
 
-  it("loads rewrite-aware pinned context before saving a replacement", async () => {
-    const chatId = await savedChatId();
-    mocks.fetchQuery.mockResolvedValueOnce(ninaContextSnapshot);
+        expect(result).toEqual(ninaContextSnapshot);
+        expect(mocks.fetchQuery).toHaveBeenCalledWith(
+          expect.anything(),
+          { chatId, messageIdentifier: message.id },
+          { token: "session-token" }
+        );
+      })
+  );
 
-    const pinnedContext = await Effect.runPromise(
-      loadPinnedNinaContext({
+  it.effect(
+    "ignores missing pinned Nina context instead of inventing chat context",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+        mocks.fetchQuery.mockResolvedValue(null);
+
+        const result = yield* loadPinnedNinaContext({
+          chatId,
+          messageIdentifier: message.id,
+          token: "session-token",
+        });
+
+        expect(result).toBeUndefined();
+      })
+  );
+
+  it.effect("maps pinned-context failures into the query error contract", () =>
+    Effect.gen(function* () {
+      const chatId = yield* savedChatId();
+      const cause = new Error("query unavailable");
+      mocks.fetchQuery.mockRejectedValueOnce(cause);
+
+      const error = yield* loadPinnedNinaContext({
         chatId,
         messageIdentifier: message.id,
         token: "session-token",
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ChatQueryError);
+      expect(error).toMatchObject({
+        cause,
+        operation: "load-context",
+      });
+    })
+  );
+
+  it.effect(
+    "saves an existing chat rewrite through one atomic Convex mutation",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+
+        yield* saveChatMessage({
+          chatId,
+          message,
+          modelId,
+          ...withNinaContext(),
+          token: "session-token",
+        });
+
+        expect(mocks.fetchQuery).not.toHaveBeenCalled();
+        expect(mocks.fetchMutation).toHaveBeenCalledTimes(1);
+        expect(mocks.fetchMutation).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            message: expect.objectContaining({
+              chatId,
+              modelId,
+            }),
+          }),
+          { token: "session-token" }
+        );
       })
-    );
-    await Effect.runPromise(
-      saveChatMessage({
+  );
+
+  it.effect(
+    "loads rewrite-aware pinned context before saving a replacement",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+        mocks.fetchQuery.mockResolvedValueOnce(ninaContextSnapshot);
+
+        const pinnedContext = yield* loadPinnedNinaContext({
+          chatId,
+          messageIdentifier: message.id,
+          token: "session-token",
+        });
+        yield* saveChatMessage({
+          chatId,
+          message,
+          modelId,
+          ...withNinaContext(),
+          token: "session-token",
+        });
+
+        expect(pinnedContext).toEqual(ninaContextSnapshot);
+        expect(mocks.fetchQuery.mock.invocationCallOrder[0]).toBeLessThan(
+          mocks.fetchMutation.mock.invocationCallOrder[0]
+        );
+        expect(mocks.fetchQuery).toHaveBeenCalledWith(
+          expect.anything(),
+          { chatId, messageIdentifier: message.id },
+          { token: "session-token" }
+        );
+      })
+  );
+
+  it.effect("loads paginated messages until the page stream is done", () =>
+    Effect.gen(function* () {
+      const chatId = yield* savedChatId();
+      const newerMessage = { ...message, id: "newer" };
+      const olderMessage = { ...message, id: "older" };
+      mocks.fetchQuery
+        .mockResolvedValueOnce({
+          continueCursor: "cursor-1",
+          isDone: false,
+          page: [newerMessage],
+        })
+        .mockResolvedValueOnce({
+          continueCursor: "",
+          isDone: true,
+          page: [olderMessage],
+        });
+
+      const messages = yield* loadMessages({
         chatId,
-        message,
-        modelId,
-        ...withNinaContext(),
         token: "session-token",
-      })
-    );
-
-    expect(pinnedContext).toEqual(ninaContextSnapshot);
-    expect(mocks.fetchQuery.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.fetchMutation.mock.invocationCallOrder[0]
-    );
-    expect(mocks.fetchQuery).toHaveBeenCalledWith(
-      expect.anything(),
-      { chatId, messageIdentifier: message.id },
-      { token: "session-token" }
-    );
-  });
-
-  it("loads paginated messages until the page stream is done", async () => {
-    const chatId = await savedChatId();
-    const newerMessage = { ...message, id: "newer" };
-    const olderMessage = { ...message, id: "older" };
-    mocks.fetchQuery
-      .mockResolvedValueOnce({
-        continueCursor: "cursor-1",
-        isDone: false,
-        page: [newerMessage],
-      })
-      .mockResolvedValueOnce({
-        continueCursor: "",
-        isDone: true,
-        page: [olderMessage],
       });
 
-    const messages = await Effect.runPromise(
-      loadMessages({ chatId, token: "session-token" })
-    );
-
-    expect(messages).toEqual([olderMessage, newerMessage]);
-    expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
-      1,
-      expect.anything(),
-      {
-        chatId,
-        paginationOpts: {
-          cursor: null,
-          numItems: expect.any(Number),
+      expect(messages).toEqual([olderMessage, newerMessage]);
+      expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        {
+          chatId,
+          paginationOpts: {
+            cursor: null,
+            numItems: expect.any(Number),
+          },
         },
-      },
-      { token: "session-token" }
-    );
-    expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
-      {
-        chatId,
-        paginationOpts: {
-          cursor: "cursor-1",
-          numItems: expect.any(Number),
+        { token: "session-token" }
+      );
+      expect(mocks.fetchQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        {
+          chatId,
+          paginationOpts: {
+            cursor: "cursor-1",
+            numItems: expect.any(Number),
+          },
         },
-      },
-      { token: "session-token" }
-    );
-  });
+        { token: "session-token" }
+      );
+    })
+  );
 
-  it("maps message page failures into the query error contract", async () => {
-    const chatId = await savedChatId();
-    const cause = new Error("query unavailable");
-    mocks.fetchQuery.mockRejectedValueOnce(cause);
+  it.effect("maps message page failures into the query error contract", () =>
+    Effect.gen(function* () {
+      const chatId = yield* savedChatId();
+      const cause = new Error("query unavailable");
+      mocks.fetchQuery.mockRejectedValueOnce(cause);
 
-    const error = await Effect.runPromise(
-      loadMessages({ chatId, token: "session-token" }).pipe(Effect.flip)
-    );
+      const error = yield* loadMessages({
+        chatId,
+        token: "session-token",
+      }).pipe(Effect.flip);
 
-    expect(error).toBeInstanceOf(ChatQueryError);
-    expect(error).toMatchObject({
-      cause,
-      operation: "load-messages",
-    });
-  });
+      expect(error).toBeInstanceOf(ChatQueryError);
+      expect(error).toMatchObject({
+        cause,
+        operation: "load-messages",
+      });
+    })
+  );
 
-  it("stops loading when compression trims the retained transcript", async () => {
-    const chatId = await savedChatId();
-    mocks.fetchQuery.mockResolvedValue({
-      continueCursor: "cursor-1",
-      isDone: false,
-      page: [message],
-    });
-    mocks.compressMessages.mockReturnValue({ messages: [], tokens: 0 });
+  it.effect(
+    "stops loading when compression trims the retained transcript",
+    () =>
+      Effect.gen(function* () {
+        const chatId = yield* savedChatId();
+        mocks.fetchQuery.mockResolvedValue({
+          continueCursor: "cursor-1",
+          isDone: false,
+          page: [message],
+        });
+        mocks.compressMessages.mockReturnValue({ messages: [], tokens: 0 });
 
-    const messages = await Effect.runPromise(
-      loadMessages({ chatId, token: "session-token" })
-    );
+        const messages = yield* loadMessages({
+          chatId,
+          token: "session-token",
+        });
 
-    expect(messages).toEqual([]);
-    expect(mocks.fetchQuery).toHaveBeenCalledTimes(1);
-  });
+        expect(messages).toEqual([]);
+        expect(mocks.fetchQuery).toHaveBeenCalledTimes(1);
+      })
+  );
 });

--- a/apps/www/app/api/chat/published.test.ts
+++ b/apps/www/app/api/chat/published.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   isPublishedMaterialPath,
   readPublishedNinaMaterial,
@@ -58,85 +59,96 @@ describe("published Nina material", () => {
     );
   });
 
-  it("fails closed when the signed route is a tombstone", async () => {
-    mocks.materialRoute.mockReturnValue(
-      Effect.succeed({ projection: null, sourcePath: null })
-    );
+  it.effect("fails closed when the signed route is a tombstone", () =>
+    Effect.gen(function* () {
+      mocks.materialRoute.mockReturnValue(
+        Effect.succeed({ projection: null, sourcePath: null })
+      );
 
-    await expect(
-      Effect.runPromise(readPublishedNinaMaterial(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      const error = yield* readPublishedNinaMaterial(input).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-  it("builds verified learning without placement when no hint exists", async () => {
-    const result = await Effect.runPromise(
-      readPublishedNinaMaterial({ ...input, contextHint: null })
-    );
+  it.effect(
+    "builds verified learning without placement when no hint exists",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* readPublishedNinaMaterial({
+          ...input,
+          contextHint: null,
+        });
 
-    expect(result).toMatchObject({
-      learning: {
-        assetId: previewProjection.graph.assetId,
-        contentId: previewProjection.graph.assetId,
-        materialKey: previewProjection.materialKey,
-        sourcePath: previewSourcePath,
-        title: previewProjection.metadata.title,
-        verified: true,
-      },
-      placement: undefined,
-    });
-    expect(mocks.materialContext).not.toHaveBeenCalled();
-  });
-
-  it("drops a stale signed program context", async () => {
-    mocks.materialContext.mockReturnValue(Effect.succeed(null));
-
-    await expect(
-      Effect.runPromise(readPublishedNinaMaterial(input))
-    ).resolves.toMatchObject({ placement: undefined });
-  });
-
-  it("rejects an invalid signed program identity", async () => {
-    mocks.materialContext.mockReturnValue(
-      Effect.succeed({
-        context: { nodeKey: "class-11-mathematics", programKey: 42 },
-        href: "/en/curriculum/invalid",
-        label: "Mathematics",
+        expect(result).toMatchObject({
+          learning: {
+            assetId: previewProjection.graph.assetId,
+            contentId: previewProjection.graph.assetId,
+            materialKey: previewProjection.materialKey,
+            sourcePath: previewSourcePath,
+            title: previewProjection.metadata.title,
+            verified: true,
+          },
+          placement: undefined,
+        });
+        expect(mocks.materialContext).not.toHaveBeenCalled();
       })
-    );
+  );
 
-    await expect(
-      Effect.runPromise(readPublishedNinaMaterial(input).pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+  it.effect("drops a stale signed program context", () =>
+    Effect.gen(function* () {
+      mocks.materialContext.mockReturnValue(Effect.succeed(null));
 
-  it("uses the signed program placement without static reconstruction", async () => {
-    mocks.materialContext.mockReturnValue(
-      Effect.succeed({
-        context: {
-          nodeKey: "class-11-mathematics",
-          programKey: "merdeka",
-        },
-        href: "/en/curriculum/merdeka/class-11/mathematics",
-        label: "Mathematics",
+      const result = yield* readPublishedNinaMaterial(input);
+      expect(result).toMatchObject({ placement: undefined });
+    })
+  );
+
+  it.effect("rejects an invalid signed program identity", () =>
+    Effect.gen(function* () {
+      mocks.materialContext.mockReturnValue(
+        Effect.succeed({
+          context: { nodeKey: "class-11-mathematics", programKey: 42 },
+          href: "/en/curriculum/invalid",
+          label: "Mathematics",
+        })
+      );
+
+      const error = yield* readPublishedNinaMaterial(input).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
+
+  it.effect(
+    "uses the signed program placement without static reconstruction",
+    () =>
+      Effect.gen(function* () {
+        mocks.materialContext.mockReturnValue(
+          Effect.succeed({
+            context: {
+              nodeKey: "class-11-mathematics",
+              programKey: "merdeka",
+            },
+            href: "/en/curriculum/merdeka/class-11/mathematics",
+            label: "Mathematics",
+          })
+        );
+
+        const result = yield* readPublishedNinaMaterial(input);
+        expect(result).toMatchObject({
+          placement: {
+            mode: "placement",
+            nodeKey: "class-11-mathematics",
+            parentHref: "/en/curriculum/merdeka/class-11/mathematics",
+            parentTitle: "Mathematics",
+            programKey: "merdeka",
+          },
+        });
+        expect(mocks.materialContext).toHaveBeenCalledWith(
+          "en",
+          previewProjection,
+          expect.anything(),
+          activeReleaseId
+        );
       })
-    );
-
-    await expect(
-      Effect.runPromise(readPublishedNinaMaterial(input))
-    ).resolves.toMatchObject({
-      placement: {
-        mode: "placement",
-        nodeKey: "class-11-mathematics",
-        parentHref: "/en/curriculum/merdeka/class-11/mathematics",
-        parentTitle: "Mathematics",
-        programKey: "merdeka",
-      },
-    });
-    expect(mocks.materialContext).toHaveBeenCalledWith(
-      "en",
-      previewProjection,
-      expect.anything(),
-      activeReleaseId
-    );
-  });
+  );
 });

--- a/apps/www/app/api/chat/utils.test.ts
+++ b/apps/www/app/api/chat/utils.test.ts
@@ -11,34 +11,33 @@ import {
   getVerified,
 } from "@/app/api/chat/utils";
 
+const mocks = vi.hoisted(() => ({
+  verify: vi.fn(),
+}));
+
 vi.mock("convex/nextjs", () => ({
   fetchMutation: vi.fn(),
   fetchQuery: vi.fn(),
 }));
 
-vi.mock("@/app/api/chat/nakafa-content", async () => {
-  const { Effect } = await import("effect");
-
-  return {
-    nakafaContent: {
-      /** Verifies chat content refs through deterministic URL fixtures. */
-      verify: (url: string) =>
-        Effect.succeed(
-          url === "https://nakafa.com/id/quran/1" ||
-            url ===
-              "https://nakafa.com/id/articles/politics/dynastic-politics-asian-values" ||
-            url ===
-              "https://nakafa.com/en/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge" ||
-            url === "asset:id:quran:quran-surah:1" ||
-            url === "nakafa://content/asset:id:quran:quran-surah:1"
-        ),
-    },
-  };
-});
+vi.mock("@/app/api/chat/nakafa-content", () => ({
+  nakafaContent: { verify: mocks.verify },
+}));
 
 describe("app/api/chat/utils", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.verify.mockImplementation((url: string) =>
+      Effect.succeed(
+        url === "https://nakafa.com/id/quran/1" ||
+          url ===
+            "https://nakafa.com/id/articles/politics/dynastic-politics-asian-values" ||
+          url ===
+            "https://nakafa.com/en/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge" ||
+          url === "asset:id:quran:quran-surah:1" ||
+          url === "nakafa://content/asset:id:quran:quran-surah:1"
+      )
+    );
   });
 
   it.effect.each([


### PR DESCRIPTION
## Scope

- migrate four WWW chat API test modules to direct `@effect/vitest`
- replace 28 direct Effect runtime boundaries with native `it.effect` and `it.effect.each` cases
- preserve existing success, typed failure, pagination, signed-publication, persistence, and context behavior
- retain direct Vitest `vi` imports only for transform-time hoisted module mocks

## Architecture

Effectful chat tests now return their Effects directly to the official Effect v4 Vitest integration. The checkpoint contains four package-owned commits, one per test module. It adds no repository testing facade, compatibility wrapper, production source, dependency, lockfile, backend, Convex, Quran, or content-runtime change.

## Verification

- focused chat suite: 4 files and 40 tests passed
- full WWW suite: 210 files and 1,520 tests passed with 100% statement, branch, function, and line coverage
- full repository tests: 15 of 15 tasks passed
- WWW typecheck passed
- root lint, test ownership, boundaries, Effect RC110 source parity, and diff checks passed
- changed-scope Doctor: 100
- forbidden-pattern scan found no testing facade import, `it.live`, direct Effect runner, `.only`, or `.skip` in the four changed files
- rebase preserved all four patches exactly

Exact head: `381b23cb05264930a9546120eb21c97fd954531e`
Exact base: `84ac59a7194dfa2b4c7303d2f1fc0780ca93bcdf`

## Rollout

This is a test-only checkpoint. It creates no Vercel Preview and changes no production behavior. Merge requires this exact head to remain current-base clean with required checks and review threads green.