### PR TITLE
test(www): run program decoding with Effect Vitest

### DIFF
--- a/apps/www/lib/content/program/decode.test.ts
+++ b/apps/www/lib/content/program/decode.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 import {
   decodeCurriculumJson,
   decodeProgramJson,
@@ -14,43 +14,47 @@ import {
 } from "@/test/content-program";
 
 describe("published program decoding", () => {
-  it("decodes exact program and curriculum rows", async () => {
-    const [program, route] = await Effect.runPromise(
-      Effect.all([
+  it.effect("decodes exact program and curriculum rows", () =>
+    Effect.gen(function* () {
+      const [program, route] = yield* Effect.all([
         decodeProgramJson(testProgramRowJson(), "en", "curricula"),
         decodeCurriculumJson(
           testCurriculumRowJson(testProgramRoot),
           "en",
           testProgramRoot.publicPath
         ),
-      ])
-    );
+      ]);
 
-    expect(program).toEqual(testPublishedProgram);
-    expect(route).toEqual(testProgramRoot);
-  });
+      expect(program).toEqual(testPublishedProgram);
+      expect(route).toEqual(testProgramRoot);
+    })
+  );
 
-  it.each([
+  it.effect.each([
     ["invalid JSON", "{"],
     ["invalid snapshot", "{}"],
     ["wrong record kind", testProgramRowJson()],
-  ])("rejects %s curriculum rows", async (_name, source) => {
-    await expect(
-      Effect.runPromise(
-        decodeCurriculumJson(source, "en", "curricula").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+  ] as const)("rejects %s curriculum rows", ([_name, source]) =>
+    Effect.gen(function* () {
+      const failure = yield* decodeCurriculumJson(
+        source,
+        "en",
+        "curricula"
+      ).pipe(Effect.flip);
 
-  it("rejects a curriculum row where a program was expected", async () => {
-    await expect(
-      Effect.runPromise(
-        decodeProgramJson(
-          testCurriculumRowJson(testProgramRoot),
-          "en",
-          "curricula"
-        ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
+
+  it.effect("rejects a curriculum row where a program was expected", () =>
+    Effect.gen(function* () {
+      const failure = yield* decodeProgramJson(
+        testCurriculumRowJson(testProgramRoot),
+        "en",
+        "curricula"
+      ).pipe(Effect.flip);
+
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- replace raw Vitest plus `Effect.runPromise` in the published-program decoder tests with the official Effect v4 Vitest integration
- run all five effectful cases through `it.effect` or `it.effect.each`
- keep the test directly coupled to `@effect/vitest`, with no repository wrapper or Promise bridge

## Effect v4 basis

This follows the vendored RC110 `@effect/vitest` implementation and its tuple-aware `it.effect.each` contract. The test callback returns an Effect directly, while assertions remain inside the Effect program.

## Validation

- focused decoder test: 5 passed
- WWW typecheck: passed
- repository test suite: passed, including 210 WWW files and 1,522 WWW tests at 100% coverage
- lint: passed
- boundaries: passed
- format: clean
- React Doctor: 100

This is test-only. Production deployment should be skipped by scope classification.