### PR TITLE
fix(quran): complete locale meanings and Tafsir access

### DIFF
--- a/apps/api/lib/content/published.test.ts
+++ b/apps/api/lib/content/published.test.ts
@@ -150,9 +150,9 @@ describe("published API content", () => {
     })
   );
 
-  it.effect("normalizes an authenticated legacy projection once", () =>
+  it.effect("rejects a non-current projection at the API boundary", () =>
     Effect.gen(function* () {
-      const legacyProjection = {
+      const storedProjection = {
         ...baseProjection,
         metadata: {
           authors: baseProjection.metadata.authors,
@@ -166,19 +166,18 @@ describe("published API content", () => {
             activeReleaseId: input.activeReleaseId,
             artifact: { payload: { rawMdx: "## Signed body" } },
             delivery: "public",
-            projection: legacyProjection,
+            projection: storedProjection,
           },
         ])
       );
 
-      const [item] = yield* readPublishedApiItems([input]);
-
-      expect(item?.metadata).toEqual({
-        authors: legacyProjection.metadata.authors,
-        date: legacyProjection.metadata.date,
-        datePublished: legacyProjection.metadata.date,
-        title: legacyProjection.metadata.title,
-      });
+      expect(yield* readPublishedApiItems([input]).pipe(Effect.flip)).toEqual(
+        new ApiPublishedContentReadError({
+          cause:
+            "Signed content does not belong to the article or material API.",
+          message: "Unable to read signed public content for the public API.",
+        })
+      );
     })
   );
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "typecheck": "next typegen && tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@repo/backend": "workspace:*",
     "@repo/contents": "workspace:*",
     "@repo/design-system": "workspace:*",

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -1,5 +1,6 @@
 import { AllahIcon } from "@hugeicons/core-free-icons";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import { slugify } from "@repo/design-system/lib/routing/slug";
 import { BookJsonLd } from "@repo/seo/json-ld/book";
 import { BreadcrumbJsonLd } from "@repo/seo/json-ld/breadcrumb";
@@ -181,8 +182,9 @@ async function CachedSurahShell({
       recoverStalePublishedQuranSnapshot(servedSnapshotId)
     );
   }
-  const description = surahData.name.meaning[locale];
-  const descriptionLanguage = locale;
+  const meaning = selectQuranMeaning(surahData.name.meaning, locale);
+  const description = meaning.text;
+  const descriptionLanguage = meaning.appLocale;
   const title = getQuranSurahName(surahData.name);
 
   const verseItems = result.verses.map((verse) => {

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -18,7 +18,10 @@ import { LayoutMaterial } from "@/components/shared/material/layout";
 import { LayoutMaterialToc } from "@/components/shared/material/toc";
 import { PaginationContent } from "@/components/shared/pagination-content";
 import { QuranBismillah } from "@/components/shared/quran/bismillah";
-import { QuranInterpretationButton } from "@/components/shared/quran/interpretation/button";
+import {
+  QuranInterpretationButton,
+  QuranInterpretationLink,
+} from "@/components/shared/quran/interpretation/button";
 import { QuranInterpretationControls } from "@/components/shared/quran/interpretation/controls";
 import { QuranVerseList } from "@/components/shared/quran/verses/list";
 import { RefContent } from "@/components/shared/ref-content";
@@ -178,8 +181,8 @@ async function CachedSurahShell({
       recoverStalePublishedQuranSnapshot(servedSnapshotId)
     );
   }
-  const description = surahData.name.meaning.text;
-  const descriptionLanguage = surahData.name.meaning.appLocale;
+  const description = surahData.name.meaning[locale];
+  const descriptionLanguage = locale;
   const title = getQuranSurahName(surahData.name);
 
   const verseItems = result.verses.map((verse) => {
@@ -246,7 +249,7 @@ async function CachedSurahShell({
                 translationNotesLabel={translationNotesLabel}
               />
             )}
-            {tafsirAccess?.kind === "embedded" ? (
+            {tafsirAccess.kind === "embedded" ? (
               <QuranInterpretationControls
                 appLocale={tafsirAccess.appLocale}
                 errorMessage={t("interpretation-error")}
@@ -270,6 +273,12 @@ async function CachedSurahShell({
             ) : (
               <QuranVerseList
                 items={verseItems}
+                renderAction={() => (
+                  <QuranInterpretationLink
+                    href={tafsirAccess.source.sourceUrl}
+                    label={interpretationLabel}
+                  />
+                )}
                 translationNotesLabel={translationNotesLabel}
               />
             )}

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -263,9 +263,9 @@ async function CachedSurahShell({
               >
                 <QuranVerseList
                   items={verseItems}
-                  renderAction={(verse) => (
+                  renderAction={(verse, verseLabel) => (
                     <QuranInterpretationButton
-                      label={interpretationLabel}
+                      label={`${interpretationLabel}: ${verseLabel}`}
                       verseNumber={verse.number.inSurah}
                     />
                   )}
@@ -275,10 +275,10 @@ async function CachedSurahShell({
             ) : (
               <QuranVerseList
                 items={verseItems}
-                renderAction={() => (
+                renderAction={(_verse, verseLabel) => (
                   <QuranInterpretationLink
                     href={tafsirAccess.source.sourceUrl}
-                    label={interpretationLabel}
+                    label={`${interpretationLabel}: ${verseLabel}`}
                   />
                 )}
                 translationNotesLabel={translationNotesLabel}

--- a/apps/www/components/shared/quran/interpretation/button.tsx
+++ b/apps/www/components/shared/quran/interpretation/button.tsx
@@ -50,6 +50,7 @@ export function QuranInterpretationLink({
     <a
       aria-label={label}
       className={buttonVariants({ size: "icon", variant: "outline" })}
+      data-quran-interpretation-link=""
       href={href}
       rel="noreferrer"
       target="_blank"

--- a/apps/www/components/shared/quran/interpretation/button.tsx
+++ b/apps/www/components/shared/quran/interpretation/button.tsx
@@ -3,6 +3,7 @@
 import { BookOpen02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
+import { buttonVariants } from "@repo/design-system/lib/button";
 import {
   useQuranInterpretationSelection,
   useQuranInterpretationState,
@@ -46,13 +47,14 @@ export function QuranInterpretationLink({
   label: string;
 }) {
   return (
-    <Button
+    <a
       aria-label={label}
-      render={<a href={href} rel="noreferrer" target="_blank" />}
-      size="icon"
-      variant="outline"
+      className={buttonVariants({ size: "icon", variant: "outline" })}
+      href={href}
+      rel="noreferrer"
+      target="_blank"
     >
       <Spinner aria-hidden="true" icon={BookOpen02Icon} isLoading={false} />
-    </Button>
+    </a>
   );
 }

--- a/apps/www/components/shared/quran/interpretation/button.tsx
+++ b/apps/www/components/shared/quran/interpretation/button.tsx
@@ -36,3 +36,23 @@ export function QuranInterpretationButton({
     </Button>
   );
 }
+
+/** Opens one official link-only Tafsir edition with the established trigger. */
+export function QuranInterpretationLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  return (
+    <Button
+      aria-label={label}
+      render={<a href={href} rel="noreferrer" target="_blank" />}
+      size="icon"
+      variant="outline"
+    >
+      <Spinner aria-hidden="true" icon={BookOpen02Icon} isLoading={false} />
+    </Button>
+  );
+}

--- a/apps/www/components/shared/quran/verses/list.tsx
+++ b/apps/www/components/shared/quran/verses/list.tsx
@@ -11,7 +11,7 @@ interface VerseItem {
 
 interface Props {
   items: readonly VerseItem[];
-  renderAction?: (verse: QuranViewVerse) => ReactNode;
+  renderAction?: (verse: QuranViewVerse, verseLabel: string) => ReactNode;
   translationNotesLabel: string;
 }
 
@@ -29,7 +29,7 @@ export function QuranVerseList({
     >
       {items.map(({ id, label, verse }, index) => (
         <QuranVerseItem
-          action={renderAction?.(verse)}
+          action={renderAction?.(verse, label)}
           id={id}
           isLast={index === items.length - 1}
           key={verse.number.inQuran}

--- a/apps/www/e2e/quran.browser.ts
+++ b/apps/www/e2e/quran.browser.ts
@@ -14,8 +14,13 @@ const rawTranslationNotePattern = /\[\d+\]/u;
 interface QuranLocaleContract {
   readonly hasEmbeddedTafsir: boolean;
   readonly hasTranslationNotes: boolean;
-  readonly meaning: string;
+  readonly meanings: readonly [QuranMeaningContract, ...QuranMeaningContract[]];
   readonly translationNotesLabel: string;
+}
+
+interface QuranMeaningContract {
+  readonly locale: AppLocaleCode;
+  readonly text: string;
 }
 
 type QuranLocaleContracts = {
@@ -29,25 +34,44 @@ const quranLocaleContracts = {
     hasEmbeddedTafsir: false,
     hasTranslationNotes: false,
     locale: "de",
-    meaning: "Die Kuh",
+    meanings: [
+      { locale: "de", text: "Die Kuh" },
+      { locale: "en", text: "The Cow" },
+    ],
     translationNotesLabel: "Anmerkungen zur Übersetzung",
   },
   en: {
     hasEmbeddedTafsir: false,
     hasTranslationNotes: true,
     locale: "en",
-    meaning: "The Cow",
+    meanings: [{ locale: "en", text: "The Cow" }],
     translationNotesLabel: "Translation notes",
   },
   id: {
     hasEmbeddedTafsir: true,
     hasTranslationNotes: true,
     locale: "id",
-    meaning: "Sapi",
+    meanings: [
+      { locale: "id", text: "Sapi" },
+      { locale: "en", text: "The Cow" },
+    ],
     translationNotesLabel: "Catatan terjemahan",
   },
 } satisfies QuranLocaleContracts;
 type QuranLocaleCase = (typeof quranLocaleContracts)[AppLocaleCode];
+
+function quranMeaningLocator(
+  page: Page,
+  selector: string,
+  meanings: readonly [QuranMeaningContract, ...QuranMeaningContract[]]
+) {
+  const [first, ...rest] = meanings;
+  return rest.reduce(
+    (locator, meaning) =>
+      locator.or(page.locator(selector).filter({ hasText: meaning.text })),
+    page.locator(selector).filter({ hasText: first.text })
+  );
+}
 
 const verifyQuranInterpretationDrawer = Effect.fn(
   "NakafaE2E.verifyQuranInterpretationDrawer"
@@ -126,18 +150,31 @@ const verifyQuranLocaleCoverage = Effect.fn(
     readinessTimeoutMilliseconds
   );
 
-  const headerMeaning = page
-    .locator("header p")
-    .filter({ hasText: contract.meaning });
-  yield* Effect.promise(() => expect(headerMeaning).toBeVisible());
-  yield* Effect.promise(() =>
-    expect(headerMeaning).toHaveAttribute("lang", contract.locale)
+  const headerMeaning = quranMeaningLocator(
+    page,
+    "header p",
+    contract.meanings
   );
-  const sidebarMeaning = page
-    .locator('[data-slot="sidebar-menu-description"]')
-    .filter({ hasText: contract.meaning });
-  yield* Effect.promise(() =>
-    expect(sidebarMeaning).toHaveAttribute("lang", contract.locale)
+  yield* Effect.promise(() => expect(headerMeaning).toHaveCount(1));
+  const renderedMeaning = yield* Effect.promise(async () => ({
+    locale: await headerMeaning.getAttribute("lang"),
+    text: (await headerMeaning.textContent())?.trim(),
+  }));
+  yield* Effect.sync(() =>
+    expect(contract.meanings).toContainEqual(renderedMeaning)
+  );
+  const sidebarMeaning = quranMeaningLocator(
+    page,
+    '[data-slot="sidebar-menu-description"]',
+    contract.meanings
+  );
+  yield* Effect.promise(() => expect(sidebarMeaning).toHaveCount(1));
+  const renderedSidebarMeaning = yield* Effect.promise(async () => ({
+    locale: await sidebarMeaning.getAttribute("lang"),
+    text: (await sidebarMeaning.textContent())?.trim(),
+  }));
+  yield* Effect.sync(() =>
+    expect(renderedSidebarMeaning).toEqual(renderedMeaning)
   );
 
   const bismillah = page.locator("[data-quran-bismillah]");

--- a/apps/www/e2e/quran.browser.ts
+++ b/apps/www/e2e/quran.browser.ts
@@ -29,7 +29,7 @@ const quranLocaleContracts = {
     hasEmbeddedTafsir: false,
     hasTranslationNotes: false,
     locale: "de",
-    meaning: "The Cow",
+    meaning: "Die Kuh",
     translationNotesLabel: "Anmerkungen zur Übersetzung",
   },
   en: {
@@ -43,7 +43,7 @@ const quranLocaleContracts = {
     hasEmbeddedTafsir: true,
     hasTranslationNotes: true,
     locale: "id",
-    meaning: "The Cow",
+    meaning: "Sapi",
     translationNotesLabel: "Catatan terjemahan",
   },
 } satisfies QuranLocaleContracts;
@@ -131,13 +131,13 @@ const verifyQuranLocaleCoverage = Effect.fn(
     .filter({ hasText: contract.meaning });
   yield* Effect.promise(() => expect(headerMeaning).toBeVisible());
   yield* Effect.promise(() =>
-    expect(headerMeaning).toHaveAttribute("lang", "en")
+    expect(headerMeaning).toHaveAttribute("lang", contract.locale)
   );
   const sidebarMeaning = page
     .locator('[data-slot="sidebar-menu-description"]')
     .filter({ hasText: contract.meaning });
   yield* Effect.promise(() =>
-    expect(sidebarMeaning).toHaveAttribute("lang", "en")
+    expect(sidebarMeaning).toHaveAttribute("lang", contract.locale)
   );
 
   const bismillah = page.locator("[data-quran-bismillah]");
@@ -157,11 +157,32 @@ const verifyQuranLocaleCoverage = Effect.fn(
   );
 
   const interpretation = page.locator("[data-quran-interpretation-verse]");
+  const interpretationLink = page.locator("[data-quran-interpretation-link]");
   if (contract.hasEmbeddedTafsir) {
     yield* Effect.promise(() => expect(interpretation.first()).toBeVisible());
     yield* Effect.promise(() => expect(interpretation.first()).toBeEnabled());
+    yield* Effect.promise(() => expect(interpretationLink).toHaveCount(0));
   } else {
     yield* Effect.promise(() => expect(interpretation).toHaveCount(0));
+    yield* Effect.promise(() =>
+      expect(interpretationLink.first()).toBeVisible()
+    );
+    yield* Effect.promise(() =>
+      expect(interpretationLink.first()).toHaveAttribute("target", "_blank")
+    );
+    yield* Effect.promise(() =>
+      expect(interpretationLink.first()).toHaveAttribute("rel", "noreferrer")
+    );
+    const interpretationHref = yield* Effect.promise(() =>
+      interpretationLink.first().getAttribute("href")
+    );
+    yield* Effect.sync(() =>
+      expect(
+        interpretationHref === null
+          ? false
+          : new URL(interpretationHref).protocol === "https:"
+      ).toBe(true)
+    );
   }
 
   const translationNotes = page.locator(

--- a/apps/www/e2e/quran.browser.ts
+++ b/apps/www/e2e/quran.browser.ts
@@ -184,6 +184,20 @@ const verifyQuranLocaleCoverage = Effect.fn(
       ).toBe(true)
     );
   }
+  const interpretationActions = page.locator(
+    "[data-quran-interpretation-verse], [data-quran-interpretation-link]"
+  );
+  const interpretationNames = yield* Effect.promise(() =>
+    interpretationActions.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("aria-label"))
+    )
+  );
+  yield* Effect.sync(() => {
+    expect(interpretationNames.every((name) => name?.includes(": "))).toBe(
+      true
+    );
+    expect(new Set(interpretationNames).size).toBe(interpretationNames.length);
+  });
 
   const translationNotes = page.locator(
     `aside[aria-label^="${contract.translationNotesLabel}: "]`

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -3,6 +3,7 @@ import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import {
   encodeTestQuranRow,
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranSurah,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
@@ -68,7 +69,7 @@ describe("published Quran content", () => {
     ).resolves.toMatchObject({
       surah: {
         name: {
-          meaning: { appLocale: "en", text: "Technical meaning 1" },
+          meaning: makeQuranMeaning(1),
         },
         number: 1,
       },
@@ -112,13 +113,13 @@ describe("published Quran content", () => {
       appLocale: "id",
       nextSurah: {
         name: {
-          meaning: { appLocale: "en", text: "Technical meaning 2" },
+          meaning: makeQuranMeaning(2),
         },
         number: 2,
       },
       surah: {
         name: {
-          meaning: { appLocale: "en", text: "Technical meaning 1" },
+          meaning: makeQuranMeaning(1),
         },
         number: 1,
       },
@@ -153,13 +154,13 @@ describe("published Quran content", () => {
       nextSurah: null,
       previousSurah: {
         name: {
-          meaning: { appLocale: "en", text: "Technical meaning 113" },
+          meaning: makeQuranMeaning(113),
         },
         number: 113,
       },
       surah: {
         name: {
-          meaning: { appLocale: "en", text: "Technical meaning 114" },
+          meaning: makeQuranMeaning(114),
         },
         number: 114,
       },
@@ -184,7 +185,7 @@ function viewResult() {
     appLocale: "id",
     nextSurah: {
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 2" },
+        sourceMeaning: makeQuranMeaning(2),
         transliteration: "Technical Surah 2",
       },
       number: 2,
@@ -193,7 +194,7 @@ function viewResult() {
     previousSurah: null,
     surah: {
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Technical Surah 1",
       },
       number: 1,
@@ -257,7 +258,7 @@ function markdownResult() {
     sources: makeQuranLocaleSources("id"),
     surah: {
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Technical Surah 1",
       },
       number: 1,

--- a/apps/www/lib/llms/quran.test.ts
+++ b/apps/www/lib/llms/quran.test.ts
@@ -113,7 +113,7 @@ describe("quran llms text", () => {
       expect(firstSurahText).toContain("### Verses");
       expect(firstSurahText).toContain("Technical English Tafsir notice.");
       expect(firstSurahText).toContain(
-        "[Technical English Tafsir link.](https://example.test/tafsir/en)"
+        "[Technical English Tafsir link.](https://example.test/tafsir/en/read)"
       );
       expect(firstSurahText).toContain("#### Verse 1");
       expect(firstSurahText).toContain("**Translation:** Translation 1.");
@@ -150,7 +150,7 @@ describe("quran llms text", () => {
           `**${t("meaning")}:** ${surahMeanings[1][locale]}`
         );
         expect(text).toContain(
-          `[${tafsirAccess.source.label}](${tafsirAccess.source.updateUrl})`
+          `[${tafsirAccess.source.label}](${tafsirAccess.source.sourceUrl})`
         );
         expect(text).toContain(
           `**${t("translation-notes")}:**\n- **1.** Source note.`
@@ -328,7 +328,8 @@ function tafsirAccessFor(locale: Locale) {
       notice: "Catatan teknis tafsir Indonesia.",
       source: {
         label: "Technical Indonesian Tafsir source.",
-        updateUrl: "https://example.test/tafsir/id",
+        sourceUrl: "https://example.test/tafsir/id/read",
+        updateUrl: "https://example.test/tafsir/id/updates",
       },
     };
   }
@@ -344,7 +345,8 @@ function tafsirAccessFor(locale: Locale) {
         locale === "en"
           ? "Technical English Tafsir link."
           : "Technischer deutscher Tafsirlink.",
-      updateUrl: `https://example.test/tafsir/${locale}`,
+      sourceUrl: `https://example.test/tafsir/${locale}/read`,
+      updateUrl: `https://example.test/tafsir/${locale}/updates`,
     },
   };
 }

--- a/apps/www/lib/llms/quran.test.ts
+++ b/apps/www/lib/llms/quran.test.ts
@@ -168,6 +168,43 @@ describe("quran llms text", () => {
     })
   );
 
+  it.effect("labels retained English meanings in localized output", () =>
+    Effect.gen(function* () {
+      const metadata = surahMetadata(1);
+      const predecessorMeaning = {
+        appLocale: "en",
+        text: "The Opening",
+      } as const;
+      const predecessorMetadata = {
+        ...metadata,
+        name: { ...metadata.name, meaning: predecessorMeaning },
+      };
+      const markdown = surahMarkdown("id", 1);
+      publicationMocks.readPublishedQuranCatalog.mockReturnValue(
+        Effect.succeed({ surahs: [predecessorMetadata] })
+      );
+      publicationMocks.readPublishedQuranMarkdown.mockReturnValue(
+        Effect.succeed({
+          ...markdown,
+          surah: {
+            ...markdown.surah,
+            name: { ...markdown.surah.name, meaning: predecessorMeaning },
+          },
+        })
+      );
+
+      expect(yield* readQuranLlmsPageEntries("id", 0)).toEqual([
+        expect.objectContaining({ description: "The Opening (en)" }),
+      ]);
+      expect(
+        yield* getQuranLlmsText({ cleanSlug: "quran", locale: "id" })
+      ).toContain("**Makna nama:** The Opening (en)");
+      expect(
+        yield* getQuranLlmsText({ cleanSlug: "quran/1", locale: "id" })
+      ).toContain("**Makna nama:** The Opening (en)");
+    })
+  );
+
   it.effect("bounds long signed surah markdown to eighty verses", () =>
     Effect.gen(function* () {
       const t = yield* createHolyTranslator("id");

--- a/apps/www/lib/llms/quran.test.ts
+++ b/apps/www/lib/llms/quran.test.ts
@@ -108,7 +108,7 @@ describe("quran llms text", () => {
 
       expect(indexText?.startsWith("# Quran")).toBe(true);
       expect(indexText).toContain("## 1. Al-Fatihah");
-      expect(indonesianIndexText).toContain("**Makna nama:** The Opening (en)");
+      expect(indonesianIndexText).toContain("**Makna nama:** Pembuka");
       expect(firstSurahText?.startsWith("# Al-Fatihah")).toBe(true);
       expect(firstSurahText).toContain("### Verses");
       expect(firstSurahText).toContain("Technical English Tafsir notice.");
@@ -146,7 +146,9 @@ describe("quran llms text", () => {
         const tafsirAccess = tafsirAccessFor(locale);
 
         expect(text).toContain(tafsirAccess.notice);
-        expect(text).toContain(`**${t("meaning")}:** The Opening (en)`);
+        expect(text).toContain(
+          `**${t("meaning")}:** ${surahMeanings[1][locale]}`
+        );
         expect(text).toContain(
           `[${tafsirAccess.source.label}](${tafsirAccess.source.updateUrl})`
         );
@@ -163,22 +165,6 @@ describe("quran llms text", () => {
         );
         expect(text).toContain(`**${t("number-of-verses")}:**`);
       }
-    })
-  );
-
-  it.effect("keeps verses available while Tafsir access is switching", () =>
-    Effect.gen(function* () {
-      publicationMocks.readPublishedQuranMarkdown.mockReturnValueOnce(
-        Effect.succeed({ ...surahMarkdown("en", 1), tafsirAccess: null })
-      );
-
-      const text = yield* getQuranLlmsText({
-        cleanSlug: "quran/1",
-        locale: "en",
-      });
-
-      expect(text).toContain("#### Verse 1");
-      expect(text).not.toContain("Technical English Tafsir link.");
     })
   );
 
@@ -228,7 +214,7 @@ describe("quran llms text", () => {
         for (const locale of ["en", "id", "de"] as const) {
           expect(yield* readQuranLlmsPageEntries(locale, 0)).toEqual([
             {
-              description: "The Opening (en)",
+              description: surahMeanings[1][locale],
               href: `${BASE_URL}/${locale}/quran/1.md`,
               route: "/quran/1",
               section: "quran",
@@ -236,7 +222,7 @@ describe("quran llms text", () => {
               title: "Al-Fatihah",
             },
             {
-              description: "The Cow (en)",
+              description: surahMeanings[2][locale],
               href: `${BASE_URL}/${locale}/quran/2.md`,
               route: "/quran/2",
               section: "quran",
@@ -268,16 +254,18 @@ describe("quran llms text", () => {
   );
 });
 
+const surahMeanings = {
+  1: { de: "Die Eröffnende", en: "The Opening", id: "Pembuka" },
+  2: { de: "Die Kuh", en: "The Cow", id: "Sapi" },
+} as const;
+
 /** Builds source-authenticated Quran metadata for tests. */
 function surahMetadata(number: number) {
   return {
     kind: "quran-surah",
     name: {
       arabic: number === 1 ? "الفاتحة" : "البقرة",
-      meaning: {
-        appLocale: "en" as const,
-        text: number === 1 ? "The Opening" : "The Cow",
-      },
+      meaning: number === 1 ? surahMeanings[1] : surahMeanings[2],
       transliteration: number === 1 ? "Al-Fatihah" : "Al-Baqarah",
     },
     number,

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -254,7 +254,10 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
 
 /** Preserves the signed source language beside one Quran meaning. */
 function formatQuranMeaning(meaning: PublishedQuranMeaning, locale: Locale) {
-  return selectQuranMeaning(meaning, locale).text;
+  const selected = selectQuranMeaning(meaning, locale);
+  return selected.appLocale === locale
+    ? selected.text
+    : `${selected.text} (${selected.appLocale})`;
 }
 
 /** Renders one semantic translation and its localized source-note heading. */

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -204,7 +204,7 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
   scanned.push(tafsirAccess.notice);
   scanned.push("");
   scanned.push(
-    `[${tafsirAccess.source.label}](${tafsirAccess.source.updateUrl})`
+    `[${tafsirAccess.source.label}](${tafsirAccess.source.sourceUrl})`
   );
   scanned.push("");
 

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -2,10 +2,7 @@ import type { QuranTranslationDocument } from "@nakafa/aksara-contracts/quran/no
 import { QuranSurahNumberSchema } from "@nakafa/aksara-contracts/quran/spec";
 import { projectQuranTranslation } from "@repo/backend/client/quran/notes";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
-import {
-  type PublishedQuranMeaning,
-  selectQuranMeaning,
-} from "@repo/backend/content/quran/contract";
+import { formatQuranMeaning } from "@repo/backend/content/quran/contract";
 import { loadLocaleMessages } from "@repo/internationalization/src/messages";
 import { Effect, Option, Schema } from "effect";
 import { createTranslator, type Locale } from "next-intl";
@@ -251,14 +248,6 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
 
   return scanned.join("\n");
 });
-
-/** Preserves the signed source language beside one Quran meaning. */
-function formatQuranMeaning(meaning: PublishedQuranMeaning, locale: Locale) {
-  const selected = selectQuranMeaning(meaning, locale);
-  return selected.appLocale === locale
-    ? selected.text
-    : `${selected.text} (${selected.appLocale})`;
-}
 
 /** Renders one semantic translation and its localized source-note heading. */
 function renderQuranTranslation(

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -1,10 +1,11 @@
 import type { QuranTranslationDocument } from "@nakafa/aksara-contracts/quran/notes";
-import {
-  QuranSurahNumberSchema,
-  type QuranSurahRow,
-} from "@nakafa/aksara-contracts/quran/spec";
+import { QuranSurahNumberSchema } from "@nakafa/aksara-contracts/quran/spec";
 import { projectQuranTranslation } from "@repo/backend/client/quran/notes";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
+import {
+  type PublishedQuranMeaning,
+  selectQuranMeaning,
+} from "@repo/backend/content/quran/contract";
 import { loadLocaleMessages } from "@repo/internationalization/src/messages";
 import { Effect, Option, Schema } from "effect";
 import { createTranslator, type Locale } from "next-intl";
@@ -252,11 +253,8 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
 });
 
 /** Preserves the signed source language beside one Quran meaning. */
-function formatQuranMeaning(
-  meaning: QuranSurahRow["name"]["meaning"],
-  locale: Locale
-) {
-  return meaning[locale];
+function formatQuranMeaning(meaning: PublishedQuranMeaning, locale: Locale) {
+  return selectQuranMeaning(meaning, locale).text;
 }
 
 /** Renders one semantic translation and its localized source-note heading. */

--- a/apps/www/lib/llms/quran.ts
+++ b/apps/www/lib/llms/quran.ts
@@ -1,5 +1,8 @@
 import type { QuranTranslationDocument } from "@nakafa/aksara-contracts/quran/notes";
-import { QuranSurahNumberSchema } from "@nakafa/aksara-contracts/quran/spec";
+import {
+  QuranSurahNumberSchema,
+  type QuranSurahRow,
+} from "@nakafa/aksara-contracts/quran/spec";
 import { projectQuranTranslation } from "@repo/backend/client/quran/notes";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
 import { loadLocaleMessages } from "@repo/internationalization/src/messages";
@@ -70,7 +73,7 @@ export const readQuranLlmsPageEntries = Effect.fn("www.llms.quran.pageEntries")(
     return buildPublishedContentLlmsEntries({
       locale,
       rows: surahs.map((surah) => ({
-        description: formatQuranMeaning(surah.name.meaning),
+        description: formatQuranMeaning(surah.name.meaning, locale),
         publicPath: `quran/${surah.number}`,
         title: getQuranSurahName(surah.name),
       })),
@@ -122,7 +125,7 @@ const getQuranIndexText = Effect.fn("www.llms.quran.indexText")(function* (
     scanned.push(`## ${surah.number}. ${title}`);
     scanned.push("");
     scanned.push(
-      `**${t("meaning")}:** ${formatQuranMeaning(surah.name.meaning)}`
+      `**${t("meaning")}:** ${formatQuranMeaning(surah.name.meaning, locale)}`
     );
     scanned.push("");
     scanned.push(
@@ -161,7 +164,7 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
   const surah = markdown.surah;
   const tafsirAccess = markdown.tafsirAccess;
   const title = getQuranSurahName(surah.name);
-  const description = surah.name.meaning.text;
+  const description = formatQuranMeaning(surah.name.meaning, locale);
   const scanned = buildHeader({
     description,
     title,
@@ -171,7 +174,7 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
   scanned.push(`## ${title}`);
   scanned.push("");
   scanned.push(
-    `**${t("meaning")}:** ${formatQuranMeaning(surah.name.meaning)}`
+    `**${t("meaning")}:** ${formatQuranMeaning(surah.name.meaning, locale)}`
   );
   scanned.push(
     `**${t("revelation")}:** ${t("revelation-place", {
@@ -197,14 +200,12 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
     `  ${markdown.sources.translation.publisher} · ${markdown.sources.translation.version}`
   );
   scanned.push("");
-  if (tafsirAccess !== null) {
-    scanned.push(tafsirAccess.notice);
-    scanned.push("");
-    scanned.push(
-      `[${tafsirAccess.source.label}](${tafsirAccess.source.updateUrl})`
-    );
-    scanned.push("");
-  }
+  scanned.push(tafsirAccess.notice);
+  scanned.push("");
+  scanned.push(
+    `[${tafsirAccess.source.label}](${tafsirAccess.source.updateUrl})`
+  );
+  scanned.push("");
 
   scanned.push(`### ${t("verses")}`);
   scanned.push("");
@@ -251,11 +252,11 @@ const getSurahLlmsText = Effect.fn("www.llms.quran.surahText")(function* ({
 });
 
 /** Preserves the signed source language beside one Quran meaning. */
-function formatQuranMeaning(meaning: {
-  readonly appLocale: string;
-  readonly text: string;
-}) {
-  return `${meaning.text} (${meaning.appLocale})`;
+function formatQuranMeaning(
+  meaning: QuranSurahRow["name"]["meaning"],
+  locale: Locale
+) {
+  return meaning[locale];
 }
 
 /** Renders one semantic translation and its localized source-note heading. */

--- a/apps/www/lib/utils/pages/quran.test.ts
+++ b/apps/www/lib/utils/pages/quran.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { describe, expect, it } from "vitest";
 import { getQuranPagination, getQuranSurahName } from "@/lib/utils/pages/quran";
@@ -53,7 +52,7 @@ function surahPage(): {
       kind: "quran-surah",
       name: {
         arabic: "البقرة",
-        meaning: { appLocale: makeAppLocale("en"), text: "The Cow" },
+        meaning: { de: "Die Kuh", en: "The Cow", id: "Sapi" },
         transliteration: "Al-Baqarah",
       },
       number: 2,
@@ -65,7 +64,7 @@ function surahPage(): {
       kind: "quran-surah",
       name: {
         arabic: "الفاتحة",
-        meaning: { appLocale: makeAppLocale("en"), text: "The Opening" },
+        meaning: { de: "Die Eröffnende", en: "The Opening", id: "Pembuka" },
         transliteration: "Al-Fatihah",
       },
       number: 1,

--- a/apps/www/lib/utils/pages/quran.ts
+++ b/apps/www/lib/utils/pages/quran.ts
@@ -1,6 +1,6 @@
-import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 
-export type QuranSurah = QuranSurahRow;
+export type QuranSurah = PublishedQuranSurah;
 
 interface QuranName {
   readonly transliteration: string;

--- a/apps/www/lib/utils/seo/fallback.test.ts
+++ b/apps/www/lib/utils/seo/fallback.test.ts
@@ -1,4 +1,3 @@
-import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
 import { describe, expect, it } from "vitest";
 import { generateFallbackMetadata } from "@/lib/utils/seo/fallback";
 
@@ -112,8 +111,9 @@ describe("generateFallbackMetadata", () => {
           name: {
             arabic: "الفاتحة",
             meaning: {
-              appLocale: makeAppLocale("en"),
-              text: "The Opening",
+              de: "Die Eröffnende",
+              en: "The Opening",
+              id: "Pembuka",
             },
             transliteration: "Al-Fatihah",
           },

--- a/apps/www/lib/utils/seo/generator.test.ts
+++ b/apps/www/lib/utils/seo/generator.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateSEOMetadata } from "@/lib/utils/seo/generator";
@@ -116,7 +115,7 @@ const surah = {
   kind: "quran-surah",
   name: {
     arabic: "Al-Fatihah",
-    meaning: { appLocale: makeAppLocale("en"), text: "The Opening" },
+    meaning: { de: "Die Eröffnende", en: "The Opening", id: "Pembuka" },
     transliteration: "Al-Fatihah",
   },
   number: 1,

--- a/apps/www/lib/utils/seo/quran.test.ts
+++ b/apps/www/lib/utils/seo/quran.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 
-import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,7 +17,7 @@ const surah = {
   kind: "quran-surah",
   name: {
     arabic: "Al-Fatihah",
-    meaning: { appLocale: makeAppLocale("en"), text: "The Opening" },
+    meaning: { de: "Die Eröffnende", en: "The Opening", id: "Pembuka" },
     transliteration: "Al-Fatihah",
   },
   number: 1,
@@ -63,7 +62,7 @@ describe("generateQuranMetadata", () => {
   it("uses the same authenticated Quran names in every shell locale", async () => {
     const result = await Effect.runPromise(generateQuranMetadata(surah, "id"));
 
-    expect(result.title).toBe("Surah 1. Al-Fatihah - Al-Fatihah | Nakafa");
-    expect(result.keywords).toEqual(["Al-Fatihah", "Meccan"]);
+    expect(result.title).toBe("Surah 1. Al-Fatihah - Pembuka | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "Pembuka", "Meccan"]);
   });
 });

--- a/apps/www/lib/utils/seo/quran.test.ts
+++ b/apps/www/lib/utils/seo/quran.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -45,9 +46,18 @@ describe("generateQuranMetadata", () => {
           return `Read Surah ${getValue(values, "name")} with ${getValue(values, "numberOfVerses")} verses.`;
         }
         if (key === "quran.keywords") {
-          return `${getValue(values, "name")}, ${getValue(values, "translation")}, ${getValue(values, "revelation")}`;
+          return [
+            getValue(values, "name"),
+            getValue(values, "translation"),
+            getValue(values, "revelation"),
+          ]
+            .filter((value) => value !== "__EMPTY__")
+            .join(", ");
         }
-        return `Surah ${getValue(values, "number")}. ${getValue(values, "name")} - ${getValue(values, "translation")} | Nakafa`;
+        const translation = getValue(values, "translation");
+        const translationSuffix =
+          translation === "__EMPTY__" ? "" : ` - ${translation}`;
+        return `Surah ${getValue(values, "number")}. ${getValue(values, "name")}${translationSuffix} | Nakafa`;
       }
     );
   });
@@ -64,5 +74,22 @@ describe("generateQuranMetadata", () => {
 
     expect(result.title).toBe("Surah 1. Al-Fatihah - Pembuka | Nakafa");
     expect(result.keywords).toEqual(["Al-Fatihah", "Pembuka", "Meccan"]);
+  });
+
+  it("does not relabel a retained English meaning as localized SEO", async () => {
+    const predecessor = {
+      ...surah,
+      name: {
+        ...surah.name,
+        meaning: { appLocale: makeAppLocale("en"), text: "The Opening" },
+      },
+    };
+
+    const result = await Effect.runPromise(
+      generateQuranMetadata(predecessor, "id")
+    );
+
+    expect(result.title).toBe("Surah 1. Al-Fatihah | Nakafa");
+    expect(result.keywords).toEqual(["Al-Fatihah", "Meccan"]);
   });
 });

--- a/apps/www/lib/utils/seo/quran.ts
+++ b/apps/www/lib/utils/seo/quran.ts
@@ -11,10 +11,9 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
     Effect.gen(function* () {
       const name = surah.name.arabic;
       const transliteration = surah.name.transliteration;
-      const localizedMeaning = selectQuranMeaning(
-        surah.name.meaning,
-        locale
-      ).text;
+      const meaning = selectQuranMeaning(surah.name.meaning, locale);
+      const localizedMeaning =
+        meaning.appLocale === locale ? meaning.text : "__EMPTY__";
       const revelation = surah.revelation.place;
 
       const t = yield* fetchSEOTranslationsNamespace(locale, "SEO");

--- a/apps/www/lib/utils/seo/quran.ts
+++ b/apps/www/lib/utils/seo/quran.ts
@@ -1,3 +1,4 @@
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import { Effect } from "effect";
 import type { Locale } from "next-intl";
 import type { QuranSurah } from "@/lib/utils/pages/quran";
@@ -10,7 +11,10 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
     Effect.gen(function* () {
       const name = surah.name.arabic;
       const transliteration = surah.name.transliteration;
-      const localizedMeaning = surah.name.meaning[locale];
+      const localizedMeaning = selectQuranMeaning(
+        surah.name.meaning,
+        locale
+      ).text;
       const revelation = surah.revelation.place;
 
       const t = yield* fetchSEOTranslationsNamespace(locale, "SEO");

--- a/apps/www/lib/utils/seo/quran.ts
+++ b/apps/www/lib/utils/seo/quran.ts
@@ -10,11 +10,7 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
     Effect.gen(function* () {
       const name = surah.name.arabic;
       const transliteration = surah.name.transliteration;
-      const localizedMeaning =
-        surah.name.meaning.appLocale === locale
-          ? surah.name.meaning.text
-          : null;
-      const translation = localizedMeaning ?? transliteration;
+      const localizedMeaning = surah.name.meaning[locale];
       const revelation = surah.revelation.place;
 
       const t = yield* fetchSEOTranslationsNamespace(locale, "SEO");
@@ -24,7 +20,7 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
           number: surah.number,
           name,
           transliteration,
-          translation,
+          translation: localizedMeaning,
         }),
         description: t("quran.description", {
           name,
@@ -35,7 +31,7 @@ export const generateQuranMetadata = Effect.fn("SEO.generateQuranMetadata")(
           t("quran.keywords", {
             name,
             transliteration,
-            translation: localizedMeaning ?? "",
+            translation: localizedMeaning,
             revelation,
           })
         ),

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -27,7 +27,7 @@
     "@hugeicons/react": "^1.1.10",
     "@mantine/hooks": "^9.5.2",
     "@mdx-js/mdx": "3.1.1",
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@paper-design/shaders-react": "^0.0.80",
     "@repo/ai": "workspace:*",
     "@repo/analytics": "workspace:*",

--- a/packages/ai/agents/nakafa/format.test.ts
+++ b/packages/ai/agents/nakafa/format.test.ts
@@ -117,7 +117,7 @@ describe("Nakafa formatter", () => {
     expect(text).toContain("# Nakafa Quran Reference");
     expect(text).not.toContain("Inline citation:");
     expect(text).not.toContain("https://nakafa.com/id/quran/1");
-    expect(text).toContain("Meaning: The Opening (en)");
+    expect(text).toContain("Meaning: Pembuka");
     expect(text).toContain("quranenc-indonesian");
     expect(text).toContain("quranenc-tafsir");
     expect(text).toContain("Kind: embedded");
@@ -134,20 +134,15 @@ describe("Nakafa formatter", () => {
     expect(text).not.toContain("Dengan nama Allah[4]");
     expect(formatQuran(reference)).not.toContain("## Bismillah");
 
-    const legacyEnglishReference = Schema.decodeUnknownSync(
-      NakafaAgentQuranReferenceSchema
-    )({
-      ...makeQuranFixture({
+    const englishReference = Schema.decodeSync(NakafaAgentQuranReferenceSchema)(
+      makeQuranFixture({
         from_verse: 1,
         include_tafsir: true,
         locale: "en",
         surah: 1,
-      }),
-      tafsir_access: null,
-    });
-    expect(formatQuran(legacyEnglishReference)).toContain(
-      "No Tafsir access metadata is available in the current signed publication."
+      })
     );
+    expect(formatQuran(englishReference)).toContain("Kind: external");
   });
 
   it("formats taxonomy", () => {

--- a/packages/ai/agents/nakafa/format.test.ts
+++ b/packages/ai/agents/nakafa/format.test.ts
@@ -134,6 +134,16 @@ describe("Nakafa formatter", () => {
     expect(text).not.toContain("Dengan nama Allah[4]");
     expect(formatQuran(reference)).not.toContain("## Bismillah");
 
+    const fallbackReference = Schema.decodeSync(
+      NakafaAgentQuranReferenceSchema
+    )({
+      ...reference,
+      meaning: { locale: "en", text: "The Opening" },
+    });
+    expect(formatQuran(fallbackReference)).toContain(
+      "Meaning: The Opening (en)"
+    );
+
     const englishReference = Schema.decodeSync(NakafaAgentQuranReferenceSchema)(
       makeQuranFixture({
         from_verse: 1,

--- a/packages/ai/agents/nakafa/format.ts
+++ b/packages/ai/agents/nakafa/format.ts
@@ -78,6 +78,10 @@ function formatQuranSource(source: {
 
 /** Formats a source-grounded Quran reference for model consumption. */
 export function formatQuran(result: NakafaAgentQuranReference) {
+  const meaning =
+    result.meaning.locale === result.locale
+      ? result.meaning.text
+      : `${result.meaning.text} (${result.meaning.locale})`;
   const preBismillah =
     result.pre_bismillah === null
       ? ""
@@ -92,7 +96,7 @@ export function formatQuran(result: NakafaAgentQuranReference) {
   return dedent(`
     # Nakafa Quran Reference
     - Name: ${result.name}
-    - Meaning: ${result.meaning.text}
+    - Meaning: ${meaning}
     - Revelation: ${result.revelation}
     - Content ID: ${result.content_id}
 

--- a/packages/ai/agents/nakafa/format.ts
+++ b/packages/ai/agents/nakafa/format.ts
@@ -78,7 +78,6 @@ function formatQuranSource(source: {
 
 /** Formats a source-grounded Quran reference for model consumption. */
 export function formatQuran(result: NakafaAgentQuranReference) {
-  const meaning = `${result.meaning.text} (${result.meaning.locale})`;
   const preBismillah =
     result.pre_bismillah === null
       ? ""
@@ -86,18 +85,14 @@ export function formatQuran(result: NakafaAgentQuranReference) {
     ## Bismillah
     - Arabic: ${result.pre_bismillah.arabic}
     ${formatQuranTranslation(result.pre_bismillah.translation)}`;
-  const tafsirAccess =
-    result.tafsir_access === null
-      ? `## Tafsir access
-    - Availability: No Tafsir access metadata is available in the current signed publication.`
-      : `## Tafsir access
+  const tafsirAccess = `## Tafsir access
     - Kind: ${result.tafsir_access.kind}
     - Notice: ${result.tafsir_access.notice}
     - Source: ${formatQuranSource(result.tafsir_access.source)}`;
   return dedent(`
     # Nakafa Quran Reference
     - Name: ${result.name}
-    - Meaning: ${meaning}
+    - Meaning: ${result.meaning.text}
     - Revelation: ${result.revelation}
     - Content ID: ${result.content_id}
 

--- a/packages/ai/agents/nakafa/preview.ts
+++ b/packages/ai/agents/nakafa/preview.ts
@@ -31,7 +31,9 @@ export function previewQuran(result: NakafaAgentQuranReference) {
 }
 
 /** Builds the shared graph-backed content reference preview fields. */
-function previewContentRef(result: NakafaAgentContentRef) {
+function previewContentRef<const Result extends NakafaAgentContentRef>(
+  result: Result
+) {
   return {
     alignmentId: result.alignmentId,
     assetId: result.assetId,

--- a/packages/ai/agents/nakafa/tools/fixture.test.ts
+++ b/packages/ai/agents/nakafa/tools/fixture.test.ts
@@ -5,6 +5,12 @@ import { Effect, Option } from "effect";
 import { describe, expect, it } from "vitest";
 
 describe("Nakafa Quran AI fixtures", () => {
+  const meaningByLocale = {
+    de: "Die Eröffnende",
+    en: "The Opening",
+    id: "Pembuka",
+  } as const;
+
   it.each([
     ["en", "quranenc-english", "mokhtasar-english", "external"],
     ["id", "quranenc-indonesian", "quranenc-tafsir", "embedded"],
@@ -25,7 +31,8 @@ describe("Nakafa Quran AI fixtures", () => {
         locale,
         source: { id: tafsirId },
       });
-      expect(result.meaning).toEqual({ locale: "en", text: "The Opening" });
+      expect(result.meaning.locale).toBe(locale);
+      expect(result.meaning.text).toBe(meaningByLocale[locale]);
       expect(result.verses[0]?.tafsir).toBe(
         locale === "id" ? "Tafsir from the injected test adapter." : undefined
       );

--- a/packages/ai/agents/nakafa/tools/fixture.ts
+++ b/packages/ai/agents/nakafa/tools/fixture.ts
@@ -14,6 +14,11 @@ const ARTIFACT = {
   digest: `sha256:${"1".repeat(64)}`,
   file_count: 1,
 };
+const meaningByLocale = {
+  de: "Die Eröffnende",
+  en: "The Opening",
+  id: "Pembuka",
+} as const;
 /** Builds one complete embedded source for injected results. */
 function embeddedSource(id: QuranEmbeddedSourceId) {
   return {
@@ -86,7 +91,7 @@ export function makeQuranFixture(input: {
   const { from_verse, include_tafsir, locale, surah } = input;
   return Schema.decodeUnknownSync(NakafaAgentQuranReferenceSchema)({
     ...readNakafaContentRefFixture(locale, `quran/${surah}`, "quran"),
-    meaning: { locale: "en", text: "The Opening" },
+    meaning: { locale, text: meaningByLocale[locale] },
     name: "Al-Faatiha",
     pre_bismillah: null,
     revelation: "Meccan",

--- a/packages/ai/agents/nakafa/tools/quran.ts
+++ b/packages/ai/agents/nakafa/tools/quran.ts
@@ -1,12 +1,13 @@
 import { formatQuran } from "@repo/ai/agents/nakafa/format";
 import { previewQuran } from "@repo/ai/agents/nakafa/preview";
 import { Nakafa } from "@repo/ai/agents/nakafa/service";
+import { NakafaDataSchema } from "@repo/ai/schema/data";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { NAKAFA_AGENT_MAX_QURAN_REFERENCE_VERSES } from "@repo/contents/_lib/agent/constants";
 import type { NakafaAgentQuranReferenceOptions } from "@repo/contents/_lib/agent/schema/quran/input";
 import type { Locale } from "@repo/contents/_types/content";
 import type { UIMessageStreamWriter } from "ai";
-import { Effect, Option, Result } from "effect";
+import { Effect, Option, Result, Schema } from "effect";
 
 type Writer = Pick<UIMessageStreamWriter<MyUIMessage>, "write">;
 const invalidRangeMessage = "Invalid Quran verse range.";
@@ -104,16 +105,17 @@ export const quran = Effect.fn("nakafa.quran")(function* ({
     return notFoundMessage;
   }
   const value = content.value;
+  const done = yield* Schema.decodeUnknownEffect(NakafaDataSchema)({
+    kind: "quran",
+    input: dataInput,
+    status: "done",
+    result: previewQuran(value),
+  });
   yield* Effect.sync(() =>
     writer.write({
       id: toolCallId,
       type: "data-nakafa",
-      data: {
-        kind: "quran",
-        input: dataInput,
-        status: "done",
-        result: previewQuran(value),
-      },
+      data: done,
     })
   );
   return formatQuran(value);

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -14,7 +14,7 @@
     "@ai-sdk/gateway": "4.0.62",
     "@ai-sdk/google": "4.0.50",
     "@mendable/firecrawl-js": "^4.35.0",
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@repo/contents": "workspace:*",
     "@repo/math": "workspace:*",
     "@repo/utilities": "workspace:*",

--- a/packages/ai/schema/data.test.ts
+++ b/packages/ai/schema/data.test.ts
@@ -34,6 +34,17 @@ describe("Nakafa persisted Quran data", () => {
     expect(
       Schema.is(NakafaDataSchema)({
         ...common,
+        input: { ...common.input, locale: "id" },
+        result: {
+          ...preview,
+          locale: "id",
+          meaning: { locale: "id", text: "Pembuka" },
+        },
+      })
+    ).toBe(true);
+    expect(
+      Schema.is(NakafaDataSchema)({
+        ...common,
         result: { ...preview, translation: "The Opening" },
       })
     ).toBe(false);

--- a/packages/ai/schema/data.test.ts
+++ b/packages/ai/schema/data.test.ts
@@ -45,6 +45,39 @@ describe("Nakafa persisted Quran data", () => {
     expect(
       Schema.is(NakafaDataSchema)({
         ...common,
+        input: { ...common.input, locale: "id" },
+        result: {
+          ...preview,
+          locale: "id",
+          meaning: { locale: "en", text: "The Opening" },
+        },
+      })
+    ).toBe(true);
+    expect(
+      Schema.is(NakafaDataSchema)({
+        ...common,
+        input: { ...common.input, locale: "id" },
+        result: {
+          ...preview,
+          locale: "id",
+          meaning: { locale: "de", text: "Die Eröffnende" },
+        },
+      })
+    ).toBe(false);
+    expect(
+      Schema.is(NakafaDataSchema)({
+        ...common,
+        input: { ...common.input, locale: "id" },
+        result: {
+          ...preview,
+          locale: "de",
+          meaning: { locale: "en", text: "The Opening" },
+        },
+      })
+    ).toBe(false);
+    expect(
+      Schema.is(NakafaDataSchema)({
+        ...common,
         result: { ...preview, translation: "The Opening" },
       })
     ).toBe(false);

--- a/packages/ai/schema/data.ts
+++ b/packages/ai/schema/data.ts
@@ -1,4 +1,10 @@
-import { ActiveAppLocaleCodeSchema } from "@nakafa/aksara-contracts/locale";
+import {
+  ActiveAppLocaleCodeSchema,
+  type AppLocaleCode,
+  ENGLISH_APP_LOCALE_CODE,
+  GERMAN_APP_LOCALE_CODE,
+  INDONESIAN_APP_LOCALE_CODE,
+} from "@nakafa/aksara-contracts/locale";
 import { NakafaAgentQuranReferenceOptionsSchema } from "@repo/contents/_lib/agent/schema/quran/input";
 import { NakafaAgentReadOptionsSchema } from "@repo/contents/_lib/agent/schema/read";
 import {
@@ -27,18 +33,45 @@ const SearchResultSchema = NakafaAgentSearchResultSchema;
 const ReadInputSchema = NakafaAgentReadOptionsSchema;
 const QuranInputSchema = NakafaAgentQuranReferenceOptionsSchema;
 const TaxonomyInputSchema = NakafaAgentTaxonomyOptionsSchema;
-const QuranPreviewSchema = Schema.Struct({
+const quranPreviewFields = {
   ...NakafaAgentContentRefSchema.fields,
   from_verse: Schema.Finite,
-  meaning: Schema.Struct({
-    locale: LocaleSchema,
-    text: Schema.String,
-  }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey))),
   name: Schema.String,
   revelation: Schema.String,
   to_verse: Schema.Finite,
   verse_count: Schema.Finite,
-}).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+};
+
+/** Builds one canonical Quran preview correlated to its request locale. */
+function makeQuranDoneSchema<const Locale extends AppLocaleCode>(
+  locale: Locale
+) {
+  return Schema.Struct({
+    input: Schema.Struct({
+      ...QuranInputSchema.fields,
+      locale: Schema.Literal(locale),
+    }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey))),
+    kind: Schema.Literal("quran"),
+    result: Schema.Struct({
+      ...quranPreviewFields,
+      locale: Schema.Literal(locale),
+      meaning: Schema.Struct({
+        locale: Schema.Union([
+          Schema.Literal(locale),
+          Schema.Literal(ENGLISH_APP_LOCALE_CODE),
+        ]),
+        text: Schema.String,
+      }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey))),
+    }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey))),
+    status: Schema.Literal("done"),
+  }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+}
+
+const NakafaQuranDoneSchema = Schema.Union([
+  makeQuranDoneSchema(ENGLISH_APP_LOCALE_CODE),
+  makeQuranDoneSchema(INDONESIAN_APP_LOCALE_CODE),
+  makeQuranDoneSchema(GERMAN_APP_LOCALE_CODE),
+]);
 const TaxonomyPreviewSchema = Schema.Struct({
   content_counts: Schema.Array(
     Schema.Struct({
@@ -94,11 +127,6 @@ const nakafaQuranLoadingFields = {
 const NakafaQuranLoadingSchema = Schema.Struct(nakafaQuranLoadingFields).pipe(
   (schema) => schema.mapFields(Struct.map(Schema.mutableKey))
 );
-const NakafaQuranDoneSchema = Schema.Struct({
-  ...nakafaQuranLoadingFields,
-  result: QuranPreviewSchema,
-  status: Schema.Literal("done"),
-}).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
 const NakafaQuranErrorSchema = Schema.Struct({
   ...nakafaQuranLoadingFields,
   error: Schema.String,

--- a/packages/ai/schema/data.ts
+++ b/packages/ai/schema/data.ts
@@ -27,20 +27,18 @@ const SearchResultSchema = NakafaAgentSearchResultSchema;
 const ReadInputSchema = NakafaAgentReadOptionsSchema;
 const QuranInputSchema = NakafaAgentQuranReferenceOptionsSchema;
 const TaxonomyInputSchema = NakafaAgentTaxonomyOptionsSchema;
-const QuranPreviewSchema = NakafaAgentContentRefSchema.mapFields((fields) => ({
-  ...fields,
+const QuranPreviewSchema = Schema.Struct({
+  ...NakafaAgentContentRefSchema.fields,
   from_verse: Schema.Finite,
-  meaning: Schema.NullOr(
-    Schema.Struct({
-      locale: Schema.Literal("en"),
-      text: Schema.String,
-    }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)))
-  ),
+  meaning: Schema.Struct({
+    locale: LocaleSchema,
+    text: Schema.String,
+  }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey))),
   name: Schema.String,
   revelation: Schema.String,
   to_verse: Schema.Finite,
   verse_count: Schema.Finite,
-})).mapFields(Struct.map(Schema.mutableKey));
+}).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
 const TaxonomyPreviewSchema = Schema.Struct({
   content_counts: Schema.Array(
     Schema.Struct({

--- a/packages/backend/agent/content.ts
+++ b/packages/backend/agent/content.ts
@@ -176,8 +176,8 @@ const renderQuranMarkdown = Effect.fn("agent.renderQuranMarkdown")(function* (
   }).pipe(Effect.mapError(contentReadError));
   const surah = publication.surah;
   const title = surah.name.transliteration;
-  const meaning = surah.name.meaning;
-  const description = meaning.text;
+  const meaning = surah.name.meaning[ref.locale];
+  const description = meaning;
   const preBismillah =
     publication.preBismillah === null
       ? []
@@ -197,7 +197,7 @@ const renderQuranMarkdown = Effect.fn("agent.renderQuranMarkdown")(function* (
       text: [
         `# ${title}`,
         "",
-        `Meaning: ${meaning.text} (${meaning.appLocale})`,
+        `Meaning: ${meaning}`,
         `Revelation: ${surah.revelation.place}`,
         "",
         ...renderQuranReadingSourcesMarkdown(publication.sources),

--- a/packages/backend/agent/content.ts
+++ b/packages/backend/agent/content.ts
@@ -8,6 +8,7 @@ import {
   renderQuranTafsirAccessMarkdown,
 } from "@repo/backend/client/quran/markdown";
 import { renderQuranTranslationMarkdown } from "@repo/backend/client/quran/notes";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
 import type { agentContentSourceValidator } from "@repo/backend/convex/contentRelease/reference/agent";
 import type { ContentReferenceInput } from "@repo/backend/convex/contentRelease/reference/spec";
@@ -176,7 +177,7 @@ const renderQuranMarkdown = Effect.fn("agent.renderQuranMarkdown")(function* (
   }).pipe(Effect.mapError(contentReadError));
   const surah = publication.surah;
   const title = surah.name.transliteration;
-  const meaning = surah.name.meaning[ref.locale];
+  const meaning = selectQuranMeaning(surah.name.meaning, ref.locale).text;
   const description = meaning;
   const preBismillah =
     publication.preBismillah === null

--- a/packages/backend/agent/content.ts
+++ b/packages/backend/agent/content.ts
@@ -8,7 +8,7 @@ import {
   renderQuranTafsirAccessMarkdown,
 } from "@repo/backend/client/quran/markdown";
 import { renderQuranTranslationMarkdown } from "@repo/backend/client/quran/notes";
-import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
+import { formatQuranMeaning } from "@repo/backend/content/quran/contract";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
 import type { agentContentSourceValidator } from "@repo/backend/convex/contentRelease/reference/agent";
 import type { ContentReferenceInput } from "@repo/backend/convex/contentRelease/reference/spec";
@@ -177,7 +177,7 @@ const renderQuranMarkdown = Effect.fn("agent.renderQuranMarkdown")(function* (
   }).pipe(Effect.mapError(contentReadError));
   const surah = publication.surah;
   const title = surah.name.transliteration;
-  const meaning = selectQuranMeaning(surah.name.meaning, ref.locale).text;
+  const meaning = formatQuranMeaning(surah.name.meaning, ref.locale);
   const description = meaning;
   const preBismillah =
     publication.preBismillah === null

--- a/packages/backend/agent/quran/projection.ts
+++ b/packages/backend/agent/quran/projection.ts
@@ -34,6 +34,7 @@ export const projectNakafaQuranReference = Effect.fn(
   const { sources, tafsirAccess } = input.reference;
   if (
     sources === null ||
+    tafsirAccess === null ||
     !hasExpectedQuranSources(sources, tafsirAccess, input.appLocale)
   ) {
     return yield* new NakafaAgentDataReadError({
@@ -49,8 +50,8 @@ export const projectNakafaQuranReference = Effect.fn(
     {
       ...input.ref,
       meaning: {
-        locale: input.reference.surah.name.meaning.appLocale,
-        text: input.reference.surah.name.meaning.text,
+        locale: input.appLocale,
+        text: input.reference.surah.name.meaning[input.appLocale],
       },
       name: input.reference.surah.name.transliteration,
       pre_bismillah: input.reference.preBismillah,
@@ -62,8 +63,7 @@ export const projectNakafaQuranReference = Effect.fn(
           locale: input.appLocale,
         },
       },
-      tafsir_access:
-        tafsirAccess === null ? null : projectTafsirAccess(tafsirAccess),
+      tafsir_access: projectTafsirAccess(tafsirAccess),
       verses,
     },
     "Unable to build Nakafa Quran reference."

--- a/packages/backend/agent/quran/projection.ts
+++ b/packages/backend/agent/quran/projection.ts
@@ -3,6 +3,7 @@ import { decodeAgentOutput } from "@repo/backend/agent/decode";
 import { projectQuranVerse } from "@repo/backend/agent/quran/verse";
 import type { PublishedQuranReference } from "@repo/backend/client/quran/reference";
 import { hasExpectedQuranSources } from "@repo/backend/client/quran/source";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import type { readQuranPassage } from "@repo/backend/convex/contentRelease/quran/reference";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { NakafaAgentQuranReferenceSchema } from "@repo/contents/_lib/agent/schema/quran/reference";
@@ -45,13 +46,17 @@ export const projectNakafaQuranReference = Effect.fn(
   const verses = yield* Effect.forEach(input.reference.verses, (verse) =>
     projectQuranVerse(verse, input.appLocale, input.includeTafsir)
   );
+  const meaning = selectQuranMeaning(
+    input.reference.surah.name.meaning,
+    input.appLocale
+  );
   return yield* decodeAgentOutput(
     NakafaAgentQuranReferenceSchema,
     {
       ...input.ref,
       meaning: {
-        locale: input.appLocale,
-        text: input.reference.surah.name.meaning[input.appLocale],
+        locale: meaning.appLocale,
+        text: meaning.text,
       },
       name: input.reference.surah.name.transliteration,
       pre_bismillah: input.reference.preBismillah,

--- a/packages/backend/client/nakafa/quran.test.ts
+++ b/packages/backend/client/nakafa/quran.test.ts
@@ -43,6 +43,11 @@ const source = {
   sourceOrigin: { kind: "git" as const, sha: "c".repeat(40) },
   sourceRevision: "c".repeat(40),
 };
+const surahMeaning = {
+  de: "Die Eröffnende",
+  en: "The Opening",
+  id: "Pembuka",
+} as const;
 beforeEach(() => {
   runtimeMocks.runtimeQuery.mockReset();
   runtimeMocks.runtimeQuery.mockImplementation(readRuntimeFixture);
@@ -97,7 +102,7 @@ describe("Quran Nakafa reader", () => {
       });
       const value = Option.getOrUndefined(reference);
 
-      expect(value?.meaning).toEqual({ locale: "en", text: "The Opening" });
+      expect(value?.meaning).toEqual({ locale: "id", text: "Pembuka" });
       expect(value?.pre_bismillah).toBeNull();
       expect(value?.sources).toMatchObject({
         arabic: { id: "tanzil-text" },
@@ -155,11 +160,9 @@ describe("Quran Nakafa reader", () => {
           readNakafaContentRefFixture("id", "quran/1", "quran")
         );
         expect(Option.getOrUndefined(markdown)?.title).toBe("Al-Fatihah");
-        expect(Option.getOrUndefined(markdown)?.description).toBe(
-          "The Opening"
-        );
+        expect(Option.getOrUndefined(markdown)?.description).toBe("Pembuka");
         expect(Option.getOrUndefined(markdown)?.text).toContain(
-          "Meaning: The Opening (en)"
+          "Meaning: Pembuka"
         );
         expect(Option.getOrUndefined(markdown)?.text).toContain("## Verses");
         expect(Option.getOrUndefined(markdown)?.text).toContain(
@@ -242,7 +245,7 @@ function markdownResult(args: Record<string, unknown>) {
     sources: makeQuranLocaleSources(appLocale),
     surah: {
       name: {
-        sourceMeaning: { appLocale: "en", text: "The Opening" },
+        sourceMeaning: surahMeaning,
         transliteration: "Al-Fatihah",
       },
       number: 1,
@@ -296,7 +299,7 @@ function surahRow(number = 1) {
     kind: "quran-surah",
     name: {
       arabic: "الفاتحة",
-      meaning: { appLocale: "en", text: "The Opening" },
+      meaning: surahMeaning,
       transliteration: "Al-Fatihah",
     },
     number,

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -11,6 +11,7 @@ import {
   renderQuranTafsirAccessMarkdown,
 } from "@repo/backend/client/quran/markdown";
 import { renderQuranTranslationMarkdown } from "@repo/backend/client/quran/notes";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import {
   decodePublishedQuranReference,
   type PublishedQuranReference,
@@ -119,7 +120,7 @@ export const readQuranMarkdown = Effect.fn("NakafaQuran.readMarkdown")(
     );
     const surah = publication.surah;
     const title = getSurahName(surah);
-    const meaning = surah.name.meaning[ref.locale];
+    const meaning = selectQuranMeaning(surah.name.meaning, ref.locale).text;
     const metadata = [
       `# ${title}`,
       "",

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -119,11 +119,11 @@ export const readQuranMarkdown = Effect.fn("NakafaQuran.readMarkdown")(
     );
     const surah = publication.surah;
     const title = getSurahName(surah);
-    const meaning = surah.name.meaning;
+    const meaning = surah.name.meaning[ref.locale];
     const metadata = [
       `# ${title}`,
       "",
-      `Meaning: ${meaning.text} (${meaning.appLocale})`,
+      `Meaning: ${meaning}`,
       `Revelation: ${surah.revelation.place}`,
       "",
       ...renderQuranReadingSourcesMarkdown(publication.sources),
@@ -144,7 +144,7 @@ export const readQuranMarkdown = Effect.fn("NakafaQuran.readMarkdown")(
           ];
     const markdown = yield* decodeNakafaMarkdown({
       ...ref,
-      description: meaning.text,
+      description: meaning,
       text: [
         ...metadata,
         ...preBismillah,

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -16,7 +16,7 @@ import {
   type PublishedQuranReference,
 } from "@repo/backend/client/quran/reference";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
-import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
+import { formatQuranMeaning } from "@repo/backend/content/quran/contract";
 import { api } from "@repo/backend/convex/_generated/api";
 import { createNakafaContentRefFromGraphProjection } from "@repo/contents/_lib/agent/refs";
 import type { NakafaAgentMarkdown } from "@repo/contents/_lib/agent/schema/read";
@@ -120,7 +120,7 @@ export const readQuranMarkdown = Effect.fn("NakafaQuran.readMarkdown")(
     );
     const surah = publication.surah;
     const title = getSurahName(surah);
-    const meaning = selectQuranMeaning(surah.name.meaning, ref.locale).text;
+    const meaning = formatQuranMeaning(surah.name.meaning, ref.locale);
     const metadata = [
       `# ${title}`,
       "",

--- a/packages/backend/client/nakafa/quran.ts
+++ b/packages/backend/client/nakafa/quran.ts
@@ -11,12 +11,12 @@ import {
   renderQuranTafsirAccessMarkdown,
 } from "@repo/backend/client/quran/markdown";
 import { renderQuranTranslationMarkdown } from "@repo/backend/client/quran/notes";
-import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import {
   decodePublishedQuranReference,
   type PublishedQuranReference,
 } from "@repo/backend/client/quran/reference";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
 import { api } from "@repo/backend/convex/_generated/api";
 import { createNakafaContentRefFromGraphProjection } from "@repo/contents/_lib/agent/refs";
 import type { NakafaAgentMarkdown } from "@repo/contents/_lib/agent/schema/read";

--- a/packages/backend/client/quran/catalog.test.ts
+++ b/packages/backend/client/quran/catalog.test.ts
@@ -11,6 +11,7 @@ import {
 import { QuranPublicationError } from "@repo/backend/client/quran/publication";
 import {
   encodeTestQuranRow,
+  makeQuranMeaning,
   makeQuranSurah,
 } from "@repo/backend/test/quran/rows";
 import { Effect } from "effect";
@@ -37,10 +38,7 @@ describe("signed Quran catalog decoder", () => {
       );
 
       expect(catalog.surahs).toHaveLength(114);
-      expect(catalog.surahs.at(0)?.name.meaning).toEqual({
-        appLocale: "en",
-        text: "Technical meaning 1",
-      });
+      expect(catalog.surahs.at(0)?.name.meaning).toEqual(makeQuranMeaning(1));
       expect(catalog.surahs.at(-1)?.number).toBe(114);
     })
   );
@@ -73,7 +71,11 @@ describe("signed Quran catalog decoder", () => {
       const decoded = yield* decodePublishedQuranSurah(
         {
           name: {
-            sourceMeaning: { appLocale: "en", text: "The Opening" },
+            sourceMeaning: {
+              de: "Die Eröffnende",
+              en: "The Opening",
+              id: "Pembuka",
+            },
             transliteration: "Al-Fatihah",
           },
           number: 1,
@@ -82,7 +84,11 @@ describe("signed Quran catalog decoder", () => {
       );
 
       expect(decoded.name).toEqual({
-        meaning: { appLocale: "en", text: "The Opening" },
+        meaning: {
+          de: "Die Eröffnende",
+          en: "The Opening",
+          id: "Pembuka",
+        },
         transliteration: "Al-Fatihah",
       });
     })
@@ -94,7 +100,7 @@ describe("signed Quran catalog decoder", () => {
         decodePublishedQuranSurah(
           {
             name: {
-              sourceMeaning: { appLocale: "id", text: "Pembukaan" },
+              sourceMeaning: { en: "The Opening" },
               transliteration: "Al-Fatihah",
             },
             number: 1,

--- a/packages/backend/client/quran/catalog.ts
+++ b/packages/backend/client/quran/catalog.ts
@@ -1,8 +1,8 @@
+import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
 import {
-  QURAN_SURAH_COUNT,
-  type QuranSurahRow,
-  QuranSurahRowSchema,
-} from "@nakafa/aksara-contracts/quran/spec";
+  PublishedQuranMeaningSchema,
+  type PublishedQuranSurah,
+} from "@repo/backend/content/quran/contract";
 import {
   decodePublishedQuranSource,
   type PublishedQuranSource,
@@ -20,7 +20,7 @@ type QuranCatalogResult = FunctionReturnType<
 
 /** Complete signed Quran metadata catalog in its canonical shape. */
 export type PublishedQuranCatalog = PublishedQuranSource & {
-  readonly surahs: readonly QuranSurahRow[];
+  readonly surahs: readonly PublishedQuranSurah[];
 };
 
 interface QuranSurahTransportProjection {
@@ -40,7 +40,7 @@ export const decodePublishedQuranSurah = Effect.fn(
 ) {
   const { sourceMeaning, ...name } = projection.name;
   const meaning = yield* Schema.decodeUnknownEffect(
-    QuranSurahRowSchema.fields.name.fields.meaning
+    PublishedQuranMeaningSchema
   )(sourceMeaning).pipe(
     Effect.mapError(() =>
       quranPublicationError(

--- a/packages/backend/client/quran/catalog.ts
+++ b/packages/backend/client/quran/catalog.ts
@@ -1,15 +1,15 @@
 import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
 import {
-  PublishedQuranMeaningSchema,
-  type PublishedQuranSurah,
-} from "@repo/backend/content/quran/contract";
-import {
   decodePublishedQuranSource,
   type PublishedQuranSource,
   type QuranPublicationOperation,
   quranPublicationError,
 } from "@repo/backend/client/quran/publication";
 import { decodeQuranSurahRow } from "@repo/backend/client/quran/rows";
+import {
+  PublishedQuranMeaningSchema,
+  type PublishedQuranSurah,
+} from "@repo/backend/content/quran/contract";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { Effect, Schema } from "effect";

--- a/packages/backend/client/quran/document.test.ts
+++ b/packages/backend/client/quran/document.test.ts
@@ -4,6 +4,7 @@ import { decodePublishedQuranDocument } from "@repo/backend/client/quran/documen
 import type { api } from "@repo/backend/convex/_generated/api";
 import {
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import type { FunctionReturnType } from "convex/server";
@@ -28,10 +29,7 @@ describe("signed Quran document decoder", () => {
         surahNumber: 1,
       });
       expect(document.surah.revelation).toEqual({ order: 5, place: "Meccan" });
-      expect(document.surah.name.meaning).toEqual({
-        appLocale: "en",
-        text: "The Opening",
-      });
+      expect(document.surah.name.meaning).toEqual(makeQuranMeaning(1));
       expect(document.verses).toEqual([
         {
           arabic: "بِسْمِ اللّٰهِ",
@@ -97,7 +95,7 @@ function documentResult(): QuranDocumentResult {
       kind: "quran-surah",
       name: {
         arabic: "الفاتحة",
-        sourceMeaning: { appLocale: "en", text: "The Opening" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Al-Fatihah",
       },
       number: 1,

--- a/packages/backend/client/quran/document.ts
+++ b/packages/backend/client/quran/document.ts
@@ -29,6 +29,8 @@ export const decodePublishedQuranDocument = Effect.fn(
   const source = yield* decodePublishedQuranSource(result, "document");
   if (
     result.surah === null ||
+    result.sources === null ||
+    result.tafsirAccess === null ||
     !hasExpectedQuranSources(
       result.sources,
       result.tafsirAccess,

--- a/packages/backend/client/quran/markdown.test.ts
+++ b/packages/backend/client/quran/markdown.test.ts
@@ -8,6 +8,7 @@ import {
 import type { api } from "@repo/backend/convex/_generated/api";
 import {
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import type { FunctionReturnType } from "convex/server";
@@ -171,7 +172,7 @@ function markdownResult(
     tafsirAccess: makeQuranTafsirProjection("en"),
     surah: {
       name: {
-        sourceMeaning: { appLocale: "en", text: "The Opening" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Al-Fatihah",
       },
       number: 1,

--- a/packages/backend/client/quran/markdown.ts
+++ b/packages/backend/client/quran/markdown.ts
@@ -44,11 +44,8 @@ function renderEmbeddedSource(
 
 /** Renders signed locale-specific Tafsir availability for agent Markdown. */
 export function renderQuranTafsirAccessMarkdown(
-  access: QuranMarkdown["tafsirAccess"]
+  access: NonNullable<QuranMarkdown["tafsirAccess"]>
 ): readonly string[] {
-  if (access === null) {
-    return [];
-  }
   return [
     "## Tafsir access",
     "",
@@ -75,6 +72,8 @@ export const decodePublishedQuranMarkdown = Effect.fn(
   const source = yield* decodePublishedQuranSource(result, "markdown");
   if (
     result.surah === null ||
+    result.sources === null ||
+    result.tafsirAccess === null ||
     !hasExpectedQuranSources(
       result.sources,
       result.tafsirAccess,
@@ -92,8 +91,7 @@ export const decodePublishedQuranMarkdown = Effect.fn(
   );
   if (
     result.appLocale !== expected.appLocale ||
-    (result.tafsirAccess !== null &&
-      result.tafsirAccess.appLocale !== expected.appLocale) ||
+    result.tafsirAccess.appLocale !== expected.appLocale ||
     result.surah.number !== expected.surahNumber ||
     result.toVerse !== expectedToVerse ||
     !hasExactQuranVerseRange(result.verses, 1, expectedToVerse)

--- a/packages/backend/client/quran/reference.ts
+++ b/packages/backend/client/quran/reference.ts
@@ -30,7 +30,7 @@ export type PublishedQuranReference = PublishedQuranSource & {
   readonly search: QuranSearchRow;
   readonly sources: NonNullable<QuranReferenceResult["sources"]>;
   readonly surah: QuranSurahRow;
-  readonly tafsirAccess: QuranReferenceResult["tafsirAccess"];
+  readonly tafsirAccess: NonNullable<QuranReferenceResult["tafsirAccess"]>;
   readonly toVerse: number;
   readonly verses: readonly QuranRuntimeVerse[];
 };
@@ -49,6 +49,8 @@ export const decodePublishedQuranReference = Effect.fn(
   if (
     result.surahJson === null ||
     result.searchJson === null ||
+    result.sources === null ||
+    result.tafsirAccess === null ||
     !hasExpectedQuranSources(
       result.sources,
       result.tafsirAccess,

--- a/packages/backend/client/quran/reference.ts
+++ b/packages/backend/client/quran/reference.ts
@@ -1,6 +1,6 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { hasExactQuranVerseRange } from "@repo/backend/client/quran/integrity";
 import {
   decodePublishedQuranSource,
@@ -29,7 +29,7 @@ export type PublishedQuranReference = PublishedQuranSource & {
   readonly preBismillah: QuranReferenceResult["preBismillah"];
   readonly search: QuranSearchRow;
   readonly sources: NonNullable<QuranReferenceResult["sources"]>;
-  readonly surah: QuranSurahRow;
+  readonly surah: PublishedQuranSurah;
   readonly tafsirAccess: NonNullable<QuranReferenceResult["tafsirAccess"]>;
   readonly toVerse: number;
   readonly verses: readonly QuranRuntimeVerse[];

--- a/packages/backend/client/quran/reference.ts
+++ b/packages/backend/client/quran/reference.ts
@@ -1,6 +1,5 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { hasExactQuranVerseRange } from "@repo/backend/client/quran/integrity";
 import {
   decodePublishedQuranSource,
@@ -15,6 +14,7 @@ import {
 } from "@repo/backend/client/quran/rows";
 import { hasExpectedQuranSources } from "@repo/backend/client/quran/source";
 import { separateQuranRuntimeBismillah } from "@repo/backend/content/quran/bismillah";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import type { api } from "@repo/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { Effect } from "effect";

--- a/packages/backend/client/quran/rows.ts
+++ b/packages/backend/client/quran/rows.ts
@@ -3,8 +3,10 @@ import {
   type QuranRuntimeVerse,
   QuranSearchRowSchema,
 } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
-import { ContentSnapshotRowSchema } from "@nakafa/aksara-contracts/release/snapshot/data";
+import {
+  PublishedQuranRowSchema,
+  PublishedQuranSurahSchema,
+} from "@repo/backend/content/quran/contract";
 import {
   type QuranPublicationOperation,
   quranPublicationError,
@@ -26,15 +28,15 @@ const parseQuranRow = Effect.fn("NakafaQuran.parseRow")(function* (
   });
 });
 
-/** Decodes one current signed Quran row and verifies snapshot ownership. */
-const decodeCurrentQuranRow = Effect.fn("NakafaQuran.decodeCurrentRow")(
+/** Decodes one signed Quran row and verifies snapshot ownership. */
+const decodeSignedQuranRow = Effect.fn("NakafaQuran.decodeSignedRow")(
   function* <A, I>(
     input: unknown,
     snapshotId: string,
     schema: Schema.Codec<A, I, never, never>,
     operation: QuranPublicationOperation
   ) {
-    const row = yield* Schema.decodeUnknownEffect(ContentSnapshotRowSchema)(
+    const row = yield* Schema.decodeUnknownEffect(PublishedQuranRowSchema)(
       input,
       { onExcessProperty: "error" }
     ).pipe(
@@ -45,7 +47,7 @@ const decodeCurrentQuranRow = Effect.fn("NakafaQuran.decodeCurrentRow")(
         )
       )
     );
-    if (row.family !== "quran" || row.record.snapshotId !== snapshotId) {
+    if (row.record.snapshotId !== snapshotId) {
       return yield* quranPublicationError(
         operation,
         "Quran row belongs to another signed snapshot."
@@ -72,10 +74,10 @@ export const decodeQuranSurahRow = Effect.fn("NakafaQuran.decodeSurahRow")(
     operation: QuranPublicationOperation
   ) {
     const input = yield* parseQuranRow(source, operation);
-    return yield* decodeCurrentQuranRow(
+    return yield* decodeSignedQuranRow(
       input,
       snapshotId,
-      QuranSurahRowSchema,
+      PublishedQuranSurahSchema,
       operation
     );
   }
@@ -89,7 +91,7 @@ export const decodeQuranSearchRow = Effect.fn("NakafaQuran.decodeSearchRow")(
     operation: QuranPublicationOperation
   ) {
     const input = yield* parseQuranRow(source, operation);
-    return yield* decodeCurrentQuranRow(
+    return yield* decodeSignedQuranRow(
       input,
       snapshotId,
       QuranSearchRowSchema,
@@ -110,7 +112,7 @@ export const decodeQuranChunkVerses = Effect.fn(
   const chunks = yield* Effect.forEach(sources, (source) =>
     parseQuranRow(source, operation).pipe(
       Effect.flatMap((input) =>
-        decodeCurrentQuranRow(input, snapshotId, QuranChunkRowSchema, operation)
+        decodeSignedQuranRow(input, snapshotId, QuranChunkRowSchema, operation)
       )
     )
   );

--- a/packages/backend/client/quran/rows.ts
+++ b/packages/backend/client/quran/rows.ts
@@ -4,13 +4,13 @@ import {
   QuranSearchRowSchema,
 } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import {
-  PublishedQuranRowSchema,
-  PublishedQuranSurahSchema,
-} from "@repo/backend/content/quran/contract";
-import {
   type QuranPublicationOperation,
   quranPublicationError,
 } from "@repo/backend/client/quran/publication";
+import {
+  PublishedQuranRowSchema,
+  PublishedQuranSurahSchema,
+} from "@repo/backend/content/quran/contract";
 import { Effect, Schema } from "effect";
 
 type QuranChunkRow = typeof QuranChunkRowSchema.Type;

--- a/packages/backend/client/quran/view.test.ts
+++ b/packages/backend/client/quran/view.test.ts
@@ -4,6 +4,7 @@ import { decodePublishedQuranView } from "@repo/backend/client/quran/view";
 import type { api } from "@repo/backend/convex/_generated/api";
 import {
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import type { FunctionReturnType } from "convex/server";
@@ -19,7 +20,7 @@ const source = {
 };
 const surah = {
   name: {
-    sourceMeaning: { appLocale: "en" as const, text: "The Opening" },
+    sourceMeaning: makeQuranMeaning(1),
     transliteration: "Al-Fatihah",
   },
   number: 1,
@@ -87,18 +88,9 @@ describe("signed Quran view decoder", () => {
           ],
         },
       });
-      expect(english.surah.name.meaning).toEqual({
-        appLocale: "en",
-        text: "The Opening",
-      });
-      expect(german.surah.name.meaning).toEqual({
-        appLocale: "en",
-        text: "The Opening",
-      });
-      expect(indonesian.surah.name.meaning).toEqual({
-        appLocale: "en",
-        text: "The Opening",
-      });
+      expect(english.surah.name.meaning).toEqual(makeQuranMeaning(1));
+      expect(german.surah.name.meaning).toEqual(makeQuranMeaning(1));
+      expect(indonesian.surah.name.meaning).toEqual(makeQuranMeaning(1));
       expect(english.tafsirAccess).toMatchObject({
         appLocale: "en",
         kind: "external",
@@ -146,22 +138,25 @@ describe("signed Quran view decoder", () => {
   );
 });
 /** Builds source and metadata shared by app-locale view fixtures. */
-function viewBase(meaning: string | null) {
+function viewBase() {
   return {
     ...source,
     nextSurah: {
       ...surah,
-      name: { ...surah.name, meaning, transliteration: "Al-Baqarah" },
+      name: {
+        sourceMeaning: makeQuranMeaning(2),
+        transliteration: "Al-Baqarah",
+      },
       number: 2,
     },
     previousSurah: null,
-    surah: { ...surah, name: { ...surah.name, meaning } },
+    surah,
   };
 }
 /** Builds one complete English view response. */
 function englishViewResult(): QuranViewResult {
   return {
-    ...viewBase("The Opening"),
+    ...viewBase(),
     appLocale: "en",
     preBismillah: null,
     sources: makeQuranLocaleSources("en"),
@@ -191,7 +186,7 @@ function englishViewResult(): QuranViewResult {
 /** Builds one complete German view response without invented source notes. */
 function germanViewResult(): QuranViewResult {
   return {
-    ...viewBase(null),
+    ...viewBase(),
     appLocale: "de",
     preBismillah: null,
     sources: makeQuranLocaleSources("de"),
@@ -211,7 +206,7 @@ function germanViewResult(): QuranViewResult {
 /** Builds one complete Indonesian view response. */
 function indonesianViewResult(): QuranViewResult {
   return {
-    ...viewBase(null),
+    ...viewBase(),
     appLocale: "id",
     preBismillah: null,
     sources: makeQuranLocaleSources("id"),

--- a/packages/backend/client/quran/view.ts
+++ b/packages/backend/client/quran/view.ts
@@ -36,6 +36,8 @@ export const decodePublishedQuranView = Effect.fn("NakafaQuran.decodeView")(
     const source = yield* decodePublishedQuranSource(result, "view");
     if (
       result.surah === null ||
+      result.sources === null ||
+      result.tafsirAccess === null ||
       !hasExpectedQuranSources(
         result.sources,
         result.tafsirAccess,
@@ -49,8 +51,7 @@ export const decodePublishedQuranView = Effect.fn("NakafaQuran.decodeView")(
     }
     if (
       result.appLocale !== expected.appLocale ||
-      (result.tafsirAccess !== null &&
-        result.tafsirAccess.appLocale !== expected.appLocale) ||
+      result.tafsirAccess.appLocale !== expected.appLocale ||
       result.surah.number !== expected.surahNumber ||
       !hasExactQuranVerseRange(result.verses, 1, result.surah.numberOfVerses) ||
       !hasExpectedQuranNeighbors(

--- a/packages/backend/content/batch.ts
+++ b/packages/backend/content/batch.ts
@@ -5,6 +5,11 @@ import {
   type PublicContentRuntimeResponse,
   PublicContentRuntimeResponseSchema,
 } from "@nakafa/aksara-contracts/runtime/spec";
+import {
+  MAX_PUBLIC_RUNTIME_RESPONSE_BYTES as MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES,
+  type PublicContentRuntimeResponse as PredecessorPublicContentRuntimeResponse,
+  PublicContentRuntimeResponseSchema as predecessorPublicContentRuntimeResponseSchema,
+} from "@nakafa/aksara-v150/runtime/spec";
 import { Schema } from "effect";
 /** Maximum exact Aksara public exchanges resolved by one batch transaction. */
 export const PUBLIC_CONTENT_RUNTIME_BATCH_SIZE = 8;
@@ -17,10 +22,13 @@ export const MAX_PUBLIC_RUNTIME_BATCH_REQUEST_BYTES =
 export const MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES =
   PUBLIC_CONTENT_RUNTIME_BATCH_SIZE * MAX_PUBLIC_RUNTIME_RESPONSE_BYTES +
   BATCH_JSON_OVERHEAD_BYTES;
+/** Complete response ceiling for one bounded predecessor runtime batch. */
+export const MAX_PREDECESSOR_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES =
+  PUBLIC_CONTENT_RUNTIME_BATCH_SIZE *
+    MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES +
+  BATCH_JSON_OVERHEAD_BYTES;
 /** Measures the exact JSON wire bytes of one decoded Aksara response. */
-export function publicRuntimeResponseBytes(
-  response: PublicContentRuntimeResponse
-) {
+export function publicRuntimeResponseBytes<Response>(response: Response) {
   return new TextEncoder().encode(JSON.stringify(response)).byteLength;
 }
 /** Nakafa batch of exact Aksara public runtime requests. */
@@ -61,3 +69,38 @@ export const PublicContentRuntimeBatchResponseSchema = Schema.Struct({
     Schema.check(Schema.isMaxLength(PUBLIC_CONTENT_RUNTIME_BATCH_SIZE))
   ),
 });
+const PredecessorPublicContentRuntimeBatchItemSchema =
+  predecessorPublicContentRuntimeResponseSchema.pipe(
+    Schema.check(
+      Schema.makeFilter(
+        (
+          response
+        ): response is Exclude<
+          PredecessorPublicContentRuntimeResponse,
+          {
+            kind: "failure";
+          }
+        > => response.kind !== "failure",
+        { message: "Batch items contain only found or missing responses." }
+      )
+    ),
+    Schema.check(
+      Schema.makeFilter(
+        (response) =>
+          publicRuntimeResponseBytes(response) <=
+          MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES,
+        { message: "Batch item exceeded the Aksara response ceiling." }
+      )
+    )
+  );
+/** Exact 0.15.0 response contract for one bounded predecessor batch. */
+export const PredecessorPublicContentRuntimeBatchResponseSchema = Schema.Struct(
+  {
+    responses: Schema.Array(
+      PredecessorPublicContentRuntimeBatchItemSchema
+    ).pipe(
+      Schema.check(Schema.isMinLength(1)),
+      Schema.check(Schema.isMaxLength(PUBLIC_CONTENT_RUNTIME_BATCH_SIZE))
+    ),
+  }
+);

--- a/packages/backend/content/quran/contract.test.ts
+++ b/packages/backend/content/quran/contract.test.ts
@@ -1,5 +1,8 @@
 import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
-import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
+import {
+  formatQuranMeaning,
+  selectQuranMeaning,
+} from "@repo/backend/content/quran/contract";
 import { describe, expect, it } from "vitest";
 
 describe("published Quran meaning selection", () => {
@@ -31,5 +34,16 @@ describe("published Quran meaning selection", () => {
       appLocale: "en",
       text: "The Cow",
     });
+    expect(formatQuranMeaning(meaning, "id")).toBe("The Cow (en)");
+  });
+
+  it("does not annotate a meaning selected in the requested locale", () => {
+    const meaning = {
+      de: "Die Kuh",
+      en: "The Cow",
+      id: "Sapi",
+    } as const;
+
+    expect(formatQuranMeaning(meaning, "de")).toBe("Die Kuh");
   });
 });

--- a/packages/backend/content/quran/contract.test.ts
+++ b/packages/backend/content/quran/contract.test.ts
@@ -1,0 +1,35 @@
+import { makeAppLocale } from "@nakafa/aksara-contracts/locale";
+import { selectQuranMeaning } from "@repo/backend/content/quran/contract";
+import { describe, expect, it } from "vitest";
+
+describe("published Quran meaning selection", () => {
+  it("selects every localized meaning from the current signed contract", () => {
+    const meaning = {
+      de: "Die Kuh",
+      en: "The Cow",
+      id: "Sapi",
+    } as const;
+
+    expect(selectQuranMeaning(meaning, "de")).toEqual({
+      appLocale: "de",
+      text: "Die Kuh",
+    });
+    expect(selectQuranMeaning(meaning, "en")).toEqual({
+      appLocale: "en",
+      text: "The Cow",
+    });
+    expect(selectQuranMeaning(meaning, "id")).toEqual({
+      appLocale: "id",
+      text: "Sapi",
+    });
+  });
+
+  it("preserves the authenticated English language of a stored transition", () => {
+    const meaning = { appLocale: makeAppLocale("en"), text: "The Cow" };
+
+    expect(selectQuranMeaning(meaning, "id")).toEqual({
+      appLocale: "en",
+      text: "The Cow",
+    });
+  });
+});

--- a/packages/backend/content/quran/contract.ts
+++ b/packages/backend/content/quran/contract.ts
@@ -58,3 +58,14 @@ export function selectQuranMeaning(
   }
   return { appLocale, text: meaning[appLocale] };
 }
+
+/** Formats one meaning without disguising a retained source language. */
+export function formatQuranMeaning(
+  meaning: PublishedQuranMeaning,
+  appLocale: AppLocaleCode
+) {
+  const selected = selectQuranMeaning(meaning, appLocale);
+  return selected.appLocale === appLocale
+    ? selected.text
+    : `${selected.text} (${selected.appLocale})`;
+}

--- a/packages/backend/content/quran/contract.ts
+++ b/packages/backend/content/quran/contract.ts
@@ -1,11 +1,21 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import { QuranSnapshotRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import { QuranSnapshotSchema } from "@nakafa/aksara-contracts/quran/snapshot/spec";
+import { QuranAttributionRowSchema } from "@nakafa/aksara-contracts/quran/source";
 import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
 import { QuranSnapshotRowSchema as TransitionQuranSnapshotRowSchema } from "@nakafa/aksara-transition/quran/snapshot/row";
 import { QuranSnapshotSchema as TransitionQuranSnapshotSchema } from "@nakafa/aksara-transition/quran/snapshot/spec";
+import { QuranAttributionRowSchema as TransitionQuranAttributionRowSchema } from "@nakafa/aksara-transition/quran/source";
 import { QuranSurahRowSchema as TransitionQuranSurahRowSchema } from "@nakafa/aksara-transition/quran/spec";
 import { Schema } from "effect";
+
+/** Exact signed attribution contracts accepted during the bounded data switch. */
+export const PublishedQuranAttributionSchema = Schema.Union([
+  QuranAttributionRowSchema,
+  TransitionQuranAttributionRowSchema,
+]);
+export type PublishedQuranAttribution =
+  typeof PublishedQuranAttributionSchema.Type;
 
 /** Exact signed surah meanings accepted during the bounded data switch. */
 export const PublishedQuranMeaningSchema = Schema.Union([

--- a/packages/backend/content/quran/contract.ts
+++ b/packages/backend/content/quran/contract.ts
@@ -1,0 +1,50 @@
+import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
+import { QuranSnapshotRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
+import { QuranSnapshotSchema } from "@nakafa/aksara-contracts/quran/snapshot/spec";
+import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
+import { QuranSnapshotRowSchema as TransitionQuranSnapshotRowSchema } from "@nakafa/aksara-transition/quran/snapshot/row";
+import { QuranSnapshotSchema as TransitionQuranSnapshotSchema } from "@nakafa/aksara-transition/quran/snapshot/spec";
+import { QuranSurahRowSchema as TransitionQuranSurahRowSchema } from "@nakafa/aksara-transition/quran/spec";
+import { Schema } from "effect";
+
+/** Exact signed surah meanings accepted during the bounded data switch. */
+export const PublishedQuranMeaningSchema = Schema.Union([
+  QuranSurahRowSchema.fields.name.fields.meaning,
+  TransitionQuranSurahRowSchema.fields.name.fields.meaning,
+]);
+export type PublishedQuranMeaning = typeof PublishedQuranMeaningSchema.Type;
+
+/** Exact signed surah contracts accepted during the bounded data switch. */
+export const PublishedQuranSurahSchema = Schema.Union([
+  QuranSurahRowSchema,
+  TransitionQuranSurahRowSchema,
+]);
+export type PublishedQuranSurah = typeof PublishedQuranSurahSchema.Type;
+
+/** Exact signed Quran row envelopes accepted during the bounded data switch. */
+export const PublishedQuranRowSchema = Schema.Struct({
+  family: Schema.Literal("quran"),
+  record: Schema.Union([
+    QuranSnapshotRowSchema,
+    TransitionQuranSnapshotRowSchema,
+  ]),
+});
+export type PublishedQuranRow = typeof PublishedQuranRowSchema.Type;
+
+/** Exact signed Quran manifests accepted during the bounded data switch. */
+export const PublishedQuranManifestSchema = Schema.Struct({
+  family: Schema.Literal("quran"),
+  manifest: Schema.Union([QuranSnapshotSchema, TransitionQuranSnapshotSchema]),
+});
+export type PublishedQuranManifest = typeof PublishedQuranManifestSchema.Type;
+
+/** Selects a truthful localized meaning without relabeling predecessor English. */
+export function selectQuranMeaning(
+  meaning: PublishedQuranMeaning,
+  appLocale: AppLocaleCode
+) {
+  if ("appLocale" in meaning) {
+    return { appLocale: meaning.appLocale, text: meaning.text };
+  }
+  return { appLocale, text: meaning[appLocale] };
+}

--- a/packages/backend/convex/chats/messageParts/dbToUi.ts
+++ b/packages/backend/convex/chats/messageParts/dbToUi.ts
@@ -423,10 +423,7 @@ function projectPersistedNakafaData(data: PersistedNakafaData): unknown {
     ...data,
     result: {
       ...result,
-      meaning:
-        data.input.locale === "en"
-          ? { locale: data.input.locale, text: translation }
-          : null,
+      meaning: { locale: "en", text: translation },
     },
   };
 }

--- a/packages/backend/convex/chats/messageParts/uiToDb.test.ts
+++ b/packages/backend/convex/chats/messageParts/uiToDb.test.ts
@@ -139,6 +139,7 @@ describe("mapUIMessagePartsToDBParts", () => {
           result: {
             ...quranRef,
             from_verse: 1,
+            locale: "en",
             meaning: { locale: "en", text: "The Opening" },
             name: "Al-Fatihah",
             revelation: "Mecca",

--- a/packages/backend/convex/chats/nakafa.test.ts
+++ b/packages/backend/convex/chats/nakafa.test.ts
@@ -36,6 +36,46 @@ describe("Nakafa chat data schema", () => {
         status: "done",
       })
     ).toBe(true);
+
+    expect(
+      validate(nakafaDataValidator, {
+        input: { ...input, locale: "id" },
+        kind: "quran",
+        result: {
+          ...preview,
+          locale: "id",
+          meaning: { locale: "en", text: "The Opening" },
+        },
+        status: "done",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects uncorrelated Quran preview locales", () => {
+    expect(
+      validate(nakafaDataValidator, {
+        input: { ...input, locale: "id" },
+        kind: "quran",
+        result: {
+          ...preview,
+          locale: "id",
+          meaning: { locale: "de", text: "Die Eröffnende" },
+        },
+        status: "done",
+      })
+    ).toBe(false);
+    expect(
+      validate(nakafaDataValidator, {
+        input: { ...input, locale: "id" },
+        kind: "quran",
+        result: {
+          ...preview,
+          locale: "de",
+          meaning: { locale: "en", text: "The Opening" },
+        },
+        status: "done",
+      })
+    ).toBe(false);
   });
 
   it("preserves persisted translation-only Quran previews", () => {

--- a/packages/backend/convex/chats/nakafa.ts
+++ b/packages/backend/convex/chats/nakafa.ts
@@ -42,13 +42,10 @@ const nakafaQuranPreviewFields = {
 
 const nakafaQuranMeaningPreviewValidator = v.object({
   ...nakafaQuranPreviewFields,
-  meaning: v.union(
-    v.null(),
-    v.object({
-      locale: v.literal("en"),
-      text: v.string(),
-    })
-  ),
+  meaning: v.object({
+    locale: localeValidator,
+    text: v.string(),
+  }),
 });
 
 const nakafaQuranTranslationPreviewValidator = v.object({
@@ -56,7 +53,7 @@ const nakafaQuranTranslationPreviewValidator = v.object({
   translation: v.string(),
 });
 
-/** Accepts current previews and persisted predecessor chat data. */
+/** Accepts current previews and retained historical chat data. */
 export const nakafaQuranPreviewValidator = v.union(
   nakafaQuranMeaningPreviewValidator,
   nakafaQuranTranslationPreviewValidator

--- a/packages/backend/convex/chats/nakafa.ts
+++ b/packages/backend/convex/chats/nakafa.ts
@@ -1,4 +1,10 @@
 import {
+  type AppLocaleCode,
+  ENGLISH_APP_LOCALE_CODE,
+  GERMAN_APP_LOCALE_CODE,
+  INDONESIAN_APP_LOCALE_CODE,
+} from "@nakafa/aksara-contracts/locale";
+import {
   contentSearchInputValidator,
   contentSearchRefValidator,
   contentSearchResultValidator,
@@ -40,24 +46,38 @@ const nakafaQuranPreviewFields = {
   verse_count: v.number(),
 };
 
-const nakafaQuranMeaningPreviewValidator = v.object({
-  ...nakafaQuranPreviewFields,
-  meaning: v.object({
-    locale: localeValidator,
-    text: v.string(),
-  }),
-});
-
 const nakafaQuranTranslationPreviewValidator = v.object({
   ...nakafaQuranPreviewFields,
   translation: v.string(),
 });
 
-/** Accepts current previews and retained historical chat data. */
-export const nakafaQuranPreviewValidator = v.union(
-  nakafaQuranMeaningPreviewValidator,
-  nakafaQuranTranslationPreviewValidator
-);
+/** Builds one canonical Quran preview correlated to its request locale. */
+function makeNakafaQuranDoneValidator<const Locale extends AppLocaleCode>(
+  locale: Locale
+) {
+  return v.object({
+    kind: v.literal("quran"),
+    status: v.literal("done"),
+    input: v.object({
+      ...nakafaQuranInputValidator.fields,
+      locale: v.literal(locale),
+    }),
+    result: v.object({
+      ...nakafaQuranPreviewFields,
+      locale: v.literal(locale),
+      meaning: v.object({
+        locale: v.union(v.literal(locale), v.literal(ENGLISH_APP_LOCALE_CODE)),
+        text: v.string(),
+      }),
+    }),
+  });
+}
+
+const nakafaQuranDoneValidators = [
+  makeNakafaQuranDoneValidator(ENGLISH_APP_LOCALE_CODE),
+  makeNakafaQuranDoneValidator(INDONESIAN_APP_LOCALE_CODE),
+  makeNakafaQuranDoneValidator(GERMAN_APP_LOCALE_CODE),
+] as const;
 
 export const nakafaTaxonomyPreviewValidator = v.object({
   content_counts: v.array(
@@ -111,11 +131,12 @@ export const nakafaDataValidator = v.union(
     status: v.literal("loading"),
     input: nakafaQuranInputValidator,
   }),
+  ...nakafaQuranDoneValidators,
   v.object({
     kind: v.literal("quran"),
     status: v.literal("done"),
     input: nakafaQuranInputValidator,
-    result: nakafaQuranPreviewValidator,
+    result: nakafaQuranTranslationPreviewValidator,
   }),
   v.object({
     kind: v.literal("quran"),

--- a/packages/backend/convex/contentRelease/article/cursor.ts
+++ b/packages/backend/convex/contentRelease/article/cursor.ts
@@ -1,7 +1,7 @@
 import { DateOnlySchema } from "@nakafa/aksara-contracts/date";
 import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
-import { ArticleCategorySchema } from "@nakafa/aksara-contracts/projection/article";
+import { ArticleCategorySchema } from "@nakafa/aksara-transition/projection/article";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
 import {

--- a/packages/backend/convex/contentRelease/article/ownership.ts
+++ b/packages/backend/convex/contentRelease/article/ownership.ts
@@ -1,7 +1,7 @@
 import {
   type ArticleRouteSlug,
   ArticleRouteSlugSchema,
-} from "@nakafa/aksara-contracts/projection/article";
+} from "@nakafa/aksara-transition/projection/article";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { adjustArticleBucket } from "@repo/backend/convex/contentRelease/article/bucket";

--- a/packages/backend/convex/contentRelease/article/predecessor.test.ts
+++ b/packages/backend/convex/contentRelease/article/predecessor.test.ts
@@ -78,23 +78,4 @@ describe("contentRelease/article/predecessor", () => {
     expect(predecessor.metadata.date).toBe(current.metadata.datePublished);
     expect(predecessorJson).not.toContain("dateModified");
   });
-
-  it("preserves a legacy projection without changing its canonical bytes", async () => {
-    const current = testArticleProjection(0);
-    const dates = normalizePublicationDates(current.metadata);
-    const legacy = ArticleProjectionSchema.make({
-      ...current,
-      metadata: {
-        authors: current.metadata.authors,
-        date: dates.datePublished,
-        description: current.metadata.description,
-        title: current.metadata.title,
-      },
-    });
-    const canonical = canonicalizeArticleProjection(legacy);
-
-    await expect(
-      Effect.runPromise(encodePredecessorProjection(legacy))
-    ).resolves.toBe(canonical);
-  });
 });

--- a/packages/backend/convex/contentRelease/article/predecessor.ts
+++ b/packages/backend/convex/contentRelease/article/predecessor.ts
@@ -1,4 +1,4 @@
-import type { ArticleProjection } from "@nakafa/aksara-contracts/projection/article";
+import type { ArticleProjection } from "@nakafa/aksara-transition/projection/article";
 import {
   canonicalizeArticleProjection as canonicalizePredecessorArticleProjection,
   ArticleProjectionSchema as predecessorArticleProjectionSchema,

--- a/packages/backend/convex/contentRelease/article/predecessor.ts
+++ b/packages/backend/convex/contentRelease/article/predecessor.ts
@@ -1,30 +1,14 @@
-import { DateOnlySchema } from "@nakafa/aksara-contracts/date";
+import type { ArticleProjection } from "@nakafa/aksara-contracts/projection/article";
 import {
-  ArticleMetadataSchema,
-  type ArticleProjection,
-  ArticleProjectionSchema,
-  canonicalizeArticleProjection,
-} from "@nakafa/aksara-contracts/projection/article";
+  canonicalizeArticleProjection as canonicalizePredecessorArticleProjection,
+  ArticleProjectionSchema as predecessorArticleProjectionSchema,
+} from "@nakafa/aksara-v150/projection/article";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
 import { normalizePublicationDates } from "@repo/contents/_types/publication";
 import { Effect, Schema } from "effect";
 
-const PredecessorArticleMetadataSchema = ArticleMetadataSchema.mapFields(
-  ({
-    dateModified: _dateModified,
-    datePublished: _datePublished,
-    ...fields
-  }) => ({ ...fields, date: DateOnlySchema })
-);
-
 /** Exact 0.15.0 article projection view derived from shared contract fields. */
-export const PredecessorArticleProjectionSchema =
-  ArticleProjectionSchema.mapFields(
-    (fields) => ({ ...fields, metadata: PredecessorArticleMetadataSchema }),
-    // The projection checks cover route, locale, graph, and parent identity.
-    // Replacing only metadata dates cannot invalidate those checks.
-    { unsafePreserveChecks: true }
-  );
+export { ArticleProjectionSchema as PredecessorArticleProjectionSchema } from "@nakafa/aksara-v150/projection/article";
 
 /**
  * Derives the exact 0.15.0 view required by the bounded predecessor query.
@@ -38,7 +22,7 @@ export const encodePredecessorProjection = Effect.fn(
 )(function* (projection: ArticleProjection) {
   const dates = normalizePublicationDates(projection.metadata);
   const predecessor = yield* Schema.decodeEffect(
-    PredecessorArticleProjectionSchema
+    predecessorArticleProjectionSchema
   )(
     {
       ...projection,
@@ -62,5 +46,5 @@ export const encodePredecessorProjection = Effect.fn(
     )
   );
 
-  return canonicalizeArticleProjection(predecessor);
+  return canonicalizePredecessorArticleProjection(predecessor);
 });

--- a/packages/backend/convex/contentRelease/article/verify.ts
+++ b/packages/backend/convex/contentRelease/article/verify.ts
@@ -1,4 +1,4 @@
-import { ArticleCategorySchema } from "@nakafa/aksara-contracts/projection/article";
+import { ArticleCategorySchema } from "@nakafa/aksara-transition/projection/article";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { readArticleDates } from "@repo/backend/convex/contentRelease/article/dates";

--- a/packages/backend/convex/contentRelease/article/write.ts
+++ b/packages/backend/convex/contentRelease/article/write.ts
@@ -1,4 +1,4 @@
-import type { ArticleProjection } from "@nakafa/aksara-contracts/projection/article";
+import type { ArticleProjection } from "@nakafa/aksara-transition/projection/article";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { adjustArticleBucket } from "@repo/backend/convex/contentRelease/article/bucket";

--- a/packages/backend/convex/contentRelease/catalog.ts
+++ b/packages/backend/convex/contentRelease/catalog.ts
@@ -1,7 +1,7 @@
 import {
   canonicalizeContentProjection,
   familyForProjection,
-} from "@nakafa/aksara-contracts/projection/spec";
+} from "@nakafa/aksara-transition/projection/spec";
 import { ContentHeadSchema } from "@nakafa/aksara-contracts/release/head";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type {

--- a/packages/backend/convex/contentRelease/catalog.ts
+++ b/packages/backend/convex/contentRelease/catalog.ts
@@ -1,8 +1,8 @@
+import { ContentHeadSchema } from "@nakafa/aksara-contracts/release/head";
 import {
   canonicalizeContentProjection,
   familyForProjection,
 } from "@nakafa/aksara-transition/projection/spec";
-import { ContentHeadSchema } from "@nakafa/aksara-contracts/release/head";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type {
   MutationCtx,

--- a/packages/backend/convex/contentRelease/http/runtime/batch.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/batch.test.ts
@@ -15,6 +15,7 @@ import type {
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import {
   insertRuntimeRelease,
+  insertSignedRelease,
   publicRuntimeRequest,
   runtimeContentKey,
 } from "@repo/backend/test/content/runtime";
@@ -68,9 +69,13 @@ function expectPrivate(response: Response) {
 }
 
 /** Seeds one active public runtime route. */
-function seedPublicRuntime(t: RuntimeTest) {
+function seedPublicRuntime(t: RuntimeTest, predecessorCompatible = false) {
   return t.mutation(async (ctx) => {
-    await insertRuntimeRelease(ctx);
+    if (predecessorCompatible) {
+      await insertSignedRelease(ctx);
+    } else {
+      await insertRuntimeRelease(ctx);
+    }
     await insertRuntimeHead(ctx, "public", runtimeContentKey("public"));
   });
 }
@@ -99,7 +104,7 @@ afterEach(() => {
 describe("public content runtime batch HTTP route", () => {
   it("routes predecessor and current batches without changing active identity", async () => {
     const t = createConvexTestWithBetterAuth();
-    await seedPublicRuntime(t);
+    await seedPublicRuntime(t, true);
     const body = JSON.stringify({ requests: [foundRequest, missingRequest] });
 
     const [predecessor, current] = await Promise.all([
@@ -134,7 +139,7 @@ describe("public content runtime batch HTTP route", () => {
 
   it("records authenticated bounded predecessor batches before dispatch", async () => {
     const t = createConvexTestWithBetterAuth();
-    await seedPublicRuntime(t);
+    await seedPublicRuntime(t, true);
     await t.mutation(armObservation, { observationId: OBSERVATION_ID });
     const body = JSON.stringify({ requests: [foundRequest] });
 

--- a/packages/backend/convex/contentRelease/http/runtime/predecessor.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/predecessor.test.ts
@@ -7,7 +7,9 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "@effect/vitest";
+import { ContentFamilySchema } from "@nakafa/aksara-contracts/content";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { SignedContentReleaseSchema } from "@nakafa/aksara-contracts/release";
 import { MAX_PROTECTED_RUNTIME_REQUEST_BYTES } from "@nakafa/aksara-contracts/runtime/protected/limits";
@@ -15,14 +17,29 @@ import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
   PREDECESSOR_PROTECTED_CONTENT_RUNTIME_PATH,
+  PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
+import { internal } from "@repo/backend/convex/_generated/api";
 import type {
+  PredecessorAbandonReceipt,
   PredecessorObservationArgs,
   PredecessorStatus,
 } from "@repo/backend/convex/contentRelease/predecessor/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { testSignedRelease } from "@repo/backend/test/content/proof";
+import {
+  testPublicationScope,
+  testRendererJson,
+} from "@repo/backend/test/content/release";
+import {
+  insertSignedRelease,
+  publicRuntimeRequest,
+  runtimeContentKey,
+} from "@repo/backend/test/content/runtime";
+import { insertZeroRelease } from "@repo/backend/test/content/state";
+import { insertRuntimeHead } from "@repo/backend/test/runtime/head";
 import { insertProtectedRuntime } from "@repo/backend/test/runtime/protected";
+import { TEST_RUNTIME_RELEASE } from "@repo/backend/test/runtime/values";
 import { makeFunctionReference } from "convex/server";
 import { Schema } from "effect";
 
@@ -30,6 +47,7 @@ const RUNTIME_TOKEN = "technical-runtime-token";
 const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
 const polarName = "POLAR_WEBHOOK_SECRET";
 const OBSERVATION_ID = "test-predecessor-observation";
+const REARMED_OBSERVATION_ID = "test-rearmed-observation";
 const digest = `sha256:${"a".repeat(64)}`;
 const request = {
   appLocale: "en",
@@ -46,11 +64,31 @@ const request = {
 };
 
 type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+const RECOVERY = {
+  manifestHash: `sha256:${"9".repeat(64)}`,
+  releaseId: "test-recovery-release",
+  sequence: TEST_RUNTIME_RELEASE.sequence + 1,
+};
 const armObservation = makeFunctionReference<
   "mutation",
   PredecessorObservationArgs,
   PredecessorStatus
 >("contentRelease/predecessor/internal:arm");
+const statusObservation = makeFunctionReference<
+  "query",
+  PredecessorObservationArgs,
+  PredecessorStatus
+>("contentRelease/predecessor/internal:status");
+const sealObservation = makeFunctionReference<
+  "mutation",
+  PredecessorObservationArgs,
+  PredecessorStatus
+>("contentRelease/predecessor/internal:seal");
+const abandonObservation = makeFunctionReference<
+  "mutation",
+  PredecessorObservationArgs,
+  PredecessorAbandonReceipt
+>("contentRelease/predecessor/internal:abandon");
 
 /** Sends one request through the predecessor Convex route. */
 function post(t: RuntimeTest, body: BodyInit | null, token = RUNTIME_TOKEN) {
@@ -75,6 +113,76 @@ function protectedCount(target: RuntimeTest) {
   });
 }
 
+/** Sends one request through the public predecessor Convex route. */
+function postPublic(t: RuntimeTest, body: BodyInit | null) {
+  return t.fetch(PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH, {
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-nakafa-content-token": RUNTIME_TOKEN,
+    },
+    method: "POST",
+  });
+}
+
+/** Asserts the private response headers shared by predecessor routes. */
+function expectPrivate(response: Response) {
+  expect(response.headers.get("cache-control")).toBe("private, no-store");
+  expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
+    CONTENT_RUNTIME_RESPONSE_MARKER
+  );
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+}
+
+/** Seeds one active public release compatible with the predecessor view. */
+function seedPublicRuntime(t: RuntimeTest) {
+  return t.mutation(async (ctx) => {
+    await insertSignedRelease(ctx);
+    await insertRuntimeHead(ctx, "public", runtimeContentKey("public"));
+  });
+}
+
+/** Activates the exact retained inverse through the production mutation. */
+async function recoverRuntime(t: RuntimeTest) {
+  await t.mutation(async (ctx) => {
+    await insertZeroRelease(ctx, {
+      ...RECOVERY,
+      base: TEST_RUNTIME_RELEASE,
+      originReleaseId: TEST_RUNTIME_RELEASE.releaseId,
+      ownership: { base: ContentFamilySchema.literals, result: [] },
+      role: "recovery",
+      scope: { content: [], ...testPublicationScope() },
+      status: "verified",
+    });
+    const state = await ctx.db.query("contentState").unique();
+    if (!state) {
+      throw new Error("Expected active content state.");
+    }
+    await ctx.db.patch("contentState", state._id, {
+      recoveryManifestHash: RECOVERY.manifestHash,
+      recoveryReleaseId: RECOVERY.releaseId,
+      recoverySequence: RECOVERY.sequence,
+    });
+  });
+  await t.mutation(internal.contentRelease.activate.activateRecovery, {
+    manifestHash: RECOVERY.manifestHash,
+    releaseId: RECOVERY.releaseId,
+    rendererJson: testRendererJson(),
+  });
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+}
+
+/** Returns the current singular predecessor invocation count. */
+async function singularCount(t: RuntimeTest) {
+  const row = await t.run((ctx) =>
+    ctx.db
+      .query("contentPredecessorReads")
+      .withIndex("by_route", (query) => query.eq("route", "singular"))
+      .unique()
+  );
+  return row?.invocationCount ?? null;
+}
+
 beforeEach(() => {
   process.env[runtimeTokenName] = RUNTIME_TOKEN;
   process.env[polarName] = "technical-webhook-secret";
@@ -83,6 +191,90 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env[runtimeTokenName];
   delete process.env[polarName];
+});
+
+describe("public predecessor observation", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("records authenticated calls before dispatch", async () => {
+    const t = createConvexTestWithBetterAuth();
+    await seedPublicRuntime(t);
+    await t.mutation(armObservation, { observationId: OBSERVATION_ID });
+
+    const unauthorized = await t.fetch(
+      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH,
+      {
+        body: publicRuntimeRequest(),
+        headers: {
+          "content-type": "application/json",
+          "x-nakafa-content-token": "wrong-token",
+        },
+        method: "POST",
+      }
+    );
+    expect(unauthorized.status).toBe(401);
+    await expect(singularCount(t)).resolves.toBe(0);
+
+    const malformed = await postPublic(t, "{");
+    expect(malformed.status).toBe(400);
+    await expect(singularCount(t)).resolves.toBe(1);
+
+    const predecessor = await postPublic(t, publicRuntimeRequest());
+    expect(predecessor.status).toBe(200);
+    await expect(singularCount(t)).resolves.toBe(2);
+
+    await recoverRuntime(t);
+    const driftedStatus = {
+      kind: "drifted",
+      live: RECOVERY,
+      stored: TEST_RUNTIME_RELEASE,
+    };
+    await expect(
+      t.query(statusObservation, { observationId: OBSERVATION_ID })
+    ).resolves.toMatchObject(driftedStatus);
+    await expect(
+      t.mutation(armObservation, { observationId: OBSERVATION_ID })
+    ).resolves.toMatchObject(driftedStatus);
+    await expect(
+      t.mutation(sealObservation, { observationId: OBSERVATION_ID })
+    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_STATE" } });
+
+    const drifted = await postPublic(t, publicRuntimeRequest());
+    expect(drifted.status).toBe(200);
+    await expect(drifted.json()).resolves.toMatchObject({ kind: "found" });
+    await expect(singularCount(t)).resolves.toBe(2);
+    expectPrivate(drifted);
+
+    await expect(
+      t.mutation(abandonObservation, { observationId: OBSERVATION_ID })
+    ).resolves.toMatchObject({
+      abandonedAt: expect.any(Number),
+      deleted: 4,
+      deploymentName: "test",
+      kind: "abandoned",
+      live: RECOVERY,
+      observationId: OBSERVATION_ID,
+      routes: {
+        batch: { invocationCount: 0, phase: "armed" },
+        singular: { invocationCount: 2, phase: "armed" },
+      },
+      stored: TEST_RUNTIME_RELEASE,
+    });
+    await expect(singularCount(t)).resolves.toBeNull();
+    await expect(
+      t.mutation(armObservation, {
+        observationId: REARMED_OBSERVATION_ID,
+      })
+    ).resolves.toMatchObject({
+      active: RECOVERY,
+      kind: "active",
+      observationId: REARMED_OBSERVATION_ID,
+    });
+    const rearmed = await postPublic(t, publicRuntimeRequest());
+    expect(rearmed.status).toBe(200);
+    await expect(singularCount(t)).resolves.toBe(1);
+  });
 });
 
 describe("predecessor protected content runtime HTTP route", () => {
@@ -204,11 +396,7 @@ describe("predecessor protected content runtime HTTP route", () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ kind: "missing" });
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
-    expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
-      CONTENT_RUNTIME_RESPONSE_MARKER
-    );
-    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expectPrivate(response);
   });
 
   it("rejects unauthorized, successor, and oversized requests", async () => {

--- a/packages/backend/convex/contentRelease/http/runtime/public.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/public.test.ts
@@ -7,7 +7,6 @@ import {
   it,
   vi,
 } from "@effect/vitest";
-import { ContentFamilySchema } from "@nakafa/aksara-contracts/content";
 import {
   decodePublicContentRuntimeRequest,
   MAX_PUBLIC_RUNTIME_REQUEST_BYTES,
@@ -23,17 +22,8 @@ import {
 } from "@repo/backend/content/endpoint";
 import { contentKeyResolver } from "@repo/backend/content/trust";
 import { internal } from "@repo/backend/convex/_generated/api";
-import type {
-  PredecessorAbandonReceipt,
-  PredecessorObservationArgs,
-  PredecessorStatus,
-} from "@repo/backend/convex/contentRelease/predecessor/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { testProjectionJson } from "@repo/backend/test/content/material";
-import {
-  testPublicationScope,
-  testRendererJson,
-} from "@repo/backend/test/content/release";
 import {
   insertRuntimeRelease,
   insertSignedRelease,
@@ -41,45 +31,13 @@ import {
   runtimeCases,
   runtimeContentKey,
 } from "@repo/backend/test/content/runtime";
-import { insertZeroRelease } from "@repo/backend/test/content/state";
 import { insertRuntimeHead } from "@repo/backend/test/runtime/head";
-import {
-  TEST_RUNTIME_PATH,
-  TEST_RUNTIME_RELEASE,
-} from "@repo/backend/test/runtime/values";
-import { makeFunctionReference } from "convex/server";
+import { TEST_RUNTIME_PATH } from "@repo/backend/test/runtime/values";
 import { Effect } from "effect";
 
 const RUNTIME_TOKEN = "technical-runtime-token";
-const OBSERVATION_ID = "test-predecessor-observation";
-const REARMED_OBSERVATION_ID = "test-rearmed-observation";
 const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
 const polarName = "POLAR_WEBHOOK_SECRET";
-const RECOVERY = {
-  manifestHash: `sha256:${"9".repeat(64)}`,
-  releaseId: "test-recovery-release",
-  sequence: TEST_RUNTIME_RELEASE.sequence + 1,
-};
-const armObservation = makeFunctionReference<
-  "mutation",
-  PredecessorObservationArgs,
-  PredecessorStatus
->("contentRelease/predecessor/internal:arm");
-const statusObservation = makeFunctionReference<
-  "query",
-  PredecessorObservationArgs,
-  PredecessorStatus
->("contentRelease/predecessor/internal:status");
-const sealObservation = makeFunctionReference<
-  "mutation",
-  PredecessorObservationArgs,
-  PredecessorStatus
->("contentRelease/predecessor/internal:seal");
-const abandonObservation = makeFunctionReference<
-  "mutation",
-  PredecessorObservationArgs,
-  PredecessorAbandonReceipt
->("contentRelease/predecessor/internal:abandon");
 type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
 type RuntimeFetcher = Pick<RuntimeTest, "fetch">;
 /** Sends one request through the actual registered Convex HTTP route. */
@@ -124,46 +82,6 @@ function seedRuntime(
   });
 }
 
-/** Activates the exact retained inverse through the production mutation. */
-async function recoverRuntime(t: RuntimeTest) {
-  await t.mutation(async (ctx) => {
-    await insertZeroRelease(ctx, {
-      ...RECOVERY,
-      base: TEST_RUNTIME_RELEASE,
-      originReleaseId: TEST_RUNTIME_RELEASE.releaseId,
-      ownership: { base: ContentFamilySchema.literals, result: [] },
-      role: "recovery",
-      scope: { content: [], ...testPublicationScope() },
-      status: "verified",
-    });
-    const state = await ctx.db.query("contentState").unique();
-    if (!state) {
-      throw new Error("Expected active content state.");
-    }
-    await ctx.db.patch("contentState", state._id, {
-      recoveryManifestHash: RECOVERY.manifestHash,
-      recoveryReleaseId: RECOVERY.releaseId,
-      recoverySequence: RECOVERY.sequence,
-    });
-  });
-  await t.mutation(internal.contentRelease.activate.activateRecovery, {
-    manifestHash: RECOVERY.manifestHash,
-    releaseId: RECOVERY.releaseId,
-    rendererJson: testRendererJson(),
-  });
-  await t.finishAllScheduledFunctions(vi.runAllTimers);
-}
-
-/** Returns the current singular predecessor invocation count. */
-async function singularCount(t: RuntimeTest) {
-  const row = await t.run((ctx) =>
-    ctx.db
-      .query("contentPredecessorReads")
-      .withIndex("by_route", (query) => query.eq("route", "singular"))
-      .unique()
-  );
-  return row?.invocationCount ?? null;
-}
 beforeEach(() => {
   vi.useFakeTimers();
   process.env[runtimeTokenName] = RUNTIME_TOKEN;
@@ -206,102 +124,6 @@ describe("public content runtime HTTP route", () => {
     expect(predecessorBody.activeReleaseId).toBe(currentBody.activeReleaseId);
     expectPrivate(predecessor);
     expectPrivate(current);
-  });
-
-  it("records authenticated bounded predecessor calls before dispatch", async () => {
-    const t = createConvexTestWithBetterAuth();
-    await seedRuntime(t, "public", true);
-    await t.mutation(armObservation, { observationId: OBSERVATION_ID });
-
-    const unauthorized = await post(
-      t,
-      publicRuntimeRequest(),
-      { "x-nakafa-content-token": "wrong-token" },
-      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH
-    );
-    const current = await post(t, publicRuntimeRequest());
-    expect(unauthorized.status).toBe(401);
-    expect(current.status).toBe(200);
-    await expect(singularCount(t)).resolves.toBe(0);
-
-    const malformed = await post(
-      t,
-      "{",
-      undefined,
-      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH
-    );
-    expect(malformed.status).toBe(400);
-    await expect(singularCount(t)).resolves.toBe(1);
-
-    const predecessor = await post(
-      t,
-      publicRuntimeRequest(),
-      undefined,
-      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH
-    );
-    expect(predecessor.status).toBe(200);
-    await expect(singularCount(t)).resolves.toBe(2);
-
-    await recoverRuntime(t);
-    const driftedStatus = {
-      kind: "drifted",
-      live: RECOVERY,
-      stored: TEST_RUNTIME_RELEASE,
-    };
-    await expect(
-      t.query(statusObservation, { observationId: OBSERVATION_ID })
-    ).resolves.toMatchObject(driftedStatus);
-    await expect(
-      t.mutation(armObservation, { observationId: OBSERVATION_ID })
-    ).resolves.toMatchObject(driftedStatus);
-    await expect(
-      t.mutation(sealObservation, { observationId: OBSERVATION_ID })
-    ).rejects.toMatchObject({ data: { code: "CONTENT_RELEASE_STATE" } });
-
-    const drifted = await post(
-      t,
-      publicRuntimeRequest(),
-      undefined,
-      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH
-    );
-    expect(drifted.status).toBe(200);
-    await expect(drifted.json()).resolves.toMatchObject({ kind: "found" });
-    await expect(singularCount(t)).resolves.toBe(2);
-    expectPrivate(drifted);
-
-    await expect(
-      t.mutation(abandonObservation, { observationId: OBSERVATION_ID })
-    ).resolves.toMatchObject({
-      abandonedAt: expect.any(Number),
-      deleted: 4,
-      deploymentName: "test",
-      kind: "abandoned",
-      live: RECOVERY,
-      observationId: OBSERVATION_ID,
-      routes: {
-        batch: { invocationCount: 0, phase: "armed" },
-        singular: { invocationCount: 2, phase: "armed" },
-      },
-      stored: TEST_RUNTIME_RELEASE,
-    });
-    await expect(singularCount(t)).resolves.toBeNull();
-    await expect(
-      t.mutation(armObservation, {
-        observationId: REARMED_OBSERVATION_ID,
-      })
-    ).resolves.toMatchObject({
-      active: RECOVERY,
-      kind: "active",
-      observationId: REARMED_OBSERVATION_ID,
-    });
-    const rearmed = await post(
-      t,
-      publicRuntimeRequest(),
-      undefined,
-      PREDECESSOR_PUBLIC_CONTENT_RUNTIME_PATH
-    );
-    expect(rearmed.status).toBe(200);
-    await expect(singularCount(t)).resolves.toBe(1);
   });
 
   it.each([

--- a/packages/backend/convex/contentRelease/http/runtime/public.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/public.test.ts
@@ -30,9 +30,13 @@ import type {
 } from "@repo/backend/convex/contentRelease/predecessor/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { testProjectionJson } from "@repo/backend/test/content/material";
-import { testRendererJson } from "@repo/backend/test/content/release";
+import {
+  testPublicationScope,
+  testRendererJson,
+} from "@repo/backend/test/content/release";
 import {
   insertRuntimeRelease,
+  insertSignedRelease,
   publicRuntimeRequest,
   runtimeCases,
   runtimeContentKey,
@@ -107,10 +111,15 @@ function expectPrivate(response: Response) {
 /** Seeds one active route for an exact stored delivery class. */
 function seedRuntime(
   t: RuntimeTest,
-  delivery: "authenticated" | "entitled" | "public"
+  delivery: "authenticated" | "entitled" | "public",
+  predecessorCompatible = false
 ) {
   return t.mutation(async (ctx) => {
-    await insertRuntimeRelease(ctx);
+    if (predecessorCompatible) {
+      await insertSignedRelease(ctx);
+    } else {
+      await insertRuntimeRelease(ctx);
+    }
     await insertRuntimeHead(ctx, delivery, runtimeContentKey(delivery));
   });
 }
@@ -124,6 +133,7 @@ async function recoverRuntime(t: RuntimeTest) {
       originReleaseId: TEST_RUNTIME_RELEASE.releaseId,
       ownership: { base: ContentFamilySchema.literals, result: [] },
       role: "recovery",
+      scope: { content: [], ...testPublicationScope() },
       status: "verified",
     });
     const state = await ctx.db.query("contentState").unique();
@@ -167,7 +177,7 @@ afterEach(() => {
 describe("public content runtime HTTP route", () => {
   it("routes predecessor and current contracts without changing active identity", async () => {
     const t = createConvexTestWithBetterAuth();
-    await seedRuntime(t, "public");
+    await seedRuntime(t, "public", true);
 
     const [predecessor, current] = await Promise.all([
       post(
@@ -200,7 +210,7 @@ describe("public content runtime HTTP route", () => {
 
   it("records authenticated bounded predecessor calls before dispatch", async () => {
     const t = createConvexTestWithBetterAuth();
-    await seedRuntime(t, "public");
+    await seedRuntime(t, "public", true);
     await t.mutation(armObservation, { observationId: OBSERVATION_ID });
 
     const unauthorized = await post(

--- a/packages/backend/convex/contentRelease/ingress/rollback.ts
+++ b/packages/backend/convex/contentRelease/ingress/rollback.ts
@@ -8,7 +8,7 @@ import {
   type RollbackPage,
   RollbackPageSchema,
   type RollbackRecord,
-} from "@nakafa/aksara-contracts/release/rollback/spec";
+} from "@nakafa/aksara-transition/release/rollback/spec";
 import {
   type RoutePage,
   RoutePageSchema,

--- a/packages/backend/convex/contentRelease/ingress/rollback.ts
+++ b/packages/backend/convex/contentRelease/ingress/rollback.ts
@@ -1,6 +1,12 @@
 "use node";
 import { verifySignedContentArtifactIntegrity } from "@nakafa/aksara-contracts/artifact/integrity";
 import {
+  type RoutePage,
+  RoutePageSchema,
+  type RouteRollbackRecord,
+} from "@nakafa/aksara-contracts/release/route/page";
+import type { PublicationRequest } from "@nakafa/aksara-contracts/transport/request";
+import {
   canonicalizeRollbackPage,
   canonicalizeRollbackRecord,
   isRollbackUpsert,
@@ -9,12 +15,6 @@ import {
   RollbackPageSchema,
   type RollbackRecord,
 } from "@nakafa/aksara-transition/release/rollback/spec";
-import {
-  type RoutePage,
-  RoutePageSchema,
-  type RouteRollbackRecord,
-} from "@nakafa/aksara-contracts/release/route/page";
-import type { PublicationRequest } from "@nakafa/aksara-contracts/transport/request";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
 import {
   ReleaseError,

--- a/packages/backend/convex/contentRelease/item.ts
+++ b/packages/backend/convex/contentRelease/item.ts
@@ -4,7 +4,7 @@ import {
   canonicalizeRollbackSnapshotEntry,
   RollbackSnapshotEntrySchema,
   type RollbackSnapshotState,
-} from "@nakafa/aksara-contracts/release/rollback/spec";
+} from "@nakafa/aksara-transition/release/rollback/spec";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { resolveContentHead } from "@repo/backend/convex/contentRelease/catalog";
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";

--- a/packages/backend/convex/contentRelease/material.test.ts
+++ b/packages/backend/convex/contentRelease/material.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeMaterialProjection,
   MaterialLessonProjectionSchema,
 } from "@nakafa/aksara-contracts/projection/material";
+import { canonicalizeMaterialProjection as canonicalizePredecessorMaterialProjection } from "@nakafa/aksara-v150/projection/material";
 import { api } from "@repo/backend/convex/_generated/api";
 import { PredecessorMaterialProjectionSchema } from "@repo/backend/convex/contentRelease/material/predecessor";
 import schema from "@repo/backend/convex/schema";
@@ -113,7 +114,9 @@ describe("contentRelease/material", () => {
         expect(projection.appLocale).toBe(appLocale);
         expect(projection.metadata).toHaveProperty("date");
         expect(projection.metadata).not.toHaveProperty("datePublished");
-        expect(canonicalizeMaterialProjection(projection)).toBe(source);
+        expect(canonicalizePredecessorMaterialProjection(projection)).toBe(
+          source
+        );
       }
       const currentProjection = decodeCurrent(
         JSON.parse(current.result.page[0] ?? "{}"),
@@ -157,7 +160,9 @@ describe("contentRelease/material", () => {
         });
         expect(projection.metadata).toHaveProperty("date");
         expect(projection.metadata).not.toHaveProperty("datePublished");
-        expect(canonicalizeMaterialProjection(projection)).toBe(source);
+        expect(canonicalizePredecessorMaterialProjection(projection)).toBe(
+          source
+        );
       }
       expect(current.projectionJson).toBe(
         canonicalizeMaterialProjection(requested)

--- a/packages/backend/convex/contentRelease/material/identity.ts
+++ b/packages/backend/convex/contentRelease/material/identity.ts
@@ -2,7 +2,7 @@ import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import {
   MaterialKeySchema,
   MaterialSectionSchema,
-} from "@nakafa/aksara-contracts/projection/material";
+} from "@nakafa/aksara-transition/projection/material";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import {

--- a/packages/backend/convex/contentRelease/material/predecessor.test.ts
+++ b/packages/backend/convex/contentRelease/material/predecessor.test.ts
@@ -80,22 +80,4 @@ describe("contentRelease/material/predecessor", () => {
     });
     expect(predecessorJson).not.toContain("dateModified");
   });
-
-  it("preserves a legacy projection without changing its canonical bytes", async () => {
-    const current = makeMaterialProjection("en", 1);
-    const dates = normalizePublicationDates(current.metadata);
-    const legacy = MaterialLessonProjectionSchema.make({
-      ...current,
-      metadata: {
-        authors: current.metadata.authors,
-        date: dates.datePublished,
-        title: current.metadata.title,
-      },
-    });
-    const canonical = canonicalizeMaterialProjection(legacy);
-
-    await expect(
-      Effect.runPromise(encodePredecessorProjection(legacy))
-    ).resolves.toBe(canonical);
-  });
 });

--- a/packages/backend/convex/contentRelease/material/predecessor.ts
+++ b/packages/backend/convex/contentRelease/material/predecessor.ts
@@ -1,33 +1,14 @@
-import { DateOnlySchema } from "@nakafa/aksara-contracts/date";
+import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import {
-  canonicalizeMaterialProjection,
-  type MaterialLessonProjection,
-  MaterialLessonProjectionSchema,
-  MaterialMetadataSchema,
-} from "@nakafa/aksara-contracts/projection/material";
+  canonicalizeMaterialProjection as canonicalizePredecessorMaterialProjection,
+  MaterialLessonProjectionSchema as predecessorMaterialProjectionSchema,
+} from "@nakafa/aksara-v150/projection/material";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
 import { normalizePublicationDates } from "@repo/contents/_types/publication";
 import { Effect, Schema } from "effect";
 
-const PredecessorMaterialMetadataSchema = MaterialMetadataSchema.mapFields(
-  ({
-    dateModified: _dateModified,
-    datePublished: _datePublished,
-    ...fields
-  }) => ({ ...fields, date: DateOnlySchema })
-);
-
 /** Exact 0.15.0 material projection view derived from shared contract fields. */
-export const PredecessorMaterialProjectionSchema =
-  MaterialLessonProjectionSchema.mapFields(
-    (fields) => ({
-      ...fields,
-      metadata: PredecessorMaterialMetadataSchema,
-    }),
-    // The projection checks cover route, locale, graph, and parent identity.
-    // Replacing only metadata dates cannot invalidate those checks.
-    { unsafePreserveChecks: true }
-  );
+export { MaterialLessonProjectionSchema as PredecessorMaterialProjectionSchema } from "@nakafa/aksara-v150/projection/material";
 
 export type MaterialProjectionContract = "predecessor" | "publication";
 
@@ -43,7 +24,7 @@ export const encodePredecessorProjection = Effect.fn(
 )(function* (projection: MaterialLessonProjection) {
   const dates = normalizePublicationDates(projection.metadata);
   const predecessor = yield* Schema.decodeEffect(
-    PredecessorMaterialProjectionSchema
+    predecessorMaterialProjectionSchema
   )(
     {
       ...projection,
@@ -70,5 +51,5 @@ export const encodePredecessorProjection = Effect.fn(
     )
   );
 
-  return canonicalizeMaterialProjection(predecessor);
+  return canonicalizePredecessorMaterialProjection(predecessor);
 });

--- a/packages/backend/convex/contentRelease/material/predecessor.ts
+++ b/packages/backend/convex/contentRelease/material/predecessor.ts
@@ -1,4 +1,4 @@
-import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
+import type { MaterialLessonProjection } from "@nakafa/aksara-transition/projection/material";
 import {
   canonicalizeMaterialProjection as canonicalizePredecessorMaterialProjection,
   MaterialLessonProjectionSchema as predecessorMaterialProjectionSchema,

--- a/packages/backend/convex/contentRelease/material/topic.ts
+++ b/packages/backend/convex/contentRelease/material/topic.ts
@@ -1,5 +1,5 @@
 import { makeLearningGraphIdentity } from "@nakafa/aksara-contracts/graph/identity";
-import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
+import type { MaterialLessonProjection } from "@nakafa/aksara-transition/projection/material";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { Effect } from "effect";
 

--- a/packages/backend/convex/contentRelease/material/verify.ts
+++ b/packages/backend/convex/contentRelease/material/verify.ts
@@ -1,4 +1,4 @@
-import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
+import { canonicalizeMaterialProjection } from "@nakafa/aksara-transition/projection/material";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type {
   MutationCtx,

--- a/packages/backend/convex/contentRelease/material/write.ts
+++ b/packages/backend/convex/contentRelease/material/write.ts
@@ -1,7 +1,7 @@
 import {
   canonicalizeMaterialProjection,
   type MaterialLessonProjection,
-} from "@nakafa/aksara-contracts/projection/material";
+} from "@nakafa/aksara-transition/projection/material";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { getHashBucket } from "@repo/backend/convex/contentRelease/bucket";

--- a/packages/backend/convex/contentRelease/parse.test.ts
+++ b/packages/backend/convex/contentRelease/parse.test.ts
@@ -5,11 +5,13 @@ import { inheritContentSnapshots } from "@nakafa/aksara-contracts/release/snapsh
 import {
   decodeArtifactJson,
   decodeCurrentProjectionJson,
+  decodeCurrentSnapshotJson,
   decodeItemJson,
   decodeProjectionJson,
   decodeProofJson,
   decodeReleaseJson,
   decodeRendererJson,
+  decodeSnapshotJson,
   parseStoredJson,
 } from "@repo/backend/convex/contentRelease/parse";
 import {
@@ -18,6 +20,7 @@ import {
   encodeProjectionJson,
   encodeReleaseJson,
   encodeRendererJson,
+  encodeSnapshotJson,
 } from "@repo/backend/convex/contentRelease/wire";
 import { testArtifactJson } from "@repo/backend/test/content/artifact";
 import {
@@ -32,6 +35,7 @@ import {
   testRendererJson,
   testUpsertJson,
 } from "@repo/backend/test/content/release";
+import { makeStoredQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { Effect, Exit } from "effect";
 
 /** Creates exact server-derived evidence for strict proof decoding. */
@@ -108,6 +112,23 @@ describe("contentRelease/parse", () => {
         );
 
         expect(stored.metadata).toMatchObject({ date: datePublished });
+        expect(rejected).toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
+      })
+  );
+
+  it.live(
+    "accepts a predecessor Quran manifest only at its stored boundary",
+    () =>
+      Effect.gen(function* () {
+        const snapshot = yield* makeStoredQuranSnapshot();
+        const storedJson = encodeSnapshotJson(snapshot);
+
+        const stored = yield* decodeSnapshotJson(storedJson);
+        const rejected = yield* decodeCurrentSnapshotJson(storedJson).pipe(
+          Effect.flip
+        );
+
+        expect(stored.family).toBe("quran");
         expect(rejected).toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
       })
   );

--- a/packages/backend/convex/contentRelease/parse.test.ts
+++ b/packages/backend/convex/contentRelease/parse.test.ts
@@ -4,6 +4,7 @@ import { EMPTY_RESULT_CATALOG_DIGEST } from "@nakafa/aksara-contracts/release/re
 import { inheritContentSnapshots } from "@nakafa/aksara-contracts/release/snapshot/spec";
 import {
   decodeArtifactJson,
+  decodeCurrentProjectionJson,
   decodeItemJson,
   decodeProjectionJson,
   decodeProofJson,
@@ -73,7 +74,9 @@ describe("contentRelease/parse", () => {
         const release = yield* decodeReleaseJson(testReleaseJson());
         const item = yield* decodeItemJson(testUpsertJson());
         const artifact = yield* decodeArtifactJson(testArtifactJson());
-        const projection = yield* decodeProjectionJson(testProjectionJson());
+        const projection = yield* decodeCurrentProjectionJson(
+          testProjectionJson()
+        );
         const renderer = yield* decodeRendererJson(testRendererJson());
         const proof = yield* decodeProofJson(testProofJson());
 
@@ -85,6 +88,27 @@ describe("contentRelease/parse", () => {
         );
         expect(encodeRendererJson(renderer)).toBe(testRendererJson());
         expect(proof.releaseId).toBe(TEST_RELEASE_ID);
+      })
+  );
+
+  it.live(
+    "accepts an authenticated stored projection only at its boundary",
+    () =>
+      Effect.gen(function* () {
+        const current = JSON.parse(testProjectionJson());
+        const { datePublished, ...metadata } = current.metadata;
+        const storedJson = JSON.stringify({
+          ...current,
+          metadata: { ...metadata, date: datePublished },
+        });
+
+        const stored = yield* decodeProjectionJson(storedJson);
+        const rejected = yield* decodeCurrentProjectionJson(storedJson).pipe(
+          Effect.flip
+        );
+
+        expect(stored.metadata).toMatchObject({ date: datePublished });
+        expect(rejected).toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
       })
   );
 

--- a/packages/backend/convex/contentRelease/parse.ts
+++ b/packages/backend/convex/contentRelease/parse.ts
@@ -1,5 +1,7 @@
 import { SignedContentArtifactSchema } from "@nakafa/aksara-contracts/content";
+import { ACTIVE_APP_LOCALES } from "@nakafa/aksara-contracts/locale";
 import { ContentProjectionSchema as CurrentContentProjectionSchema } from "@nakafa/aksara-contracts/projection/spec";
+import { quranSourceFileCount } from "@nakafa/aksara-contracts/quran/source";
 import {
   ContentReleaseItemSchema,
   PublicationReceiptSchema,
@@ -18,6 +20,27 @@ import { RollbackSnapshotEntrySchema } from "@nakafa/aksara-transition/release/r
 import { PublishedQuranManifestSchema } from "@repo/backend/content/quran/contract";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
 import { Effect, Schema } from "effect";
+
+const CurrentContentSnapshotManifestSchema = ContentSnapshotManifestSchema.pipe(
+  Schema.check(
+    Schema.makeFilter(
+      (snapshot) =>
+        snapshot.family !== "quran" ||
+        (snapshot.manifest.activeAppLocales.length ===
+          ACTIVE_APP_LOCALES.length &&
+          snapshot.manifest.activeAppLocales.every(
+            (locale, index) => locale === ACTIVE_APP_LOCALES[index]
+          ) &&
+          snapshot.manifest.sourceFileCount ===
+            quranSourceFileCount(ACTIVE_APP_LOCALES)),
+      {
+        message:
+          "Expected the complete current Quran locale and source inventory.",
+      }
+    )
+  )
+);
+
 /** Parses one stored JSON value without allowing thrown parser failures. */
 export const parseStoredJson = Effect.fn("contentRelease.parseStoredJson")(
   (source: string, label = "Stored publication JSON") =>
@@ -216,6 +239,26 @@ export const decodeSnapshotJson = Effect.fn(
         new ReleaseError({
           code: "CONTENT_RELEASE_INTEGRITY",
           message: "Content snapshot does not satisfy its exact contract.",
+        })
+    )
+  )
+);
+/** Strictly decodes one newly staged manifest through the current contract. */
+export const decodeCurrentSnapshotJson = Effect.fn(
+  "contentRelease.decodeCurrentSnapshotJson"
+)((source: string) =>
+  parseStoredJson(source, "Current content snapshot").pipe(
+    Effect.flatMap(
+      Schema.decodeUnknownEffect(CurrentContentSnapshotManifestSchema, {
+        onExcessProperty: "error",
+      })
+    ),
+    Effect.mapError(
+      () =>
+        new ReleaseError({
+          code: "CONTENT_RELEASE_INTEGRITY",
+          message:
+            "New content snapshot does not satisfy the current contract.",
         })
     )
   )

--- a/packages/backend/convex/contentRelease/parse.ts
+++ b/packages/backend/convex/contentRelease/parse.ts
@@ -1,12 +1,11 @@
 import { SignedContentArtifactSchema } from "@nakafa/aksara-contracts/content";
-import { ContentProjectionSchema } from "@nakafa/aksara-contracts/projection/spec";
+import { ContentProjectionSchema as CurrentContentProjectionSchema } from "@nakafa/aksara-contracts/projection/spec";
 import {
   ContentReleaseItemSchema,
   PublicationReceiptSchema,
   ReleaseVerificationEvidenceSchema,
   SignedContentReleaseSchema,
 } from "@nakafa/aksara-contracts/release";
-import { RollbackSnapshotEntrySchema } from "@nakafa/aksara-contracts/release/rollback/spec";
 import { ContentRouteItemSchema } from "@nakafa/aksara-contracts/release/route/spec";
 import {
   ContentSnapshotManifestSchema,
@@ -14,6 +13,9 @@ import {
 } from "@nakafa/aksara-contracts/release/snapshot/data";
 import { RendererManifestEnvelopeSchema } from "@nakafa/aksara-contracts/renderer/contract";
 import { SignedTryoutRuntimeBundleSchema } from "@nakafa/aksara-contracts/tryout/runtime/spec";
+import { ContentProjectionSchema as StoredContentProjectionSchema } from "@nakafa/aksara-transition/projection/spec";
+import { RollbackSnapshotEntrySchema } from "@nakafa/aksara-transition/release/rollback/spec";
+import { PublishedQuranManifestSchema } from "@repo/backend/content/quran/contract";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
 import { Effect, Schema } from "effect";
 /** Parses one stored JSON value without allowing thrown parser failures. */
@@ -101,13 +103,13 @@ export const decodeArtifactJson = Effect.fn(
     )
   )
 );
-/** Strictly decodes one content projection from canonical storage JSON. */
+/** Strictly decodes one authenticated projection already present in storage. */
 export const decodeProjectionJson = Effect.fn(
   "contentRelease.decodeProjectionJson"
 )((source: string) =>
   parseStoredJson(source, "Content projection").pipe(
     Effect.flatMap(
-      Schema.decodeUnknownEffect(ContentProjectionSchema, {
+      Schema.decodeUnknownEffect(StoredContentProjectionSchema, {
         onExcessProperty: "error",
       })
     ),
@@ -116,6 +118,26 @@ export const decodeProjectionJson = Effect.fn(
         new ReleaseError({
           code: "CONTENT_RELEASE_INTEGRITY",
           message: "Content projection does not satisfy its exact contract.",
+        })
+    )
+  )
+);
+/** Strictly decodes one newly staged projection through the current contract. */
+export const decodeCurrentProjectionJson = Effect.fn(
+  "contentRelease.decodeCurrentProjectionJson"
+)((source: string) =>
+  parseStoredJson(source, "Current content projection").pipe(
+    Effect.flatMap(
+      Schema.decodeUnknownEffect(CurrentContentProjectionSchema, {
+        onExcessProperty: "error",
+      })
+    ),
+    Effect.mapError(
+      () =>
+        new ReleaseError({
+          code: "CONTENT_RELEASE_INTEGRITY",
+          message:
+            "New content projection does not satisfy the current contract.",
         })
     )
   )
@@ -181,9 +203,13 @@ export const decodeSnapshotJson = Effect.fn(
 )((source: string) =>
   parseStoredJson(source, "Content snapshot").pipe(
     Effect.flatMap(
-      Schema.decodeUnknownEffect(ContentSnapshotManifestSchema, {
-        onExcessProperty: "error",
-      })
+      Schema.decodeUnknownEffect(
+        Schema.Union([
+          ContentSnapshotManifestSchema,
+          PublishedQuranManifestSchema,
+        ]),
+        { onExcessProperty: "error" }
+      )
     ),
     Effect.mapError(
       () =>

--- a/packages/backend/convex/contentRelease/projection.ts
+++ b/packages/backend/convex/contentRelease/projection.ts
@@ -23,8 +23,8 @@ import {
   loadStaged,
 } from "@repo/backend/convex/contentRelease/model";
 import {
+  decodeCurrentProjectionJson,
   decodeItemJson,
-  decodeProjectionJson,
   decodeReleaseJson,
 } from "@repo/backend/convex/contentRelease/parse";
 import { encodeProjectionJson } from "@repo/backend/convex/contentRelease/wire";
@@ -54,7 +54,7 @@ const decodeBatch = Effect.fn("contentRelease.decodeProjectionBatch")(
     }
     const projections = yield* Effect.forEach(
       projectionJson,
-      decodeProjectionJson
+      decodeCurrentProjectionJson
     );
     return yield* Schema.decodeUnknownEffect(StageProjectionBatchInputSchema)({
       batchIndex,

--- a/packages/backend/convex/contentRelease/proof/routes.ts
+++ b/packages/backend/convex/contentRelease/proof/routes.ts
@@ -1,5 +1,5 @@
 import { ArtifactLocaleSchema } from "@nakafa/aksara-contracts/locale";
-import { familyForProjection } from "@nakafa/aksara-contracts/projection/spec";
+import { familyForProjection } from "@nakafa/aksara-transition/projection/spec";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { internalQuery } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";

--- a/packages/backend/convex/contentRelease/quran/attribution.test.ts
+++ b/packages/backend/convex/contentRelease/quran/attribution.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
 import { ActiveAppLocaleListSchema } from "@nakafa/aksara-contracts/locale";
+import { Sha256HashSchema as StoredSha256HashSchema } from "@nakafa/aksara-transition/ids";
+import { QuranSourceIdSchema as StoredQuranSourceIdSchema } from "@nakafa/aksara-transition/quran/identity";
+import { bindQuranRow as bindStoredQuranRow } from "@nakafa/aksara-transition/quran/snapshot/row/hash";
+import { QuranAttributionRowSchema as StoredQuranAttributionRowSchema } from "@nakafa/aksara-transition/quran/source";
+import { canonicalizeContentSnapshotRow as canonicalizeStoredQuranRow } from "@nakafa/aksara-transition/release/snapshot/data";
 import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
 import { readQuranAttribution } from "@repo/backend/convex/contentRelease/quran/attribution";
+import { quranRowFacts } from "@repo/backend/convex/contentRelease/quran/facts";
 import { readQuranLocaleSources } from "@repo/backend/convex/contentRelease/quran/sources";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -64,6 +70,94 @@ describe("contentRelease/quran/attribution", () => {
             },
           })
         );
+      })
+  );
+
+  it.live(
+    "reads the exact predecessor attribution during the data switch",
+    () =>
+      Effect.gen(function* () {
+        const active = convexTest(schema, convexModules);
+        const currentAttribution = makeQuranAttribution();
+        const snapshotId = yield* Effect.promise(() =>
+          active.mutation((ctx) =>
+            activateQuranSnapshot(ctx, [currentAttribution])
+          )
+        );
+        const storedAttribution = yield* Schema.decodeUnknownEffect(
+          StoredQuranAttributionRowSchema
+        )({
+          ...currentAttribution,
+          sources: currentAttribution.sources.filter((source) =>
+            Schema.is(StoredQuranSourceIdSchema)(source.id)
+          ),
+        });
+        const record = yield* bindStoredQuranRow(
+          StoredSha256HashSchema.make(snapshotId),
+          storedAttribution
+        );
+        yield* Effect.promise(() =>
+          active.mutation(async (ctx) => {
+            const row = await ctx.db.query("quranRows").unique();
+            expect(row).toBeDefined();
+            if (!row) {
+              return;
+            }
+            await ctx.db.patch("quranRows", row._id, {
+              ...quranRowFacts(record),
+              rowHash: record.rowHash,
+              rowJson: canonicalizeStoredQuranRow({ family: "quran", record }),
+            });
+          })
+        );
+
+        const locales = yield* Effect.all(
+          {
+            de: Effect.promise(() =>
+              active.query((ctx) =>
+                runConvexProgram(readQuranLocaleSources(ctx, snapshotId, "de"))
+              )
+            ),
+            en: Effect.promise(() =>
+              active.query((ctx) =>
+                runConvexProgram(readQuranLocaleSources(ctx, snapshotId, "en"))
+              )
+            ),
+            id: Effect.promise(() =>
+              active.query((ctx) =>
+                runConvexProgram(readQuranLocaleSources(ctx, snapshotId, "id"))
+              )
+            ),
+          },
+          { concurrency: "unbounded" }
+        );
+
+        expect(locales).toMatchObject({
+          de: {
+            sources: { translation: { id: "quranenc-german" } },
+            tafsirAccess: {
+              appLocale: "de",
+              kind: "external",
+              source: { id: "mokhtasar-german" },
+            },
+          },
+          en: {
+            sources: { translation: { id: "quranenc-english" } },
+            tafsirAccess: {
+              appLocale: "en",
+              kind: "external",
+              source: { id: "mokhtasar-english" },
+            },
+          },
+          id: {
+            sources: { translation: { id: "quranenc-indonesian" } },
+            tafsirAccess: {
+              appLocale: "id",
+              kind: "embedded",
+              source: { id: "quranenc-tafsir" },
+            },
+          },
+        });
       })
   );
 

--- a/packages/backend/convex/contentRelease/quran/attribution.ts
+++ b/packages/backend/convex/contentRelease/quran/attribution.ts
@@ -1,4 +1,4 @@
-import { QuranAttributionRowSchema } from "@nakafa/aksara-contracts/quran/source";
+import { PublishedQuranAttributionSchema } from "@repo/backend/content/quran/contract";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { loadQuranOwner } from "@repo/backend/convex/contentRelease/quran/owner";
@@ -29,7 +29,7 @@ export const readQuranAttributionRow = Effect.fn(
   const payload = yield* verifyQuranRow(
     row,
     snapshotId,
-    QuranAttributionRowSchema
+    PublishedQuranAttributionSchema
   );
   return { payload, rowJson: row.rowJson };
 });

--- a/packages/backend/convex/contentRelease/quran/document.test.ts
+++ b/packages/backend/convex/contentRelease/quran/document.test.ts
@@ -6,6 +6,7 @@ import {
   makeQuranAttribution,
   makeQuranChunk,
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranSurah,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
@@ -69,7 +70,7 @@ describe("contentRelease/quran/document", () => {
       kind: "quran-surah",
       name: {
         arabic: "سورة 1",
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Technical Surah 1",
       },
       number: 1,
@@ -102,7 +103,7 @@ describe("contentRelease/quran/document", () => {
       sources: makeQuranLocaleSources("de"),
       surah: {
         name: {
-          sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+          sourceMeaning: makeQuranMeaning(1),
         },
       },
       tafsirAccess: makeQuranTafsirProjection("de"),

--- a/packages/backend/convex/contentRelease/quran/document.ts
+++ b/packages/backend/convex/contentRelease/quran/document.ts
@@ -1,7 +1,7 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import {
   quranBismillahValidator,

--- a/packages/backend/convex/contentRelease/quran/document.ts
+++ b/packages/backend/convex/contentRelease/quran/document.ts
@@ -1,6 +1,6 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import {
@@ -62,7 +62,7 @@ type QuranDocument = Infer<typeof quranDocumentValidator>;
 type QuranDocumentSurah = NonNullable<QuranDocument["surah"]>;
 
 /** Projects complete public surah metadata without signed envelope fields. */
-function projectSurah(surah: QuranSurahRow): QuranDocumentSurah {
+function projectSurah(surah: PublishedQuranSurah): QuranDocumentSurah {
   return {
     kind: surah.kind,
     name: {

--- a/packages/backend/convex/contentRelease/quran/facts.test.ts
+++ b/packages/backend/convex/contentRelease/quran/facts.test.ts
@@ -37,7 +37,7 @@ describe("contentRelease/quran/facts", () => {
       expect(records.map(quranRowFacts)).toEqual([
         {
           identity:
-            "attribution:tanzil-text:tanzil-metadata:quranenc-english:quranenc-indonesian:quranenc-german:quranenc-tafsir:mokhtasar-english:mokhtasar-german",
+            "attribution:tanzil-text:tanzil-metadata:kemenag-names:bubenheim-names:quranenc-english:quranenc-indonesian:quranenc-german:quranenc-tafsir:mokhtasar-english:mokhtasar-german",
           kind: "quran-attribution",
         },
         { identity: "surah:1", kind: "quran-surah", surahNumber: 1 },

--- a/packages/backend/convex/contentRelease/quran/facts.ts
+++ b/packages/backend/convex/contentRelease/quran/facts.ts
@@ -1,5 +1,7 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
-import type { QuranSnapshotRow } from "@nakafa/aksara-contracts/quran/snapshot/row";
+import type { PublishedQuranRow } from "@repo/backend/content/quran/contract";
+
+type QuranSnapshotRow = PublishedQuranRow["record"];
 
 type QuranSearch = Extract<
   QuranSnapshotRow["payload"],

--- a/packages/backend/convex/contentRelease/quran/markdown.test.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.test.ts
@@ -6,6 +6,7 @@ import {
   makeQuranAttribution,
   makeQuranChunk,
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranSurah,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
@@ -50,7 +51,7 @@ describe("contentRelease/quran/markdown", () => {
 
     expect(markdown.surah).toEqual({
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Technical Surah 1",
       },
       number: 1,
@@ -119,10 +120,7 @@ describe("contentRelease/quran/markdown", () => {
     expect(markdown.toVerse).toBe(80);
     expect(markdown.verses).toHaveLength(80);
     expect(markdown.preBismillah?.arabic).toBe(bismillah);
-    expect(markdown.surah?.name.sourceMeaning).toEqual({
-      appLocale: "en",
-      text: "Technical meaning 2",
-    });
+    expect(markdown.surah?.name.sourceMeaning).toEqual(makeQuranMeaning(2));
     expect(markdown.verses[0]?.arabic).toBe("آية 1");
     expect(markdown.verses.at(-1)?.number.inSurah).toBe(80);
   });

--- a/packages/backend/convex/contentRelease/quran/markdown.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.ts
@@ -1,7 +1,7 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import {

--- a/packages/backend/convex/contentRelease/quran/markdown.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.ts
@@ -1,6 +1,6 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
@@ -59,7 +59,7 @@ export type QuranMarkdown = Infer<typeof quranMarkdownValidator>;
 type QuranMarkdownSurah = NonNullable<QuranMarkdown["surah"]>;
 
 /** Projects only metadata rendered by Quran markdown consumers. */
-function projectSurah(surah: QuranSurahRow): QuranMarkdownSurah {
+function projectSurah(surah: PublishedQuranSurah): QuranMarkdownSurah {
   return {
     name: {
       sourceMeaning: surah.name.meaning,

--- a/packages/backend/convex/contentRelease/quran/spec.ts
+++ b/packages/backend/convex/contentRelease/quran/spec.ts
@@ -30,10 +30,11 @@ export const quranRevelationPlaceValidator = literals(
   ...QuranSurahRowSchema.fields.revelation.fields.place.literals
 );
 
-/** Source-language meaning retained from the signed surah metadata row. */
+/** Complete locale-keyed meanings retained from the signed surah metadata row. */
 export const quranSurahMeaningValidator = v.object({
-  appLocale: v.literal(ENGLISH_APP_LOCALE_CODE),
-  text: v.string(),
+  de: v.string(),
+  en: v.string(),
+  id: v.string(),
 });
 
 const quranSourceArtifactValidator = v.object({

--- a/packages/backend/convex/contentRelease/quran/spec.ts
+++ b/packages/backend/convex/contentRelease/quran/spec.ts
@@ -31,11 +31,17 @@ export const quranRevelationPlaceValidator = literals(
 );
 
 /** Complete locale-keyed meanings retained from the signed surah metadata row. */
-export const quranSurahMeaningValidator = v.object({
-  de: v.string(),
-  en: v.string(),
-  id: v.string(),
-});
+export const quranSurahMeaningValidator = v.union(
+  v.object({
+    de: v.string(),
+    en: v.string(),
+    id: v.string(),
+  }),
+  v.object({
+    appLocale: v.literal(ENGLISH_APP_LOCALE_CODE),
+    text: v.string(),
+  })
+);
 
 const quranSourceArtifactValidator = v.object({
   byteCount: v.number(),

--- a/packages/backend/convex/contentRelease/quran/surah.ts
+++ b/packages/backend/convex/contentRelease/quran/surah.ts
@@ -1,4 +1,4 @@
-import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
+import { PublishedQuranSurahSchema } from "@repo/backend/content/quran/contract";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
@@ -13,7 +13,7 @@ import { Effect } from "effect";
 export const verifyQuranSurahRow = Effect.fn(
   "contentRelease.verifyQuranSurahRow"
 )(function* (row: Doc<"quranRows">, snapshotId: string) {
-  return yield* verifyQuranRow(row, snapshotId, QuranSurahRowSchema);
+  return yield* verifyQuranRow(row, snapshotId, PublishedQuranSurahSchema);
 });
 
 /** Reads and authenticates one surah under the active signed contract. */

--- a/packages/backend/convex/contentRelease/quran/verify.test.ts
+++ b/packages/backend/convex/contentRelease/quran/verify.test.ts
@@ -1,14 +1,21 @@
 import { QuranSearchRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
+import { Sha256HashSchema as StoredSha256HashSchema } from "@nakafa/aksara-transition/ids";
+import { makeAppLocale as makeStoredAppLocale } from "@nakafa/aksara-transition/locale";
+import { bindQuranRow as bindStoredQuranRow } from "@nakafa/aksara-transition/quran/snapshot/row/hash";
+import { QuranSurahRowSchema as StoredQuranSurahRowSchema } from "@nakafa/aksara-transition/quran/spec";
+import { canonicalizeContentSnapshotRow as canonicalizeStoredQuranRow } from "@nakafa/aksara-transition/release/snapshot/data";
+import { PublishedQuranSurahSchema } from "@repo/backend/content/quran/contract";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { QURAN_SEARCH_DOCUMENT_LIMIT } from "@repo/backend/convex/contentRelease/quran/limits";
 import { verifyQuranRow } from "@repo/backend/convex/contentRelease/quran/verify";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
-import { makeQuranSearch } from "@repo/backend/test/quran/rows";
+import { makeQuranSearch, makeQuranSurah } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 /** Loads the only technical Quran row inside one test transaction. */
@@ -21,6 +28,49 @@ async function loadRow(ctx: Pick<QueryCtx, "db">) {
 }
 
 describe("contentRelease/quran/verify", () => {
+  it("verifies the exact authenticated surah stored during the data switch", async () => {
+    const t = convexTest(schema, convexModules);
+    const snapshotId = await t.mutation((ctx) =>
+      activateQuranSnapshot(ctx, [makeQuranSurah(1)])
+    );
+    const storedSurah = StoredQuranSurahRowSchema.make({
+      kind: "quran-surah",
+      name: {
+        arabic: "سورة 1",
+        meaning: {
+          appLocale: makeStoredAppLocale("en"),
+          text: "The Opening",
+        },
+        transliteration: "Al-Fatihah",
+      },
+      number: 1,
+      numberOfVerses: 7,
+      revelation: { order: 5, place: "Meccan" },
+    });
+    const record = await Effect.runPromise(
+      bindStoredQuranRow(StoredSha256HashSchema.make(snapshotId), storedSurah)
+    );
+    await t.mutation(async (ctx) => {
+      const row = await loadRow(ctx);
+      await ctx.db.patch("quranRows", row._id, {
+        rowHash: record.rowHash,
+        rowJson: canonicalizeStoredQuranRow({ family: "quran", record }),
+      });
+    });
+
+    const verified = await t.query(async (ctx) => {
+      const row = await loadRow(ctx);
+      return runConvexProgram(
+        verifyQuranRow(row, snapshotId, PublishedQuranSurahSchema)
+      );
+    });
+
+    expect(verified.name.meaning).toEqual({
+      appLocale: "en",
+      text: "The Opening",
+    });
+  });
+
   it("rejects a changed signed identity", async () => {
     const signed = convexTest(schema, convexModules);
     const signedId = await signed.mutation((ctx) =>

--- a/packages/backend/convex/contentRelease/quran/verify.ts
+++ b/packages/backend/convex/contentRelease/quran/verify.ts
@@ -1,10 +1,11 @@
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import { PublishedQuranRowSchema } from "@repo/backend/content/quran/contract";
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";
 import {
   ReleaseError,
   releaseFail,
 } from "@repo/backend/convex/contentRelease/error";
-import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
+import { parseStoredJson } from "@repo/backend/convex/contentRelease/parse";
 import { quranRowFacts } from "@repo/backend/convex/contentRelease/quran/facts";
 import { quranRowDocumentLimit } from "@repo/backend/convex/contentRelease/quran/limits";
 import { Effect, Schema } from "effect";
@@ -15,9 +16,25 @@ export const verifyQuranRow = Effect.fn("contentRelease.verifyQuranRow")(
     snapshotId: string,
     payloadSchema: Schema.Codec<A, I, never, never>
   ) {
-    const decoded = yield* decodeSnapshotRowJson(row.rowJson);
+    const decoded = yield* parseStoredJson(
+      row.rowJson,
+      "Quran snapshot row"
+    ).pipe(
+      Effect.flatMap(
+        Schema.decodeUnknownEffect(PublishedQuranRowSchema, {
+          onExcessProperty: "error",
+        })
+      ),
+      Effect.mapError(
+        () =>
+          new ReleaseError({
+            code: "CONTENT_RELEASE_INTEGRITY",
+            message:
+              "Quran snapshot row does not satisfy its bounded publication contract.",
+          })
+      )
+    );
     if (
-      decoded.family !== "quran" ||
       decoded.record.rowHash !== row.rowHash ||
       decoded.record.snapshotId !== snapshotId ||
       row.snapshotId !== snapshotId

--- a/packages/backend/convex/contentRelease/quran/verify.ts
+++ b/packages/backend/convex/contentRelease/quran/verify.ts
@@ -1,5 +1,5 @@
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import { PublishedQuranRowSchema } from "@repo/backend/content/quran/contract";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";
 import {
   ReleaseError,

--- a/packages/backend/convex/contentRelease/quran/view.test.ts
+++ b/packages/backend/convex/contentRelease/quran/view.test.ts
@@ -6,6 +6,7 @@ import {
   makeQuranAttribution,
   makeQuranChunk,
   makeQuranLocaleSources,
+  makeQuranMeaning,
   makeQuranSearch,
   makeQuranSurah,
   makeQuranTafsirProjection,
@@ -116,7 +117,7 @@ describe("contentRelease/quran/view", () => {
 
     expect(english.nextSurah).toEqual({
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 2" },
+        sourceMeaning: makeQuranMeaning(2),
         transliteration: "Technical Surah 2",
       },
       number: 2,
@@ -125,7 +126,7 @@ describe("contentRelease/quran/view", () => {
     expect(english.previousSurah).toBeNull();
     expect(english.surah).toEqual({
       name: {
-        sourceMeaning: { appLocale: "en", text: "Technical meaning 1" },
+        sourceMeaning: makeQuranMeaning(1),
         transliteration: "Technical Surah 1",
       },
       number: 1,
@@ -173,14 +174,10 @@ describe("contentRelease/quran/view", () => {
     ]);
     expect(indonesian.sources).toEqual(makeQuranLocaleSources("id"));
     expect(indonesian.tafsirAccess).toEqual(makeQuranTafsirProjection("id"));
-    expect(indonesian.nextSurah?.name.sourceMeaning).toEqual({
-      appLocale: "en",
-      text: "Technical meaning 2",
-    });
-    expect(indonesian.surah?.name.sourceMeaning).toEqual({
-      appLocale: "en",
-      text: "Technical meaning 1",
-    });
+    expect(indonesian.nextSurah?.name.sourceMeaning).toEqual(
+      makeQuranMeaning(2)
+    );
+    expect(indonesian.surah?.name.sourceMeaning).toEqual(makeQuranMeaning(1));
     expect(JSON.stringify(indonesian)).not.toContain("Tafsir teknis");
     expect({
       english: english.appLocale,

--- a/packages/backend/convex/contentRelease/quran/view.ts
+++ b/packages/backend/convex/contentRelease/quran/view.ts
@@ -1,9 +1,7 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
-import {
-  QURAN_SURAH_COUNT,
-  type QuranSurahRow,
-} from "@nakafa/aksara-contracts/quran/spec";
+import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import {
@@ -78,7 +76,7 @@ const readNeighbor = Effect.fn("contentRelease.readQuranNeighbor")(function* (
 });
 
 /** Projects only the signed surah metadata needed by the Quran page. */
-function projectSurah(surah: QuranSurahRow): QuranViewSurah {
+function projectSurah(surah: PublishedQuranSurah): QuranViewSurah {
   return {
     name: {
       sourceMeaning: surah.name.meaning,

--- a/packages/backend/convex/contentRelease/quran/view.ts
+++ b/packages/backend/convex/contentRelease/quran/view.ts
@@ -1,8 +1,8 @@
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import type { QuranRuntimeVerse } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
-import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import { separateQuranBismillah } from "@repo/backend/content/quran/bismillah";
+import type { PublishedQuranSurah } from "@repo/backend/content/quran/contract";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import {
   quranBismillahValidator,

--- a/packages/backend/convex/contentRelease/reference/input.ts
+++ b/packages/backend/convex/contentRelease/reference/input.ts
@@ -6,7 +6,7 @@ import {
   type ActiveAppLocale,
   ActiveAppLocaleSchema,
 } from "@nakafa/aksara-contracts/locale";
-import { materialPublicNamespace } from "@nakafa/aksara-contracts/projection/material";
+import { materialPublicNamespace } from "@nakafa/aksara-transition/projection/material";
 import type { ContentReferenceInput } from "@repo/backend/convex/contentRelease/reference/spec";
 import type { Locale } from "@repo/contents/_types/content";
 import { LocaleSchema } from "@repo/contents/_types/content";

--- a/packages/backend/convex/contentRelease/rollback.ts
+++ b/packages/backend/convex/contentRelease/rollback.ts
@@ -1,5 +1,11 @@
 import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import {
+  MAX_ROUTE_PAGE_RECORDS,
+  type RoutePage,
+  RoutePageRequestSchema,
+  type RouteRollbackRecord,
+} from "@nakafa/aksara-contracts/release/route/page";
+import {
   canonicalizeRollbackPage,
   MAX_ROLLBACK_PAGE_BYTES,
   MAX_ROLLBACK_PAGE_RECORDS,
@@ -7,12 +13,6 @@ import {
   RollbackPageRequestSchema,
   type RollbackRecord,
 } from "@nakafa/aksara-transition/release/rollback/spec";
-import {
-  MAX_ROUTE_PAGE_RECORDS,
-  type RoutePage,
-  RoutePageRequestSchema,
-  type RouteRollbackRecord,
-} from "@nakafa/aksara-contracts/release/route/page";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { internalQuery } from "@repo/backend/convex/_generated/server";

--- a/packages/backend/convex/contentRelease/rollback.ts
+++ b/packages/backend/convex/contentRelease/rollback.ts
@@ -6,7 +6,7 @@ import {
   type RollbackPage,
   RollbackPageRequestSchema,
   type RollbackRecord,
-} from "@nakafa/aksara-contracts/release/rollback/spec";
+} from "@nakafa/aksara-transition/release/rollback/spec";
 import {
   MAX_ROUTE_PAGE_RECORDS,
   type RoutePage,

--- a/packages/backend/convex/contentRelease/rollback/state.ts
+++ b/packages/backend/convex/contentRelease/rollback/state.ts
@@ -1,4 +1,4 @@
-import { canonicalizeContentProjection } from "@nakafa/aksara-contracts/projection/spec";
+import { canonicalizeContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import {
   type ContentChange,
   ContentUpsertSchema,
@@ -7,7 +7,7 @@ import {
   RollbackRecordSchema,
   type RollbackState,
   RollbackUpsertStateSchema,
-} from "@nakafa/aksara-contracts/release/rollback/spec";
+} from "@nakafa/aksara-transition/release/rollback/spec";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";

--- a/packages/backend/convex/contentRelease/rollback/state.ts
+++ b/packages/backend/convex/contentRelease/rollback/state.ts
@@ -1,8 +1,8 @@
-import { canonicalizeContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import {
   type ContentChange,
   ContentUpsertSchema,
 } from "@nakafa/aksara-contracts/release";
+import { canonicalizeContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import {
   RollbackRecordSchema,
   type RollbackState,

--- a/packages/backend/convex/contentRelease/runtime/public/batch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/batch.ts
@@ -1,11 +1,11 @@
-import type {
-  PublicContentRuntimeRequest,
-  PublicContentRuntimeResponse,
-} from "@nakafa/aksara-contracts/runtime/spec";
+import type { PublicContentRuntimeRequest } from "@nakafa/aksara-contracts/runtime/spec";
 import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
+import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES as MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-v150/runtime/spec";
 import {
+  MAX_PREDECESSOR_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES,
   MAX_PUBLIC_RUNTIME_BATCH_REQUEST_BYTES,
   MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES,
+  PredecessorPublicContentRuntimeBatchResponseSchema,
   PublicContentRuntimeBatchRequestSchema,
   PublicContentRuntimeBatchResponseSchema,
   publicRuntimeResponseBytes,
@@ -41,7 +41,9 @@ class PublicRuntimeBatchReadError extends Schema.TaggedError<PublicRuntimeBatchR
   "PublicRuntimeBatchReadError",
   {}
 ) {}
-type RuntimeRowDecoder = typeof decodePublicRuntimeRow;
+type RuntimeRowDecoder<Found, Failure> = (
+  row: PublicRuntimeRow
+) => Effect.Effect<Found | null, Failure>;
 /** Strictly parses one bounded UTF-8 public batch request. */
 const decodeBatchRequest = Effect.fn("contentRelease.decodePublicBatchRequest")(
   function* (source: string, byteLength: number) {
@@ -66,10 +68,10 @@ const decodeBatchRequest = Effect.fn("contentRelease.decodePublicBatchRequest")(
 /** Reads and decodes one transactionally consistent public batch. */
 const resolvePublicRuntimeBatch = Effect.fn(
   "contentRelease.resolvePublicRuntimeBatch"
-)(function* (
+)(function* <Found, Failure>(
   ctx: ActionCtx,
   requests: readonly PublicContentRuntimeRequest[],
-  decodeRow: RuntimeRowDecoder
+  decodeRow: RuntimeRowDecoder<Found, Failure>
 ) {
   const rows = yield* Effect.tryPromise({
     catch: () => new PublicRuntimeBatchReadError(),
@@ -87,14 +89,8 @@ const resolvePublicRuntimeBatch = Effect.fn(
   return yield* Effect.forEach(rows, (row) =>
     decodeRow(row).pipe(
       Effect.map(
-        (
-          response
-        ): Exclude<
-          PublicContentRuntimeResponse,
-          {
-            kind: "failure";
-          }
-        > => response ?? { kind: "missing" }
+        (response): Found | { readonly kind: "missing" } =>
+          response ?? { kind: "missing" }
       ),
       Effect.mapError(() => new PublicRuntimeBatchReadError())
     )
@@ -103,11 +99,14 @@ const resolvePublicRuntimeBatch = Effect.fn(
 /** Decodes, resolves, and safely encodes one public runtime batch. */
 const dispatchRuntimeBatchProgram = Effect.fn(
   "contentRelease.dispatchPublicRuntimeBatch"
-)(function* (
+)(function* <Found, Failure, A, I>(
   ctx: ActionCtx,
   source: string,
   byteLength: number,
-  decodeRow: RuntimeRowDecoder
+  decodeRow: RuntimeRowDecoder<Found, Failure>,
+  responseSchema: Schema.Codec<A, I, never, never>,
+  maxItemBytes: number,
+  maxResponseBytes: number
 ) {
   const decoded = yield* decodeBatchRequest(source, byteLength).pipe(
     Effect.result
@@ -125,15 +124,14 @@ const dispatchRuntimeBatchProgram = Effect.fn(
   }
   if (
     responses.success.some(
-      (response) =>
-        publicRuntimeResponseBytes(response) > MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
+      (response) => publicRuntimeResponseBytes(response) > maxItemBytes
     )
   ) {
     return failureResult("CONTENT_RUNTIME_RESPONSE_TOO_LARGE", 500);
   }
   return encodeRuntimeResult(
-    PublicContentRuntimeBatchResponseSchema,
-    MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES,
+    responseSchema,
+    maxResponseBytes,
     { responses: responses.success },
     200
   );
@@ -147,7 +145,10 @@ export const dispatchBatchProgram = Effect.fn(
     ctx,
     source,
     byteLength,
-    decodePublicRuntimeRow
+    decodePublicRuntimeRow,
+    PublicContentRuntimeBatchResponseSchema,
+    MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
+    MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES
   );
 });
 
@@ -159,6 +160,9 @@ export const dispatchPredecessorBatchProgram = Effect.fn(
     ctx,
     source,
     byteLength,
-    decodePredecessorRuntimeRow
+    decodePredecessorRuntimeRow,
+    PredecessorPublicContentRuntimeBatchResponseSchema,
+    MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES,
+    MAX_PREDECESSOR_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES
   );
 });

--- a/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
@@ -10,6 +10,10 @@ import {
   type PublicContentRuntimeRequest,
   PublicContentRuntimeResponseSchema,
 } from "@nakafa/aksara-contracts/runtime/spec";
+import {
+  MAX_PUBLIC_RUNTIME_RESPONSE_BYTES as MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES,
+  PublicContentRuntimeResponseSchema as predecessorPublicContentRuntimeResponseSchema,
+} from "@nakafa/aksara-v150/runtime/spec";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
 import {
   decodeArtifactJson,
@@ -121,13 +125,15 @@ export const decodePredecessorRuntimeRow = Effect.fn(
   );
 });
 
-type RuntimeRowDecoder = typeof decodePublicRuntimeRow;
+type RuntimeRowDecoder<Found> = (
+  row: PublicRuntimeRow
+) => Effect.Effect<Found | null, PublicRuntimeReadError>;
 /** Reads one active public artifact for Nakafa verification. */
 const resolvePublicRuntime = Effect.fn("contentRelease.resolvePublicRuntime")(
-  function* (
+  function* <Found>(
     ctx: ActionCtx,
     request: PublicContentRuntimeRequest,
-    decodeRow: RuntimeRowDecoder
+    decodeRow: RuntimeRowDecoder<Found>
   ) {
     const row = yield* Effect.tryPromise({
       catch: () => new PublicRuntimeReadError(),
@@ -143,11 +149,13 @@ const resolvePublicRuntime = Effect.fn("contentRelease.resolvePublicRuntime")(
 /** Decodes, resolves, and safely encodes one public runtime request. */
 const dispatchRuntimeProgram = Effect.fn(
   "contentRelease.dispatchPublicRuntime"
-)(function* (
+)(function* <Found, A, I>(
   ctx: ActionCtx,
   source: string,
   byteLength: number,
-  decodeRow: RuntimeRowDecoder
+  decodeRow: RuntimeRowDecoder<Found>,
+  responseSchema: Schema.Codec<A, I, never, never>,
+  maxResponseBytes: number
 ) {
   const decoded = yield* decodePublicRequest(source, byteLength).pipe(
     Effect.result
@@ -165,15 +173,15 @@ const dispatchRuntimeProgram = Effect.fn(
   }
   if (resolved.success === null) {
     return encodeRuntimeResult(
-      PublicContentRuntimeResponseSchema,
-      MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
+      responseSchema,
+      maxResponseBytes,
       { kind: "missing" },
       404
     );
   }
   return encodeRuntimeResult(
-    PublicContentRuntimeResponseSchema,
-    MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
+    responseSchema,
+    maxResponseBytes,
     resolved.success,
     200
   );
@@ -187,7 +195,9 @@ export const dispatchProgram = Effect.fn(
     ctx,
     source,
     byteLength,
-    decodePublicRuntimeRow
+    decodePublicRuntimeRow,
+    PublicContentRuntimeResponseSchema,
+    MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
   );
 });
 
@@ -199,6 +209,8 @@ export const dispatchPredecessorProgram = Effect.fn(
     ctx,
     source,
     byteLength,
-    decodePredecessorRuntimeRow
+    decodePredecessorRuntimeRow,
+    predecessorPublicContentRuntimeResponseSchema,
+    MAX_PREDECESSOR_PUBLIC_RUNTIME_RESPONSE_BYTES
   );
 });

--- a/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
@@ -78,12 +78,12 @@ export const decodePublicRuntimeRow = Effect.fn(
   }
   const [artifact, storedProjection, release, rendererManifest, sourcePath] =
     yield* Effect.all([
-    decodeArtifactJson(row.artifactJson),
-    decodeProjectionJson(row.projectionJson),
-    decodeReleaseJson(row.releaseJson),
-    decodeRendererJson(row.rendererJson),
-    Schema.decodeEffect(CorpusSourcePathSchema)(row.sourcePath),
-  ]).pipe(Effect.mapError(() => new PublicRuntimeReadError()));
+      decodeArtifactJson(row.artifactJson),
+      decodeProjectionJson(row.projectionJson),
+      decodeReleaseJson(row.releaseJson),
+      decodeRendererJson(row.rendererJson),
+      Schema.decodeEffect(CorpusSourcePathSchema)(row.sourcePath),
+    ]).pipe(Effect.mapError(() => new PublicRuntimeReadError()));
   yield* Schema.decodeEffect(Sha256HashSchema)(row.projectionHash).pipe(
     Effect.mapError(() => new PublicRuntimeReadError())
   );

--- a/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
@@ -15,6 +15,7 @@ import {
   PublicContentRuntimeResponseSchema as predecessorPublicContentRuntimeResponseSchema,
 } from "@nakafa/aksara-v150/runtime/spec";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
+import { hashText } from "@repo/backend/convex/contentRelease/digest";
 import {
   decodeArtifactJson,
   decodeProjectionJson,
@@ -23,6 +24,7 @@ import {
 } from "@repo/backend/convex/contentRelease/parse";
 import type { PublicRuntimeRow } from "@repo/backend/convex/contentRelease/runtime/public/internal";
 import { makePredecessorRuntime } from "@repo/backend/convex/contentRelease/runtime/public/predecessor";
+import { encodePublicProjection } from "@repo/backend/convex/contentRelease/runtime/public/projection";
 import {
   encodeRuntimeResult,
   failureResult,
@@ -74,21 +76,24 @@ export const decodePublicRuntimeRow = Effect.fn(
   if (row.delivery !== "public") {
     return yield* new PublicRuntimeReadError();
   }
-  const [
-    artifact,
-    projection,
-    projectionHash,
-    release,
-    rendererManifest,
-    sourcePath,
-  ] = yield* Effect.all([
+  const [artifact, storedProjection, release, rendererManifest, sourcePath] =
+    yield* Effect.all([
     decodeArtifactJson(row.artifactJson),
     decodeProjectionJson(row.projectionJson),
-    Schema.decodeEffect(Sha256HashSchema)(row.projectionHash),
     decodeReleaseJson(row.releaseJson),
     decodeRendererJson(row.rendererJson),
     Schema.decodeEffect(CorpusSourcePathSchema)(row.sourcePath),
   ]).pipe(Effect.mapError(() => new PublicRuntimeReadError()));
+  yield* Schema.decodeEffect(Sha256HashSchema)(row.projectionHash).pipe(
+    Effect.mapError(() => new PublicRuntimeReadError())
+  );
+  const { projection, projectionJson } = yield* encodePublicProjection(
+    storedProjection
+  ).pipe(Effect.mapError(() => new PublicRuntimeReadError()));
+  const projectionHash = yield* hashText(
+    "the current public content projection",
+    projectionJson
+  ).pipe(Effect.mapError(() => new PublicRuntimeReadError()));
   if (projection.kind === "question-body") {
     return yield* new PublicRuntimeReadError();
   }

--- a/packages/backend/convex/contentRelease/runtime/public/internal.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/internal.ts
@@ -2,7 +2,7 @@ import { ArtifactLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import {
   canonicalizeContentProjection,
   familyForProjection,
-} from "@nakafa/aksara-contracts/projection/spec";
+} from "@nakafa/aksara-transition/projection/spec";
 import { PUBLIC_CONTENT_RUNTIME_BATCH_SIZE } from "@repo/backend/content/batch";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { internalQuery } from "@repo/backend/convex/_generated/server";

--- a/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
@@ -1,5 +1,5 @@
-import type { RoutedContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import type { PublicContentRuntimeFound } from "@nakafa/aksara-contracts/runtime/spec";
+import type { RoutedContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import {
   canonicalizeContentProjection as canonicalizePredecessorContentProjection,
   RoutedContentProjectionSchema as predecessorRoutedContentProjectionSchema,

--- a/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
@@ -1,4 +1,4 @@
-import type { RoutedContentProjection } from "@nakafa/aksara-contracts/projection/spec";
+import type { RoutedContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import type { PublicContentRuntimeFound } from "@nakafa/aksara-contracts/runtime/spec";
 import {
   canonicalizeContentProjection as canonicalizePredecessorContentProjection,

--- a/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/predecessor.ts
@@ -1,9 +1,10 @@
-import {
-  canonicalizeContentProjection,
-  type RoutedContentProjection,
-  RoutedContentProjectionSchema,
-} from "@nakafa/aksara-contracts/projection/spec";
+import type { RoutedContentProjection } from "@nakafa/aksara-contracts/projection/spec";
 import type { PublicContentRuntimeFound } from "@nakafa/aksara-contracts/runtime/spec";
+import {
+  canonicalizeContentProjection as canonicalizePredecessorContentProjection,
+  RoutedContentProjectionSchema as predecessorRoutedContentProjectionSchema,
+} from "@nakafa/aksara-v150/projection/spec";
+import { PublicContentRuntimeFoundSchema as predecessorPublicContentRuntimeFoundSchema } from "@nakafa/aksara-v150/runtime/spec";
 import { encodePredecessorProjection as encodeArticleProjection } from "@repo/backend/convex/contentRelease/article/predecessor";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";
 import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
@@ -21,7 +22,7 @@ const encodeProjection = Effect.fn(
   if (projection.kind === "subject-lesson") {
     return yield* encodeMaterialProjection(projection);
   }
-  return canonicalizeContentProjection(projection);
+  return canonicalizePredecessorContentProjection(projection);
 });
 
 /** Decodes one derived predecessor projection without widening its family. */
@@ -30,7 +31,7 @@ const decodeProjection = Effect.fn(
 )((source: string) =>
   parseStoredJson(source, "Predecessor content projection").pipe(
     Effect.flatMap(
-      Schema.decodeUnknownEffect(RoutedContentProjectionSchema, {
+      Schema.decodeUnknownEffect(predecessorRoutedContentProjectionSchema, {
         onExcessProperty: "error",
       })
     ),
@@ -63,9 +64,23 @@ export const makePredecessorRuntime = Effect.fn(
     projectionJson
   );
 
-  return {
-    ...found,
-    projection,
-    projectionHash,
-  } satisfies PublicContentRuntimeFound;
+  return yield* Schema.decodeUnknownEffect(
+    predecessorPublicContentRuntimeFoundSchema
+  )(
+    {
+      ...found,
+      projection,
+      projectionHash,
+    },
+    { onExcessProperty: "error" }
+  ).pipe(
+    Effect.mapError(
+      () =>
+        new ReleaseError({
+          code: "CONTENT_RELEASE_INTEGRITY",
+          message:
+            "Predecessor public runtime does not satisfy its exact contract.",
+        })
+    )
+  );
 });

--- a/packages/backend/convex/contentRelease/runtime/public/projection.test.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/projection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  ContentProjectionSchema,
+  canonicalizeContentProjection,
+} from "@nakafa/aksara-contracts/projection/spec";
+import { ArticleProjectionSchema as StoredArticleProjectionSchema } from "@nakafa/aksara-transition/projection/article";
+import { encodePublicProjection } from "@repo/backend/convex/contentRelease/runtime/public/projection";
+import { testLocalizedArticleProjection } from "@repo/backend/test/content/runtime";
+import { normalizePublicationDates } from "@repo/contents/_types/publication";
+import { Effect, Schema } from "effect";
+
+describe("current public content projection", () => {
+  it.effect("normalizes an authenticated stored date exactly once", () =>
+    Effect.gen(function* () {
+      const current = testLocalizedArticleProjection(0, "id");
+      const { datePublished } = normalizePublicationDates(current.metadata);
+      const stored = StoredArticleProjectionSchema.make({
+        ...current,
+        metadata: {
+          authors: current.metadata.authors,
+          date: datePublished,
+          title: current.metadata.title,
+        },
+      });
+
+      const encoded = yield* encodePublicProjection(stored);
+
+      expect(Schema.is(ContentProjectionSchema)(encoded.projection)).toBe(true);
+      expect(encoded.projection.metadata).toMatchObject({
+        datePublished,
+      });
+      expect(encoded.projection.metadata).not.toHaveProperty("date");
+      expect(encoded.projectionJson).toBe(
+        canonicalizeContentProjection(encoded.projection)
+      );
+    })
+  );
+
+  it.effect("preserves a current projection without compatibility fields", () =>
+    Effect.gen(function* () {
+      const current = testLocalizedArticleProjection(0, "de");
+
+      const encoded = yield* encodePublicProjection(current);
+
+      expect(encoded.projection).toEqual(current);
+      expect(encoded.projectionJson).toBe(
+        canonicalizeContentProjection(encoded.projection)
+      );
+    })
+  );
+});

--- a/packages/backend/convex/contentRelease/runtime/public/projection.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/projection.ts
@@ -1,0 +1,46 @@
+import {
+  ContentProjectionSchema,
+  canonicalizeContentProjection,
+} from "@nakafa/aksara-contracts/projection/spec";
+import type { ContentProjection as TransitionProjection } from "@nakafa/aksara-transition/projection/spec";
+import { ReleaseError } from "@repo/backend/convex/contentRelease/error";
+import { Effect, Schema } from "effect";
+
+/** Converts one authenticated stored projection into the current public wire. */
+export const encodePublicProjection = Effect.fn(
+  "contentRelease.encodePublicProjection"
+)(function* (projection: TransitionProjection) {
+  const candidate = normalizeStoredProjection(projection);
+  const current = yield* Schema.decodeUnknownEffect(ContentProjectionSchema)(
+    candidate,
+    { onExcessProperty: "error" }
+  ).pipe(
+    Effect.mapError(
+      () =>
+        new ReleaseError({
+          code: "CONTENT_RELEASE_INTEGRITY",
+          message:
+            "Authenticated content cannot produce its current public projection.",
+        })
+    )
+  );
+  return {
+    projection: current,
+    projectionJson: canonicalizeContentProjection(current),
+  };
+});
+
+/** Removes the sole retired metadata field before current public decoding. */
+function normalizeStoredProjection(projection: TransitionProjection) {
+  if (
+    (projection.kind !== "article" && projection.kind !== "subject-lesson") ||
+    !("date" in projection.metadata)
+  ) {
+    return projection;
+  }
+  const { date, ...metadata } = projection.metadata;
+  return {
+    ...projection,
+    metadata: { ...metadata, datePublished: date },
+  };
+}

--- a/packages/backend/convex/contentRelease/search/write.ts
+++ b/packages/backend/convex/contentRelease/search/write.ts
@@ -1,4 +1,4 @@
-import type { ContentProjection } from "@nakafa/aksara-contracts/projection/spec";
+import type { ContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {

--- a/packages/backend/convex/contentRelease/snapshot/manifest.test.ts
+++ b/packages/backend/convex/contentRelease/snapshot/manifest.test.ts
@@ -9,7 +9,10 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { TEST_RELEASE_ID } from "@repo/backend/test/content/release";
 import { insertTestRelease } from "@repo/backend/test/content/stage";
 import { makeProgramSnapshotData } from "@repo/backend/test/program/snapshot";
-import { makeBlockedQuranSnapshot } from "@repo/backend/test/quran/snapshot";
+import {
+  makeBlockedQuranSnapshot,
+  makeStoredQuranSnapshot,
+} from "@repo/backend/test/quran/snapshot";
 import { TEST_STAGE_SNAPSHOT } from "@repo/backend/test/snapshot/routes";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
@@ -132,6 +135,41 @@ describe("contentRelease/snapshot/manifest", () => {
       t.run((ctx) => ctx.db.query("contentSnapshots").unique())
     ).resolves.toBeNull();
   });
+
+  it.live("rejects a predecessor Quran manifest before storing it", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* makeStoredQuranSnapshot();
+      const snapshots = {
+        ...inheritContentSnapshots(null),
+        quran: replaceContentSnapshot({
+          baseSnapshotId: null,
+          resultSnapshotId: snapshot.manifest.snapshotId,
+          rowCount: snapshot.manifest.projectionCount,
+          rowDigest: snapshot.manifest.projectionDigest,
+        }),
+      };
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) => insertTestRelease(ctx, { snapshots }))
+      );
+
+      yield* Effect.promise(() =>
+        expect(
+          t.mutation(TEST_STAGE_SNAPSHOT, {
+            releaseId: TEST_RELEASE_ID,
+            snapshotJson: encodeSnapshotJson(snapshot),
+          })
+        ).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      yield* Effect.promise(() =>
+        expect(
+          t.run((ctx) => ctx.db.query("contentSnapshots").unique())
+        ).resolves.toBeNull()
+      );
+    })
+  );
 
   it.live("rejects manifests after release staging closes", () =>
     Effect.gen(function* () {

--- a/packages/backend/convex/contentRelease/snapshot/manifest.ts
+++ b/packages/backend/convex/contentRelease/snapshot/manifest.ts
@@ -12,8 +12,8 @@ import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { loadStaged } from "@repo/backend/convex/contentRelease/model";
 import {
+  decodeCurrentSnapshotJson,
   decodeReleaseJson,
-  decodeSnapshotJson,
 } from "@repo/backend/convex/contentRelease/parse";
 import {
   ROLLBACK_RETENTION_MS,
@@ -77,7 +77,7 @@ const stageManifest = Effect.fn("contentRelease.stageSnapshot")(function* (
   releaseId: string,
   snapshotJson: string
 ) {
-  const snapshot = yield* decodeSnapshotJson(snapshotJson);
+  const snapshot = yield* decodeCurrentSnapshotJson(snapshotJson);
   const canonicalJson = encodeSnapshotJson(snapshot);
   const snapshotId = contentSnapshotId(snapshot);
   const { release } = yield* loadStaged(ctx, releaseId);

--- a/packages/backend/convex/contentRelease/verify/upsert.ts
+++ b/packages/backend/convex/contentRelease/verify/upsert.ts
@@ -2,7 +2,7 @@ import {
   canonicalizeContentProjection,
   familyForProjection,
   projectionArtifactLocale,
-} from "@nakafa/aksara-contracts/projection/spec";
+} from "@nakafa/aksara-transition/projection/spec";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";

--- a/packages/backend/convex/contents/views/target.ts
+++ b/packages/backend/convex/contents/views/target.ts
@@ -2,11 +2,11 @@ import {
   type MaterialDomain,
   MaterialDomainSchema,
 } from "@nakafa/aksara-contracts/material/domain";
-import type { ArticleProjection } from "@nakafa/aksara-contracts/projection/article";
+import type { ArticleProjection } from "@nakafa/aksara-transition/projection/article";
 import {
   MaterialKeySchema,
   type MaterialLessonProjection,
-} from "@nakafa/aksara-contracts/projection/material";
+} from "@nakafa/aksara-transition/projection/material";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { loadArticleOwner } from "@repo/backend/convex/contentRelease/article/owner";
 import { verifyArticle } from "@repo/backend/convex/contentRelease/article/verify";

--- a/packages/backend/convex/emails/welcome.ts
+++ b/packages/backend/convex/emails/welcome.ts
@@ -4,8 +4,8 @@ import {
   type PageKey,
   PageKeySchema,
   type PublicPageProjection,
-} from "@nakafa/aksara-contracts/projection/page";
-import type { ContentProjection } from "@nakafa/aksara-contracts/projection/spec";
+} from "@nakafa/aksara-transition/projection/page";
+import type { ContentProjection } from "@nakafa/aksara-transition/projection/spec";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import {
   internalQuery,

--- a/packages/backend/convex/routes/agent/quran.test.ts
+++ b/packages/backend/convex/routes/agent/quran.test.ts
@@ -81,7 +81,7 @@ describe("public Quran API routes", () => {
       ),
       title: "Technical Surah 1",
     });
-    expect(body.text).toContain("Meaning: Technical meaning 1 (en)");
+    expect(body.text).toContain("Meaning: Technical meaning 1");
     expect(body.text).toContain("Translation notes:");
     expect(body.text).toContain("Exact English source note.");
     expect(body.text).toContain("## Reading sources");
@@ -130,7 +130,7 @@ describe("public Quran API routes", () => {
       lensId: "lens:quran",
       locale: "id",
       markdown_url: "https://nakafa.com/id/quran/1.md",
-      meaning: { locale: "en", text: "Technical meaning 1" },
+      meaning: { locale: "id", text: "Arti teknis 1" },
       name: "Technical Surah 1",
       pre_bismillah: null,
       revelation: "Meccan",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,6 +30,8 @@
     "@effect/platform-node": "catalog:",
     "@modelcontextprotocol/server": "2.0.0",
     "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
+    "@nakafa/aksara-transition": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-v150": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz",
     "@polar-sh/sdk": "^0.49.0",
     "@posthog/convex": "2.1.1",
     "@repo/ai": "workspace:*",
@@ -53,7 +55,6 @@
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",
     "@effect/vitest": "catalog:",
-    "@nakafa/aksara-v150": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz",
     "@repo/testing": "workspace:*",
     "@scalar/openapi-parser": "0.28.16",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,7 @@
     "@convex-dev/workpool": "^0.4.10",
     "@effect/platform-node": "catalog:",
     "@modelcontextprotocol/server": "2.0.0",
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@polar-sh/sdk": "^0.49.0",
     "@posthog/convex": "2.1.1",
     "@repo/ai": "workspace:*",

--- a/packages/backend/test/quran/rows.ts
+++ b/packages/backend/test/quran/rows.ts
@@ -258,6 +258,15 @@ export function makeQuranAttribution(
   });
 }
 
+/** Creates the complete locale-keyed meaning map for protocol tests. */
+export function makeQuranMeaning(surahNumber: number) {
+  return {
+    de: `Technische Bedeutung ${surahNumber}`,
+    en: `Technical meaning ${surahNumber}`,
+    id: `Arti teknis ${surahNumber}`,
+  } as const;
+}
+
 /** Creates one signed-contract surah metadata row for protocol tests. */
 export function makeQuranSurah(
   surahNumber: number,
@@ -267,10 +276,7 @@ export function makeQuranSurah(
     kind: "quran-surah",
     name: {
       arabic: `سورة ${surahNumber}`,
-      meaning: {
-        appLocale: makeAppLocale("en"),
-        text: `Technical meaning ${surahNumber}`,
-      },
+      meaning: makeQuranMeaning(surahNumber),
       transliteration: `Technical Surah ${surahNumber}`,
     },
     number: surahNumber,

--- a/packages/backend/test/quran/snapshot.ts
+++ b/packages/backend/test/quran/snapshot.ts
@@ -23,6 +23,8 @@ import {
   replaceContentSnapshot,
   restoreContentSnapshot,
 } from "@nakafa/aksara-contracts/release/snapshot/spec";
+import { makeQuranSnapshot as makeStoredSignedQuranSnapshot } from "@nakafa/aksara-transition/quran/snapshot/hash";
+import { quranSourceFileCount as storedQuranSourceFileCount } from "@nakafa/aksara-transition/quran/source";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
   quranRowFacts,
@@ -116,6 +118,18 @@ export const makeQuranSnapshot = Effect.fn("backendTest.makeQuranSnapshot")(
     } satisfies ContentSnapshotManifest;
   }
 );
+
+/** Creates the authenticated predecessor manifest retained in production. */
+export const makeStoredQuranSnapshot = Effect.fn(
+  "backendTest.makeStoredQuranSnapshot"
+)(function* () {
+  const facts = makeQuranSnapshotFacts("approved");
+  const manifest = yield* makeStoredSignedQuranSnapshot({
+    ...facts,
+    sourceFileCount: storedQuranSourceFileCount(facts.activeAppLocales),
+  });
+  return { family: "quran", manifest } as const;
+});
 
 /** Promotes the only staged technical release to the active slot. */
 async function completeTestRelease(ctx: MutationCtx) {

--- a/packages/contents/_lib/agent/schema/quran/reference.test.ts
+++ b/packages/contents/_lib/agent/schema/quran/reference.test.ts
@@ -160,6 +160,46 @@ describe("NakafaAgentQuranReferenceSchema", () => {
     expect(german.meaning).toEqual({ locale: "de", text: "Die Eröffnende" });
   });
 
+  it("preserves retained English meanings for localized references", () => {
+    const indonesian = reference("id", {
+      kind: "embedded",
+      locale: "id",
+      notice: "Tafsir Indonesia is embedded.",
+      source: embeddedSource("quranenc-tafsir"),
+    });
+    const german = reference("de", {
+      kind: "external",
+      locale: "de",
+      notice: "Read the official linked German edition.",
+      source: externalSource("mokhtasar-german"),
+    });
+    indonesian.meaning = { locale: "en", text: "The Opening" };
+    german.meaning = { locale: "en", text: "The Opening" };
+
+    expect(Schema.is(NakafaAgentQuranReferenceSchema)(indonesian)).toBe(true);
+    expect(Schema.is(NakafaAgentQuranReferenceSchema)(german)).toBe(true);
+    expect(indonesian).toMatchObject({
+      locale: "id",
+      meaning: { locale: "en", text: "The Opening" },
+    });
+    expect(german).toMatchObject({
+      locale: "de",
+      meaning: { locale: "en", text: "The Opening" },
+    });
+  });
+
+  it("rejects a localized meaning from another requested locale", () => {
+    const indonesian = reference("id", {
+      kind: "embedded",
+      locale: "id",
+      notice: "Tafsir Indonesia is embedded.",
+      source: embeddedSource("quranenc-tafsir"),
+    });
+    indonesian.meaning = { locale: "de", text: "Die Eröffnende" };
+
+    expect(Schema.is(NakafaAgentQuranReferenceSchema)(indonesian)).toBe(false);
+  });
+
   it("rejects missing Tafsir access for every locale", () => {
     expect(
       Schema.is(NakafaAgentQuranReferenceSchema)(reference("en", null))

--- a/packages/contents/_lib/agent/schema/quran/reference.test.ts
+++ b/packages/contents/_lib/agent/schema/quran/reference.test.ts
@@ -1,7 +1,4 @@
-import {
-  type AppLocaleCode,
-  ENGLISH_APP_LOCALE_CODE,
-} from "@nakafa/aksara-contracts/locale";
+import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import {
   type QuranEmbeddedSourceId,
   type QuranExternalSourceId,
@@ -16,6 +13,11 @@ const ARTIFACT = {
   digest: `sha256:${"1".repeat(64)}`,
   file_count: 1,
 };
+const meaningByLocale = {
+  de: "Die Eröffnende",
+  en: "The Opening",
+  id: "Pembuka",
+} as const;
 
 /** Builds one schema-valid embedded source fixture. */
 function embeddedSource(id: QuranEmbeddedSourceId) {
@@ -67,7 +69,7 @@ function reference(appLocale: AppLocaleCode, tafsir_access: unknown) {
     lensId: "lens:quran",
     locale: appLocale,
     markdown_url: `https://nakafa.com/${appLocale}/quran/1.md`,
-    meaning: { locale: ENGLISH_APP_LOCALE_CODE, text: "The Opening" },
+    meaning: { locale: appLocale, text: meaningByLocale[appLocale] },
     name: "Al-Fatihah",
     pre_bismillah: null,
     revelation: "Meccan",
@@ -154,17 +156,17 @@ describe("NakafaAgentQuranReferenceSchema", () => {
 
     expect(Schema.is(NakafaAgentQuranReferenceSchema)(indonesian)).toBe(true);
     expect(Schema.is(NakafaAgentQuranReferenceSchema)(german)).toBe(true);
-    expect(indonesian.meaning).toEqual({ locale: "en", text: "The Opening" });
-    expect(german.meaning).toEqual({ locale: "en", text: "The Opening" });
+    expect(indonesian.meaning).toEqual({ locale: "id", text: "Pembuka" });
+    expect(german.meaning).toEqual({ locale: "de", text: "Die Eröffnende" });
   });
 
-  it("accepts legacy missing access only for external Tafsir locales", () => {
+  it("rejects missing Tafsir access for every locale", () => {
     expect(
       Schema.is(NakafaAgentQuranReferenceSchema)(reference("en", null))
-    ).toBe(true);
+    ).toBe(false);
     expect(
       Schema.is(NakafaAgentQuranReferenceSchema)(reference("de", null))
-    ).toBe(true);
+    ).toBe(false);
     expect(
       Schema.is(NakafaAgentQuranReferenceSchema)(reference("id", null))
     ).toBe(false);

--- a/packages/contents/_lib/agent/schema/quran/reference.ts
+++ b/packages/contents/_lib/agent/schema/quran/reference.ts
@@ -28,6 +28,20 @@ function makeNakafaQuranMeaningSchema<const Locale extends AppLocaleCode>(
   }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
 }
 
+const NakafaQuranEnglishMeaningSchema = makeNakafaQuranMeaningSchema(
+  ENGLISH_APP_LOCALE_CODE
+);
+
+/** Accepts current locale meaning or truthful English from retained storage. */
+function makeNakafaQuranLocalizedMeaningSchema(
+  locale: typeof GERMAN_APP_LOCALE_CODE | typeof INDONESIAN_APP_LOCALE_CODE
+) {
+  return Schema.Union([
+    makeNakafaQuranMeaningSchema(locale),
+    NakafaQuranEnglishMeaningSchema,
+  ]);
+}
+
 const NakafaQuranTranslationDocumentSchema =
   QuranTranslationDocumentSchema.mapFields((fields) => ({
     notes: fields.notes.pipe(Schema.mutable),
@@ -88,7 +102,7 @@ const NakafaQuranReferenceFields = {
 const NakafaQuranEnglishReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(ENGLISH_APP_LOCALE_CODE),
-  meaning: makeNakafaQuranMeaningSchema(ENGLISH_APP_LOCALE_CODE),
+  meaning: NakafaQuranEnglishMeaningSchema,
   sources: NakafaQuranEnglishReadingSourcesSchema,
   tafsir_access: NakafaQuranEnglishTafsirAccessSchema.annotate({
     description: "Signed link-only English Tafsir access.",
@@ -98,7 +112,7 @@ const NakafaQuranEnglishReferenceSchema = Schema.Struct({
 const NakafaQuranIndonesianReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(INDONESIAN_APP_LOCALE_CODE),
-  meaning: makeNakafaQuranMeaningSchema(INDONESIAN_APP_LOCALE_CODE),
+  meaning: makeNakafaQuranLocalizedMeaningSchema(INDONESIAN_APP_LOCALE_CODE),
   sources: NakafaQuranIndonesianReadingSourcesSchema,
   tafsir_access: NakafaQuranIndonesianTafsirAccessSchema,
 }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
@@ -106,7 +120,7 @@ const NakafaQuranIndonesianReferenceSchema = Schema.Struct({
 const NakafaQuranGermanReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(GERMAN_APP_LOCALE_CODE),
-  meaning: makeNakafaQuranMeaningSchema(GERMAN_APP_LOCALE_CODE),
+  meaning: makeNakafaQuranLocalizedMeaningSchema(GERMAN_APP_LOCALE_CODE),
   sources: NakafaQuranGermanReadingSourcesSchema,
   tafsir_access: NakafaQuranGermanTafsirAccessSchema.annotate({
     description: "Signed link-only German Tafsir access.",

--- a/packages/contents/_lib/agent/schema/quran/reference.ts
+++ b/packages/contents/_lib/agent/schema/quran/reference.ts
@@ -1,10 +1,12 @@
 import {
+  type AppLocaleCode,
   ENGLISH_APP_LOCALE_CODE,
   GERMAN_APP_LOCALE_CODE,
   INDONESIAN_APP_LOCALE_CODE,
 } from "@nakafa/aksara-contracts/locale";
 import { QuranTranslationDocumentSchema } from "@nakafa/aksara-contracts/quran/notes";
 import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
+import { QuranMeaningfulTextSchema } from "@nakafa/aksara-contracts/quran/text";
 import {
   NakafaQuranEnglishReadingSourcesSchema,
   NakafaQuranEnglishTafsirAccessSchema,
@@ -16,11 +18,15 @@ import {
 import { NakafaAgentReadableContentRefSchema } from "@repo/contents/_lib/agent/schema/ref";
 import { Schema, Struct } from "effect";
 
-/** English-only source-authenticated meaning of a surah name. */
-export const NakafaQuranMeaningSchema = Schema.Struct({
-  locale: Schema.Literal(ENGLISH_APP_LOCALE_CODE),
-  text: QuranSurahRowSchema.fields.name.fields.meaning.fields.text,
-}).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+/** Builds one source-authenticated surah meaning for an exact app locale. */
+function makeNakafaQuranMeaningSchema<const Locale extends AppLocaleCode>(
+  locale: Locale
+) {
+  return Schema.Struct({
+    locale: Schema.Literal(locale),
+    text: QuranMeaningfulTextSchema,
+  }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
+}
 
 const NakafaQuranTranslationDocumentSchema =
   QuranTranslationDocumentSchema.mapFields((fields) => ({
@@ -64,7 +70,6 @@ const NakafaQuranReferenceVerseSchema = Schema.Struct({
 
 const NakafaQuranReferenceFields = {
   ...NakafaAgentReadableContentRefSchema.fields,
-  meaning: NakafaQuranMeaningSchema,
   name: QuranSurahRowSchema.fields.name.fields.transliteration.annotate({
     description: "Source-authenticated transliterated surah name.",
   }),
@@ -83,16 +88,17 @@ const NakafaQuranReferenceFields = {
 const NakafaQuranEnglishReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(ENGLISH_APP_LOCALE_CODE),
+  meaning: makeNakafaQuranMeaningSchema(ENGLISH_APP_LOCALE_CODE),
   sources: NakafaQuranEnglishReadingSourcesSchema,
-  tafsir_access: Schema.NullOr(NakafaQuranEnglishTafsirAccessSchema).annotate({
-    description:
-      "Signed English Tafsir access, or null for a legacy signed publication without access metadata.",
+  tafsir_access: NakafaQuranEnglishTafsirAccessSchema.annotate({
+    description: "Signed link-only English Tafsir access.",
   }),
 }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
 
 const NakafaQuranIndonesianReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(INDONESIAN_APP_LOCALE_CODE),
+  meaning: makeNakafaQuranMeaningSchema(INDONESIAN_APP_LOCALE_CODE),
   sources: NakafaQuranIndonesianReadingSourcesSchema,
   tafsir_access: NakafaQuranIndonesianTafsirAccessSchema,
 }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
@@ -100,14 +106,14 @@ const NakafaQuranIndonesianReferenceSchema = Schema.Struct({
 const NakafaQuranGermanReferenceSchema = Schema.Struct({
   ...NakafaQuranReferenceFields,
   locale: Schema.Literal(GERMAN_APP_LOCALE_CODE),
+  meaning: makeNakafaQuranMeaningSchema(GERMAN_APP_LOCALE_CODE),
   sources: NakafaQuranGermanReadingSourcesSchema,
-  tafsir_access: Schema.NullOr(NakafaQuranGermanTafsirAccessSchema).annotate({
-    description:
-      "Signed German Tafsir access, or null for a legacy signed publication without access metadata.",
+  tafsir_access: NakafaQuranGermanTafsirAccessSchema.annotate({
+    description: "Signed link-only German Tafsir access.",
   }),
 }).pipe((schema) => schema.mapFields(Struct.map(Schema.mutableKey)));
 
-/** Quran output with source-language meaning and locale-selected reading access. */
+/** Quran output with locale-selected meaning and signed reading access. */
 export const NakafaAgentQuranReferenceSchema = Schema.Union([
   NakafaQuranEnglishReferenceSchema,
   NakafaQuranIndonesianReferenceSchema,

--- a/packages/contents/package.json
+++ b/packages/contents/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@hugeicons/core-free-icons": "^4.3.0",
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@repo/design-system": "workspace:*",
     "@repo/internationalization": "workspace:*",
     "@repo/utilities": "workspace:*",

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -1144,9 +1144,9 @@
       "keywords": "{title}, {category}, Analyse, Fakten, aktuell, Forschung, Informationen, Nachrichten"
     },
     "quran": {
-      "title": "Sure {number}. {name} ({transliteration}) | Nakafa",
+      "title": "Sure {number}. {name} ({transliteration}) - {translation} | Nakafa",
       "description": "Lies die Sure {name} ({transliteration}) mit einer Übersetzung Vers für Vers. {numberOfVerses} Verse aus dem heiligen Quran.",
-      "keywords": "Sure {name}, Quran, {transliteration}, {revelation}"
+      "keywords": "Sure {name}, Quran, {translation}, {revelation}"
     }
   }
 }

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -1144,9 +1144,9 @@
       "keywords": "{title}, {category}, Analyse, Fakten, aktuell, Forschung, Informationen, Nachrichten"
     },
     "quran": {
-      "title": "Sure {number}. {name} ({transliteration}) - {translation} | Nakafa",
+      "title": "Sure {number}. {name} ({transliteration}){translation, select, __EMPTY__ {} other { - {translation}}} | Nakafa",
       "description": "Lies die Sure {name} ({transliteration}) mit einer Übersetzung Vers für Vers. {numberOfVerses} Verse aus dem heiligen Quran.",
-      "keywords": "Sure {name}, Quran, {translation}, {revelation}"
+      "keywords": "Sure {name}, Quran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}"
     }
   }
 }

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -1144,9 +1144,9 @@
       "keywords": "{title}, {category}, analysis, facts, latest, research, information, news"
     },
     "quran": {
-      "title": "Surah {number}. {name} ({transliteration}) - {translation} | Nakafa",
+      "title": "Surah {number}. {name} ({transliteration}){translation, select, __EMPTY__ {} other { - {translation}}} | Nakafa",
       "description": "Read Surah {name} ({transliteration}) with verse-by-verse translation. {numberOfVerses} verses from the Holy Quran.",
-      "keywords": "Surah {name}, Quran, {translation}, {revelation}"
+      "keywords": "Surah {name}, Quran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}"
     }
   }
 }

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -1144,9 +1144,9 @@
       "keywords": "{title}, {category}, analisis, fakta, terkini, riset, informasi, berita"
     },
     "quran": {
-      "title": "Surat {number}. {name} ({transliteration}) | Nakafa",
+      "title": "Surat {number}. {name} ({transliteration}) - {translation} | Nakafa",
       "description": "Baca Surat {name} ({transliteration}) dengan terjemahan dan tafsir. {numberOfVerses} ayat dari Al-Quran.",
-      "keywords": "Surat {name}, Al-Quran, {transliteration}, {revelation}, tafsir"
+      "keywords": "Surat {name}, Al-Quran, {translation}, {revelation}, tafsir"
     }
   }
 }

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -1144,9 +1144,9 @@
       "keywords": "{title}, {category}, analisis, fakta, terkini, riset, informasi, berita"
     },
     "quran": {
-      "title": "Surat {number}. {name} ({transliteration}) - {translation} | Nakafa",
+      "title": "Surat {number}. {name} ({transliteration}){translation, select, __EMPTY__ {} other { - {translation}}} | Nakafa",
       "description": "Baca Surat {name} ({transliteration}) dengan terjemahan dan tafsir. {numberOfVerses} ayat dari Al-Quran.",
-      "keywords": "Surat {name}, Al-Quran, {translation}, {revelation}, tafsir"
+      "keywords": "Surat {name}, Al-Quran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}, tafsir"
     }
   }
 }

--- a/packages/internationalization/package.json
+++ b/packages/internationalization/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz",
+    "@nakafa/aksara-contracts": "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz",
     "@repo/utilities": "workspace:*",
     "next": "16.3.2",
     "next-intl": "^4.13.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
   apps/api:
     dependencies:
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@repo/backend':
         specifier: workspace:*
         version: link:../../packages/backend
@@ -277,8 +277,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(supports-color@7.2.0)
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@paper-design/shaders-react':
         specifier: ^0.0.80
         version: 0.0.80(@types/react@19.2.18)(react@19.2.8)
@@ -476,8 +476,8 @@ importers:
         specifier: ^4.35.0
         version: 4.35.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@repo/contents':
         specifier: workspace:*
         version: link:../contents
@@ -586,8 +586,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@polar-sh/sdk':
         specifier: ^0.49.0
         version: 0.49.0
@@ -725,8 +725,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@repo/design-system':
         specifier: workspace:*
         version: link:../design-system
@@ -1007,8 +1007,8 @@ importers:
   packages/internationalization:
     dependencies:
       '@nakafa/aksara-contracts':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
-        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
+        version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
       '@repo/utilities':
         specifier: workspace:*
         version: link:../utilities
@@ -2780,9 +2780,9 @@ packages:
     peerDependencies:
       effect: 4.0.0-rc.110
 
-  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz':
-    resolution: {integrity: sha512-GlqxogjyqVXBJvrQCK7pB9DAMTxPLerLL4F5Czk0BDNT9IkuBBer7CUqtyZ60eBGnpYcIzNLjRK+di1n6DDm8w==, tarball: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz}
-    version: 0.21.1
+  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz':
+    resolution: {integrity: sha512-v7b3v23N1BAZBznelaV358efpQf5ZflI94FgRcZ1blakeZmDccYRCWUKbuB0ft+9o3eq0QlDTtDt/8HNGDruGg==, tarball: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz}
+    version: 0.23.0
     engines: {node: '>=24.0.0 <25.0.0'}
     peerDependencies:
       effect: 4.0.0-rc.110
@@ -9241,7 +9241,7 @@ snapshots:
     dependencies:
       effect: 4.0.0-rc.110
 
-  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)':
+  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)':
     dependencies:
       effect: 4.0.0-rc.110
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,12 @@ importers:
       '@nakafa/aksara-contracts':
         specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz
         version: https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz(effect@4.0.0-rc.110)
+      '@nakafa/aksara-transition':
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz
+        version: '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)'
+      '@nakafa/aksara-v150':
+        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz
+        version: '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz(effect@4.0.0-rc.110)'
       '@polar-sh/sdk':
         specifier: ^0.49.0
         version: 0.49.0
@@ -652,9 +658,6 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
-      '@nakafa/aksara-v150':
-        specifier: https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz
-        version: '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz(effect@4.0.0-rc.110)'
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing
@@ -2776,6 +2779,13 @@ packages:
   '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz':
     resolution: {integrity: sha512-Ty6Af71mH/fDrwkbO+tKNVXFiq2IKt8vENAU9O0azHy8BzV/jSuUn3uqmFwBHHEjZ5VxcVVmw4bG0Fx3oCZ7Mw==, tarball: https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz}
     version: 0.15.0
+    engines: {node: '>=24.0.0 <25.0.0'}
+    peerDependencies:
+      effect: 4.0.0-rc.110
+
+  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz':
+    resolution: {integrity: sha512-GlqxogjyqVXBJvrQCK7pB9DAMTxPLerLL4F5Czk0BDNT9IkuBBer7CUqtyZ60eBGnpYcIzNLjRK+di1n6DDm8w==, tarball: https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz}
+    version: 0.21.1
     engines: {node: '>=24.0.0 <25.0.0'}
     peerDependencies:
       effect: 4.0.0-rc.110
@@ -9238,6 +9248,10 @@ snapshots:
     optional: true
 
   '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.15.0/nakafa-aksara-contracts-0.15.0.tgz(effect@4.0.0-rc.110)':
+    dependencies:
+      effect: 4.0.0-rc.110
+
+  '@nakafa/aksara-contracts@https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz(effect@4.0.0-rc.110)':
     dependencies:
       effect: 4.0.0-rc.110
 

--- a/scripts/dependencies/policy.ts
+++ b/scripts/dependencies/policy.ts
@@ -6,7 +6,7 @@ interface DependencyHold {
 }
 
 export const CONTRACT_ARCHIVE =
-  "https://github.com/nakafaai/aksara/releases/download/contracts-v0.21.1/nakafa-aksara-contracts-0.21.1.tgz";
+  "https://github.com/nakafaai/aksara/releases/download/contracts-v0.23.0/nakafa-aksara-contracts-0.23.0.tgz";
 
 export const DEPENDENCY_RELEASE_AGE_MINUTES = 1440;
 


### PR DESCRIPTION
## Outcome

Completes the signed Quran reading contract for all active Nakafa locales.

- shows the signed localized surah meaning in Indonesian, English, and German instead of an English-only or generic description
- requires Arabic, translation, source provenance, and Tafsir access metadata for every active locale
- keeps Indonesian Al-Mukhtasar embedded per verse
- exposes official publisher links for the English and German Al-Mukhtasar editions because their reviewed terms do not permit Nakafa to republish the full text
- preserves the existing Bismillah, verse, translation-note, and button styling
- upgrades consumers to immutable Aksara contracts 0.23.0
- keeps retained historical chat previews readable while new previews are locale-correlated and fully typed

## Data switch

Production still serves the authenticated Aksara 0.21.1 Quran snapshot. This PR accepts that exact stored attribution and surah shape while preferring 0.23.0. It does not add a route alias, fallback string, or second source of truth.

The transition dependency is removed after the signed 0.23.0 Quran snapshot is active and the current contract is verified in production.

## Source release

- Aksara data PR: https://github.com/nakafaai/aksara/pull/232
- immutable contracts: https://github.com/nakafaai/aksara/releases/tag/contracts-v0.23.0
- signed Quran release run: https://github.com/nakafaai/aksara/actions/runs/33143362405
- the first publish attempt failed before activation with ProductionStateError, so the active production snapshot remains 0.21.1 until the release state repair is complete

## Local verification

- format
- focused Quran attribution, verification, and page projection tests: 12 passed
- full backend suite: 389 files and 1,637 tests passed
- affected package typechecks
- lint
- dependency boundaries
- security audit
- Effect source parity
- diff integrity

No Vercel Preview is requested. Production deployment remains protected-main only.