### PR TITLE
test(www): run content access with Effect Vitest

### DIFF
--- a/apps/www/lib/content/cache.test.ts
+++ b/apps/www/lib/content/cache.test.ts
@@ -1,20 +1,43 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   ArtifactCacheTagSchema,
   ContentCacheTagsSchema,
   makeArtifactCacheTag,
 } from "@nakafa/aksara-contracts/cache/content";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
-import { Effect, Result, Schema } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Data, Effect, Schema } from "effect";
+import { vi } from "vitest";
+import {
+  applyContentRuntimeCache,
+  applyPublishedCatalogCache,
+  applyPublishedContentBatchCache,
+  applyPublishedContentCache,
+  applyPublishedSnapshotCache,
+  ContentCacheInvalidationError,
+  invalidateContentCache,
+} from "@/lib/content/cache";
 
 const artifactHash = Sha256HashSchema.make(`sha256:${"a".repeat(64)}`);
 const artifactTag = makeArtifactCacheTag(artifactHash);
 const otherArtifactHash = Sha256HashSchema.make(`sha256:${"b".repeat(64)}`);
 const otherArtifactTag = makeArtifactCacheTag(otherArtifactHash);
+const familyCacheTags = Schema.decodeSync(ContentCacheTagsSchema)([
+  "content-runtime",
+  "content-family:material",
+]);
+const artifactCacheTags = Schema.decodeSync(ContentCacheTagsSchema)([
+  ...familyCacheTags,
+  artifactTag,
+]);
 const cacheLifeMock = vi.hoisted(() => vi.fn());
 const cacheTagMock = vi.hoisted(() => vi.fn());
 const revalidateTagMock = vi.hoisted(() => vi.fn());
 const dangerouslyDeleteByTagMock = vi.hoisted(() => vi.fn());
+
+class TestCacheFailure extends Data.TaggedError("TestCacheFailure")<{
+  readonly layer: "next" | "sitemap";
+}> {}
+
 vi.mock("@vercel/functions", () => ({
   /** Records immediate CDN deletion without calling Vercel. */
   dangerouslyDeleteByTag: dangerouslyDeleteByTagMock,
@@ -34,21 +57,18 @@ describe("content runtime cache", () => {
     revalidateTagMock.mockClear();
     dangerouslyDeleteByTagMock.mockReset().mockResolvedValue(undefined);
   });
-  it("applies the shared tag and cache profile", async () => {
-    const cache = await import("@/lib/content/cache");
-    cache.applyContentRuntimeCache();
+  it("applies the shared tag and cache profile", () => {
+    applyContentRuntimeCache();
     expect(cacheTagMock).toHaveBeenCalledWith("content-runtime");
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
-  it("applies global and exact immutable snapshot tags", async () => {
-    const cache = await import("@/lib/content/cache");
-    cache.applyPublishedSnapshotCache(artifactHash);
+  it("applies global and exact immutable snapshot tags", () => {
+    applyPublishedSnapshotCache(artifactHash);
     expect(cacheTagMock).toHaveBeenCalledWith("content-runtime", artifactTag);
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
-  it("applies global, family, and exact artifact tags", async () => {
-    const cache = await import("@/lib/content/cache");
-    cache.applyPublishedContentCache("material", artifactHash);
+  it("applies global, family, and exact artifact tags", () => {
+    applyPublishedContentCache("material", artifactHash);
     expect(cacheTagMock).toHaveBeenCalledWith(
       "content-runtime",
       "content-family:material",
@@ -56,9 +76,8 @@ describe("content runtime cache", () => {
     );
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
-  it("applies every immutable artifact tag in a bounded batch", async () => {
-    const cache = await import("@/lib/content/cache");
-    cache.applyPublishedContentBatchCache("question", [
+  it("applies every immutable artifact tag in a bounded batch", () => {
+    applyPublishedContentBatchCache("question", [
       artifactHash,
       otherArtifactHash,
     ]);
@@ -70,73 +89,54 @@ describe("content runtime cache", () => {
     );
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
-  it("applies global and family tags to published catalogs", async () => {
-    const cache = await import("@/lib/content/cache");
-    cache.applyPublishedCatalogCache("article");
+  it("applies global and family tags to published catalogs", () => {
+    applyPublishedCatalogCache("article");
     expect(cacheTagMock).toHaveBeenCalledWith(
       "content-runtime",
       "content-family:article"
     );
     expect(cacheLifeMock).toHaveBeenCalledWith("contentRuntime");
   });
-  it("invalidates exact Next tags and the sitemap CDN tag", async () => {
-    const cache = await import("@/lib/content/cache");
-    const tags = Schema.decodeSync(ContentCacheTagsSchema)([
-      "content-runtime",
-      "content-family:material",
-      artifactTag,
-    ]);
-    await expect(
-      Effect.runPromise(cache.invalidateContentCache(tags))
-    ).resolves.toEqual(tags);
-    expect(revalidateTagMock.mock.calls).toEqual([
-      ["content-runtime", { expire: 0 }],
-      ["content-family:material", { expire: 0 }],
-      [artifactTag, { expire: 0 }],
-    ]);
-    expect(dangerouslyDeleteByTagMock).toHaveBeenCalledWith("content-sitemap", {
-      revalidationDeadlineSeconds: 0,
-    });
-  });
-  it("keeps a failed CDN purge in the typed error channel", async () => {
-    dangerouslyDeleteByTagMock.mockRejectedValueOnce(new Error("unavailable"));
-    const cache = await import("@/lib/content/cache");
-    const tags = Schema.decodeSync(ContentCacheTagsSchema)([
-      "content-runtime",
-      "content-family:material",
-    ]);
-    const result = await Effect.runPromise(
-      cache.invalidateContentCache(tags).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toEqual(
-        new cache.ContentCacheInvalidationError({ layer: "sitemap" })
+  it.effect("invalidates exact Next tags and the sitemap CDN tag", () =>
+    Effect.gen(function* () {
+      expect(yield* invalidateContentCache(artifactCacheTags)).toEqual(
+        artifactCacheTags
       );
-    }
-  });
-  it("keeps a failed Next invalidation in the typed error channel", async () => {
-    revalidateTagMock.mockImplementationOnce(() => {
-      throw new Error("unavailable");
-    });
-    const cache = await import("@/lib/content/cache");
-    const tags = Schema.decodeSync(ContentCacheTagsSchema)([
-      "content-runtime",
-      "content-family:material",
-    ]);
-    const result = await Effect.runPromise(
-      cache.invalidateContentCache(tags).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toEqual(
-        new cache.ContentCacheInvalidationError({ layer: "next" })
+      expect(revalidateTagMock.mock.calls).toEqual([
+        ["content-runtime", { expire: 0 }],
+        ["content-family:material", { expire: 0 }],
+        [artifactTag, { expire: 0 }],
+      ]);
+      expect(dangerouslyDeleteByTagMock).toHaveBeenCalledWith(
+        "content-sitemap",
+        { revalidationDeadlineSeconds: 0 }
       );
-    }
-    expect(dangerouslyDeleteByTagMock).not.toHaveBeenCalled();
-  });
-  it("rejects an artifact tag without a canonical signed hash", async () => {
-    await import("@/lib/content/cache");
+    })
+  );
+  it.effect("keeps a failed CDN purge in the typed error channel", () =>
+    Effect.gen(function* () {
+      dangerouslyDeleteByTagMock.mockRejectedValueOnce(
+        new TestCacheFailure({ layer: "sitemap" })
+      );
+
+      expect(
+        yield* invalidateContentCache(familyCacheTags).pipe(Effect.flip)
+      ).toEqual(new ContentCacheInvalidationError({ layer: "sitemap" }));
+    })
+  );
+  it.effect("keeps a failed Next invalidation in the typed error channel", () =>
+    Effect.gen(function* () {
+      revalidateTagMock.mockImplementationOnce(() => {
+        throw new TestCacheFailure({ layer: "next" });
+      });
+
+      expect(
+        yield* invalidateContentCache(familyCacheTags).pipe(Effect.flip)
+      ).toEqual(new ContentCacheInvalidationError({ layer: "next" }));
+      expect(dangerouslyDeleteByTagMock).not.toHaveBeenCalled();
+    })
+  );
+  it("rejects an artifact tag without a canonical signed hash", () => {
     expect(() =>
       Schema.decodeSync(ArtifactCacheTagSchema)("content-artifact:unknown")
     ).toThrow(

--- a/apps/www/lib/content/material/context.test.ts
+++ b/apps/www/lib/content/material/context.test.ts
@@ -1,12 +1,16 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   PublicPathSchema,
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
-import type { CurriculumRoute } from "@nakafa/aksara-contracts/program/curriculum";
-import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CurriculumRoute,
+  CurriculumRouteSchema,
+} from "@nakafa/aksara-contracts/program/curriculum";
+import { Effect, Schema } from "effect";
+import { vi } from "vitest";
 import {
   getPublishedMaterialContext,
   readPublishedMaterialContext,
@@ -21,20 +25,16 @@ import {
 
 const runtimeQueryMock = vi.hoisted(() => vi.fn());
 const cacheMock = vi.hoisted(() => vi.fn());
-const group = testProgramGroups[0];
-if (!group) {
-  throw new Error("Expected the real Function Concept curriculum group.");
-}
+const [group] = Schema.decodeUnknownSync(Schema.Tuple([CurriculumRouteSchema]))(
+  testProgramGroups
+);
 const context = {
   nodeKey: group.nodeKey,
   programKey: group.programKey,
 };
-const mapping = testProgramContexts.find(
-  (route) => route.materialContextNodeKey === group.nodeKey
-);
-if (!mapping) {
-  throw new Error("Expected the real Function Concept curriculum mapping.");
-}
+const [mapping] = Schema.decodeUnknownSync(
+  Schema.Tuple([CurriculumRouteSchema])
+)(testProgramContexts);
 const publishedContext = {
   groupJson: testCurriculumRowJson(group),
   managed: true,
@@ -46,12 +46,9 @@ const publishedContext = {
 vi.mock("@/lib/content/cache", () => ({
   applyContentRuntimeCache: cacheMock,
 }));
-vi.mock("@/lib/content/runtime/query", async () => {
-  const { createTestRuntimeQuery } = await import("@/test/runtime-query");
-  return {
-    readRuntimeQuery: createTestRuntimeQuery(runtimeQueryMock),
-  };
-});
+vi.mock("@/lib/content/runtime/query", () => ({
+  readRuntimeQuery: runtimeQueryMock,
+}));
 
 beforeEach(() => {
   runtimeQueryMock.mockReset();
@@ -59,149 +56,167 @@ beforeEach(() => {
 });
 
 describe("published material context", () => {
-  it("builds a return link from verified curriculum rows", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(publishedContext);
+  it.effect("builds a return link from verified curriculum rows", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockReturnValueOnce(Effect.succeed(publishedContext));
 
-    await expect(
-      getPublishedMaterialContext("en", previewProjection, context)
-    ).resolves.toMatchObject({
-      context,
-      group: {
-        nodeKey: group.nodeKey,
-        publicPath: group.publicPath,
-      },
-      href: expect.stringContaining(
-        "/en/curriculum/merdeka/class-11/mathematics#"
-      ),
-      label: "Function Composition and Inverses",
-      mapping: {
-        canonicalPath: mapping.canonicalPath,
-      },
-      parent: {
-        nodeKey: testProgramSubject.nodeKey,
-        publicPath: testProgramSubject.publicPath,
-      },
-    });
-    expect(cacheMock).toHaveBeenCalledOnce();
-  });
-
-  it("rejects unmanaged context and preserves an invalid optional hint", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        groupJson: null,
-        managed: false,
-        mappingJson: null,
-        parentJson: null,
-        resolvedCanonicalPath: null,
-      })
-      .mockResolvedValueOnce({
-        groupJson: null,
-        managed: true,
-        mappingJson: null,
-        parentJson: null,
-        resolvedCanonicalPath: null,
-      });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context).pipe(
-          Effect.flip
+      expect(
+        yield* Effect.promise(() =>
+          getPublishedMaterialContext("en", previewProjection, context)
         )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context)
-      )
-    ).resolves.toBeNull();
-  });
+      ).toMatchObject({
+        context,
+        group: {
+          nodeKey: group.nodeKey,
+          publicPath: group.publicPath,
+        },
+        href: expect.stringContaining(
+          "/en/curriculum/merdeka/class-11/mathematics#"
+        ),
+        label: "Function Composition and Inverses",
+        mapping: {
+          canonicalPath: mapping.canonicalPath,
+        },
+        parent: {
+          nodeKey: testProgramSubject.nodeKey,
+          publicPath: testProgramSubject.publicPath,
+        },
+      });
+      expect(cacheMock).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("pins a context read to the expected active release", async () => {
-    const activeReleaseId = ReleaseIdSchema.make("release-material");
-    runtimeQueryMock.mockResolvedValueOnce({
-      groupJson: null,
-      managed: true,
-      mappingJson: null,
-      parentJson: null,
-      resolvedCanonicalPath: null,
-    });
+  it.effect(
+    "rejects unmanaged context and preserves an invalid optional hint",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock
+          .mockReturnValueOnce(
+            Effect.succeed({
+              groupJson: null,
+              managed: false,
+              mappingJson: null,
+              parentJson: null,
+              resolvedCanonicalPath: null,
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              groupJson: null,
+              managed: true,
+              mappingJson: null,
+              parentJson: null,
+              resolvedCanonicalPath: null,
+            })
+          );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext(
+        expect(
+          yield* readPublishedMaterialContext(
+            "en",
+            previewProjection,
+            context
+          ).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(
+          yield* readPublishedMaterialContext("en", previewProjection, context)
+        ).toBeNull();
+      })
+  );
+
+  it.effect("pins a context read to the expected active release", () =>
+    Effect.gen(function* () {
+      const activeReleaseId = ReleaseIdSchema.make("release-material");
+      runtimeQueryMock.mockReturnValueOnce(
+        Effect.succeed({
+          groupJson: null,
+          managed: true,
+          mappingJson: null,
+          parentJson: null,
+          resolvedCanonicalPath: null,
+        })
+      );
+
+      expect(
+        yield* readPublishedMaterialContext(
           "en",
           previewProjection,
           context,
           activeReleaseId
         )
-      )
-    ).resolves.toBeNull();
-    expect(runtimeQueryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        contentKey: previewProjection.contentKey,
-        expectedActiveReleaseId: activeReleaseId,
-      })
-    );
-  });
+      ).toBeNull();
+      expect(runtimeQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          contentKey: previewProjection.contentKey,
+          expectedActiveReleaseId: activeReleaseId,
+        })
+      );
+    })
+  );
 
-  it("accepts course parents and falls back to the authored group title", async () => {
-    const courseParent = {
-      ...testProgramSubject,
-      level: "course",
-    } satisfies CurriculumRoute;
-    const groupWithoutCardTitle = {
-      ...group,
-      materialCardTitle: undefined,
-    };
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        ...publishedContext,
-        parentJson: testCurriculumRowJson(courseParent),
+  it.effect(
+    "accepts course parents and falls back to the authored group title",
+    () =>
+      Effect.gen(function* () {
+        const courseParent = {
+          ...testProgramSubject,
+          level: "course",
+        } satisfies CurriculumRoute;
+        const groupWithoutCardTitle = {
+          ...group,
+          materialCardTitle: undefined,
+        };
+        runtimeQueryMock
+          .mockReturnValueOnce(
+            Effect.succeed({
+              ...publishedContext,
+              parentJson: testCurriculumRowJson(courseParent),
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              ...publishedContext,
+              groupJson: testCurriculumRowJson(groupWithoutCardTitle),
+            })
+          );
+
+        expect(
+          yield* readPublishedMaterialContext("en", previewProjection, context)
+        ).toMatchObject({ parent: { level: "course" } });
+        expect(
+          yield* readPublishedMaterialContext("en", previewProjection, context)
+        ).toMatchObject({ label: group.title });
       })
-      .mockResolvedValueOnce({
-        ...publishedContext,
-        groupJson: testCurriculumRowJson(groupWithoutCardTitle),
+  );
+
+  it.effect("accepts a backend-verified renamed material parent", () =>
+    Effect.gen(function* () {
+      const renamedParent = PublicPathSchema.make(
+        "subjects/mathematics/renamed-functions"
+      );
+      const renamedMaterial = {
+        ...previewProjection,
+        parentPath: renamedParent,
+        publicPath: PublicPathSchema.make(
+          `${renamedParent}/renamed-function-concept`
+        ),
+      };
+      runtimeQueryMock.mockReturnValueOnce(
+        Effect.succeed({
+          ...publishedContext,
+          resolvedCanonicalPath: renamedParent,
+        })
+      );
+
+      expect(
+        yield* readPublishedMaterialContext("en", renamedMaterial, context)
+      ).toMatchObject({
+        mapping: { canonicalPath: mapping.canonicalPath },
       });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context)
-      )
-    ).resolves.toMatchObject({ parent: { level: "course" } });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context)
-      )
-    ).resolves.toMatchObject({ label: group.title });
-  });
-
-  it("accepts a backend-verified renamed material parent", async () => {
-    const renamedParent = PublicPathSchema.make(
-      "subjects/mathematics/renamed-functions"
-    );
-    const renamedMaterial = {
-      ...previewProjection,
-      parentPath: renamedParent,
-      publicPath: PublicPathSchema.make(
-        `${renamedParent}/renamed-function-concept`
-      ),
-    };
-    runtimeQueryMock.mockResolvedValueOnce({
-      ...publishedContext,
-      resolvedCanonicalPath: renamedParent,
-    });
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", renamedMaterial, context)
-      )
-    ).resolves.toMatchObject({
-      mapping: { canonicalPath: mapping.canonicalPath },
-    });
-  });
-
-  it.each([
+  it.effect.each([
     [
       "partial rows",
       {
@@ -231,38 +246,44 @@ describe("published material context", () => {
         }),
       },
     ],
-  ])("rejects %s", async (_label, result) => {
-    runtimeQueryMock.mockResolvedValueOnce(result);
+  ])("rejects %s", ([, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockReturnValueOnce(Effect.succeed(result));
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      expect(
+        yield* readPublishedMaterialContext(
+          "en",
+          previewProjection,
+          context
+        ).pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 
-  it("rejects a mapping for a different material route", async () => {
-    runtimeQueryMock.mockResolvedValueOnce({
-      ...publishedContext,
-      mappingJson: testCurriculumRowJson({
-        ...mapping,
-        canonicalPath: PublicPathSchema.make(
-          `${previewProjection.parentPath}/other-lesson`
-        ),
-      }),
-      resolvedCanonicalPath: PublicPathSchema.make(
-        `${previewProjection.parentPath}/other-lesson`
-      ),
-    });
+  it.effect("rejects a mapping for a different material route", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockReturnValueOnce(
+        Effect.succeed({
+          ...publishedContext,
+          mappingJson: testCurriculumRowJson({
+            ...mapping,
+            canonicalPath: PublicPathSchema.make(
+              `${previewProjection.parentPath}/other-lesson`
+            ),
+          }),
+          resolvedCanonicalPath: PublicPathSchema.make(
+            `${previewProjection.parentPath}/other-lesson`
+          ),
+        })
+      );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialContext("en", previewProjection, context).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      expect(
+        yield* readPublishedMaterialContext(
+          "en",
+          previewProjection,
+          context
+        ).pipe(Effect.flip)
+      ).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate content-cache invalidation and material-context suites to direct `@effect/vitest`
- run every effectful case through `it.effect` or `it.effect.each`
- mock the runtime-query seam with Effects directly instead of an asynchronous adapter factory
- lift the intentional cached Next.js Promise boundary with `Effect.promise`
- retain deterministic cache tagging and Schema rejection cases as ordinary Vitest tests

## Effect v4 basis

The implementation follows the vendored Effect RC110 source for `@effect/vitest`, `Effect.gen`, `Effect.flip`, `Effect.promise`, tagged errors, and Schema boundaries. The touched tests contain no direct Effect runner, repository testing wrapper, raw async test callback, Promise assertion, generic error, or generic throw.

## Commits

- content-cache execution and typed invalidation failures
- material-context execution and native Effect query mocks

Each capability is one independently reviewable file commit. Both touched files remain below the repository readiness limit.

## Validation

- focused suites: 18 passed
- WWW typecheck: passed with no Effect compiler suggestions
- full repository suite: passed, including 210 WWW files and 1,521 WWW tests at 100% coverage
- lint, boundaries, test ownership, and Effect source parity: passed
- React Doctor: 100
- exact-base patch replay and diff checks: passed

This is test-only. Production deployment should be skipped by scope classification.