### PR TITLE
test(www): run program routes with Effect Vitest

### DIFF
--- a/apps/www/lib/content/program/cards.test.ts
+++ b/apps/www/lib/content/program/cards.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { CurriculumRouteSchema } from "@nakafa/aksara-contracts/program/curriculum";
 import {
   MaterialKeySchema,
   MaterialLessonProjectionSchema,
 } from "@nakafa/aksara-contracts/projection/material";
 import { Effect, Schema } from "effect";
-import { describe, expect, it } from "vitest";
 import { readPublishedMaterialCards } from "@/lib/content/program/cards";
 import {
   previewNextProjection,
@@ -21,275 +21,275 @@ import {
 } from "@/test/content-program";
 
 describe("published program material cards", () => {
-  it("builds contextual cards from real curriculum and lesson projections", async () => {
-    const group = testProgramGroups[0];
-    expect(group).toBeDefined();
-    if (!group) {
-      return;
-    }
-    const cards = await Effect.runPromise(
-      readPublishedMaterialCards({
-        contexts: [
-          testProgramRoot,
+  it.effect(
+    "builds contextual cards from real curriculum and lesson projections",
+    () =>
+      Effect.gen(function* () {
+        const group = testProgramGroups[0];
+        expect(group).toBeDefined();
+        if (!group) {
+          return;
+        }
+        const cards = yield* readPublishedMaterialCards({
+          contexts: [
+            testProgramRoot,
+            {
+              ...testProgramClass,
+              materialContextPublicPath: group.publicPath,
+            },
+            ...testProgramContexts,
+          ],
+          groups: testProgramGroups,
+          locale: "en",
+          materials: [previewProjection],
+          route: testProgramSubject,
+        });
+
+        expect(cards).toEqual([
           {
-            ...testProgramClass,
-            materialContextPublicPath: group.publicPath,
+            description: "Operate on functions and domains.",
+            href: expect.stringContaining(
+              "/en/subjects/mathematics/function-composition-inverse-function/function-concept?ctx=merdeka~"
+            ),
+            items: [
+              {
+                href: expect.stringContaining("?ctx=merdeka~"),
+                title: "Function Concept",
+              },
+            ],
+            title: "Function Composition and Inverses",
           },
-          ...testProgramContexts,
+        ]);
+      })
+  );
+
+  it.effect("returns no cards for a route that does not own a card list", () =>
+    Effect.gen(function* () {
+      const cards = yield* readPublishedMaterialCards({
+        contexts: testProgramContexts,
+        groups: testProgramGroups,
+        locale: "en",
+        materials: [previewProjection],
+        route: testProgramClass,
+      });
+      expect(cards).toEqual([]);
+    })
+  );
+
+  it.effect("rejects a group without source-owned description copy", () =>
+    Effect.gen(function* () {
+      const group = testProgramGroups[0];
+      expect(group).toBeDefined();
+      if (!group) {
+        return;
+      }
+
+      const failure = yield* readPublishedMaterialCards({
+        contexts: testProgramContexts,
+        groups: [
+          {
+            ...group,
+            materialCardDescription: undefined,
+            materialCardTitle: undefined,
+          },
         ],
+        locale: "en",
+        materials: [previewProjection],
+        route: testProgramSubject,
+      }).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
+
+  it.effect("rejects a group without a connected published lesson", () =>
+    Effect.gen(function* () {
+      const failure = yield* readPublishedMaterialCards({
+        contexts: [],
         groups: testProgramGroups,
         locale: "en",
         materials: [previewProjection],
         route: testProgramSubject,
-      })
-    );
+      }).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-    expect(cards).toEqual([
-      {
-        description: "Operate on functions and domains.",
-        href: expect.stringContaining(
-          "/en/subjects/mathematics/function-composition-inverse-function/function-concept?ctx=merdeka~"
-        ),
-        items: [
-          {
-            href: expect.stringContaining("?ctx=merdeka~"),
-            title: "Function Concept",
-          },
-        ],
-        title: "Function Composition and Inverses",
-      },
-    ]);
-  });
+  it.effect(
+    "selects one exact lesson when the context owns its public path",
+    () =>
+      Effect.gen(function* () {
+        const context = testProgramContexts[0];
+        const group = testProgramGroups[0];
+        expect(context).toBeDefined();
+        expect(group).toBeDefined();
+        if (!(context && group)) {
+          return;
+        }
+        const exactContext = yield* Schema.decodeEffect(CurriculumRouteSchema)({
+          ...context,
+          canonicalPath: previewProjection.publicPath,
+        });
 
-  it("returns no cards for a route that does not own a card list", async () => {
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: testProgramContexts,
-          groups: testProgramGroups,
-          locale: "en",
-          materials: [previewProjection],
-          route: testProgramClass,
-        })
-      )
-    ).resolves.toEqual([]);
-  });
-
-  it("rejects a group without source-owned description copy", async () => {
-    const group = testProgramGroups[0];
-    expect(group).toBeDefined();
-    if (!group) {
-      return;
-    }
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: testProgramContexts,
-          groups: [
-            {
-              ...group,
-              materialCardDescription: undefined,
-              materialCardTitle: undefined,
-            },
-          ],
-          locale: "en",
-          materials: [previewProjection],
-          route: testProgramSubject,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
-
-  it("rejects a group without a connected published lesson", async () => {
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: [],
-          groups: testProgramGroups,
-          locale: "en",
-          materials: [previewProjection],
-          route: testProgramSubject,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
-
-  it("selects one exact lesson when the context owns its public path", async () => {
-    const context = testProgramContexts[0];
-    const group = testProgramGroups[0];
-    expect(context).toBeDefined();
-    expect(group).toBeDefined();
-    if (!(context && group)) {
-      return;
-    }
-    const exactContext = Schema.decodeSync(CurriculumRouteSchema)({
-      ...context,
-      canonicalPath: previewProjection.publicPath,
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
+        const cards = yield* readPublishedMaterialCards({
           contexts: [exactContext],
           groups: [group],
           locale: "en",
           materials: [previewProjection],
           route: testProgramSubject,
-        })
-      )
-    ).resolves.toMatchObject([
-      {
-        items: [{ title: previewProjection.metadata.title }],
-      },
-    ]);
-  });
-
-  it("rejects a material context without a canonical path", async () => {
-    const context = testProgramContexts[0];
-    expect(context).toBeDefined();
-    if (!context) {
-      return;
-    }
-    const malformedContext = {
-      ...context,
-      canonicalPath: undefined,
-    };
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: [malformedContext],
-          groups: testProgramGroups,
-          locale: "en",
-          materials: [previewProjection],
-          route: testProgramSubject,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
-
-  it("omits a context whose material was tombstoned", async () => {
-    const context = testProgramContexts[0];
-    expect(context).toBeDefined();
-    if (!context) {
-      return;
-    }
-    const missingContext = Schema.decodeSync(CurriculumRouteSchema)({
-      ...context,
-      materialKey: MaterialKeySchema.make("lesson.mathematics.missing-topic"),
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: [missingContext],
-          groups: testProgramGroups,
-          locale: "en",
-          materials: [previewProjection],
-          route: testProgramSubject,
-        })
-      )
-    ).resolves.toEqual([]);
-  });
-
-  it("maps a stable material key to its one renamed parent", async () => {
-    const context = testProgramContexts[0];
-    const group = testProgramGroups[0];
-    expect(context).toBeDefined();
-    expect(group).toBeDefined();
-    if (!(context && group)) {
-      return;
-    }
-    const renamed = Schema.decodeSync(MaterialLessonProjectionSchema)({
-      ...previewProjection,
-      parentPath: "subjects/mathematics/renamed-functions",
-      publicPath:
-        "subjects/mathematics/renamed-functions/function-concept-renamed",
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: [context],
-          groups: [group],
-          locale: "en",
-          materials: [renamed],
-          route: testProgramSubject,
-        })
-      )
-    ).resolves.toMatchObject([
-      {
-        items: [
+        });
+        expect(cards).toMatchObject([
           {
-            href: expect.stringContaining(renamed.publicPath),
-            title: renamed.metadata.title,
+            items: [{ title: previewProjection.metadata.title }],
           },
-        ],
-      },
-    ]);
-  });
-
-  it("keeps source siblings when one exact lesson moves", async () => {
-    const context = testProgramContexts[0];
-    const group = testProgramGroups[0];
-    expect(context).toBeDefined();
-    expect(group).toBeDefined();
-    if (!(context && group)) {
-      return;
-    }
-    const moved = Schema.decodeSync(MaterialLessonProjectionSchema)({
-      ...previewProjection,
-      parentPath: "subjects/mathematics/moved-functions",
-      publicPath: "subjects/mathematics/moved-functions/function-concept-moved",
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
-          contexts: [context],
-          groups: [group],
-          locale: "en",
-          materials: [moved, previewNextProjection],
-          route: testProgramSubject,
-        })
-      )
-    ).resolves.toMatchObject([
-      {
-        items: [
-          { title: moved.metadata.title },
-          { title: previewNextProjection.metadata.title },
-        ],
-      },
-    ]);
-  });
-
-  it("rejects a renamed material key with ambiguous current parents", async () => {
-    const context = testProgramContexts[0];
-    const group = testProgramGroups[0];
-    expect(context).toBeDefined();
-    expect(group).toBeDefined();
-    if (!(context && group)) {
-      return;
-    }
-    const materials = ["first", "second"].map((suffix) =>
-      Schema.decodeSync(MaterialLessonProjectionSchema)({
-        ...previewProjection,
-        parentPath: `subjects/mathematics/${suffix}-functions`,
-        publicPath: `subjects/mathematics/${suffix}-functions/function-concept`,
+        ]);
       })
-    );
+  );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialCards({
+  it.effect("rejects a material context without a canonical path", () =>
+    Effect.gen(function* () {
+      const context = testProgramContexts[0];
+      expect(context).toBeDefined();
+      if (!context) {
+        return;
+      }
+      const malformedContext = {
+        ...context,
+        canonicalPath: undefined,
+      };
+
+      const failure = yield* readPublishedMaterialCards({
+        contexts: [malformedContext],
+        groups: testProgramGroups,
+        locale: "en",
+        materials: [previewProjection],
+        route: testProgramSubject,
+      }).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
+
+  it.effect("omits a context whose material was tombstoned", () =>
+    Effect.gen(function* () {
+      const context = testProgramContexts[0];
+      expect(context).toBeDefined();
+      if (!context) {
+        return;
+      }
+      const missingContext = yield* Schema.decodeEffect(CurriculumRouteSchema)({
+        ...context,
+        materialKey: MaterialKeySchema.make("lesson.mathematics.missing-topic"),
+      });
+
+      const cards = yield* readPublishedMaterialCards({
+        contexts: [missingContext],
+        groups: testProgramGroups,
+        locale: "en",
+        materials: [previewProjection],
+        route: testProgramSubject,
+      });
+      expect(cards).toEqual([]);
+    })
+  );
+
+  it.effect("maps a stable material key to its one renamed parent", () =>
+    Effect.gen(function* () {
+      const context = testProgramContexts[0];
+      const group = testProgramGroups[0];
+      expect(context).toBeDefined();
+      expect(group).toBeDefined();
+      if (!(context && group)) {
+        return;
+      }
+      const renamed = yield* Schema.decodeEffect(
+        MaterialLessonProjectionSchema
+      )({
+        ...previewProjection,
+        parentPath: "subjects/mathematics/renamed-functions",
+        publicPath:
+          "subjects/mathematics/renamed-functions/function-concept-renamed",
+      });
+
+      const cards = yield* readPublishedMaterialCards({
+        contexts: [context],
+        groups: [group],
+        locale: "en",
+        materials: [renamed],
+        route: testProgramSubject,
+      });
+      expect(cards).toMatchObject([
+        {
+          items: [
+            {
+              href: expect.stringContaining(renamed.publicPath),
+              title: renamed.metadata.title,
+            },
+          ],
+        },
+      ]);
+    })
+  );
+
+  it.effect("keeps source siblings when one exact lesson moves", () =>
+    Effect.gen(function* () {
+      const context = testProgramContexts[0];
+      const group = testProgramGroups[0];
+      expect(context).toBeDefined();
+      expect(group).toBeDefined();
+      if (!(context && group)) {
+        return;
+      }
+      const moved = yield* Schema.decodeEffect(MaterialLessonProjectionSchema)({
+        ...previewProjection,
+        parentPath: "subjects/mathematics/moved-functions",
+        publicPath:
+          "subjects/mathematics/moved-functions/function-concept-moved",
+      });
+
+      const cards = yield* readPublishedMaterialCards({
+        contexts: [context],
+        groups: [group],
+        locale: "en",
+        materials: [moved, previewNextProjection],
+        route: testProgramSubject,
+      });
+      expect(cards).toMatchObject([
+        {
+          items: [
+            { title: moved.metadata.title },
+            { title: previewNextProjection.metadata.title },
+          ],
+        },
+      ]);
+    })
+  );
+
+  it.effect(
+    "rejects a renamed material key with ambiguous current parents",
+    () =>
+      Effect.gen(function* () {
+        const context = testProgramContexts[0];
+        const group = testProgramGroups[0];
+        expect(context).toBeDefined();
+        expect(group).toBeDefined();
+        if (!(context && group)) {
+          return;
+        }
+        const materials = yield* Effect.forEach(["first", "second"], (suffix) =>
+          Schema.decodeEffect(MaterialLessonProjectionSchema)({
+            ...previewProjection,
+            parentPath: `subjects/mathematics/${suffix}-functions`,
+            publicPath: `subjects/mathematics/${suffix}-functions/function-concept`,
+          })
+        );
+
+        const failure = yield* readPublishedMaterialCards({
           contexts: [context],
           groups: [group],
           locale: "en",
           materials,
           route: testProgramSubject,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+        }).pipe(Effect.flip);
+        expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+      })
+  );
 });

--- a/apps/www/lib/content/program/route.test.ts
+++ b/apps/www/lib/content/program/route.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedProgramRoute,
   readPublishedProgramRoute,
@@ -87,77 +88,76 @@ describe("published program route", () => {
     );
   });
 
-  it("decodes one complete real curriculum route model", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(routeResponse());
+  it.effect("decodes one complete real curriculum route model", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(routeResponse());
 
-    const model = await getPublishedProgramRoute(
-      "en",
-      testProgramSubject.publicPath
-    );
+      const model = yield* Effect.tryPromise(() =>
+        getPublishedProgramRoute("en", testProgramSubject.publicPath)
+      );
 
-    expect(model).toMatchObject({
-      activeReleaseId: "program-release",
-      alternates: [
-        { appLocale: "en" },
-        { appLocale: "id" },
-        { appLocale: "de" },
-      ],
-      ancestors: [{ level: "track" }, { level: "class" }],
-      contexts: expect.any(Array),
-      groups: expect.any(Array),
-      materials: [{ metadata: { title: "Function Concept" } }],
-      program: { key: "merdeka" },
-      route: { publicPath: testProgramSubject.publicPath },
-      sourceRevision: revision,
-    });
-    expect(cacheMock).toHaveBeenCalledOnce();
-  });
+      expect(model).toMatchObject({
+        activeReleaseId: "program-release",
+        alternates: [
+          { appLocale: "en" },
+          { appLocale: "id" },
+          { appLocale: "de" },
+        ],
+        ancestors: [{ level: "track" }, { level: "class" }],
+        contexts: expect.any(Array),
+        groups: expect.any(Array),
+        materials: [{ metadata: { title: "Function Concept" } }],
+        program: { key: "merdeka" },
+        route: { publicPath: testProgramSubject.publicPath },
+        sourceRevision: revision,
+      });
+      expect(cacheMock).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("fails when a requested signed route fixture does not exist", () => {
-    expect(() => readTestPublishedRoute("curriculum/missing")).toThrow(
-      "Missing published route fixture: en/curriculum/missing"
-    );
-  });
+  it.effect("rejects an unmanaged family", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(
+        routeResponse({
+          managed: false,
+          materialJson: [],
+          programJson: null,
+          routeJson: null,
+        })
+      );
 
-  it("rejects an unmanaged family", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(
-      routeResponse({
-        managed: false,
-        materialJson: [],
-        programJson: null,
-        routeJson: null,
-      })
-    );
+      const failure = yield* readPublishedProgramRoute(
+        "en",
+        testProgramSubject.publicPath
+      ).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedProgramRoute("en", testProgramSubject.publicPath).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+  it.effect("distinguishes a managed missing route", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(
+        routeResponse({
+          materialJson: [],
+          programJson: null,
+          routeJson: null,
+        })
+      );
 
-  it("distinguishes a managed missing route", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(
-      routeResponse({
-        materialJson: [],
-        programJson: null,
-        routeJson: null,
-      })
-    );
+      const model = yield* readPublishedProgramRoute(
+        "en",
+        "curriculum/missing"
+      );
+      expect(model).toMatchObject({
+        activeReleaseId: "program-release",
+        program: null,
+        route: null,
+        sourceRevision: revision,
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readPublishedProgramRoute("en", "curriculum/missing"))
-    ).resolves.toMatchObject({
-      activeReleaseId: "program-release",
-      program: null,
-      route: null,
-      sourceRevision: revision,
-    });
-  });
-
-  it.each([
+  it.effect.each([
     [
       "invalid active release",
       {
@@ -190,15 +190,15 @@ describe("published program route", () => {
         materialJson: [canonicalizeMaterialProjection(previewIdProjection)],
       }),
     ],
-  ])("rejects a %s", async (_name, response) => {
-    runtimeQueryMock.mockResolvedValueOnce(response);
+  ] as const)("rejects a %s", ([_name, response]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(response);
 
-    await expect(
-      Effect.runPromise(
-        readPublishedProgramRoute("en", testProgramSubject.publicPath).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      const failure = yield* readPublishedProgramRoute(
+        "en",
+        testProgramSubject.publicPath
+      ).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate published program route and material-card suites to direct `@effect/vitest`
- run all 19 effectful cases through `it.effect` or tuple-aware `it.effect.each`
- compose Effect failures directly and use `Schema.decodeEffect` for already typed fixtures
- retain direct Vitest `vi` only for transform-time module mocking

## Effect v4 basis

This follows vendored Effect RC110 contracts for `@effect/vitest`, `Effect.tryPromise`, `Effect.flip`, `Schema.decodeEffect`, and `it.effect.each`. The sole raw async callback is the Vitest-hoisted mock factory. Domain and test execution contain no direct Effect runner, Promise assertion bridge, or legacy testing wrapper.

## Commits

- route execution migration
- card projection migration

Each capability remains an independently reviewable small commit.

## Validation

- focused route and card suites: 19 passed
- WWW typecheck with validated local environment shape: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- Effect source identity, test ownership, lint, boundaries, and format: passed
- React Doctor: 100
- both stable patch IDs and the full range diff stayed exact after replay onto current main

This is test-only. Production deployment should be skipped by scope classification.