### PR TITLE
test(www): run localized routing with Effect Vitest

### DIFF
--- a/apps/www/lib/routing/locale/published.test.ts
+++ b/apps/www/lib/routing/locale/published.test.ts
@@ -1,6 +1,7 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readPublishedLocalizedHref } from "@/lib/routing/locale/published";
 import {
   testArticleDeProjection,
@@ -127,311 +128,330 @@ beforeEach(() => {
 
 /** Reads one English material route through its Indonesian signed target. */
 function readMaterialHref(search = "") {
-  return Effect.runSync(
-    readPublishedLocalizedHref({
-      currentLocale: "en",
-      hash: "",
-      locale: "id",
-      publicPath: previewProjection.publicPath,
-      search,
-    })
-  );
+  return readPublishedLocalizedHref({
+    currentLocale: "en",
+    hash: "",
+    locale: "id",
+    publicPath: previewProjection.publicPath,
+    search,
+  });
 }
 
 describe("published localized route ownership", () => {
-  it.each(articleLocalePairs)(
+  it.effect.each(articleLocalePairs)(
     "projects $current.appLocale article categories to $target.appLocale",
-    ({ current, target }) => {
-      expect(
-        Effect.runSync(
-          readPublishedLocalizedHref({
-            currentLocale: current.appLocale,
-            hash: "#latest",
-            locale: target.appLocale,
-            publicPath: current.parentPath,
-            search:
-              "?cursor=source&manifest=source&release=source&source=locale",
-          })
-        )
-      ).toBe(`/${target.parentPath}?source=locale#latest`);
-    }
-  );
+    ({ current, target }) =>
+      Effect.gen(function* () {
+        const href = yield* readPublishedLocalizedHref({
+          currentLocale: current.appLocale,
+          hash: "#latest",
+          locale: target.appLocale,
+          publicPath: current.parentPath,
+          search: "?cursor=source&manifest=source&release=source&source=locale",
+        });
 
-  it.each(articleLocalePairs)(
-    "projects $current.appLocale article details to $target.appLocale",
-    ({ current, target }) => {
-      expect(
-        Effect.runSync(
-          readPublishedLocalizedHref({
-            currentLocale: current.appLocale,
-            hash: "#references",
-            locale: target.appLocale,
-            publicPath: current.publicPath,
-            search: "?source=locale",
-          })
-        )
-      ).toBe(`/${target.publicPath}?source=locale#references`);
-    }
-  );
-
-  it("fails closed for missing or malformed article projections", () => {
-    expect(
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "id",
-          publicPath: "articles",
-          search: "",
-        })
-      )
-    ).toBeNull();
-
-    publishedMocks.articleCategory.mockReturnValueOnce(
-      Effect.succeed(Option.none())
-    );
-    expect(() =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "id",
-          publicPath: "articles/missing",
-          search: "",
-        })
-      )
-    ).toThrow();
-
-    publishedMocks.categoryAlternates.mockReturnValueOnce(
-      Effect.succeed([
-        {
-          appLocale: testArticleProjection.appLocale,
-          publicPath: testArticleProjection.parentPath,
-        },
-      ])
-    );
-    expect(() =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "de",
-          publicPath: testArticleProjection.parentPath,
-          search: "",
-        })
-      )
-    ).toThrow();
-
-    publishedMocks.articleRoute.mockReturnValueOnce(
-      Effect.succeed({ activeReleaseId, alternates: [], projection: null })
-    );
-    expect(() =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "de",
-          publicPath: testArticleProjection.publicPath,
-          search: "",
-        })
-      )
-    ).toThrow();
-
-    publishedMocks.articleRoute.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        alternates: [testArticleProjection],
-        projection: testArticleProjection,
+        expect(href).toBe(`/${target.parentPath}?source=locale#latest`);
       })
-    );
-    expect(() =>
-      Effect.runSync(
+  );
+
+  it.effect.each(articleLocalePairs)(
+    "projects $current.appLocale article details to $target.appLocale",
+    ({ current, target }) =>
+      Effect.gen(function* () {
+        const href = yield* readPublishedLocalizedHref({
+          currentLocale: current.appLocale,
+          hash: "#references",
+          locale: target.appLocale,
+          publicPath: current.publicPath,
+          search: "?source=locale",
+        });
+
+        expect(href).toBe(`/${target.publicPath}?source=locale#references`);
+      })
+  );
+
+  it.effect("fails closed for missing or malformed article projections", () =>
+    Effect.gen(function* () {
+      const read = (publicPath: string, locale: "de" | "id" = "id") =>
         readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "",
-          locale: "de",
-          publicPath: testArticleProjection.publicPath,
+          locale,
+          publicPath,
           search: "",
-        })
-      )
-    ).toThrow();
+        });
 
-    expect(() =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "de",
-          publicPath: "articles/politics/article/extra",
-          search: "",
-        })
-      )
-    ).toThrow();
-  });
+      const unmanaged = yield* read("articles");
+      expect(unmanaged).toBeNull();
 
-  it("projects a material route through signed locale counterparts", () => {
-    expect(readMaterialHref()).toBe(`/${previewIdProjection.publicPath}`);
-    expect(publishedMocks.materialRoute).toHaveBeenCalledWith(
-      "en",
-      previewProjection.publicPath
-    );
-  });
+      publishedMocks.articleCategory.mockReturnValueOnce(
+        Effect.succeed(Option.none())
+      );
+      const missingCategory = yield* read("articles/missing").pipe(Effect.flip);
+      expect(missingCategory).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+        locale: "id",
+        publicPath: "articles/missing",
+      });
 
-  it("keeps only backend-verified material context", () => {
-    const search =
-      "?ctx=merdeka~class-11-mathematics-function-composition-inverse-function";
-    publishedMocks.materialContext
-      .mockReturnValueOnce(Effect.succeed({ context: {} }))
-      .mockReturnValueOnce(Effect.succeed(null));
+      publishedMocks.categoryAlternates.mockReturnValueOnce(
+        Effect.succeed([
+          {
+            appLocale: testArticleProjection.appLocale,
+            publicPath: testArticleProjection.parentPath,
+          },
+        ])
+      );
+      const missingCategoryAlternate = yield* read(
+        testArticleProjection.parentPath,
+        "de"
+      ).pipe(Effect.flip);
+      expect(missingCategoryAlternate).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+        locale: "de",
+        publicPath: testArticleProjection.parentPath,
+      });
 
-    expect(readMaterialHref(search)).toBe(
-      `/${previewIdProjection.publicPath}${search}`
-    );
-    expect(readMaterialHref(search)).toBe(`/${previewIdProjection.publicPath}`);
-  });
+      publishedMocks.articleRoute.mockReturnValueOnce(
+        Effect.succeed({ activeReleaseId, alternates: [], projection: null })
+      );
+      const missingArticle = yield* read(
+        testArticleProjection.publicPath,
+        "de"
+      ).pipe(Effect.flip);
+      expect(missingArticle).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+        locale: "de",
+        publicPath: testArticleProjection.publicPath,
+      });
 
-  it("fails closed for material tombstones and missing counterparts", () => {
-    publishedMocks.materialRoute
-      .mockReturnValueOnce(
+      publishedMocks.articleRoute.mockReturnValueOnce(
         Effect.succeed({
           activeReleaseId,
-          alternates: [],
-          projection: null,
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId,
-          alternates: [previewProjection],
-          projection: previewProjection,
+          alternates: [testArticleProjection],
+          projection: testArticleProjection,
         })
       );
+      const missingArticleAlternate = yield* read(
+        testArticleProjection.publicPath,
+        "de"
+      ).pipe(Effect.flip);
+      expect(missingArticleAlternate).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+        locale: "de",
+        publicPath: testArticleProjection.publicPath,
+      });
 
-    expect(() => readMaterialHref()).toThrow();
-    expect(() => readMaterialHref()).toThrow();
-  });
+      const malformedArticle = yield* read(
+        "articles/politics/article/extra",
+        "de"
+      ).pipe(Effect.flip);
+      expect(malformedArticle).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+        locale: "de",
+        publicPath: "articles/politics/article/extra",
+      });
+    })
+  );
 
-  it("projects signed curriculum counterparts and ignores static surfaces", () => {
-    expect(
-      Effect.runSync(
-        readPublishedLocalizedHref({
+  it.effect(
+    "projects a material route through signed locale counterparts",
+    () =>
+      Effect.gen(function* () {
+        const href = yield* readMaterialHref();
+
+        expect(href).toBe(`/${previewIdProjection.publicPath}`);
+        expect(publishedMocks.materialRoute).toHaveBeenCalledWith(
+          "en",
+          previewProjection.publicPath
+        );
+      })
+  );
+
+  it.effect("keeps only backend-verified material context", () =>
+    Effect.gen(function* () {
+      const search =
+        "?ctx=merdeka~class-11-mathematics-function-composition-inverse-function";
+      publishedMocks.materialContext
+        .mockReturnValueOnce(Effect.succeed({ context: {} }))
+        .mockReturnValueOnce(Effect.succeed(null));
+
+      const verified = yield* readMaterialHref(search);
+      expect(verified).toBe(`/${previewIdProjection.publicPath}${search}`);
+
+      const omitted = yield* readMaterialHref(search);
+      expect(omitted).toBe(`/${previewIdProjection.publicPath}`);
+    })
+  );
+
+  it.effect(
+    "fails closed for material tombstones and missing counterparts",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.materialRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId,
+              alternates: [],
+              projection: null,
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId,
+              alternates: [previewProjection],
+              projection: previewProjection,
+            })
+          );
+
+        const tombstone = yield* readMaterialHref().pipe(Effect.flip);
+        expect(tombstone).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+
+        const missingCounterpart = yield* readMaterialHref().pipe(Effect.flip);
+        expect(missingCounterpart).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+      })
+  );
+
+  it.effect(
+    "projects signed curriculum counterparts and ignores static surfaces",
+    () =>
+      Effect.gen(function* () {
+        const indonesian = yield* readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "",
           locale: "id",
           publicPath: testProgramSubject.publicPath,
           search: "",
-        })
-      )
-    ).toBe(`/${idProgramSubject.publicPath}`);
-    expect(
-      Effect.runSync(
-        readPublishedLocalizedHref({
+        });
+        expect(indonesian).toBe(`/${idProgramSubject.publicPath}`);
+
+        const german = yield* readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "",
           locale: "de",
           publicPath: testProgramSubject.publicPath,
           search: "",
-        })
-      )
-    ).toBe(`/${deProgramSubject.publicPath}`);
-    expect(
-      Effect.runSync(
-        readPublishedLocalizedHref({
+        });
+        expect(german).toBe(`/${deProgramSubject.publicPath}`);
+
+        const staticSurface = yield* readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "",
           locale: "id",
           publicPath: "search",
           search: "",
-        })
-      )
-    ).toBeNull();
-  });
+        });
+        expect(staticSurface).toBeNull();
+      })
+  );
 
-  it("projects signed try-out counterparts and fails closed for tombstones", () => {
-    publishedMocks.tryoutPath
-      .mockReturnValueOnce(
-        Effect.succeed(
-          "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge"
-        )
-      )
-      .mockReturnValueOnce(Effect.succeed(null));
-    const read = () =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "id",
-          hash: "",
-          locale: "en",
-          publicPath:
-            "try-out/indonesia/snbt/2027/set-1/pengetahuan-kuantitatif",
-          search: "",
-        })
-      );
+  it.effect(
+    "projects signed try-out counterparts and fails closed for tombstones",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.tryoutPath
+          .mockReturnValueOnce(
+            Effect.succeed(
+              "try-out/indonesia/snbt/2027/set-1/quantitative-knowledge"
+            )
+          )
+          .mockReturnValueOnce(Effect.succeed(null));
+        const read = () =>
+          readPublishedLocalizedHref({
+            currentLocale: "id",
+            hash: "",
+            locale: "en",
+            publicPath:
+              "try-out/indonesia/snbt/2027/set-1/pengetahuan-kuantitatif",
+            search: "",
+          });
 
-    expect(read()).toBe(
-      "/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge"
-    );
-    expect(read).toThrow();
-  });
+        const href = yield* read();
+        expect(href).toBe(
+          "/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge"
+        );
 
-  it("fails closed for curriculum tombstones and missing counterparts", () => {
-    publishedMocks.programRoute
-      .mockReturnValueOnce(Effect.succeed({ alternates: [], route: null }))
-      .mockReturnValueOnce(
-        Effect.succeed({
-          alternates: [testProgramSubject],
-          route: testProgramSubject,
-        })
-      );
-    const read = () =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
-          currentLocale: "en",
-          hash: "",
-          locale: "id",
-          publicPath: testProgramSubject.publicPath,
-          search: "",
-        })
-      );
+        const tombstone = yield* read().pipe(Effect.flip);
+        expect(tombstone).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+      })
+  );
 
-    expect(read).toThrow();
-    expect(read).toThrow();
-  });
+  it.effect(
+    "fails closed for curriculum tombstones and missing counterparts",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.programRoute
+          .mockReturnValueOnce(Effect.succeed({ alternates: [], route: null }))
+          .mockReturnValueOnce(
+            Effect.succeed({
+              alternates: [testProgramSubject],
+              route: testProgramSubject,
+            })
+          );
+        const read = () =>
+          readPublishedLocalizedHref({
+            currentLocale: "en",
+            hash: "",
+            locale: "id",
+            publicPath: testProgramSubject.publicPath,
+            search: "",
+          });
 
-  it("projects signed Page counterparts and preserves safe URL state", () => {
-    publishedMocks.pagePath.mockReturnValueOnce(
-      Effect.succeed({ kind: "found", publicPath: "impressum" })
-    );
+        const tombstone = yield* read().pipe(Effect.flip);
+        expect(tombstone).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
 
-    expect(
-      Effect.runSync(
-        readPublishedLocalizedHref({
+        const missingCounterpart = yield* read().pipe(Effect.flip);
+        expect(missingCounterpart).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+      })
+  );
+
+  it.effect(
+    "projects signed Page counterparts and preserves safe URL state",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.pagePath.mockReturnValueOnce(
+          Effect.succeed({ kind: "found", publicPath: "impressum" })
+        );
+
+        const href = yield* readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "#company",
           locale: "de",
           publicPath: "legal-notice",
           search: "?source=footer",
-        })
-      )
-    ).toBe("/impressum?source=footer#company");
-    expect(publishedMocks.pagePath).toHaveBeenCalledWith({
-      currentLocale: "en",
-      locale: "de",
-      publicPath: "legal-notice",
-    });
+        });
+        expect(href).toBe("/impressum?source=footer#company");
+        expect(publishedMocks.pagePath).toHaveBeenCalledWith({
+          currentLocale: "en",
+          locale: "de",
+          publicPath: "legal-notice",
+        });
 
-    publishedMocks.pagePath.mockReturnValueOnce(
-      Effect.succeed({ kind: "missing" })
-    );
-    expect(() =>
-      Effect.runSync(
-        readPublishedLocalizedHref({
+        publishedMocks.pagePath.mockReturnValueOnce(
+          Effect.succeed({ kind: "missing" })
+        );
+        const missing = yield* readPublishedLocalizedHref({
           currentLocale: "en",
           hash: "",
           locale: "de",
           publicPath: "legal-notice",
           search: "",
-        })
-      )
-    ).toThrow();
-  });
+        }).pipe(Effect.flip);
+        expect(missing).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+          locale: "de",
+          publicPath: "legal-notice",
+        });
+      })
+  );
 });

--- a/apps/www/lib/routing/locale/resolve.test.ts
+++ b/apps/www/lib/routing/locale/resolve.test.ts
@@ -1,10 +1,11 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   PublicPathSchema,
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
 import type { ActiveAppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import { Effect, Option } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { resolveLocalizedNavigationHref } from "@/lib/routing/locale/resolve";
 import {
   testArticleDeProjection,
@@ -71,7 +72,7 @@ vi.mock("@/lib/content/tryout/path", () => ({
 }));
 /** Resolves a localized href through the Effect boundary used by callers. */
 function resolveHref(href: string, locale: ActiveAppLocaleCode) {
-  return Effect.runSync(resolveLocalizedNavigationHref({ href, locale }));
+  return resolveLocalizedNavigationHref({ href, locale });
 }
 
 beforeEach(() => {
@@ -138,232 +139,275 @@ beforeEach(() => {
 });
 
 describe("resolveLocalizedNavigationHref", () => {
-  it("projects every EN, ID, and DE article route direction", () => {
-    for (const current of articleProjections) {
-      for (const target of articleProjections) {
-        if (current.appLocale === target.appLocale) {
-          continue;
-        }
+  it.effect("projects every EN, ID, and DE article route direction", () =>
+    Effect.gen(function* () {
+      for (const current of articleProjections) {
+        for (const target of articleProjections) {
+          if (current.appLocale === target.appLocale) {
+            continue;
+          }
 
-        expect(
-          resolveHref(
+          const category = yield* resolveHref(
             `/${current.appLocale}/${current.parentPath}`,
             target.appLocale
-          )
-        ).toBe(`/${target.parentPath}`);
-        expect(
-          resolveHref(
+          );
+          expect(category).toBe(`/${target.parentPath}`);
+
+          const article = yield* resolveHref(
             `/${current.appLocale}/${current.publicPath}`,
             target.appLocale
-          )
-        ).toBe(`/${target.publicPath}`);
+          );
+          expect(article).toBe(`/${target.publicPath}`);
+        }
       }
-    }
 
-    expect(
-      resolveHref(
+      const articleWithState = yield* resolveHref(
         `/${testArticleProjection.appLocale}/${testArticleProjection.publicPath}?source=locale#references`,
         "de"
-      )
-    ).toBe(`/${testArticleDeProjection.publicPath}?source=locale#references`);
-    expect(
-      resolveHref(
+      );
+      expect(articleWithState).toBe(
+        `/${testArticleDeProjection.publicPath}?source=locale#references`
+      );
+
+      const categoryWithState = yield* resolveHref(
         `/${testArticleProjection.appLocale}/${testArticleProjection.parentPath}?cursor=source&manifest=source&release=source&source=locale#latest`,
         "de"
-      )
-    ).toBe(`/${testArticleDeProjection.parentPath}?source=locale#latest`);
-  });
+      );
+      expect(categoryWithState).toBe(
+        `/${testArticleDeProjection.parentPath}?source=locale#latest`
+      );
+    })
+  );
 
-  it("projects signed material and curriculum counterparts", () => {
-    expect(
-      resolveHref(
+  it.effect("projects signed material and curriculum counterparts", () =>
+    Effect.gen(function* () {
+      const material = yield* resolveHref(
         `/${previewProjection.appLocale}/${previewProjection.publicPath}`,
         "id"
-      )
-    ).toBe(`/${previewIdProjection.publicPath}`);
+      );
+      expect(material).toBe(`/${previewIdProjection.publicPath}`);
 
-    publishedMocks.programRoute.mockReturnValue(
-      Effect.succeed({
-        alternates: [testProgramSubject, idProgramSubject, deProgramSubject],
-        route: testProgramSubject,
-      })
-    );
-    expect(
-      resolveHref(
+      publishedMocks.programRoute.mockReturnValue(
+        Effect.succeed({
+          alternates: [testProgramSubject, idProgramSubject, deProgramSubject],
+          route: testProgramSubject,
+        })
+      );
+      const indonesian = yield* resolveHref(
         `/${testProgramSubject.appLocale}/${testProgramSubject.publicPath}`,
         "id"
-      )
-    ).toBe(`/${idProgramSubject.publicPath}`);
-    expect(
-      resolveHref(
+      );
+      expect(indonesian).toBe(`/${idProgramSubject.publicPath}`);
+
+      const german = yield* resolveHref(
         `/${testProgramSubject.appLocale}/${testProgramSubject.publicPath}`,
         "de"
-      )
-    ).toBe(`/${deProgramSubject.publicPath}`);
-  });
+      );
+      expect(german).toBe(`/${deProgramSubject.publicPath}`);
+    })
+  );
 
-  it("keeps material context only while the signed program verifies it", () => {
-    const href = `/${previewProjection.appLocale}/${previewProjection.publicPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`;
-    publishedMocks.materialContext
-      .mockReturnValueOnce(Effect.succeed({ context: {} }))
-      .mockReturnValueOnce(Effect.succeed(null));
+  it.effect(
+    "keeps material context only while the signed program verifies it",
+    () =>
+      Effect.gen(function* () {
+        const href = `/${previewProjection.appLocale}/${previewProjection.publicPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`;
+        publishedMocks.materialContext
+          .mockReturnValueOnce(Effect.succeed({ context: {} }))
+          .mockReturnValueOnce(Effect.succeed(null));
 
-    expect(resolveHref(href, "id")).toBe(
-      `/${previewIdProjection.publicPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`
-    );
-    expect(resolveHref(href, "id")).toBe(`/${previewIdProjection.publicPath}`);
-  });
+        const verified = yield* resolveHref(href, "id");
+        expect(verified).toBe(
+          `/${previewIdProjection.publicPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`
+        );
 
-  it("preserves verified context across signed material route renames", () => {
-    const currentPath = PublicPathSchema.make(
-      "subjects/mathematics/function-composition-inverse-function/renamed-function"
-    );
-    const targetPath = PublicPathSchema.make(
-      "materi/matematika/fungsi-komposisi-dan-fungsi-invers/fungsi-berganti"
-    );
-    publishedMocks.materialRoute.mockReturnValue(
-      Effect.succeed({
-        activeReleaseId,
-        alternates: [
-          { ...previewProjection, publicPath: currentPath },
-          { ...previewIdProjection, publicPath: targetPath },
-        ],
-        projection: { ...previewProjection, publicPath: currentPath },
+        const omitted = yield* resolveHref(href, "id");
+        expect(omitted).toBe(`/${previewIdProjection.publicPath}`);
       })
-    );
-    publishedMocks.materialContext.mockReturnValue(
-      Effect.succeed({ context: {} })
-    );
+  );
 
-    expect(
-      resolveHref(
-        `/en/${currentPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`,
-        "id"
-      )
-    ).toBe(
-      `/${targetPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`
-    );
-  });
+  it.effect(
+    "preserves verified context across signed material route renames",
+    () =>
+      Effect.gen(function* () {
+        const currentPath = PublicPathSchema.make(
+          "subjects/mathematics/function-composition-inverse-function/renamed-function"
+        );
+        const targetPath = PublicPathSchema.make(
+          "materi/matematika/fungsi-komposisi-dan-fungsi-invers/fungsi-berganti"
+        );
+        publishedMocks.materialRoute.mockReturnValue(
+          Effect.succeed({
+            activeReleaseId,
+            alternates: [
+              { ...previewProjection, publicPath: currentPath },
+              { ...previewIdProjection, publicPath: targetPath },
+            ],
+            projection: { ...previewProjection, publicPath: currentPath },
+          })
+        );
+        publishedMocks.materialContext.mockReturnValue(
+          Effect.succeed({ context: {} })
+        );
 
-  it("fails closed for signed tombstones and missing locale rows", () => {
-    publishedMocks.materialRoute
-      .mockReturnValueOnce(
+        const href = yield* resolveHref(
+          `/en/${currentPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`,
+          "id"
+        );
+        expect(href).toBe(
+          `/${targetPath}?ctx=merdeka~class-11-mathematics-function-composition-inverse-function`
+        );
+      })
+  );
+
+  it.effect("fails closed for signed tombstones and missing locale rows", () =>
+    Effect.gen(function* () {
+      publishedMocks.materialRoute
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            alternates: [],
+            projection: null,
+          })
+        )
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId,
+            alternates: [previewProjection],
+            projection: previewProjection,
+          })
+        );
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const failure = yield* resolveLocalizedNavigationHref({
+          href: `/${previewProjection.appLocale}/${previewProjection.publicPath}`,
+          locale: "id",
+        }).pipe(Effect.flip);
+        expect(failure).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+      }
+
+      publishedMocks.programRoute
+        .mockReturnValueOnce(Effect.succeed({ alternates: [], route: null }))
+        .mockReturnValueOnce(
+          Effect.succeed({ alternates: [], route: testProgramSubject })
+        );
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const failure = yield* resolveLocalizedNavigationHref({
+          href: `/${testProgramSubject.appLocale}/${testProgramSubject.publicPath}`,
+          locale: "id",
+        }).pipe(Effect.flip);
+        expect(failure).toMatchObject({
+          _tag: "MissingLocalizedRouteProjectionError",
+        });
+      }
+    })
+  );
+
+  it.effect("projects mapped curriculum and tryout paths", () =>
+    Effect.gen(function* () {
+      const englishCurriculum = yield* resolveHref("/id/kurikulum", "en");
+      expect(englishCurriculum).toBe("/curriculum");
+
+      const indonesianCurriculum = yield* resolveHref("/en/curriculum", "id");
+      expect(indonesianCurriculum).toBe("/kurikulum");
+
+      const tryout = yield* resolveHref("/id/try-out/indonesia", "en");
+      expect(tryout).toBe("/try-out/indonesia");
+
+      const section = yield* resolveHref(
+        "/id/try-out/indonesia/snbt/2027/set-1/pengetahuan-kuantitatif",
+        "en"
+      );
+      expect(section).toBe(
+        "/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge"
+      );
+    })
+  );
+
+  it.effect("projects signed Page identities across German route changes", () =>
+    Effect.gen(function* () {
+      publishedMocks.pagePath.mockReturnValueOnce(
+        Effect.succeed({ kind: "found", publicPath: "impressum" })
+      );
+
+      const href = yield* resolveHref(
+        "/en/legal-notice?source=footer#company",
+        "de"
+      );
+      expect(href).toBe("/impressum?source=footer#company");
+    })
+  );
+
+  it.effect("keeps static app routes and safe URL state", () =>
+    Effect.gen(function* () {
+      const search = yield* resolveHref("/id/search?q=vektor#results", "en");
+      expect(search).toBe("/search?q=vektor#results");
+
+      const home = yield* resolveHref("/en/home", "id");
+      expect(home).toBe("/home");
+
+      const unlocalizedSearch = yield* resolveHref("/search?q=vektor", "en");
+      expect(unlocalizedSearch).toBe("/search?q=vektor");
+
+      const currentLocale = yield* resolveHref("/id/search", "id");
+      expect(currentLocale).toBe("/search");
+
+      const englishRoot = yield* resolveHref("/id", "en");
+      expect(englishRoot).toBe("/");
+
+      const indonesianRoot = yield* resolveHref("/en", "id");
+      expect(indonesianRoot).toBe("/");
+
+      const preview = yield* resolveHref(
+        "/id/internal-preview/alpha?source=meeting#top",
+        "en"
+      );
+      expect(preview).toBe("/internal-preview/alpha?source=meeting#top");
+    })
+  );
+
+  it.effect("fails malformed and missing projected routes", () =>
+    Effect.gen(function* () {
+      const invalid = yield* resolveLocalizedNavigationHref({
+        href: "http://[",
+        locale: "en",
+      }).pipe(Effect.flip);
+      expect(invalid).toMatchObject({
+        _tag: "InvalidLocalizedHrefError",
+        href: "http://[",
+      });
+
+      publishedMocks.materialRoute.mockReturnValueOnce(
         Effect.succeed({
           activeReleaseId,
           alternates: [],
           projection: null,
         })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId,
-          alternates: [previewProjection],
-          projection: previewProjection,
-        })
       );
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const result = Effect.runSyncExit(
-        resolveLocalizedNavigationHref({
-          href: `/${previewProjection.appLocale}/${previewProjection.publicPath}`,
-          locale: "id",
-        })
-      );
-      expect(result._tag).toBe("Failure");
-    }
+      const material = yield* resolveLocalizedNavigationHref({
+        href: "/id/materi/fisika/tidak-ada",
+        locale: "en",
+      }).pipe(Effect.flip);
+      expect(material).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+      });
 
-    publishedMocks.programRoute
-      .mockReturnValueOnce(Effect.succeed({ alternates: [], route: null }))
-      .mockReturnValueOnce(
-        Effect.succeed({ alternates: [], route: testProgramSubject })
-      );
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const result = Effect.runSyncExit(
-        resolveLocalizedNavigationHref({
-          href: `/${testProgramSubject.appLocale}/${testProgramSubject.publicPath}`,
-          locale: "id",
-        })
-      );
-      expect(result._tag).toBe("Failure");
-    }
-  });
+      const missingTryout = yield* resolveLocalizedNavigationHref({
+        href: "/id/try-out/tidak-ada",
+        locale: "en",
+      }).pipe(Effect.flip);
+      expect(missingTryout).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+      });
 
-  it("projects mapped curriculum and tryout paths", () => {
-    expect(resolveHref("/id/kurikulum", "en")).toBe("/curriculum");
-    expect(resolveHref("/en/curriculum", "id")).toBe("/kurikulum");
-    expect(resolveHref("/id/try-out/indonesia", "en")).toBe(
-      "/try-out/indonesia"
-    );
-    expect(
-      resolveHref(
-        "/id/try-out/indonesia/snbt/2027/set-1/pengetahuan-kuantitatif",
-        "en"
-      )
-    ).toBe("/try-out/indonesia/snbt/2027/set-1/quantitative-knowledge");
-  });
-
-  it("projects signed Page identities across German route changes", () => {
-    publishedMocks.pagePath.mockReturnValueOnce(
-      Effect.succeed({ kind: "found", publicPath: "impressum" })
-    );
-
-    expect(resolveHref("/en/legal-notice?source=footer#company", "de")).toBe(
-      "/impressum?source=footer#company"
-    );
-  });
-
-  it("keeps static app routes and safe URL state", () => {
-    expect(resolveHref("/id/search?q=vektor#results", "en")).toBe(
-      "/search?q=vektor#results"
-    );
-    expect(resolveHref("/en/home", "id")).toBe("/home");
-    expect(resolveHref("/search?q=vektor", "en")).toBe("/search?q=vektor");
-    expect(resolveHref("/id/search", "id")).toBe("/search");
-    expect(resolveHref("/id", "en")).toBe("/");
-    expect(resolveHref("/en", "id")).toBe("/");
-    expect(
-      resolveHref("/id/internal-preview/alpha?source=meeting#top", "en")
-    ).toBe("/internal-preview/alpha?source=meeting#top");
-  });
-
-  it("fails malformed and missing projected routes", () => {
-    expect(
-      Effect.runSyncExit(
-        resolveLocalizedNavigationHref({ href: "http://[", locale: "en" })
-      )._tag
-    ).toBe("Failure");
-
-    publishedMocks.materialRoute.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId,
-        alternates: [],
-        projection: null,
-      })
-    );
-    expect(
-      Effect.runSyncExit(
-        resolveLocalizedNavigationHref({
-          href: "/id/materi/fisika/tidak-ada",
-          locale: "en",
-        })
-      )._tag
-    ).toBe("Failure");
-
-    expect(
-      Effect.runSyncExit(
-        resolveLocalizedNavigationHref({
-          href: "/id/try-out/tidak-ada",
-          locale: "en",
-        })
-      )._tag
-    ).toBe("Failure");
-
-    expect(
-      Effect.runSyncExit(
-        resolveLocalizedNavigationHref({
-          href: "/id/try-out/indonesia/untranslated",
-          locale: "en",
-        })
-      )._tag
-    ).toBe("Failure");
-  });
+      const untranslatedTryout = yield* resolveLocalizedNavigationHref({
+        href: "/id/try-out/indonesia/untranslated",
+        locale: "en",
+      }).pipe(Effect.flip);
+      expect(untranslatedTryout).toMatchObject({
+        _tag: "MissingLocalizedRouteProjectionError",
+      });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate the published localized-route and browser locale-resolver suites to direct `@effect/vitest`
- run all 29 effectful cases through `it.effect` or `it.effect.each`
- return Effects from test helpers instead of starting nested runtimes
- replace throw and Exit-tag checks with direct typed failure assertions through `Effect.flip`
- retain direct Vitest `vi` only for transform-time module mocking

## Effect v4 basis

This follows vendored Effect RC110 contracts for `@effect/vitest`, generator composition, `Effect.flip`, and Effect-returning test helpers. Test and helper execution contain no direct Effect runner, Promise bridge, legacy testing wrapper, raw async callback, or generic throw assertion.

## Commits

- published locale-route execution migration
- localized navigation resolution migration

Each capability remains an independently reviewable one-file commit. Both touched files remain below the repository's 500-line readiness limit.

## Validation

- focused localized-routing suites: 29 passed
- WWW typecheck with validated local environment shape: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- Effect source identity, test ownership, lint, boundaries, and format: passed
- React Doctor: 100
- both stable patch IDs and the full range diff stayed exact after replay onto current main

This is test-only. Production deployment should be skipped by scope classification.