### PR TITLE
test(www): run page publication with Effect Vitest

### DIFF
--- a/apps/www/lib/content/page/catalog.test.ts
+++ b/apps/www/lib/content/page/catalog.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   PublicPathSchema,
   ReleaseIdSchema,
@@ -9,7 +10,7 @@ import {
   ArtifactLocaleSchema,
 } from "@nakafa/aksara-contracts/locale";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedPageCatalog,
   readPublishedPageCatalog,
@@ -54,174 +55,175 @@ describe("published Page catalog", () => {
     );
   });
 
-  it("decodes every verified Page projection with its release pin", async () => {
-    await expect(
-      Effect.runPromise(readPublishedPageCatalog())
-    ).resolves.toEqual({
-      activeReleaseId,
-      projections: [testPageProjection],
-    });
-  });
+  it.effect("decodes every verified Page projection with its release pin", () =>
+    Effect.gen(function* () {
+      const catalog = yield* readPublishedPageCatalog();
 
-  it("caches the complete signed Page catalog", async () => {
-    await expect(getPublishedPageCatalog()).resolves.toEqual({
-      activeReleaseId,
-      projections: [testPageProjection],
-    });
-    expect(cacheMock).toHaveBeenCalledWith("page");
-  });
+      expect(catalog).toEqual({
+        activeReleaseId,
+        projections: [testPageProjection],
+      });
+    })
+  );
 
-  it.each([
+  it.effect("caches the complete signed Page catalog", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Effect.tryPromise(() => getPublishedPageCatalog());
+
+      expect(catalog).toEqual({
+        activeReleaseId,
+        projections: [testPageProjection],
+      });
+      expect(cacheMock).toHaveBeenCalledWith("page");
+    })
+  );
+
+  it.effect.each([
     ["unmanaged", { activeReleaseId, managed: false, projectionJson: [] }],
     [
       "missing release",
       { activeReleaseId: null, managed: true, projectionJson: [] },
     ],
-  ])("rejects an %s Page catalog", async (_label, result) => {
-    runtimeQueryMock.mockReturnValueOnce(Effect.succeed(result));
+  ])("rejects an %s Page catalog", ([, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockReturnValueOnce(Effect.succeed(result));
 
-    await expect(
-      Effect.runPromise(readPublishedPageCatalog().pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      publicPath: "pages",
-    });
-  });
+      const failure = yield* readPublishedPageCatalog().pipe(Effect.flip);
 
-  it("rejects malformed Page projection JSON", async () => {
-    runtimeQueryMock.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        managed: true,
-        projectionJson: ["{"],
-      })
-    );
+      expect(failure).toMatchObject({
+        _tag: "PublishedProjectionError",
+        publicPath: "pages",
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(readPublishedPageCatalog().pipe(Effect.flip))
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      publicPath: "pages",
-    });
-  });
-
-  it.each(["search", "lehrplaene/merdeka"])(
-    "rejects a Page shadowed by the application route %s",
-    async (publicPath) => {
-      const projection = {
-        ...testPageProjection,
-        appLocale: AppLocaleSchema.make("de"),
-        artifactLocale: ArtifactLocaleSchema.make("de"),
-        publicPath: PublicPathSchema.make(publicPath),
-      };
+  it.effect("rejects malformed Page projection JSON", () =>
+    Effect.gen(function* () {
       runtimeQueryMock.mockReturnValueOnce(
         Effect.succeed({
           activeReleaseId,
           managed: true,
-          projectionJson: [JSON.stringify(projection)],
+          projectionJson: ["{"],
         })
       );
 
-      await expect(
-        Effect.runPromise(readPublishedPageCatalog().pipe(Effect.flip))
-      ).resolves.toMatchObject({
+      const failure = yield* readPublishedPageCatalog().pipe(Effect.flip);
+
+      expect(failure).toMatchObject({
         _tag: "PublishedProjectionError",
-        appLocale: "de",
-        publicPath,
+        publicPath: "pages",
       });
-    }
+    })
   );
 
-  it("verifies the exact runtime Page against its localized catalog", async () => {
-    const catalog = {
-      activeReleaseId,
-      projections: [testPageProjection],
-    };
-    await expect(
-      Effect.runPromise(
-        verifyPublishedPageCatalog(catalog, {
+  it.effect.each(["search", "lehrplaene/merdeka"])(
+    "rejects a Page shadowed by the application route %s",
+    (publicPath) =>
+      Effect.gen(function* () {
+        const projection = {
+          ...testPageProjection,
+          appLocale: AppLocaleSchema.make("de"),
+          artifactLocale: ArtifactLocaleSchema.make("de"),
+          publicPath: PublicPathSchema.make(publicPath),
+        };
+        runtimeQueryMock.mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            managed: true,
+            projectionJson: [JSON.stringify(projection)],
+          })
+        );
+
+        const failure = yield* readPublishedPageCatalog().pipe(Effect.flip);
+
+        expect(failure).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: "de",
+          publicPath,
+        });
+      })
+  );
+
+  it.effect(
+    "verifies the exact runtime Page against its localized catalog",
+    () =>
+      Effect.gen(function* () {
+        const catalog = {
+          activeReleaseId,
+          projections: [testPageProjection],
+        };
+        const verified = yield* verifyPublishedPageCatalog(catalog, {
           activeReleaseId,
           projection: testPageProjection,
-        })
-      )
-    ).resolves.toEqual([testPageProjection]);
+        });
+        expect(verified).toEqual([testPageProjection]);
 
-    await expect(
-      Effect.runPromise(
-        verifyPublishedPageCatalog(catalog, {
+        const releaseFailure = yield* verifyPublishedPageCatalog(catalog, {
           activeReleaseId: ReleaseIdSchema.make("release-next"),
           projection: testPageProjection,
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-    });
-    await expect(
-      Effect.runPromise(
-        verifyPublishedPageCatalog(catalog, {
+        }).pipe(Effect.flip);
+        expect(releaseFailure).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+        });
+
+        const projectionFailure = yield* verifyPublishedPageCatalog(catalog, {
           activeReleaseId,
           projection: {
             ...testPageProjection,
             publicPath: PublicPathSchema.make("other-page"),
           },
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedProjectionError",
-      publicPath: "other-page",
-    });
-  });
-
-  it("resolves signed locale counterparts without a route map", async () => {
-    runtimeQueryMock.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId,
-        managed: true,
-        projectionJson: [
-          testPageProjection,
-          idPageProjection,
-          dePageProjection,
-        ].map((projection) => JSON.stringify(projection)),
-      })
-    );
-
-    await expect(
-      Effect.runPromise(
-        readPublishedPageLocalePath({
-          currentLocale: "en",
-          locale: "de",
-          publicPath: "terms-of-service",
-        })
-      )
-    ).resolves.toEqual({
-      kind: "found",
-      publicPath: "nutzungsbedingungen",
-    });
-    await expect(
-      Effect.runPromise(
-        readPublishedPageLocalePath({
-          currentLocale: "en",
-          locale: "de",
+        }).pipe(Effect.flip);
+        expect(projectionFailure).toMatchObject({
+          _tag: "PublishedProjectionError",
           publicPath: "other-page",
-        })
-      )
-    ).resolves.toEqual({ kind: "unmanaged" });
-
-    runtimeQueryMock.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        managed: true,
-        projectionJson: [JSON.stringify(testPageProjection)],
+        });
       })
-    );
-    await expect(
-      Effect.runPromise(
-        readPublishedPageLocalePath({
-          currentLocale: "en",
-          locale: "de",
-          publicPath: "terms-of-service",
+  );
+
+  it.effect("resolves signed locale counterparts without a route map", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId,
+          managed: true,
+          projectionJson: [
+            testPageProjection,
+            idPageProjection,
+            dePageProjection,
+          ].map((projection) => JSON.stringify(projection)),
         })
-      )
-    ).resolves.toEqual({ kind: "missing" });
-  });
+      );
+
+      const found = yield* readPublishedPageLocalePath({
+        currentLocale: "en",
+        locale: "de",
+        publicPath: "terms-of-service",
+      });
+      expect(found).toEqual({
+        kind: "found",
+        publicPath: "nutzungsbedingungen",
+      });
+
+      const unmanaged = yield* readPublishedPageLocalePath({
+        currentLocale: "en",
+        locale: "de",
+        publicPath: "other-page",
+      });
+      expect(unmanaged).toEqual({ kind: "unmanaged" });
+
+      runtimeQueryMock.mockReturnValueOnce(
+        Effect.succeed({
+          activeReleaseId,
+          managed: true,
+          projectionJson: [JSON.stringify(testPageProjection)],
+        })
+      );
+      const missing = yield* readPublishedPageLocalePath({
+        currentLocale: "en",
+        locale: "de",
+        publicPath: "terms-of-service",
+      });
+      expect(missing).toEqual({ kind: "missing" });
+    })
+  );
 });

--- a/apps/www/lib/content/page/navigation.test.ts
+++ b/apps/www/lib/content/page/navigation.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ContentKeySchema,
   CorpusSourcePathSchema,
@@ -13,8 +14,8 @@ import {
   PageKeySchema,
   PublicPageProjectionSchema,
 } from "@nakafa/aksara-contracts/projection/page";
-import { Cause, Effect, Exit, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import { vi } from "vitest";
 import {
   getShellPageNavigation,
   PageNavigationMissingError,
@@ -94,68 +95,86 @@ beforeEach(() => {
 });
 
 describe("signed Page navigation", () => {
-  it("selects route and title metadata from the locale-owned catalog", async () => {
-    await expect(Effect.runPromise(readPageNavigation("de"))).resolves.toEqual({
-      items: [
-        {
-          href: "/privacy-policy",
-          pageKey: "privacy-policy",
-          title: "Datenschutzrichtlinie",
-        },
-        {
-          href: "/security-policy",
-          pageKey: "security-policy",
-          title: "Sicherheitsrichtlinie",
-        },
-        {
-          href: "/terms-of-service",
-          pageKey: "terms-of-service",
-          title: "Nutzungsbedingungen",
-        },
-      ],
-      privacyPolicyHref: "/privacy-policy",
-      termsOfServiceHref: "/terms-of-service",
-    });
-  });
+  it.effect(
+    "selects route and title metadata from the locale-owned catalog",
+    () =>
+      Effect.gen(function* () {
+        const navigation = yield* readPageNavigation("de");
 
-  it("fails closed when a required legal destination is absent", async () => {
-    catalogMock.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId: "release-pages",
-        projections: germanPages.filter(
-          ({ pageKey }) => pageKey !== "privacy-policy"
-        ),
+        expect(navigation).toEqual({
+          items: [
+            {
+              href: "/privacy-policy",
+              pageKey: "privacy-policy",
+              title: "Datenschutzrichtlinie",
+            },
+            {
+              href: "/security-policy",
+              pageKey: "security-policy",
+              title: "Sicherheitsrichtlinie",
+            },
+            {
+              href: "/terms-of-service",
+              pageKey: "terms-of-service",
+              title: "Nutzungsbedingungen",
+            },
+          ],
+          privacyPolicyHref: "/privacy-policy",
+          termsOfServiceHref: "/terms-of-service",
+        });
       })
-    );
+  );
 
-    const exit = await Effect.runPromiseExit(readPageNavigation("de"));
-    const failure = Exit.isFailure(exit)
-      ? Cause.findErrorOption(exit.cause)
-      : Option.none();
+  it.effect("fails closed when a required legal destination is absent", () =>
+    Effect.gen(function* () {
+      catalogMock.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-pages",
+          projections: germanPages.filter(
+            ({ pageKey }) => pageKey !== "privacy-policy"
+          ),
+        })
+      );
 
-    expect(Option.isSome(failure)).toBe(true);
-    if (Option.isSome(failure)) {
-      expect(failure.value).toEqual(
+      const failure = yield* readPageNavigation("de").pipe(Effect.flip);
+
+      expect(failure).toEqual(
         new PageNavigationMissingError({
           locale: "de",
           pageKey: PageKeySchema.make("privacy-policy"),
         })
       );
-    }
-  });
+    })
+  );
 
-  it("keeps isolated document previews independent from full Page state", async () => {
-    previewMock.mockReturnValue(true);
+  it.effect(
+    "keeps isolated document previews independent from full Page state",
+    () =>
+      Effect.gen(function* () {
+        previewMock.mockReturnValue(true);
 
-    await expect(getShellPageNavigation("de")).resolves.toBeNull();
-    expect(catalogMock).not.toHaveBeenCalled();
-  });
+        const navigation = yield* Effect.tryPromise(() =>
+          getShellPageNavigation("de")
+        );
 
-  it("loads and caches complete signed navigation for the product shell", async () => {
-    await expect(getShellPageNavigation("de")).resolves.toMatchObject({
-      privacyPolicyHref: "/privacy-policy",
-      termsOfServiceHref: "/terms-of-service",
-    });
-    expect(cacheMock).toHaveBeenCalledWith("page");
-  });
+        expect(navigation).toBeNull();
+        expect(catalogMock).not.toHaveBeenCalled();
+      })
+  );
+
+  it.effect(
+    "loads and caches complete signed navigation for the product shell",
+    () =>
+      Effect.gen(function* () {
+        const navigation = yield* Effect.tryPromise(() =>
+          getShellPageNavigation("de")
+        );
+
+        expect(navigation).toMatchObject({
+          privacyPolicyHref: "/privacy-policy",
+          termsOfServiceHref: "/terms-of-service",
+        });
+        expect(cacheMock).toHaveBeenCalledWith("page");
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate the complete signed Page catalog and navigation suites to direct `@effect/vitest`
- run all 13 effectful cases through `it.effect` or tuple-aware `it.effect.each`
- assert typed publication and navigation failures directly through `Effect.flip`
- retain direct Vitest `vi` only for transform-time module mocking

## Effect v4 basis

This follows vendored Effect RC110 contracts for `@effect/vitest`, `Effect.tryPromise`, `Effect.flip`, and `it.effect.each`. `Effect.tryPromise` appears only at the public Next cache Promise boundaries. Test and domain execution contain no direct Effect runner, Promise assertion bridge, legacy testing wrapper, or raw async callback.

## Commits

- Page catalog execution migration
- Page navigation execution migration

Each capability remains an independently reviewable one-file commit.

## Validation

- focused Page catalog and navigation suites: 13 passed
- WWW typecheck with validated local environment shape: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- Effect source identity, test ownership, lint, boundaries, and format: passed
- React Doctor: 100
- both stable patch IDs and the full range diff stayed exact after replay onto current main

This is test-only. Production deployment should be skipped by scope classification.