### PR TITLE
test(www): use native Effect Vitest for LLM publication

### DIFF
--- a/apps/www/lib/llms/indexes.test.ts
+++ b/apps/www/lib/llms/indexes.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import type { LlmsEntry } from "@/lib/llms/entries";
 import {
@@ -106,207 +107,223 @@ beforeEach(() => {
 });
 
 describe("llms indexes", () => {
-  it("builds locale indexes with direct starter pages", async () => {
-    const text = await Effect.runPromise(getLlmsSectionIndexText("llms/en"));
+  it.effect("builds locale indexes with direct starter pages", () =>
+    Effect.gen(function* () {
+      const text = yield* getLlmsSectionIndexText("llms/en");
 
-    expect(text).toContain("# Nakafa English Content");
-    expect(text).toContain("## Sections");
-    expect(text).toContain("## Starter Pages");
-    for (const prefix of [
-      "articles",
-      "subjects",
-      "curriculum",
-      "try-out",
-      "quran",
-    ]) {
-      expect(text).toContain(`${BASE_URL}/en/${prefix}/llms.txt`);
-    }
-    expect(text).toContain(`${BASE_URL}/en/search`);
-    expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
-    expect(mockGetContentPageLlmsEntries).toHaveBeenCalled();
-  });
+      expect(text).toContain("# Nakafa English Content");
+      expect(text).toContain("## Sections");
+      expect(text).toContain("## Starter Pages");
+      for (const prefix of [
+        "articles",
+        "subjects",
+        "curriculum",
+        "try-out",
+        "quran",
+      ]) {
+        expect(text).toContain(`${BASE_URL}/en/${prefix}/llms.txt`);
+      }
+      expect(text).toContain(`${BASE_URL}/en/search`);
+      expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
+      expect(mockGetContentPageLlmsEntries).toHaveBeenCalled();
+    })
+  );
 
-  it("omits missing locale page artifacts from starter pages", async () => {
-    mockGetContentPageLlmsEntries.mockReturnValue(Effect.succeed(null));
-    mockReadSiteLlmsEntries.mockReturnValue(Effect.succeed([]));
+  it.effect("omits missing locale page artifacts from starter pages", () =>
+    Effect.gen(function* () {
+      mockGetContentPageLlmsEntries.mockReturnValue(Effect.succeed(null));
+      mockReadSiteLlmsEntries.mockReturnValue(Effect.succeed([]));
 
-    const text = await Effect.runPromise(getLlmsSectionIndexText("llms/en"));
+      const text = yield* getLlmsSectionIndexText("llms/en");
 
-    expect(text).toContain("# Nakafa English Content");
-    expect(text).not.toContain("## Starter Pages");
-  });
+      expect(text).toContain("# Nakafa English Content");
+      expect(text).not.toContain("## Starter Pages");
+    })
+  );
 
-  it("builds section page-map indexes without reading content pages", async () => {
-    mockGetContentPageLlmsEntries.mockClear();
+  it.effect(
+    "builds section page-map indexes without reading content pages",
+    () =>
+      Effect.gen(function* () {
+        mockGetContentPageLlmsEntries.mockClear();
 
-    const sectionIndex = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles")
-    );
+        const sectionIndex = yield* getLlmsSectionIndexText("llms/en/articles");
 
-    expect(sectionIndex).toContain("# Nakafa English Articles Pages");
-    expect(sectionIndex).toContain(
-      `${BASE_URL}/llms/en/articles/page/0/llms.txt`
-    );
-    expect(sectionIndex).toContain(
-      `${BASE_URL}/llms/en/articles/page/2/llms.txt`
-    );
-    expect(sectionIndex).toContain(
-      `${BASE_URL}/llms/en/articles/page/{page}/llms.txt`
-    );
-    expect(sectionIndex).not.toContain(
-      `${BASE_URL}/llms/en/articles/page/1/llms.txt`
-    );
-    expect(sectionIndex).toContain("250 English articles routes");
-    expect(mockGetContentPageLlmsEntries).not.toHaveBeenCalled();
-  });
-
-  it("builds article page maps from the signed catalog", async () => {
-    mockReadPublishedArticleBuckets.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-article",
-        articleCount: 42,
-        buckets: ["000", "abc"],
+        expect(sectionIndex).toContain("# Nakafa English Articles Pages");
+        expect(sectionIndex).toContain(
+          `${BASE_URL}/llms/en/articles/page/0/llms.txt`
+        );
+        expect(sectionIndex).toContain(
+          `${BASE_URL}/llms/en/articles/page/2/llms.txt`
+        );
+        expect(sectionIndex).toContain(
+          `${BASE_URL}/llms/en/articles/page/{page}/llms.txt`
+        );
+        expect(sectionIndex).not.toContain(
+          `${BASE_URL}/llms/en/articles/page/1/llms.txt`
+        );
+        expect(sectionIndex).toContain("250 English articles routes");
+        expect(mockGetContentPageLlmsEntries).not.toHaveBeenCalled();
       })
-    );
+  );
 
-    const text = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles")
-    );
+  it.effect("builds article page maps from the signed catalog", () =>
+    Effect.gen(function* () {
+      mockReadPublishedArticleBuckets.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-article",
+          articleCount: 42,
+          buckets: ["000", "abc"],
+        })
+      );
 
-    expect(text).toContain("42 English articles routes");
-    expect(text).toContain("2 bounded published partitions");
-    expect(text).toContain(`${BASE_URL}/llms/en/articles/page/1/llms.txt`);
-  });
+      const text = yield* getLlmsSectionIndexText("llms/en/articles");
 
-  it("keeps empty and single-page section maps constant", async () => {
-    const singlePageIndex = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/material")
-    );
+      expect(text).toContain("42 English articles routes");
+      expect(text).toContain("2 bounded published partitions");
+      expect(text).toContain(`${BASE_URL}/llms/en/articles/page/1/llms.txt`);
+    })
+  );
 
-    expect(singlePageIndex).toContain(
-      `${BASE_URL}/llms/en/material/page/0/llms.txt`
-    );
-    expect(singlePageIndex).not.toContain("last bounded route-catalog page");
+  it.effect("keeps empty and single-page section maps constant", () =>
+    Effect.gen(function* () {
+      const singlePageIndex =
+        yield* getLlmsSectionIndexText("llms/en/material");
 
-    mockReadPublishedArticleBuckets.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId: "release-article",
-        articleCount: 0,
-        buckets: [],
+      expect(singlePageIndex).toContain(
+        `${BASE_URL}/llms/en/material/page/0/llms.txt`
+      );
+      expect(singlePageIndex).not.toContain("last bounded route-catalog page");
+
+      mockReadPublishedArticleBuckets.mockReturnValueOnce(
+        Effect.succeed({
+          activeReleaseId: "release-article",
+          articleCount: 0,
+          buckets: [],
+        })
+      );
+
+      const emptyIndex = yield* getLlmsSectionIndexText("llms/en/articles");
+
+      expect(emptyIndex).toContain("0 English articles routes");
+      expect(emptyIndex).not.toContain("/page/0/llms.txt");
+    })
+  );
+
+  it.effect("builds one bounded content page index from the page reader", () =>
+    Effect.gen(function* () {
+      mockGetContentPageLlmsEntries.mockReturnValueOnce(
+        Effect.succeed([{ ...articleEntry, description: "" }])
+      );
+
+      const text = yield* getLlmsSectionIndexText(
+        "llms/en/articles/page/7/llms.txt"
+      );
+
+      expect(text).toContain("# Nakafa English Articles Page 7");
+      expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
+      expect(mockGetContentPageLlmsEntries).toHaveBeenCalledWith({
+        locale: "en",
+        page: 7,
+        section: "articles",
+      });
+    })
+  );
+
+  it.effect("builds one content listing index from route-catalog entries", () =>
+    Effect.gen(function* () {
+      mockGetContentListingLlmsEntries.mockReturnValueOnce(
+        Effect.succeed([articleEntry])
+      );
+
+      const text = yield* getLlmsSectionIndexText("llms/en/articles/politics");
+
+      expect(text).toContain("# Politics Articles");
+      expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
+      expect(mockGetContentListingLlmsEntries).toHaveBeenCalledWith({
+        locale: "en",
+        route: "articles/politics",
+      });
+    })
+  );
+
+  it.effect("renders explicit empty listing and page indexes", () =>
+    Effect.gen(function* () {
+      mockGetContentListingLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
+
+      const text = yield* getLlmsSectionIndexText("llms/en/articles/politics");
+
+      expect(text).toContain("# Politics Articles");
+      expect(text).toContain(
+        "This English articles listing currently has no markdown entries."
+      );
+      mockGetContentPageLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
+
+      const pageText = yield* getLlmsSectionIndexText(
+        "llms/en/articles/page/99/llms.txt"
+      );
+
+      expect(pageText).toContain("# Nakafa English Articles Page 99");
+      expect(pageText).toContain(
+        "This bounded articles content page is currently empty."
+      );
+    })
+  );
+
+  it.effect("returns null when a bounded page artifact is missing", () =>
+    Effect.gen(function* () {
+      mockGetContentPageLlmsEntries.mockReturnValueOnce(Effect.succeed(null));
+
+      const text = yield* getLlmsSectionIndexText(
+        "llms/en/articles/page/999/llms.txt"
+      );
+
+      expect(text).toBeNull();
+    })
+  );
+
+  it.effect("builds the site index from static site entries only", () =>
+    Effect.gen(function* () {
+      const text = yield* getLlmsSectionIndexText("llms/en/site");
+
+      expect(text).toContain("# Nakafa English Site Pages");
+      expect(text).toContain(`${BASE_URL}/en/search`);
+      expect(mockReadSiteLlmsEntries).toHaveBeenCalledWith("en");
+      expect(mockGetContentPageLlmsEntries).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "does not generate indexes for unknown or malformed llms paths",
+    () =>
+      Effect.gen(function* () {
+        const paths = [
+          "docs",
+          "llms/fr",
+          "llms/en/unknown",
+          "llms/en/articles/shard/999",
+          "llms/en/articles/page/not-a-number/llms.txt",
+          "llms/en/articles/page/7junk/llms.txt",
+          "llms/en/articles/page/07/llms.txt",
+        ];
+
+        for (const path of paths) {
+          expect(yield* getLlmsSectionIndexText(path)).toBeNull();
+        }
       })
-    );
+  );
 
-    const emptyIndex = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles")
-    );
+  it.effect(
+    "uses the Next cache boundary without changing section output",
+    () =>
+      Effect.gen(function* () {
+        const text = yield* Effect.tryPromise(() =>
+          getCachedLlmsSectionIndexText({ cleanSlug: "llms/en" })
+        );
 
-    expect(emptyIndex).toContain("0 English articles routes");
-    expect(emptyIndex).not.toContain("/page/0/llms.txt");
-  });
-
-  it("builds one bounded content page index from the page reader", async () => {
-    mockGetContentPageLlmsEntries.mockReturnValueOnce(
-      Effect.succeed([{ ...articleEntry, description: "" }])
-    );
-
-    const text = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles/page/7/llms.txt")
-    );
-
-    expect(text).toContain("# Nakafa English Articles Page 7");
-    expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
-    expect(mockGetContentPageLlmsEntries).toHaveBeenCalledWith({
-      locale: "en",
-      page: 7,
-      section: "articles",
-    });
-  });
-
-  it("builds one content listing index from route-catalog entries", async () => {
-    mockGetContentListingLlmsEntries.mockReturnValueOnce(
-      Effect.succeed([articleEntry])
-    );
-
-    const text = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles/politics")
-    );
-
-    expect(text).toContain("# Politics Articles");
-    expect(text).toContain(`- [${articleEntry.title}](${articleEntry.href})`);
-    expect(mockGetContentListingLlmsEntries).toHaveBeenCalledWith({
-      locale: "en",
-      route: "articles/politics",
-    });
-  });
-
-  it("renders explicit empty listing and page indexes", async () => {
-    mockGetContentListingLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
-
-    const text = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles/politics")
-    );
-
-    expect(text).toContain("# Politics Articles");
-    expect(text).toContain(
-      "This English articles listing currently has no markdown entries."
-    );
-    mockGetContentPageLlmsEntries.mockReturnValueOnce(Effect.succeed([]));
-
-    const pageText = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/articles/page/99/llms.txt")
-    );
-
-    expect(pageText).toContain("# Nakafa English Articles Page 99");
-    expect(pageText).toContain(
-      "This bounded articles content page is currently empty."
-    );
-  });
-
-  it("returns null when a bounded page artifact is missing", async () => {
-    mockGetContentPageLlmsEntries.mockReturnValueOnce(Effect.succeed(null));
-
-    await expect(
-      Effect.runPromise(
-        getLlmsSectionIndexText("llms/en/articles/page/999/llms.txt")
-      )
-    ).resolves.toBeNull();
-  });
-
-  it("builds the site index from static site entries only", async () => {
-    const text = await Effect.runPromise(
-      getLlmsSectionIndexText("llms/en/site")
-    );
-
-    expect(text).toContain("# Nakafa English Site Pages");
-    expect(text).toContain(`${BASE_URL}/en/search`);
-    expect(mockReadSiteLlmsEntries).toHaveBeenCalledWith("en");
-    expect(mockGetContentPageLlmsEntries).not.toHaveBeenCalled();
-  });
-
-  it("does not generate indexes for unknown or malformed llms paths", async () => {
-    const paths = [
-      "docs",
-      "llms/fr",
-      "llms/en/unknown",
-      "llms/en/articles/shard/999",
-      "llms/en/articles/page/not-a-number/llms.txt",
-      "llms/en/articles/page/7junk/llms.txt",
-      "llms/en/articles/page/07/llms.txt",
-    ];
-
-    for (const path of paths) {
-      await expect(
-        Effect.runPromise(getLlmsSectionIndexText(path))
-      ).resolves.toBeNull();
-    }
-  });
-
-  it("uses the Next cache boundary without changing section output", async () => {
-    await expect(
-      getCachedLlmsSectionIndexText({ cleanSlug: "llms/en" })
-    ).resolves.toContain("# Nakafa English Content");
-
-    expect(mockCacheTag).toHaveBeenCalledWith("content-runtime");
-    expect(mockCacheLife).toHaveBeenCalledWith("contentRuntime");
-  });
+        expect(text).toContain("# Nakafa English Content");
+        expect(mockCacheTag).toHaveBeenCalledWith("content-runtime");
+        expect(mockCacheLife).toHaveBeenCalledWith("contentRuntime");
+      })
+  );
 });

--- a/apps/www/lib/llms/published.test.ts
+++ b/apps/www/lib/llms/published.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   GitCommitShaSchema,
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
-import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Data, Effect } from "effect";
+import { vi } from "vitest";
 import { readPublishedPage } from "@/lib/content/page/published";
 import { readPublishedArticle } from "@/lib/content/published/article";
 import { readPublishedMaterial } from "@/lib/content/published/material";
@@ -29,44 +30,66 @@ const cacheTagMock = vi.hoisted(() => vi.fn());
 const readArticleMock = vi.hoisted(() => vi.fn());
 const readMaterialMock = vi.hoisted(() => vi.fn());
 const readPageMock = vi.hoisted(() => vi.fn());
-const liveRenderer = await Effect.runPromise(rendererManifest);
 const sourceRevision = GitCommitShaSchema.make("a".repeat(40));
+
+/** Test-only typed failure for the cached Promise boundary. */
+class TestPublishedTextError extends Data.TaggedError(
+  "TestPublishedTextError"
+)<{
+  readonly cause: unknown;
+}> {}
+
 const rawMdx = `## What is a Function?
 
 A function maps one input to exactly one output.
 
 <FunctionMachine />`;
-const materialData = {
-  activeReleaseId: ReleaseIdSchema.make("release-function-concept"),
-  artifact: {
-    ...previewWireArtifact,
-    payload: {
-      ...previewWireArtifact.payload,
-      rawMdx,
+
+const preparePublishedFixtures = Effect.fn(
+  "llms.test.preparePublishedFixtures"
+)(function* () {
+  const liveRenderer = yield* rendererManifest;
+  const materialData = {
+    activeReleaseId: ReleaseIdSchema.make("release-function-concept"),
+    artifact: {
+      ...previewWireArtifact,
+      payload: {
+        ...previewWireArtifact.payload,
+        rawMdx,
+      },
     },
-  },
-  metadata: previewMetadata,
-  projection: previewProjection,
-  rendererManifest: liveRenderer,
-  sourcePath: previewSourcePath,
-  sourceRevision,
-};
-const articleData = {
-  activeReleaseId: ReleaseIdSchema.make("release-article"),
-  artifact: testArticleArtifact,
-  projection: testArticleProjection,
-  rendererManifest: liveRenderer,
-  sourcePath: testArticleSourcePath,
-  sourceRevision,
-};
-const pageData = {
-  activeReleaseId: ReleaseIdSchema.make("release-pages"),
-  artifact: testPageArtifact,
-  projection: testPageProjection,
-  rendererManifest: liveRenderer,
-  sourcePath: testPageProjection.sourcePath,
-  sourceRevision,
-};
+    metadata: previewMetadata,
+    projection: previewProjection,
+    rendererManifest: liveRenderer,
+    sourcePath: previewSourcePath,
+    sourceRevision,
+  };
+  const articleData = {
+    activeReleaseId: ReleaseIdSchema.make("release-article"),
+    artifact: testArticleArtifact,
+    projection: testArticleProjection,
+    rendererManifest: liveRenderer,
+    sourcePath: testArticleSourcePath,
+    sourceRevision,
+  };
+  const pageData = {
+    activeReleaseId: ReleaseIdSchema.make("release-pages"),
+    artifact: testPageArtifact,
+    projection: testPageProjection,
+    rendererManifest: liveRenderer,
+    sourcePath: testPageProjection.sourcePath,
+    sourceRevision,
+  };
+
+  yield* Effect.sync(() => {
+    readArticleMock.mockReturnValue(Effect.succeed(articleData));
+    readMaterialMock.mockReturnValue(Effect.succeed(materialData));
+    readPageMock.mockReturnValue(Effect.succeed(pageData));
+  });
+
+  return { articleData, materialData, pageData } as const;
+});
+
 vi.mock("next/cache", () => ({
   cacheLife: cacheLifeMock,
   cacheTag: cacheTagMock,
@@ -83,122 +106,163 @@ vi.mock("@/lib/content/page/published", () => ({
 beforeEach(() => {
   cacheLifeMock.mockReset();
   cacheTagMock.mockReset();
-  readArticleMock.mockReset().mockReturnValue(Effect.succeed(articleData));
+  readArticleMock.mockReset();
   readMaterialMock.mockReset();
-  readMaterialMock.mockReturnValue(Effect.succeed(materialData));
-  readPageMock.mockReset().mockReturnValue(Effect.succeed(pageData));
+  readPageMock.mockReset();
 });
 
 describe("published llms markdown", () => {
-  it("projects verified source with immutable provenance and exact cache tags", async () => {
-    const text = await getCachedPublishedText({
-      activeReleaseId: materialData.activeReleaseId,
-      appLocale: previewProjection.appLocale,
-      family: "material",
-      publicPath: previewProjection.publicPath,
-    });
+  it.effect(
+    "projects verified source with immutable provenance and exact cache tags",
+    () =>
+      Effect.gen(function* () {
+        const { materialData } = yield* preparePublishedFixtures();
+        const text = yield* Effect.tryPromise(() =>
+          getCachedPublishedText({
+            activeReleaseId: materialData.activeReleaseId,
+            appLocale: previewProjection.appLocale,
+            family: "material",
+            publicPath: previewProjection.publicPath,
+          })
+        );
 
-    expect(text).toContain(previewMetadata.description);
-    expect(text).toContain("What is a Function?");
-    expect(text).toContain("Component: FunctionMachine");
-    expect(text).toContain(
-      `https://raw.githubusercontent.com/nakafaai/aksara/${sourceRevision}/${previewSourcePath}`
-    );
-    expect(readPublishedMaterial).toHaveBeenCalledWith({
-      activeReleaseId: materialData.activeReleaseId,
-      appLocale: previewProjection.appLocale,
-      family: "material",
-      publicPath: previewProjection.publicPath,
-    });
-    expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
-    expect(cacheTagMock).toHaveBeenCalledWith(
-      "content-runtime",
-      "content-family:material",
-      `content-artifact:${materialData.artifact.artifactHash}`
-    );
-  });
-
-  it("selects article metadata and provenance through the same cache seam", async () => {
-    const text = await getCachedPublishedText({
-      activeReleaseId: articleData.activeReleaseId,
-      appLocale: testArticleProjection.appLocale,
-      family: "article",
-      publicPath: testArticleProjection.publicPath,
-    });
-
-    expect(text).toContain(testArticleProjection.metadata.description);
-    expect(text).toContain(testArticleArtifact.payload.rawMdx);
-    expect(readPublishedArticle).toHaveBeenCalledWith({
-      activeReleaseId: articleData.activeReleaseId,
-      appLocale: testArticleProjection.appLocale,
-      family: "article",
-      publicPath: testArticleProjection.publicPath,
-    });
-    expect(cacheTagMock).toHaveBeenCalledWith(
-      "content-runtime",
-      "content-family:article",
-      `content-artifact:${testArticleArtifact.artifactHash}`
-    );
-  });
-
-  it("selects signed Page metadata and provenance without filesystem fallback", async () => {
-    const text = await getCachedPublishedText({
-      activeReleaseId: pageData.activeReleaseId,
-      appLocale: testPageProjection.appLocale,
-      family: "page",
-      publicPath: testPageProjection.publicPath,
-    });
-
-    expect(text).toContain(testPageProjection.metadata.description);
-    expect(text).toContain(testPageArtifact.payload.rawMdx);
-    expect(readPublishedPage).toHaveBeenCalledWith({
-      activeReleaseId: pageData.activeReleaseId,
-      appLocale: testPageProjection.appLocale,
-      family: "page",
-      publicPath: testPageProjection.publicPath,
-    });
-    expect(cacheTagMock).toHaveBeenCalledWith(
-      "content-runtime",
-      "content-family:page",
-      `content-artifact:${testPageArtifact.artifactHash}`
-    );
-  });
-
-  it("omits source links for rollback state without an exact Git revision", async () => {
-    readMaterialMock.mockReturnValueOnce(
-      Effect.succeed({ ...materialData, sourceRevision: null })
-    );
-    const text = await getCachedPublishedText({
-      activeReleaseId: materialData.activeReleaseId,
-      appLocale: previewProjection.appLocale,
-      family: "material",
-      publicPath: previewProjection.publicPath,
-    });
-
-    expect(text).not.toContain("Source:");
-  });
-
-  it("fails closed when semantic projection cannot parse signed source", async () => {
-    const incompleteMdx = `${rawMdx}\n{`;
-    readMaterialMock.mockReturnValueOnce(
-      Effect.succeed({
-        ...materialData,
-        artifact: {
-          ...materialData.artifact,
-          payload: {
-            ...materialData.artifact.payload,
-            rawMdx: incompleteMdx,
-          },
-        },
+        expect(text).toContain(previewMetadata.description);
+        expect(text).toContain("What is a Function?");
+        expect(text).toContain("Component: FunctionMachine");
+        expect(text).toContain(
+          `https://raw.githubusercontent.com/nakafaai/aksara/${sourceRevision}/${previewSourcePath}`
+        );
+        expect(readPublishedMaterial).toHaveBeenCalledWith({
+          activeReleaseId: materialData.activeReleaseId,
+          appLocale: previewProjection.appLocale,
+          family: "material",
+          publicPath: previewProjection.publicPath,
+        });
+        expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
+        expect(cacheTagMock).toHaveBeenCalledWith(
+          "content-runtime",
+          "content-family:material",
+          `content-artifact:${materialData.artifact.artifactHash}`
+        );
       })
-    );
-    await expect(
-      getCachedPublishedText({
-        activeReleaseId: materialData.activeReleaseId,
-        appLocale: previewProjection.appLocale,
-        family: "material",
-        publicPath: previewProjection.publicPath,
+  );
+
+  it.effect(
+    "selects article metadata and provenance through the same cache seam",
+    () =>
+      Effect.gen(function* () {
+        const { articleData } = yield* preparePublishedFixtures();
+        const text = yield* Effect.tryPromise(() =>
+          getCachedPublishedText({
+            activeReleaseId: articleData.activeReleaseId,
+            appLocale: testArticleProjection.appLocale,
+            family: "article",
+            publicPath: testArticleProjection.publicPath,
+          })
+        );
+
+        expect(text).toContain(testArticleProjection.metadata.description);
+        expect(text).toContain(testArticleArtifact.payload.rawMdx);
+        expect(readPublishedArticle).toHaveBeenCalledWith({
+          activeReleaseId: articleData.activeReleaseId,
+          appLocale: testArticleProjection.appLocale,
+          family: "article",
+          publicPath: testArticleProjection.publicPath,
+        });
+        expect(cacheTagMock).toHaveBeenCalledWith(
+          "content-runtime",
+          "content-family:article",
+          `content-artifact:${testArticleArtifact.artifactHash}`
+        );
       })
-    ).rejects.toThrow("Unexpected end of file in expression");
-  });
+  );
+
+  it.effect(
+    "selects signed Page metadata and provenance without filesystem fallback",
+    () =>
+      Effect.gen(function* () {
+        const { pageData } = yield* preparePublishedFixtures();
+        const text = yield* Effect.tryPromise(() =>
+          getCachedPublishedText({
+            activeReleaseId: pageData.activeReleaseId,
+            appLocale: testPageProjection.appLocale,
+            family: "page",
+            publicPath: testPageProjection.publicPath,
+          })
+        );
+
+        expect(text).toContain(testPageProjection.metadata.description);
+        expect(text).toContain(testPageArtifact.payload.rawMdx);
+        expect(readPublishedPage).toHaveBeenCalledWith({
+          activeReleaseId: pageData.activeReleaseId,
+          appLocale: testPageProjection.appLocale,
+          family: "page",
+          publicPath: testPageProjection.publicPath,
+        });
+        expect(cacheTagMock).toHaveBeenCalledWith(
+          "content-runtime",
+          "content-family:page",
+          `content-artifact:${testPageArtifact.artifactHash}`
+        );
+      })
+  );
+
+  it.effect(
+    "omits source links for rollback state without an exact Git revision",
+    () =>
+      Effect.gen(function* () {
+        const { materialData } = yield* preparePublishedFixtures();
+        readMaterialMock.mockReturnValueOnce(
+          Effect.succeed({ ...materialData, sourceRevision: null })
+        );
+        const text = yield* Effect.tryPromise(() =>
+          getCachedPublishedText({
+            activeReleaseId: materialData.activeReleaseId,
+            appLocale: previewProjection.appLocale,
+            family: "material",
+            publicPath: previewProjection.publicPath,
+          })
+        );
+
+        expect(text).not.toContain("Source:");
+      })
+  );
+
+  it.effect(
+    "fails closed when semantic projection cannot parse signed source",
+    () =>
+      Effect.gen(function* () {
+        const { materialData } = yield* preparePublishedFixtures();
+        const incompleteMdx = `${rawMdx}\n{`;
+        readMaterialMock.mockReturnValueOnce(
+          Effect.succeed({
+            ...materialData,
+            artifact: {
+              ...materialData.artifact,
+              payload: {
+                ...materialData.artifact.payload,
+                rawMdx: incompleteMdx,
+              },
+            },
+          })
+        );
+        const failure = yield* Effect.tryPromise({
+          catch: (cause) => new TestPublishedTextError({ cause }),
+          try: () =>
+            getCachedPublishedText({
+              activeReleaseId: materialData.activeReleaseId,
+              appLocale: previewProjection.appLocale,
+              family: "material",
+              publicPath: previewProjection.publicPath,
+            }),
+        }).pipe(Effect.flip);
+
+        expect(failure.cause).toBeInstanceOf(Error);
+        if (failure.cause instanceof Error) {
+          expect(failure.cause.message).toContain(
+            "Unexpected end of file in expression"
+          );
+        }
+      })
+  );
 });


### PR DESCRIPTION
## Scope

- migrate the WWW LLM index and published-markdown tests to direct `@effect/vitest`
- replace 14 direct Effect runtime boundaries with 17 native `it.effect` cases
- retain direct Vitest `vi` only for transform-time hoisted module mocks

## Effect v4 architecture

Effect values are yielded directly inside the official Effect v4 Vitest runtime. Cached Next.js Promise boundaries use `Effect.tryPromise`, and expected rejection has a concrete typed `Data.TaggedError` channel. This checkpoint adds no testing facade, compatibility wrapper, dependency, lockfile, production source, backend, Convex, Quran, or content-runtime change.

## Rebase

The two-commit patch rebased cleanly onto current main after PR #440. Stable patch IDs and `git range-diff` prove the patch is unchanged.

## Verification

- focused suite: 2 files and 17 tests passed
- full WWW suite: 210 files and 1,522 tests passed with 100% statement, branch, function, and line coverage
- full repository: 15 of 15 test tasks passed
- WWW typecheck, root lint, test ownership, boundaries, Effect RC110 source parity, formatting, and diff checks passed
- changed-scope Doctor: 100
- no testing facade import, `it.live`, direct Effect runner, raw async test, `.only`, or `.skip` remains in the two files

## Exact identity

Head: `5474717b8df2140d1631a1e9f8a127792b561867`

Base: `9491dc3ead2dd11d0cf775d9387e2bd124760db4`

## Rollout

This is test-only. It creates no Vercel Preview and changes no production behavior. Merge requires this exact head to remain current-base clean with required checks and review threads green.