### PR TITLE
test(www): run public routing with Effect Vitest

### DIFF
--- a/apps/www/lib/routing/public/migration.test.ts
+++ b/apps/www/lib/routing/public/migration.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readPublicUrlMigrationRedirect } from "@/lib/routing/public/migration";
 
 const readRuntimeQueryMock = vi.hoisted(() => vi.fn());
@@ -33,37 +34,36 @@ describe("public URL migration redirects", () => {
     articleMocks.readActiveRoute.mockReset();
   });
 
-  it("redirects a retired URL to its authenticated current route", async () => {
-    readRuntimeQueryMock.mockReturnValueOnce(
-      Effect.succeed({
-        activeReleaseId: "release-test",
-        managed: true,
-        publicPath:
-          "materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling",
-      })
-    );
-
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
-          method: "GET",
-          pathname:
-            "/id/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+  it.effect("redirects a retired URL to its authenticated current route", () =>
+    Effect.gen(function* () {
+      readRuntimeQueryMock.mockReturnValueOnce(
+        Effect.succeed({
+          activeReleaseId: "release-test",
+          managed: true,
+          publicPath:
+            "materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling",
         })
-      )
-    ).resolves.toBe(
-      "/id/materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling"
-    );
-    expect(readRuntimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      contentKey:
-        "material/lesson/mathematics/circle/central-angle-and-inscribed-angle",
-      expectedMaterialKey: "lesson.mathematics.circle",
-      expectedSectionKey: "central-angle-and-inscribed-angle",
-    });
-  });
+      );
 
-  it.each([
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "GET",
+        pathname:
+          "/id/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+      });
+      expect(redirect).toBe(
+        "/id/materi/matematika/lingkaran/sudut-pusat-dan-sudut-keliling"
+      );
+      expect(readRuntimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        contentKey:
+          "material/lesson/mathematics/circle/central-angle-and-inscribed-angle",
+        expectedMaterialKey: "lesson.mathematics.circle",
+        expectedSectionKey: "central-angle-and-inscribed-angle",
+      });
+    })
+  );
+
+  it.effect.each([
     {
       expectedIdentity: {
         appLocale: "id",
@@ -89,28 +89,29 @@ describe("public URL migration redirects", () => {
     },
   ])(
     "redirects the source-proven statistics topic split for $pathname",
-    async ({ expectedIdentity, pathname, publicPath }) => {
-      readRuntimeQueryMock.mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-test",
-          managed: true,
-          publicPath,
-        })
-      );
+    ({ expectedIdentity, pathname, publicPath }) =>
+      Effect.gen(function* () {
+        readRuntimeQueryMock.mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId: "release-test",
+            managed: true,
+            publicPath,
+          })
+        );
 
-      await expect(
-        Effect.runPromise(
-          readPublicUrlMigrationRedirect({ method: "GET", pathname })
-        )
-      ).resolves.toBe(`/${expectedIdentity.appLocale}/${publicPath}`);
-      expect(readRuntimeQueryMock).toHaveBeenCalledWith(
-        expect.anything(),
-        expectedIdentity
-      );
-    }
+        const redirect = yield* readPublicUrlMigrationRedirect({
+          method: "GET",
+          pathname,
+        });
+        expect(redirect).toBe(`/${expectedIdentity.appLocale}/${publicPath}`);
+        expect(readRuntimeQueryMock).toHaveBeenCalledWith(
+          expect.anything(),
+          expectedIdentity
+        );
+      })
   );
 
-  it.each([
+  it.effect.each([
     ["/de/articles/politics", "/de/articles/politik"],
     [
       "/de/articles/politics/regional-elections-turmoil",
@@ -140,102 +141,104 @@ describe("public URL migration redirects", () => {
       "/de/articles/politics/dynastic-politics-asian-values",
       "/de/articles/politik/politische-dynastien-und-asiatische-werte",
     ],
-  ])("redirects exposed German article URL %s", async (pathname, expected) => {
-    articleMocks.hasCategory
-      .mockReturnValueOnce(Effect.succeed(false))
-      .mockReturnValueOnce(Effect.succeed(true));
-    articleMocks.readActiveRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-current",
-          kind: "missing",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-current",
-          kind: "found",
-        })
-      );
+  ])("redirects exposed German article URL %s", ([pathname, expected]) =>
+    Effect.gen(function* () {
+      articleMocks.hasCategory
+        .mockReturnValueOnce(Effect.succeed(false))
+        .mockReturnValueOnce(Effect.succeed(true));
+      articleMocks.readActiveRoute
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId: "release-current",
+            kind: "missing",
+          })
+        )
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId: "release-current",
+            kind: "found",
+          })
+        );
 
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({ method: "GET", pathname })
-      )
-    ).resolves.toBe(expected);
-    expect(readRuntimeQueryMock).not.toHaveBeenCalled();
-  });
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "GET",
+        pathname,
+      });
+      expect(redirect).toBe(expected);
+      expect(readRuntimeQueryMock).not.toHaveBeenCalled();
+    })
+  );
 
-  it("redirects HEAD requests for an exposed article category", async () => {
-    articleMocks.hasCategory
-      .mockReturnValueOnce(Effect.succeed(false))
-      .mockReturnValueOnce(Effect.succeed(true));
+  it.effect("redirects HEAD requests for an exposed article category", () =>
+    Effect.gen(function* () {
+      articleMocks.hasCategory
+        .mockReturnValueOnce(Effect.succeed(false))
+        .mockReturnValueOnce(Effect.succeed(true));
 
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
-          method: "HEAD",
-          pathname: "/de/articles/politics",
-        })
-      )
-    ).resolves.toBe("/de/articles/politik");
-  });
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "HEAD",
+        pathname: "/de/articles/politics",
+      });
+      expect(redirect).toBe("/de/articles/politik");
+    })
+  );
 
-  it("keeps article routes owned by a recovered signed release", async () => {
-    articleMocks.readActiveRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-recovery",
-          kind: "found",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-recovery",
-          kind: "missing",
-        })
-      );
+  it.effect("keeps article routes owned by a recovered signed release", () =>
+    Effect.gen(function* () {
+      articleMocks.readActiveRoute
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId: "release-recovery",
+            kind: "found",
+          })
+        )
+        .mockReturnValueOnce(
+          Effect.succeed({
+            activeReleaseId: "release-recovery",
+            kind: "missing",
+          })
+        );
 
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "GET",
+        pathname: "/de/articles/politics/regional-elections-turmoil",
+      });
+      expect(redirect).toBeNull();
+    })
+  );
+
+  it.effect("keeps category routes owned by a recovered signed release", () =>
+    Effect.gen(function* () {
+      articleMocks.hasCategory
+        .mockReturnValueOnce(Effect.succeed(true))
+        .mockReturnValueOnce(Effect.succeed(false));
+
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "HEAD",
+        pathname: "/de/articles/politics",
+      });
+      expect(redirect).toBeNull();
+    })
+  );
+
+  it.effect(
+    "does not redirect an article without active signed ownership",
+    () =>
+      Effect.gen(function* () {
+        articleMocks.readActiveIdentity.mockReturnValueOnce(
+          Effect.succeed(null)
+        );
+
+        const redirect = yield* readPublicUrlMigrationRedirect({
           method: "GET",
           pathname: "/de/articles/politics/regional-elections-turmoil",
-        })
-      )
-    ).resolves.toBeNull();
-  });
+        });
+        expect(redirect).toBeNull();
+        expect(articleMocks.readActiveRoute).not.toHaveBeenCalled();
+      })
+  );
 
-  it("keeps category routes owned by a recovered signed release", async () => {
-    articleMocks.hasCategory
-      .mockReturnValueOnce(Effect.succeed(true))
-      .mockReturnValueOnce(Effect.succeed(false));
-
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
-          method: "HEAD",
-          pathname: "/de/articles/politics",
-        })
-      )
-    ).resolves.toBeNull();
-  });
-
-  it("does not redirect an article without active signed ownership", async () => {
-    articleMocks.readActiveIdentity.mockReturnValueOnce(Effect.succeed(null));
-
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
-          method: "GET",
-          pathname: "/de/articles/politics/regional-elections-turmoil",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(articleMocks.readActiveRoute).not.toHaveBeenCalled();
-  });
-
-  it.each([
+  it.effect.each([
     { activeReleaseId: "release-test", managed: true, publicPath: null },
     { activeReleaseId: null, managed: false, publicPath: null },
     {
@@ -243,21 +246,20 @@ describe("public URL migration redirects", () => {
       managed: true,
       publicPath: "subjects/mathematics/circle/section",
     },
-  ])("does not redirect an absent signed identity", async (decision) => {
-    readRuntimeQueryMock.mockReturnValueOnce(Effect.succeed(decision));
+  ])("does not redirect an absent signed identity", (decision) =>
+    Effect.gen(function* () {
+      readRuntimeQueryMock.mockReturnValueOnce(Effect.succeed(decision));
 
-    await expect(
-      Effect.runPromise(
-        readPublicUrlMigrationRedirect({
-          method: "HEAD",
-          pathname:
-            "/en/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
-        })
-      )
-    ).resolves.toBeNull();
-  });
+      const redirect = yield* readPublicUrlMigrationRedirect({
+        method: "HEAD",
+        pathname:
+          "/en/subject/high-school/11/mathematics/circle/central-angle-and-inscribed-angle",
+      });
+      expect(redirect).toBeNull();
+    })
+  );
 
-  it.each([
+  it.effect.each([
     {
       method: "POST",
       pathname:
@@ -295,12 +297,14 @@ describe("public URL migration redirects", () => {
       method: "GET",
       pathname: "/en/subject/high-school/11/mathematics/circle/NotAContentKey",
     },
-  ])("ignores a non-migration request", async (request) => {
-    await expect(
-      Effect.runPromise(readPublicUrlMigrationRedirect(request))
-    ).resolves.toBeNull();
-    expect(readRuntimeQueryMock).not.toHaveBeenCalled();
-    expect(articleMocks.hasCategory).not.toHaveBeenCalled();
-    expect(articleMocks.readActiveIdentity).not.toHaveBeenCalled();
-  });
+  ])("ignores a non-migration request", (request) =>
+    Effect.gen(function* () {
+      const redirect = yield* readPublicUrlMigrationRedirect(request);
+
+      expect(redirect).toBeNull();
+      expect(readRuntimeQueryMock).not.toHaveBeenCalled();
+      expect(articleMocks.hasCategory).not.toHaveBeenCalled();
+      expect(articleMocks.readActiveIdentity).not.toHaveBeenCalled();
+    })
+  );
 });

--- a/apps/www/lib/routing/public/projected.test.ts
+++ b/apps/www/lib/routing/public/projected.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readProjectedHtmlRouteRejection } from "@/lib/routing/public/projected";
 
 const mockReadRuntimeContentReference = vi.hoisted(() => vi.fn());
@@ -28,9 +29,7 @@ vi.mock("@/lib/content/program/path", () => ({
 
 /** Runs one projected route decision with an explicit attempt capability. */
 function readRejection(pathname: string, hasAttemptCapability = false) {
-  return Effect.runPromise(
-    readProjectedHtmlRouteRejection({ hasAttemptCapability, pathname })
-  );
+  return readProjectedHtmlRouteRejection({ hasAttemptCapability, pathname });
 }
 
 describe("projected public html route rejection", () => {
@@ -51,196 +50,251 @@ describe("projected public html route rejection", () => {
     mockMatchesPreviewRoute.mockReturnValue(Effect.succeed(false));
   });
 
-  it("fails closed when signed curriculum ownership is unavailable", async () => {
-    await expect(
-      readRejection("/en/curriculum/merdeka/class-11-afdocs-nonexistent-8f3a")
-    ).resolves.toBe("en");
-    expect(mockReadPublishedProgramPath).toHaveBeenCalledWith(
-      "en",
-      "curriculum/merdeka/class-11-afdocs-nonexistent-8f3a"
-    );
-  });
-
-  it("accepts concrete renderable routes", async () => {
-    const paths = [
-      ["/en/subjects/chemistry/green-chemistry/definition", "subject-lesson"],
-      ["/id/kurikulum/merdeka/kelas-10/biologi", "curriculum-context"],
-    ] as const;
-
-    for (const [pathname, kind] of paths) {
-      if (kind === "subject-lesson") {
-        mockReadActiveContentRoute.mockReturnValueOnce(
-          Effect.succeed({ activeReleaseId, kind: "found" })
+  it.effect(
+    "fails closed when signed curriculum ownership is unavailable",
+    () =>
+      Effect.gen(function* () {
+        const rejection = yield* readRejection(
+          "/en/curriculum/merdeka/class-11-afdocs-nonexistent-8f3a"
         );
-      } else {
-        mockReadPublishedProgramPath.mockReturnValueOnce(
-          Effect.succeed({ managed: true, route: { sitemap: true } })
+
+        expect(rejection).toBe("en");
+        expect(mockReadPublishedProgramPath).toHaveBeenCalledWith(
+          "en",
+          "curriculum/merdeka/class-11-afdocs-nonexistent-8f3a"
         );
+      })
+  );
+
+  it.effect("accepts concrete renderable routes", () =>
+    Effect.gen(function* () {
+      const paths = [
+        ["/en/subjects/chemistry/green-chemistry/definition", "subject-lesson"],
+        ["/id/kurikulum/merdeka/kelas-10/biologi", "curriculum-context"],
+      ] as const;
+
+      for (const [pathname, kind] of paths) {
+        if (kind === "subject-lesson") {
+          mockReadActiveContentRoute.mockReturnValueOnce(
+            Effect.succeed({ activeReleaseId, kind: "found" })
+          );
+        } else {
+          mockReadPublishedProgramPath.mockReturnValueOnce(
+            Effect.succeed({ managed: true, route: { sitemap: true } })
+          );
+        }
+
+        const rejection = yield* readRejection(pathname);
+        expect(rejection).toBeNull();
+      }
+    })
+  );
+
+  it.effect(
+    "uses signed try-out ownership for exact routes and tombstones",
+    () =>
+      Effect.gen(function* () {
+        const pathname = "/en/try-out/indonesia/snbt/2027";
+        mockReadRuntimeContentReference
+          .mockReturnValueOnce(Effect.succeed({ content_id: "tryout:test" }))
+          .mockReturnValueOnce(Effect.succeed(null));
+
+        const owned = yield* readRejection(pathname);
+        expect(owned).toBeNull();
+
+        const tombstone = yield* readRejection(pathname);
+        expect(tombstone).toBe("en");
+        expect(mockReadRuntimeContentReference).toHaveBeenCalledWith(
+          expect.anything(),
+          {
+            input: {
+              appLocale: "en",
+              kind: "route",
+              publicPath: "try-out/indonesia/snbt/2027",
+            },
+          }
+        );
+      })
+  );
+
+  it.effect("requires signed ownership for public set and section routes", () =>
+    Effect.gen(function* () {
+      const paths = [
+        "/en/try-out/indonesia/snbt/2027/set-1",
+        "/en/try-out/indonesia/snbt/2027/set-1/general-reasoning",
+      ];
+      for (const pathname of paths) {
+        mockReadRuntimeContentReference
+          .mockReturnValueOnce(Effect.succeed({ content_id: "tryout:test" }))
+          .mockReturnValueOnce(Effect.succeed(null));
+
+        const owned = yield* readRejection(pathname);
+        expect(owned).toBeNull();
+
+        const tombstone = yield* readRejection(pathname);
+        expect(tombstone).toBe("en");
+      }
+      expect(mockReadRuntimeContentReference).toHaveBeenCalledTimes(4);
+    })
+  );
+
+  it.effect(
+    "delegates retained set and section capabilities to page ownership",
+    () =>
+      Effect.gen(function* () {
+        const paths = [
+          "/en/try-out/indonesia/snbt/2027/set-1",
+          "/en/try-out/indonesia/snbt/2027/set-1/general-reasoning",
+        ];
+        for (const pathname of paths) {
+          const rejection = yield* readRejection(pathname, true);
+          expect(rejection).toBeNull();
+        }
+        expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
+      })
+  );
+
+  it.effect("accepts exact local preview routes before published lookups", () =>
+    Effect.gen(function* () {
+      const paths = [
+        [
+          "/en/subjects/mathematics/function-composition-inverse-function/function-concept",
+          "subjects/mathematics/function-composition-inverse-function/function-concept",
+        ],
+        [
+          "/de/try-out/indonesien/snbt/2027/aufgabensatz-1/quantitatives-wissen",
+          "try-out/indonesien/snbt/2027/aufgabensatz-1/quantitatives-wissen",
+        ],
+      ] as const;
+
+      for (const [pathname, publicPath] of paths) {
+        mockMatchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
+        const rejection = yield* readRejection(pathname);
+        expect(rejection).toBeNull();
+        expect(mockMatchesPreviewRoute).toHaveBeenLastCalledWith({
+          appLocale: pathname.startsWith("/de/") ? "de" : "en",
+          publicPath,
+        });
       }
 
-      await expect(readRejection(pathname)).resolves.toBe(null);
-    }
-  });
+      expect(mockReadActiveContentRoute).not.toHaveBeenCalled();
+      expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
+    })
+  );
 
-  it("uses signed try-out ownership for exact routes and tombstones", async () => {
-    const pathname = "/en/try-out/indonesia/snbt/2027";
-    mockReadRuntimeContentReference
-      .mockReturnValueOnce(Effect.succeed({ content_id: "tryout:test" }))
-      .mockReturnValueOnce(Effect.succeed(null));
-
-    await expect(readRejection(pathname)).resolves.toBeNull();
-    await expect(readRejection(pathname)).resolves.toBe("en");
-    expect(mockReadRuntimeContentReference).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        input: {
-          appLocale: "en",
-          kind: "route",
-          publicPath: "try-out/indonesia/snbt/2027",
-        },
-      }
-    );
-  });
-
-  it("requires signed ownership for public set and section routes", async () => {
-    const paths = [
-      "/en/try-out/indonesia/snbt/2027/set-1",
-      "/en/try-out/indonesia/snbt/2027/set-1/general-reasoning",
-    ];
-    for (const pathname of paths) {
-      mockReadRuntimeContentReference
-        .mockReturnValueOnce(Effect.succeed({ content_id: "tryout:test" }))
-        .mockReturnValueOnce(Effect.succeed(null));
-
-      await expect(readRejection(pathname)).resolves.toBeNull();
-      await expect(readRejection(pathname)).resolves.toBe("en");
-    }
-    expect(mockReadRuntimeContentReference).toHaveBeenCalledTimes(4);
-  });
-
-  it("delegates retained set and section capabilities to page ownership", async () => {
-    const paths = [
-      "/en/try-out/indonesia/snbt/2027/set-1",
-      "/en/try-out/indonesia/snbt/2027/set-1/general-reasoning",
-    ];
-    for (const pathname of paths) {
-      await expect(readRejection(pathname, true)).resolves.toBeNull();
-    }
-    expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
-  });
-
-  it("accepts exact local preview routes before published lookups", async () => {
-    const paths = [
-      [
-        "/en/subjects/mathematics/function-composition-inverse-function/function-concept",
-        "subjects/mathematics/function-composition-inverse-function/function-concept",
-      ],
-      [
-        "/de/try-out/indonesien/snbt/2027/aufgabensatz-1/quantitatives-wissen",
-        "try-out/indonesien/snbt/2027/aufgabensatz-1/quantitatives-wissen",
-      ],
-    ] as const;
-
-    for (const [pathname, publicPath] of paths) {
-      mockMatchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
-      await expect(readRejection(pathname)).resolves.toBe(null);
-      expect(mockMatchesPreviewRoute).toHaveBeenLastCalledWith({
-        appLocale: pathname.startsWith("/de/") ? "de" : "en",
-        publicPath,
-      });
-    }
-
-    expect(mockReadActiveContentRoute).not.toHaveBeenCalled();
-    expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
-  });
-
-  it("uses active ownership for German material routes", async () => {
-    await expect(
-      readRejection(
+  it.effect("uses active ownership for German material routes", () =>
+    Effect.gen(function* () {
+      const rejection = yield* readRejection(
         "/de/faecher/mathematik/analytische-geometrie/stellung-zweier-kreise"
-      )
-    ).resolves.toBe("de");
+      );
+      expect(rejection).toBe("de");
 
-    expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId,
-      appLocale: "de",
-      family: "material",
-      publicPath:
-        "faecher/mathematik/analytische-geometrie/stellung-zweier-kreise",
-    });
-    expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
-  });
+      expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
+        activeReleaseId,
+        appLocale: "de",
+        family: "material",
+        publicPath:
+          "faecher/mathematik/analytische-geometrie/stellung-zweier-kreise",
+      });
+      expect(mockReadRuntimeContentReference).not.toHaveBeenCalled();
+    })
+  );
 
-  it("uses active ownership for new routes and permanent tombstones", async () => {
-    const pathname = "/en/subjects/mathematics/new-topic/new-published-lesson";
-    mockReadActiveContentRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
+  it.effect(
+    "uses active ownership for new routes and permanent tombstones",
+    () =>
+      Effect.gen(function* () {
+        const pathname =
+          "/en/subjects/mathematics/new-topic/new-published-lesson";
+        mockReadActiveContentRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId,
+              kind: "found",
+              rendererDomain: "mathematics",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({ activeReleaseId, kind: "missing" })
+          );
+
+        const found = yield* readRejection(pathname);
+        expect(found).toBeNull();
+
+        const tombstone = yield* readRejection(pathname);
+        expect(tombstone).toBe("en");
+        expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
           activeReleaseId,
-          kind: "found",
-          rendererDomain: "mathematics",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({ activeReleaseId, kind: "missing" })
+          appLocale: "en",
+          family: "material",
+          publicPath: "subjects/mathematics/new-topic/new-published-lesson",
+        });
+      })
+  );
+
+  it.effect("fails closed when signed material ownership is unavailable", () =>
+    Effect.gen(function* () {
+      mockReadActiveContentIdentity.mockReturnValueOnce(Effect.succeed(null));
+      mockReadActiveContentRoute.mockReturnValueOnce(
+        Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
       );
 
-    await expect(readRejection(pathname)).resolves.toBeNull();
-    await expect(readRejection(pathname)).resolves.toBe("en");
-    expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId,
-      appLocale: "en",
-      family: "material",
-      publicPath: "subjects/mathematics/new-topic/new-published-lesson",
-    });
-  });
+      const rejection = yield* readRejection(
+        "/en/subjects/chemistry/green-chemistry/definition"
+      );
+      expect(rejection).toBe("en");
+      expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
+        activeReleaseId: null,
+        appLocale: "en",
+        family: "material",
+        publicPath: "subjects/chemistry/green-chemistry/definition",
+      });
+    })
+  );
 
-  it("fails closed when signed material ownership is unavailable", async () => {
-    mockReadActiveContentIdentity.mockReturnValueOnce(Effect.succeed(null));
-    mockReadActiveContentRoute.mockReturnValueOnce(
-      Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
-    );
+  it.effect(
+    "uses active curriculum ownership for new routes and tombstones",
+    () =>
+      Effect.gen(function* () {
+        const pathname = "/en/curriculum/merdeka/class-12/mathematics";
+        mockReadPublishedProgramPath
+          .mockReturnValueOnce(
+            Effect.succeed({ managed: true, route: { sitemap: true } })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({ managed: true, route: { sitemap: false } })
+          )
+          .mockReturnValueOnce(Effect.succeed({ managed: true, route: null }));
 
-    await expect(
-      readRejection("/en/subjects/chemistry/green-chemistry/definition")
-    ).resolves.toBe("en");
-    expect(mockReadActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId: null,
-      appLocale: "en",
-      family: "material",
-      publicPath: "subjects/chemistry/green-chemistry/definition",
-    });
-  });
+        const found = yield* readRejection(pathname);
+        expect(found).toBeNull();
 
-  it("uses active curriculum ownership for new routes and tombstones", async () => {
-    const pathname = "/en/curriculum/merdeka/class-12/mathematics";
-    mockReadPublishedProgramPath
-      .mockReturnValueOnce(
-        Effect.succeed({ managed: true, route: { sitemap: true } })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({ managed: true, route: { sitemap: false } })
-      )
-      .mockReturnValueOnce(Effect.succeed({ managed: true, route: null }));
+        const hidden = yield* readRejection(pathname);
+        expect(hidden).toBe("en");
 
-    await expect(readRejection(pathname)).resolves.toBeNull();
-    await expect(readRejection(pathname)).resolves.toBe("en");
-    await expect(readRejection(pathname)).resolves.toBe("en");
-  });
+        const tombstone = yield* readRejection(pathname);
+        expect(tombstone).toBe("en");
+      })
+  );
 
-  it("delegates application roots and unrelated routes without a lookup", async () => {
-    const paths = [
-      "/en/curriculum",
-      "/id/try-out",
-      "/en/search",
-      "/fr/subjects/mathematics/algebra/linear-equations",
-    ];
+  it.effect(
+    "delegates application roots and unrelated routes without a lookup",
+    () =>
+      Effect.gen(function* () {
+        const paths = [
+          "/en/curriculum",
+          "/id/try-out",
+          "/en/search",
+          "/fr/subjects/mathematics/algebra/linear-equations",
+        ];
 
-    for (const pathname of paths) {
-      await expect(readRejection(pathname)).resolves.toBe(null);
-    }
+        for (const pathname of paths) {
+          const rejection = yield* readRejection(pathname);
+          expect(rejection).toBeNull();
+        }
 
-    expect(mockReadActiveContentRoute).not.toHaveBeenCalled();
-    expect(mockReadActiveContentIdentity).not.toHaveBeenCalled();
-  });
+        expect(mockReadActiveContentRoute).not.toHaveBeenCalled();
+        expect(mockReadActiveContentIdentity).not.toHaveBeenCalled();
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate public URL migration and projected-route suites to direct `@effect/vitest`
- run all 37 effectful cases through `it.effect` or `it.effect.each`
- return Effects from rejection helpers instead of starting nested runtimes
- assert typed failures through `Effect.flip`
- retain direct Vitest `vi` only for transform-time module mocking

## Effect v4 basis

This follows the vendored Effect RC110 `@effect/vitest` contracts. The touched test modules contain no direct Effect runner, testing wrapper, raw async callback, Promise rejection assertion, or generic throw assertion.

## Commits

- public URL migration execution
- projected public-route execution

Each capability is one independently reviewable file commit. Both files stay below the repository's 500-line readiness limit.

## Validation

- focused suites: 37 passed at 100% coverage
- WWW typecheck: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- production-acceptance fixture: passed in isolation after a resource-contention timeout during parallel local gates
- lint, boundaries, test ownership, and Effect source parity: passed
- React Doctor: 100
- stable patch IDs and full range diff remained exact after replay onto current main

This is test-only. Production deployment should be skipped by scope classification.