### PR TITLE
test(www): run preview boundaries with Effect Vitest

### DIFF
--- a/apps/www/lib/content/preview/config.test.ts
+++ b/apps/www/lib/content/preview/config.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option, Redacted } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   hasPreviewConfig,
   previewUrl,
@@ -14,16 +15,6 @@ import { previewConfig } from "@/test/content-preview";
 afterEach(() => {
   vi.unstubAllEnvs();
 });
-
-/** Runs the dedicated preview environment boundary. */
-function readConfig() {
-  return Effect.runPromise(readPreviewConfig());
-}
-
-/** Runs the independent local renderer environment boundary. */
-function readRendererConfig() {
-  return Effect.runPromise(readPreviewRendererConfig());
-}
 
 /** Installs one complete test-only child environment. */
 function stubPreviewEnvironment() {
@@ -79,144 +70,172 @@ describe("local preview configuration", () => {
     expect(hasPreviewRendererEnvironment()).toBe(false);
   });
 
-  it("returns one redacted development token", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    stubPreviewEnvironment();
-    const config = await readConfig();
+  it.effect("returns one redacted development token", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      stubPreviewEnvironment();
+      const config = yield* readPreviewConfig();
 
-    expect(Option.map(config, ({ token }) => Redacted.value(token))).toEqual(
-      Option.some("provider-token")
-    );
-    expect(Option.map(config, ({ origin }) => origin.toString())).toEqual(
-      Option.some("http://127.0.0.1:4000/")
-    );
-  });
+      expect(Option.map(config, ({ token }) => Redacted.value(token))).toEqual(
+        Option.some("provider-token")
+      );
+      expect(Option.map(config, ({ origin }) => origin.toString())).toEqual(
+        Option.some("http://127.0.0.1:4000/")
+      );
+    })
+  );
 
-  it("ignores absent and non-development preview configuration", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("AKSARA_PREVIEW_PROVIDER_TOKEN", undefined);
-    await expect(readConfig()).resolves.toEqual(Option.none());
+  it.effect("ignores absent and non-development preview configuration", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("AKSARA_PREVIEW_PROVIDER_TOKEN", undefined);
+      expect(yield* readPreviewConfig()).toEqual(Option.none());
 
-    vi.stubEnv("NODE_ENV", "production");
-    stubPreviewEnvironment();
-    await expect(readConfig()).resolves.toEqual(Option.none());
-  });
+      vi.stubEnv("NODE_ENV", "production");
+      stubPreviewEnvironment();
+      expect(yield* readPreviewConfig()).toEqual(Option.none());
+    })
+  );
 
-  it("fails closed for an invalid development token", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("AKSARA_PREVIEW_PROVIDER_TOKEN", " ");
-    const error = await Effect.runPromise(
-      readPreviewConfig().pipe(Effect.flip)
-    );
+  it.effect("fails closed for an invalid development token", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("AKSARA_PREVIEW_PROVIDER_TOKEN", " ");
+      const error = yield* readPreviewConfig().pipe(Effect.flip);
 
-    expect(error._tag).toBe("PreviewConfigError");
-  });
+      expect(error._tag).toBe("PreviewConfigError");
+    })
+  );
 
-  it("keeps provider and renderer credentials independent", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    stubPreviewEnvironment();
-    stubRendererEnvironment();
+  it.effect("keeps provider and renderer credentials independent", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      stubPreviewEnvironment();
+      stubRendererEnvironment();
 
-    const [provider, renderer] = await Promise.all([
-      readConfig(),
-      readRendererConfig(),
-    ]);
+      const [provider, renderer] = yield* Effect.all([
+        readPreviewConfig(),
+        readPreviewRendererConfig(),
+      ]);
 
-    expect(Option.map(provider, ({ token }) => Redacted.value(token))).toEqual(
-      Option.some("provider-token")
-    );
-    expect(Option.map(renderer, ({ token }) => Redacted.value(token))).toEqual(
-      Option.some("renderer-token")
-    );
-    expect(Option.map(renderer, ({ secret }) => secret)).toEqual(
-      Option.some("s".repeat(43))
-    );
-  });
+      expect(
+        Option.map(provider, ({ token }) => Redacted.value(token))
+      ).toEqual(Option.some("provider-token"));
+      expect(
+        Option.map(renderer, ({ token }) => Redacted.value(token))
+      ).toEqual(Option.some("renderer-token"));
+      expect(Option.map(renderer, ({ secret }) => secret)).toEqual(
+        Option.some("s".repeat(43))
+      );
+    })
+  );
 
-  it("ignores absent or production renderer credentials", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    await expect(readRendererConfig()).resolves.toEqual(Option.none());
+  it.effect("ignores absent or production renderer credentials", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      expect(yield* readPreviewRendererConfig()).toEqual(Option.none());
 
-    vi.stubEnv("NODE_ENV", "production");
-    stubRendererEnvironment();
-    await expect(readRendererConfig()).resolves.toEqual(Option.none());
-  });
+      vi.stubEnv("NODE_ENV", "production");
+      stubRendererEnvironment();
+      expect(yield* readPreviewRendererConfig()).toEqual(Option.none());
+    })
+  );
 
-  it("fails closed for partial or invalid renderer credentials", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("AKSARA_PREVIEW_RENDERER_TOKEN", "renderer-token");
-    await expect(
-      Effect.runPromise(readPreviewRendererConfig().pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PreviewRendererConfigError" });
+  it.effect("fails closed for partial or invalid renderer credentials", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("AKSARA_PREVIEW_RENDERER_TOKEN", "renderer-token");
+      expect(
+        yield* readPreviewRendererConfig().pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PreviewRendererConfigError" });
 
-    stubRendererEnvironment();
-    vi.stubEnv("AKSARA_PREVIEW_RENDERER_SECRET", "invalid");
-    await expect(
-      Effect.runPromise(readPreviewRendererConfig().pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PreviewRendererConfigError" });
-  });
+      stubRendererEnvironment();
+      vi.stubEnv("AKSARA_PREVIEW_RENDERER_SECRET", "invalid");
+      expect(
+        yield* readPreviewRendererConfig().pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PreviewRendererConfigError" });
+    })
+  );
 
-  it("requires each environment field to use its exact provider endpoint", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    stubPreviewEnvironment();
-    vi.stubEnv("AKSARA_PREVIEW_EVENTS_PATH", "/v1/manifest");
+  it.effect(
+    "requires each environment field to use its exact provider endpoint",
+    () =>
+      Effect.gen(function* () {
+        vi.stubEnv("NODE_ENV", "development");
+        stubPreviewEnvironment();
+        vi.stubEnv("AKSARA_PREVIEW_EVENTS_PATH", "/v1/manifest");
 
-    await expect(
-      Effect.runPromise(readPreviewConfig().pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PreviewConfigError" });
-  });
+        expect(yield* readPreviewConfig().pipe(Effect.flip)).toMatchObject({
+          _tag: "PreviewConfigError",
+        });
+      })
+  );
 
-  it("keeps invalid loopback ports in the typed configuration error channel", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    stubPreviewEnvironment();
-    vi.stubEnv("AKSARA_PREVIEW_ORIGIN", "http://127.0.0.1:99999/");
+  it.effect(
+    "keeps invalid loopback ports in the typed configuration error channel",
+    () =>
+      Effect.gen(function* () {
+        vi.stubEnv("NODE_ENV", "development");
+        stubPreviewEnvironment();
+        vi.stubEnv("AKSARA_PREVIEW_ORIGIN", "http://127.0.0.1:99999/");
 
-    await expect(
-      Effect.runPromise(readPreviewConfig().pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PreviewConfigError" });
-  });
+        expect(yield* readPreviewConfig().pipe(Effect.flip)).toMatchObject({
+          _tag: "PreviewConfigError",
+        });
+      })
+  );
 
-  it("rejects a network path and any resolved origin mismatch", async () => {
-    const networkPath = await Effect.runPromise(
-      previewUrl(previewConfig, "//attacker.test/steal").pipe(Effect.flip)
-    );
-    const origin = new URL(previewConfig.origin);
-    Object.defineProperty(origin, "origin", {
-      value: "http://attacker.test",
-    });
-    const originMismatch = await Effect.runPromise(
-      previewUrl({ ...previewConfig, origin }, "/v1/manifest").pipe(Effect.flip)
-    );
+  it.effect("rejects a network path and any resolved origin mismatch", () =>
+    Effect.gen(function* () {
+      const networkPath = yield* previewUrl(
+        previewConfig,
+        "//attacker.test/steal"
+      ).pipe(Effect.flip);
+      const origin = new URL(previewConfig.origin);
+      Object.defineProperty(origin, "origin", {
+        value: "http://attacker.test",
+      });
+      const originMismatch = yield* previewUrl(
+        { ...previewConfig, origin },
+        "/v1/manifest"
+      ).pipe(Effect.flip);
 
-    expect(networkPath._tag).toBe("PreviewConfigError");
-    expect(originMismatch._tag).toBe("PreviewConfigError");
-  });
+      expect(networkPath._tag).toBe("PreviewConfigError");
+      expect(originMismatch._tag).toBe("PreviewConfigError");
+    })
+  );
 
-  it("accepts only the two provider endpoints and exact artifact address", async () => {
-    const artifactPath = `/v1/artifacts/sha256%3A${"a".repeat(64)}`;
-    const accepted = await Promise.all(
-      ["/v1/events", "/v1/manifest", artifactPath].map((path) =>
-        Effect.runPromise(previewUrl(previewConfig, path))
-      )
-    );
+  it.effect(
+    "accepts only the two provider endpoints and exact artifact address",
+    () =>
+      Effect.gen(function* () {
+        const artifactPath = `/v1/artifacts/sha256%3A${"a".repeat(64)}`;
+        const accepted = yield* Effect.all(
+          ["/v1/events", "/v1/manifest", artifactPath].map((path) =>
+            previewUrl(previewConfig, path)
+          )
+        );
 
-    expect(accepted.map((url) => url.pathname)).toEqual([
-      "/v1/events",
-      "/v1/manifest",
-      artifactPath,
-    ]);
-  });
+        expect(accepted.map((url) => url.pathname)).toEqual([
+          "/v1/events",
+          "/v1/manifest",
+          artifactPath,
+        ]);
+      })
+  );
 
-  it.each([
+  it.effect.each([
     "/v1/unknown",
     `/v1/artifacts/sha256%3a${"a".repeat(64)}`,
     `/v1/artifacts/sha256%3A${"A".repeat(64)}`,
     `/v1/artifacts/sha256%3A${"a".repeat(63)}`,
     "/v1/artifacts/%2e%2e%2fmanifest",
     "/v1/manifest?next=artifact",
-  ])("rejects non-contract provider path %s", async (path) => {
-    await expect(
-      Effect.runPromise(previewUrl(previewConfig, path).pipe(Effect.flip))
-    ).resolves.toMatchObject({ _tag: "PreviewConfigError" });
-  });
+  ])("rejects non-contract provider path %s", (path) =>
+    Effect.gen(function* () {
+      expect(
+        yield* previewUrl(previewConfig, path).pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PreviewConfigError" });
+    })
+  );
 });

--- a/apps/www/lib/content/preview/events.test.ts
+++ b/apps/www/lib/content/preview/events.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment node
 
-import { Effect, Option } from "effect";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { Data, Effect, Option } from "effect";
+import { vi } from "vitest";
 import {
   PreviewConfigError,
   readPreviewConfig,
 } from "@/lib/content/preview/config";
+import { PreviewEventError } from "@/lib/content/preview/errors";
 import { openPreviewEvents } from "@/lib/content/preview/events";
 import { previewConfig, previewRoute } from "@/test/content-preview";
 
@@ -21,6 +23,10 @@ const route = {
   publicPath: previewRoute.publicPath,
 };
 
+class UnexpectedPreviewStreamError extends Data.TaggedError(
+  "UnexpectedPreviewStreamError"
+)<{ readonly cause: unknown }> {}
+
 /** Builds one response whose final URL matches the Fetch contract. */
 function response(
   body: BodyInit | null,
@@ -32,22 +38,21 @@ function response(
 }
 
 /** Opens and consumes one finite test event stream. */
-async function readEvents() {
-  const stream = await Effect.runPromise(
-    openPreviewEvents(new AbortController().signal)
+function readEvents() {
+  return openPreviewEvents(new AbortController().signal).pipe(
+    Effect.flatMap((stream) =>
+      Effect.promise(() => new Response(stream).text())
+    )
   );
-  return await new Response(stream).text();
 }
 
 /** Returns the typed failure produced before a stream is established. */
 function openFailure() {
-  return Effect.runPromise(
-    openPreviewEvents(new AbortController().signal).pipe(Effect.flip)
-  );
+  return openPreviewEvents(new AbortController().signal).pipe(Effect.flip);
 }
 
 /** Consumes one stream that is expected to fail after response validation. */
-async function streamFailure(source: string) {
+function streamFailure(source: string) {
   vi.stubGlobal(
     "fetch",
     vi.fn(() =>
@@ -59,10 +64,21 @@ async function streamFailure(source: string) {
       )
     )
   );
-  const stream = await Effect.runPromise(
-    openPreviewEvents(new AbortController().signal)
+  return openPreviewEvents(new AbortController().signal).pipe(
+    Effect.flatMap((stream) =>
+      Effect.tryPromise({
+        catch: (cause) =>
+          cause instanceof PreviewEventError
+            ? cause
+            : new UnexpectedPreviewStreamError({ cause }),
+        try: () => new Response(stream).text(),
+      })
+    ),
+    Effect.catchTag("UnexpectedPreviewStreamError", ({ cause }) =>
+      Effect.die(cause)
+    ),
+    Effect.flip
   );
-  return new Response(stream).text();
 }
 
 beforeEach(() => {
@@ -75,40 +91,50 @@ afterEach(() => {
 });
 
 describe("local preview events", () => {
-  it("fails explicitly when no local provider is configured", async () => {
-    configMock.mockReturnValueOnce(Effect.succeed(Option.none()));
+  it.effect("fails explicitly when no local provider is configured", () =>
+    Effect.gen(function* () {
+      configMock.mockReturnValueOnce(Effect.succeed(Option.none()));
 
-    await expect(openFailure()).resolves.toMatchObject({
-      _tag: "PreviewUnavailableError",
-    });
-  });
+      expect(yield* openFailure()).toMatchObject({
+        _tag: "PreviewUnavailableError",
+      });
+    })
+  );
 
-  it("maps provider connection failures without exposing their cause", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => Promise.reject(new TypeError("private failure")))
-    );
+  it.effect(
+    "maps provider connection failures without exposing their cause",
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(() => Promise.reject(new TypeError("private failure")))
+        );
 
-    await expect(openFailure()).resolves.toMatchObject({
-      _tag: "PreviewRequestError",
-      stage: "connect",
-    });
-  });
+        expect(yield* openFailure()).toMatchObject({
+          _tag: "PreviewRequestError",
+          stage: "connect",
+        });
+      })
+  );
 
-  it("does not send its bearer token after configuration validation fails", async () => {
-    const fetcher = vi.fn();
-    configMock.mockReturnValueOnce(
-      Effect.fail(new PreviewConfigError({ name: "AKSARA_PREVIEW" }))
-    );
-    vi.stubGlobal("fetch", fetcher);
+  it.effect(
+    "does not send its bearer token after configuration validation fails",
+    () =>
+      Effect.gen(function* () {
+        const fetcher = vi.fn();
+        configMock.mockReturnValueOnce(
+          Effect.fail(new PreviewConfigError({ name: "AKSARA_PREVIEW" }))
+        );
+        vi.stubGlobal("fetch", fetcher);
 
-    await expect(openFailure()).resolves.toMatchObject({
-      _tag: "PreviewConfigError",
-    });
-    expect(fetcher).not.toHaveBeenCalled();
-  });
+        expect(yield* openFailure()).toMatchObject({
+          _tag: "PreviewConfigError",
+        });
+        expect(fetcher).not.toHaveBeenCalled();
+      })
+  );
 
-  it.each([
+  it.effect.each([
     ["status", response(null, { status: 401 })],
     [
       "url",
@@ -133,78 +159,86 @@ describe("local preview events", () => {
         status: 200,
       }),
     ],
-  ])("rejects an invalid %s response", async (_label, value) => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => Promise.resolve(value))
-    );
+  ])("rejects an invalid %s response", ([_label, value]) =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => Promise.resolve(value))
+      );
 
-    await expect(openFailure()).resolves.toMatchObject({
-      _tag: "PreviewEventError",
-      stage: "response",
-    });
-  });
+      expect(yield* openFailure()).toMatchObject({
+        _tag: "PreviewEventError",
+        stage: "response",
+      });
+    })
+  );
 
-  it("forwards only complete schema-validated updates and heartbeats", async () => {
-    const pending = JSON.stringify({
-      format: "aksara-local-preview",
-      revision: 1,
-      route,
-      status: "pending",
-    });
-    const ready = JSON.stringify({
-      format: "aksara-local-preview",
-      revision: 2,
-      route,
-      status: "ready",
-    });
-    const source = new ReadableStream<Uint8Array>({
-      /** Splits two valid events across provider chunks. */
-      start(controller) {
-        controller.enqueue(
-          new TextEncoder().encode(
-            `event: update\ndata: ${pending.slice(0, 48)}`
+  it.effect(
+    "forwards only complete schema-validated updates and heartbeats",
+    () =>
+      Effect.gen(function* () {
+        const pending = JSON.stringify({
+          format: "aksara-local-preview",
+          revision: 1,
+          route,
+          status: "pending",
+        });
+        const ready = JSON.stringify({
+          format: "aksara-local-preview",
+          revision: 2,
+          route,
+          status: "ready",
+        });
+        const source = new ReadableStream<Uint8Array>({
+          /** Splits two valid events across provider chunks. */
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                `event: update\ndata: ${pending.slice(0, 48)}`
+              )
+            );
+            controller.enqueue(
+              new TextEncoder().encode(
+                `${pending.slice(48)}\n\n: provider-owned-heartbeat\n\nevent: update\ndata: ${ready}\n\n`
+              )
+            );
+            controller.close();
+          },
+        });
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(() =>
+            Promise.resolve(
+              response(source, {
+                headers: {
+                  "content-type": "text/event-stream; charset=utf-8",
+                },
+                status: 200,
+              })
+            )
           )
         );
-        controller.enqueue(
-          new TextEncoder().encode(
-            `${pending.slice(48)}\n\n: provider-owned-heartbeat\n\nevent: update\ndata: ${ready}\n\n`
-          )
+
+        expect(yield* readEvents()).toBe(
+          `event: update\ndata: ${pending}\n\n: keep-alive\n\nevent: update\ndata: ${ready}\n\n`
         );
-        controller.close();
-      },
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() =>
-        Promise.resolve(
-          response(source, {
-            headers: { "content-type": "text/event-stream; charset=utf-8" },
-            status: 200,
+        expect(fetch).toHaveBeenCalledWith(
+          new URL(target),
+          expect.objectContaining({
+            cache: "no-store",
+            credentials: "omit",
+            headers: {
+              accept: "text/event-stream",
+              authorization: "Bearer test-token",
+            },
+            redirect: "error",
+            referrerPolicy: "no-referrer",
           })
-        )
-      )
-    );
-
-    await expect(readEvents()).resolves.toBe(
-      `event: update\ndata: ${pending}\n\n: keep-alive\n\nevent: update\ndata: ${ready}\n\n`
-    );
-    expect(fetch).toHaveBeenCalledWith(
-      new URL(target),
-      expect.objectContaining({
-        cache: "no-store",
-        credentials: "omit",
-        headers: {
-          accept: "text/event-stream",
-          authorization: "Bearer test-token",
-        },
-        redirect: "error",
-        referrerPolicy: "no-referrer",
+        );
       })
-    );
-  });
+  );
 
-  it.each([
+  it.effect.each([
     ["event name", 'event: other\ndata: {"revision":1}\n\n'],
     ["multiline comment", ": first\n: second\n\n"],
     ["extra line", "event: update\ndata: {}\nextra: value\n\n"],
@@ -215,10 +249,12 @@ describe("local preview events", () => {
     ],
     ["oversized partial event", "x".repeat(4097)],
     ["unfinished event", "event: update\ndata: {}"],
-  ])("rejects a malformed %s", async (_label, source) => {
-    await expect(streamFailure(source)).rejects.toMatchObject({
-      _tag: "PreviewEventError",
-      stage: "event",
-    });
-  });
+  ])("rejects a malformed %s", ([_label, source]) =>
+    Effect.gen(function* () {
+      expect(yield* streamFailure(source)).toMatchObject({
+        _tag: "PreviewEventError",
+        stage: "event",
+      });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate preview configuration and event-stream suites to direct `@effect/vitest`
- run all 34 effectful cases through `it.effect` or `it.effect.each`, while retaining six synchronous environment checks
- return Effects from configuration, request, stream-open, and stream-consumption helpers instead of starting nested runtimes
- preserve typed preview failures with `Effect.flip`
- convert unexpected stream-consumption rejection into a test-only tagged error and defect, so an unrelated rejection cannot falsely satisfy a `PreviewEventError` assertion
- retain direct Vitest `vi` only for environment/global stubs and the required transform-time `importOriginal` mock factory

## Effect v4 basis

This follows the vendored Effect RC110 `@effect/vitest`, `Effect.tryPromise`, `Effect.catchTag`, `Effect.flip`, and tagged-error contracts. The touched tests contain no direct Effect runner, testing wrapper, raw async test callback, Promise assertion, or generic throw assertion.

## Commits

- preview configuration boundary
- preview event-stream boundary

Each capability is one independently reviewable file commit. Both files stay below the repository's 500-line readiness limit.

## Validation

- focused preview suites: 40 passed
- WWW typecheck: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- lint, boundaries, test ownership, and Effect source parity: passed
- React Doctor: 100
- stable patch IDs and full range diff remained exact after replay onto current main

This is test-only. Production deployment should be skipped by scope classification.