### PR TITLE
test(www): use native Effect Vitest for sitemaps

### DIFF
--- a/apps/www/lib/sitemap/catalog.test.ts
+++ b/apps/www/lib/sitemap/catalog.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readSitemapPageDescriptors } from "@/lib/sitemap/catalog";
 
 class MissingSignedMaterialInventory extends Schema.TaggedError<MissingSignedMaterialInventory>()(
@@ -112,177 +113,198 @@ beforeEach(() => {
 });
 
 describe("sitemap page catalog", () => {
-  it("builds stable descriptors without loading route rows", async () => {
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors())
-    ).resolves.toEqual([
-      { id: "base" },
-      { id: "quran_en", kind: "quran", locale: "en" },
-      { id: "page_en", kind: "page", locale: "en" },
-      { id: "quran_id", kind: "quran", locale: "id" },
-      { id: "page_id", kind: "page", locale: "id" },
-      { id: "quran_de", kind: "quran", locale: "de" },
-      { id: "page_de", kind: "page", locale: "de" },
-    ]);
-  });
+  it.effect("builds stable descriptors without loading route rows", () =>
+    Effect.gen(function* () {
+      expect(yield* readSitemapPageDescriptors()).toEqual([
+        { id: "base" },
+        { id: "quran_en", kind: "quran", locale: "en" },
+        { id: "page_en", kind: "page", locale: "en" },
+        { id: "quran_id", kind: "quran", locale: "id" },
+        { id: "page_id", kind: "page", locale: "id" },
+        { id: "quran_de", kind: "quran", locale: "de" },
+        { id: "page_de", kind: "page", locale: "de" },
+      ]);
+    })
+  );
 
-  it("adds signed article partitions", async () => {
-    articleMocks.readPublishedArticleBuckets.mockImplementation(
-      (locale, expectedReleaseId) => {
-        expect(expectedReleaseId).toBe("release-material");
-        return Effect.succeed({
-          activeReleaseId: "release-material",
-          articleCount: locale === "en" ? 1 : 0,
-          buckets: locale === "en" ? ["abc"] : [],
+  it.effect("adds signed article partitions", () =>
+    Effect.gen(function* () {
+      articleMocks.readPublishedArticleBuckets.mockImplementation(
+        (locale, expectedReleaseId) => {
+          expect(expectedReleaseId).toBe("release-material");
+          return Effect.succeed({
+            activeReleaseId: "release-material",
+            articleCount: locale === "en" ? 1 : 0,
+            buckets: locale === "en" ? ["abc"] : [],
+          });
+        }
+      );
+
+      const descriptors = yield* readSitemapPageDescriptors();
+
+      expect(descriptors).toContainEqual({
+        bucket: "abc",
+        id: "article_en_abc",
+        kind: "article",
+        locale: "en",
+      });
+    })
+  );
+
+  it.effect(
+    "replaces material rows and adds curriculum partitions after cutover",
+    () =>
+      Effect.gen(function* () {
+        const activeReleaseId = "release-material";
+        activeMocks.readActiveContentIdentity.mockReturnValue(
+          Effect.succeed({ releaseId: activeReleaseId })
+        );
+        materialMocks.readPublishedMaterialBuckets.mockImplementation(
+          (locale, expectedReleaseId) => {
+            expect(expectedReleaseId).toBe(activeReleaseId);
+            return Effect.succeed({
+              activeReleaseId,
+              buckets: locale === "en" ? ["def"] : [],
+              materialCount: locale === "en" ? 2 : 0,
+            });
+          }
+        );
+        programMocks.readPublishedProgramBuckets.mockImplementation((locale) =>
+          Effect.succeed({
+            buckets: locale === "en" ? ["abc"] : [],
+            managed: locale === "en",
+            routeCount: locale === "en" ? 3 : 0,
+          })
+        );
+
+        const descriptors = yield* readSitemapPageDescriptors();
+
+        expect(descriptors).toContainEqual({
+          bucket: "def",
+          id: "material_en_def",
+          kind: "material",
+          locale: "en",
         });
-      }
-    );
-
-    const descriptors = await Effect.runPromise(readSitemapPageDescriptors());
-
-    expect(descriptors).toContainEqual({
-      bucket: "abc",
-      id: "article_en_abc",
-      kind: "article",
-      locale: "en",
-    });
-  });
-
-  it("replaces material rows and adds curriculum partitions after cutover", async () => {
-    const activeReleaseId = "release-material";
-    activeMocks.readActiveContentIdentity.mockReturnValue(
-      Effect.succeed({ releaseId: activeReleaseId })
-    );
-    materialMocks.readPublishedMaterialBuckets.mockImplementation(
-      (locale, expectedReleaseId) => {
-        expect(expectedReleaseId).toBe(activeReleaseId);
-        return Effect.succeed({
-          activeReleaseId,
-          buckets: locale === "en" ? ["def"] : [],
-          materialCount: locale === "en" ? 2 : 0,
+        expect(descriptors).toContainEqual({
+          bucket: "abc",
+          id: "program_en_abc",
+          kind: "program",
+          locale: "en",
         });
-      }
-    );
-    programMocks.readPublishedProgramBuckets.mockImplementation((locale) =>
-      Effect.succeed({
-        buckets: locale === "en" ? ["abc"] : [],
-        managed: locale === "en",
-        routeCount: locale === "en" ? 3 : 0,
       })
-    );
+  );
 
-    const descriptors = await Effect.runPromise(readSitemapPageDescriptors());
-
-    expect(descriptors).toContainEqual({
-      bucket: "def",
-      id: "material_en_def",
-      kind: "material",
-      locale: "en",
-    });
-    expect(descriptors).toContainEqual({
-      bucket: "abc",
-      id: "program_en_abc",
-      kind: "program",
-      locale: "en",
-    });
-  });
-
-  it("replaces legacy try-out rows with signed catalog pages", async () => {
-    tryoutMocks.readPublishedTryoutSitemapCount.mockImplementation((locale) =>
-      Effect.succeed({
-        pageCount: locale === "en" ? 1 : 0,
-        routeCount: locale === "en" ? 48 : 0,
-      })
-    );
-
-    const descriptors = await Effect.runPromise(readSitemapPageDescriptors());
-
-    expect(descriptors).toContainEqual({
-      id: "tryout_en_0",
-      kind: "tryout",
-      locale: "en",
-      page: 0,
-    });
-  });
-
-  it("propagates a missing signed material inventory", async () => {
-    materialMocks.readPublishedMaterialBuckets.mockReturnValue(
-      Effect.fail(
-        new MissingSignedMaterialInventory({
-          message: "Signed material inventory is unavailable.",
+  it.effect("replaces legacy try-out rows with signed catalog pages", () =>
+    Effect.gen(function* () {
+      tryoutMocks.readPublishedTryoutSitemapCount.mockImplementation((locale) =>
+        Effect.succeed({
+          pageCount: locale === "en" ? 1 : 0,
+          routeCount: locale === "en" ? 48 : 0,
         })
-      )
-    );
+      );
 
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors())
-    ).rejects.toThrow("Signed material inventory is unavailable.");
-  });
+      const descriptors = yield* readSitemapPageDescriptors();
 
-  it("rejects a missing active publication before reading families", async () => {
-    activeMocks.readActiveContentIdentity.mockReturnValue(Effect.succeed(null));
+      expect(descriptors).toContainEqual({
+        id: "tryout_en_0",
+        kind: "tryout",
+        locale: "en",
+        page: 0,
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors().pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      appLocale: "en",
-      publicPath: "sitemap.xml",
-    });
-    expect(quranMocks.readPublishedQuranCatalog).not.toHaveBeenCalled();
-  });
+  it.effect("propagates a missing signed material inventory", () =>
+    Effect.gen(function* () {
+      materialMocks.readPublishedMaterialBuckets.mockReturnValue(
+        Effect.fail(
+          new MissingSignedMaterialInventory({
+            message: "Signed material inventory is unavailable.",
+          })
+        )
+      );
 
-  it("rejects descriptors assembled across publication releases", async () => {
-    activeMocks.readActiveContentIdentity
-      .mockReturnValueOnce(Effect.succeed({ releaseId: "release-material" }))
-      .mockReturnValueOnce(Effect.succeed({ releaseId: "release-next" }));
-    materialMocks.readPublishedMaterialBuckets.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-material",
-        buckets: [],
-        materialCount: 0,
+      const failure = yield* readSitemapPageDescriptors().pipe(Effect.flip);
+
+      expect(failure).toBeInstanceOf(MissingSignedMaterialInventory);
+      expect(failure.message).toBe("Signed material inventory is unavailable.");
+    })
+  );
+
+  it.effect(
+    "rejects a missing active publication before reading families",
+    () =>
+      Effect.gen(function* () {
+        activeMocks.readActiveContentIdentity.mockReturnValue(
+          Effect.succeed(null)
+        );
+
+        expect(
+          yield* readSitemapPageDescriptors().pipe(Effect.flip)
+        ).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: "en",
+          publicPath: "sitemap.xml",
+        });
+        expect(quranMocks.readPublishedQuranCatalog).not.toHaveBeenCalled();
       })
-    );
+  );
 
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors().pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: "release-next",
-      expectedReleaseId: "release-material",
-    });
-  });
+  it.effect("rejects descriptors assembled across publication releases", () =>
+    Effect.gen(function* () {
+      activeMocks.readActiveContentIdentity
+        .mockReturnValueOnce(Effect.succeed({ releaseId: "release-material" }))
+        .mockReturnValueOnce(Effect.succeed({ releaseId: "release-next" }));
+      materialMocks.readPublishedMaterialBuckets.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-material",
+          buckets: [],
+          materialCount: 0,
+        })
+      );
 
-  it("rejects a Quran catalog from another active release", async () => {
-    quranMocks.readPublishedQuranCatalog.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-next",
-        surahs: [{ number: 1 }],
-      })
-    );
+      expect(
+        yield* readSitemapPageDescriptors().pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: "release-next",
+        expectedReleaseId: "release-material",
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors().pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: "release-next",
-      expectedReleaseId: "release-material",
-    });
-  });
+  it.effect("rejects a Quran catalog from another active release", () =>
+    Effect.gen(function* () {
+      quranMocks.readPublishedQuranCatalog.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-next",
+          surahs: [{ number: 1 }],
+        })
+      );
 
-  it("omits Quran pages when the signed catalog is empty", async () => {
-    pageMocks.readPublishedPageCatalog.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-material",
-        projections: [],
-      })
-    );
-    quranMocks.readPublishedQuranCatalog.mockReturnValue(
-      Effect.succeed({ activeReleaseId: "release-material", surahs: [] })
-    );
+      expect(
+        yield* readSitemapPageDescriptors().pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: "release-next",
+        expectedReleaseId: "release-material",
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readSitemapPageDescriptors())
-    ).resolves.toEqual([{ id: "base" }]);
-  });
+  it.effect("omits Quran pages when the signed catalog is empty", () =>
+    Effect.gen(function* () {
+      pageMocks.readPublishedPageCatalog.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-material",
+          projections: [],
+        })
+      );
+      quranMocks.readPublishedQuranCatalog.mockReturnValue(
+        Effect.succeed({ activeReleaseId: "release-material", surahs: [] })
+      );
+
+      expect(yield* readSitemapPageDescriptors()).toEqual([{ id: "base" }]);
+    })
+  );
 });

--- a/apps/www/lib/sitemap/entries.test.ts
+++ b/apps/www/lib/sitemap/entries.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { getPathname } from "@repo/internationalization/src/navigation";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { getSitemapEntries } from "@/lib/sitemap/entries";
 
 const mockReadSitemapRoutePage = vi.hoisted(() => vi.fn());
@@ -71,188 +72,200 @@ beforeEach(() => {
 });
 
 describe("sitemap entries", () => {
-  it("generates sitemap entries from route and locale inputs", async () => {
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "base" })
-    );
-    const urls = entries.map((entry) => entry.url);
+  it.effect("generates sitemap entries from route and locale inputs", () =>
+    Effect.gen(function* () {
+      const entries = yield* getSitemapEntries({ pageId: "base" });
+      const urls = entries.map((entry) => entry.url);
 
-    expect(new Set(urls).size).toBe(urls.length);
-    expect(urls).toContain("https://nakafa.com/en");
-    expect(urls).toContain("https://nakafa.com/id");
-    expect(urls).toContain("https://nakafa.com/de");
-    expect(urls).not.toContain("https://nakafa.com/en/about");
-    expect(urls).not.toContain("https://nakafa.com/id/about");
-    expect(urls).toContain(
-      "https://nakafa.com/en/subjects/chemistry/green-chemistry/definition"
-    );
-    expect(entries).toContainEqual({
-      lastModified: "2024-01-02",
-      url: "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values",
-    });
-    expect(entries).toContainEqual({
-      url: "https://nakafa.com/en/subjects/chemistry/green-chemistry/definition",
-    });
-    expect(
-      entries.every(
-        (entry) =>
-          entry.changeFrequency === undefined &&
-          entry.priority === undefined &&
-          entry.alternates === undefined
-      )
-    ).toBe(true);
-  });
+      expect(new Set(urls).size).toBe(urls.length);
+      expect(urls).toContain("https://nakafa.com/en");
+      expect(urls).toContain("https://nakafa.com/id");
+      expect(urls).toContain("https://nakafa.com/de");
+      expect(urls).not.toContain("https://nakafa.com/en/about");
+      expect(urls).not.toContain("https://nakafa.com/id/about");
+      expect(urls).toContain(
+        "https://nakafa.com/en/subjects/chemistry/green-chemistry/definition"
+      );
+      expect(entries).toContainEqual({
+        lastModified: "2024-01-02",
+        url: "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values",
+      });
+      expect(entries).toContainEqual({
+        url: "https://nakafa.com/en/subjects/chemistry/green-chemistry/definition",
+      });
+      expect(
+        entries.every(
+          (entry) =>
+            entry.changeFrequency === undefined &&
+            entry.priority === undefined &&
+            entry.alternates === undefined
+        )
+      ).toBe(true);
+    })
+  );
 
-  it("keeps English content sitemap pages scoped to English URLs", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({
-      id: "content_en_articles_0",
-      kind: "content",
-      locale: "en",
-      page: 0,
-      section: "articles",
-    });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({
-        routes: [
-          {
-            lastModified: "2024-01-02",
-            path: "/articles/politics/dynastic-politics-asian-values",
-          },
-        ],
+  it.effect("keeps English content sitemap pages scoped to English URLs", () =>
+    Effect.gen(function* () {
+      mockGetSitemapPageDescriptor.mockReturnValueOnce({
+        id: "content_en_articles_0",
+        kind: "content",
+        locale: "en",
+        page: 0,
+        section: "articles",
+      });
+      mockReadSitemapRoutePage.mockReturnValueOnce(
+        Effect.succeed({
+          routes: [
+            {
+              lastModified: "2024-01-02",
+              path: "/articles/politics/dynastic-politics-asian-values",
+            },
+          ],
+        })
+      );
+
+      const entries = yield* getSitemapEntries({
+        pageId: "content_en_articles_0",
+      });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.url).toBe(
+        "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values"
+      );
+      expect(entries[0]).toEqual({
+        lastModified: "2024-01-02",
+        url: "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values",
+      });
+    })
+  );
+
+  it.effect(
+    "keeps Indonesian content sitemap pages scoped to Indonesian URLs",
+    () =>
+      Effect.gen(function* () {
+        mockGetSitemapPageDescriptor.mockReturnValueOnce({
+          id: "content_id_articles_0",
+          kind: "content",
+          locale: "id",
+          page: 0,
+          section: "articles",
+        });
+        mockReadSitemapRoutePage.mockReturnValueOnce(
+          Effect.succeed({
+            routes: [
+              {
+                lastModified: "2024-01-02",
+                path: "/articles/politics/nepotism-in-political-governance",
+              },
+            ],
+          })
+        );
+
+        const entries = yield* getSitemapEntries({
+          pageId: "content_id_articles_0",
+        });
+
+        expect(entries).toHaveLength(1);
+        expect(entries[0]?.url).toBe(
+          "https://nakafa.com/id/articles/politics/nepotism-in-political-governance"
+        );
+        expect(entries[0]).toEqual({
+          lastModified: "2024-01-02",
+          url: "https://nakafa.com/id/articles/politics/nepotism-in-political-governance",
+        });
       })
-    );
+  );
 
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "content_en_articles_0" })
-    );
+  it.effect("keeps base sitemap pages localized across supported locales", () =>
+    Effect.gen(function* () {
+      mockGetSitemapPageDescriptor.mockReturnValueOnce({ id: "base" });
+      mockReadSitemapRoutePage.mockReturnValueOnce(
+        Effect.succeed({ routes: [{ path: "/search" }] })
+      );
 
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.url).toBe(
-      "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values"
-    );
-    expect(entries[0]).toEqual({
-      lastModified: "2024-01-02",
-      url: "https://nakafa.com/en/articles/politics/dynastic-politics-asian-values",
-    });
-  });
+      const entries = yield* getSitemapEntries({ pageId: "base" });
 
-  it("keeps Indonesian content sitemap pages scoped to Indonesian URLs", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({
-      id: "content_id_articles_0",
-      kind: "content",
-      locale: "id",
-      page: 0,
-      section: "articles",
-    });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({
-        routes: [
-          {
-            lastModified: "2024-01-02",
-            path: "/articles/politics/nepotism-in-political-governance",
-          },
-        ],
+      expect(entries.map((entry) => entry.url)).toEqual([
+        "https://nakafa.com/en/search",
+        "https://nakafa.com/id/search",
+        "https://nakafa.com/de/search",
+      ]);
+      expect(entries.every((entry) => entry.alternates === undefined)).toBe(
+        true
+      );
+    })
+  );
+
+  it.effect(
+    "localizes the curriculum index route in base sitemap entries",
+    () =>
+      Effect.gen(function* () {
+        mockGetSitemapPageDescriptor.mockReturnValueOnce({ id: "base" });
+        mockReadSitemapRoutePage.mockReturnValueOnce(
+          Effect.succeed({ routes: [{ path: "/curricula" }] })
+        );
+
+        const entries = yield* getSitemapEntries({ pageId: "base" });
+
+        expect(entries.map((entry) => entry.url)).toEqual([
+          "https://nakafa.com/en/curriculum",
+          "https://nakafa.com/id/kurikulum",
+          "https://nakafa.com/de/lehrplaene",
+        ]);
       })
-    );
+  );
 
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "content_id_articles_0" })
-    );
+  it.effect(
+    "publishes signed Page paths with only their source-owned date",
+    () =>
+      Effect.gen(function* () {
+        mockGetSitemapPageDescriptor.mockReturnValueOnce({
+          id: "page_de",
+          kind: "page",
+          locale: "de",
+        });
+        mockReadSitemapRoutePage.mockReturnValueOnce(
+          Effect.succeed({
+            routes: [
+              {
+                lastModified: "2026-08-21",
+                path: "/impressum",
+              },
+            ],
+          })
+        );
 
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.url).toBe(
-      "https://nakafa.com/id/articles/politics/nepotism-in-political-governance"
-    );
-    expect(entries[0]).toEqual({
-      lastModified: "2024-01-02",
-      url: "https://nakafa.com/id/articles/politics/nepotism-in-political-governance",
-    });
-  });
+        const entries = yield* getSitemapEntries({ pageId: "page_de" });
 
-  it("keeps base sitemap pages localized across supported locales", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({ id: "base" });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({ routes: [{ path: "/search" }] })
-    );
-
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "base" })
-    );
-
-    expect(entries.map((entry) => entry.url)).toEqual([
-      "https://nakafa.com/en/search",
-      "https://nakafa.com/id/search",
-      "https://nakafa.com/de/search",
-    ]);
-    expect(entries.every((entry) => entry.alternates === undefined)).toBe(true);
-  });
-
-  it("localizes the curriculum index route in base sitemap entries", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({ id: "base" });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({ routes: [{ path: "/curricula" }] })
-    );
-
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "base" })
-    );
-
-    expect(entries.map((entry) => entry.url)).toEqual([
-      "https://nakafa.com/en/curriculum",
-      "https://nakafa.com/id/kurikulum",
-      "https://nakafa.com/de/lehrplaene",
-    ]);
-  });
-
-  it("publishes signed Page paths with only their source-owned date", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({
-      id: "page_de",
-      kind: "page",
-      locale: "de",
-    });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({
-        routes: [
-          {
+        expect(entries).toEqual([
+          expect.objectContaining({
             lastModified: "2026-08-21",
-            path: "/impressum",
-          },
-        ],
+            url: "https://nakafa.com/de/impressum",
+          }),
+        ]);
       })
-    );
+  );
 
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "page_de" })
-    );
+  it.effect("does not invent dates for undated routes", () =>
+    Effect.gen(function* () {
+      mockGetSitemapPageDescriptor.mockReturnValueOnce({
+        id: "page_de",
+        kind: "page",
+        locale: "de",
+      });
+      mockReadSitemapRoutePage.mockReturnValueOnce(
+        Effect.succeed({
+          routes: [
+            {
+              path: "/impressum",
+            },
+          ],
+        })
+      );
 
-    expect(entries).toEqual([
-      expect.objectContaining({
-        lastModified: "2026-08-21",
-        url: "https://nakafa.com/de/impressum",
-      }),
-    ]);
-  });
+      const entries = yield* getSitemapEntries({ pageId: "page_de" });
 
-  it("does not invent dates for undated routes", async () => {
-    mockGetSitemapPageDescriptor.mockReturnValueOnce({
-      id: "page_de",
-      kind: "page",
-      locale: "de",
-    });
-    mockReadSitemapRoutePage.mockReturnValueOnce(
-      Effect.succeed({
-        routes: [
-          {
-            path: "/impressum",
-          },
-        ],
-      })
-    );
-
-    const entries = await Effect.runPromise(
-      getSitemapEntries({ pageId: "page_de" })
-    );
-
-    expect(entries).toEqual([{ url: "https://nakafa.com/de/impressum" }]);
-  });
+      expect(entries).toEqual([{ url: "https://nakafa.com/de/impressum" }]);
+    })
+  );
 });


### PR DESCRIPTION
## Scope

- migrate the WWW sitemap catalog and entry tests to direct `@effect/vitest`
- replace 16 direct Effect runtime boundaries with 16 native `it.effect` cases
- keep direct Vitest `vi` only for transform-time hoisted module mocks

## Effect v4 architecture

The tests yield the production sitemap Effects directly to the official Effect v4 Vitest runtime. Successes and typed failures remain in the Effect graph, with no Promise bridge or manual runtime boundary. This checkpoint adds no testing facade, compatibility wrapper, dependency, lockfile, production source, backend, Convex, Quran, or content-runtime change.

## Rebase

The two-commit patch rebased cleanly onto current main after PR #443. Stable patch IDs and `git range-diff` prove the patch is unchanged.

## Verification

- focused suite: 2 files and 16 tests passed
- full WWW suite: 210 files and 1,522 tests passed with 100% statement, branch, function, and line coverage
- full repository: 15 of 15 test tasks passed
- WWW typecheck, root lint, test ownership, boundaries, Effect RC110 source parity, formatting, and diff checks passed
- changed-scope Doctor: 100
- no testing facade import, `it.live`, direct Effect runner, raw async test, `.only`, or `.skip` remains in the two files

## Exact identity

Head: `a245bbecbc2be87d69ad311dd53322a3dbaa85f8`

Base: `5ace100a1853bf0e780f9b4a2215d722b39940fb`

## Rollout

This is test-only. It creates no Vercel Preview and changes no production behavior. Merge requires this exact head to remain current-base clean with required checks and review threads green.