### PR TITLE
test(backend): run read-model waiter with Effect Vitest

### DIFF
--- a/packages/backend/convex/contentRelease/ingress/readModels.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/readModels.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { internal } from "@repo/backend/convex/_generated/api";
 import {
@@ -16,27 +17,41 @@ import type {
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { Effect } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { Data, Duration, Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
 
 const releaseId = ReleaseIdSchema.make("release-read-model-waiter");
 
+class UnexpectedReadModelTestState extends Data.TaggedError(
+  "UnexpectedReadModelTestState"
+)<{
+  readonly operation: "restart" | "status";
+}> {}
+
 /** Allocates valid scheduler identities without executing their test jobs. */
-function createScheduledJobIds() {
-  const t = convexTest(schema, convexModules);
-  return t.mutation((ctx) =>
-    Promise.all([
-      ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
-        generation: 1,
-        releaseId,
-      }),
-      ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
-        generation: 2,
-        releaseId,
-      }),
-    ])
-  );
-}
+const createScheduledJobIds = Effect.fn(
+  "test.contentRelease.createScheduledJobIds"
+)(function* () {
+  const t = yield* Effect.sync(() => convexTest(schema, convexModules));
+  return yield* Effect.all([
+    Effect.promise(() =>
+      t.mutation((ctx) =>
+        ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
+          generation: 1,
+          releaseId,
+        })
+      )
+    ),
+    Effect.promise(() =>
+      t.mutation((ctx) =>
+        ctx.scheduler.runAfter(0, internal.contentRelease.models.resume, {
+          generation: 2,
+          releaseId,
+        })
+      )
+    ),
+  ]);
+});
 
 /** Builds a deterministic coordinator for one waiter state-machine proof. */
 function makeReadModelCoordinator(
@@ -53,14 +68,16 @@ function makeReadModelCoordinator(
       restartIndex += 1;
       return result
         ? Effect.succeed(result)
-        : Effect.die(new Error("Unexpected read-model restart."));
+        : Effect.die(
+            new UnexpectedReadModelTestState({ operation: "restart" })
+          );
     },
     status: () => {
       const status = statuses[statusIndex];
       statusIndex += 1;
       return status
         ? Effect.succeed(status)
-        : Effect.die(new Error("Unexpected read-model status poll."));
+        : Effect.die(new UnexpectedReadModelTestState({ operation: "status" }));
     },
   };
   return { restarts, service };
@@ -71,137 +88,150 @@ function runReadModelWait(
   policy: ReadModelWaitPolicy,
   service: ReadModelCoordinatorService
 ) {
-  return Effect.runPromise(
-    waitForReadModels(releaseId, policy).pipe(
-      Effect.provideService(ReadModelCoordinator, service)
-    )
+  return waitForReadModels(releaseId, policy).pipe(
+    Effect.provideService(ReadModelCoordinator, service)
   );
 }
 
-afterEach(() => vi.useRealTimers());
-
 describe("content release read-model waiter", () => {
-  it("observes an initial activation failure without restarting", async () => {
-    const [failedJobId] = await createScheduledJobIds();
-    const { restarts, service } = makeReadModelCoordinator([
-      {
-        phase: "failed",
-        releaseId,
-        syncGeneration: 1,
-        syncJobId: failedJobId,
-      },
-    ]);
-
-    await expect(runReadModelWait("observe", service)).rejects.toMatchObject({
-      _tag: "ReleaseError",
-      code: "CONTENT_RELEASE_INTEGRITY",
-    });
-    expect(restarts).toEqual([]);
-  });
-
-  it("restarts one explicitly retried failed activation", async () => {
-    const [failedJobId, successorJobId] = await createScheduledJobIds();
-    const { restarts, service } = makeReadModelCoordinator(
-      [
+  it.effect("observes an initial activation failure without restarting", () =>
+    Effect.gen(function* () {
+      const [failedJobId] = yield* createScheduledJobIds();
+      const { restarts, service } = makeReadModelCoordinator([
         {
           phase: "failed",
           releaseId,
           syncGeneration: 1,
           syncJobId: failedJobId,
+        },
+      ]);
+
+      expect(
+        yield* runReadModelWait("observe", service).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "ReleaseError",
+        code: "CONTENT_RELEASE_INTEGRITY",
+      });
+      expect(restarts).toEqual([]);
+    })
+  );
+
+  it.effect("restarts one explicitly retried failed activation", () =>
+    Effect.gen(function* () {
+      const [failedJobId, successorJobId] = yield* createScheduledJobIds();
+      const { restarts, service } = makeReadModelCoordinator(
+        [
+          {
+            phase: "failed",
+            releaseId,
+            syncGeneration: 1,
+            syncJobId: failedJobId,
+          },
+          { phase: "completed", releaseId },
+        ],
+        [
+          {
+            status: "restarted",
+            syncGeneration: 2,
+            syncJobId: successorJobId,
+          },
+        ]
+      );
+
+      expect(
+        yield* runReadModelWait("restart-failed-once", service)
+      ).toBeUndefined();
+      expect(restarts).toEqual([
+        {
+          expectedGeneration: 1,
+          expectedJobId: failedJobId,
+          releaseId,
+        },
+      ]);
+    })
+  );
+
+  it.effect("follows the winning lineage after a stale restart", () =>
+    Effect.gen(function* () {
+      const [failedJobId] = yield* createScheduledJobIds();
+      const { restarts, service } = makeReadModelCoordinator(
+        [
+          {
+            phase: "failed",
+            releaseId,
+            syncGeneration: 1,
+            syncJobId: failedJobId,
+          },
+          { phase: "completed", releaseId },
+        ],
+        [{ status: "stale" }]
+      );
+
+      expect(
+        yield* runReadModelWait("restart-failed-once", service)
+      ).toBeUndefined();
+      expect(restarts).toHaveLength(1);
+    })
+  );
+
+  it.effect(
+    "fails after the sole successor also reaches terminal failure",
+    () =>
+      Effect.gen(function* () {
+        const [failedJobId, successorJobId] = yield* createScheduledJobIds();
+        const { restarts, service } = makeReadModelCoordinator(
+          [
+            {
+              phase: "failed",
+              releaseId,
+              syncGeneration: 1,
+              syncJobId: failedJobId,
+            },
+            {
+              phase: "failed",
+              releaseId,
+              syncGeneration: 2,
+              syncJobId: successorJobId,
+            },
+          ],
+          [
+            {
+              status: "restarted",
+              syncGeneration: 2,
+              syncJobId: successorJobId,
+            },
+          ]
+        );
+
+        expect(
+          yield* runReadModelWait("restart-failed-once", service).pipe(
+            Effect.flip
+          )
+        ).toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
+        expect(restarts).toHaveLength(1);
+      })
+  );
+
+  it.effect("polls a running lineage until it completes", () =>
+    Effect.gen(function* () {
+      const [runningJobId] = yield* createScheduledJobIds();
+      const { restarts, service } = makeReadModelCoordinator([
+        {
+          phase: "syncing",
+          releaseId,
+          syncGeneration: 1,
+          syncJobId: runningJobId,
         },
         { phase: "completed", releaseId },
-      ],
-      [
-        {
-          status: "restarted",
-          syncGeneration: 2,
-          syncJobId: successorJobId,
-        },
-      ]
-    );
+      ]);
 
-    await expect(
-      runReadModelWait("restart-failed-once", service)
-    ).resolves.toBeUndefined();
-    expect(restarts).toEqual([
-      {
-        expectedGeneration: 1,
-        expectedJobId: failedJobId,
-        releaseId,
-      },
-    ]);
-  });
+      const waiting = yield* runReadModelWait("observe", service).pipe(
+        Effect.forkChild
+      );
+      yield* TestClock.adjust(Duration.millis(100));
 
-  it("follows the winning lineage after a stale restart", async () => {
-    const [failedJobId] = await createScheduledJobIds();
-    const { restarts, service } = makeReadModelCoordinator(
-      [
-        {
-          phase: "failed",
-          releaseId,
-          syncGeneration: 1,
-          syncJobId: failedJobId,
-        },
-        { phase: "completed", releaseId },
-      ],
-      [{ status: "stale" }]
-    );
-
-    await expect(
-      runReadModelWait("restart-failed-once", service)
-    ).resolves.toBeUndefined();
-    expect(restarts).toHaveLength(1);
-  });
-
-  it("fails after the sole successor also reaches terminal failure", async () => {
-    const [failedJobId, successorJobId] = await createScheduledJobIds();
-    const { restarts, service } = makeReadModelCoordinator(
-      [
-        {
-          phase: "failed",
-          releaseId,
-          syncGeneration: 1,
-          syncJobId: failedJobId,
-        },
-        {
-          phase: "failed",
-          releaseId,
-          syncGeneration: 2,
-          syncJobId: successorJobId,
-        },
-      ],
-      [
-        {
-          status: "restarted",
-          syncGeneration: 2,
-          syncJobId: successorJobId,
-        },
-      ]
-    );
-
-    await expect(
-      runReadModelWait("restart-failed-once", service)
-    ).rejects.toMatchObject({ code: "CONTENT_RELEASE_INTEGRITY" });
-    expect(restarts).toHaveLength(1);
-  });
-
-  it("polls a running lineage until it completes", async () => {
-    vi.useFakeTimers();
-    const [runningJobId] = await createScheduledJobIds();
-    const { restarts, service } = makeReadModelCoordinator([
-      {
-        phase: "syncing",
-        releaseId,
-        syncGeneration: 1,
-        syncJobId: runningJobId,
-      },
-      { phase: "completed", releaseId },
-    ]);
-
-    const waiting = runReadModelWait("observe", service);
-    await vi.advanceTimersByTimeAsync(100);
-
-    await expect(waiting).resolves.toBeUndefined();
-    expect(restarts).toEqual([]);
-  });
+      expect(yield* Fiber.join(waiting)).toBeUndefined();
+      expect(restarts).toEqual([]);
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate the content-release read-model waiter suite to direct `@effect/vitest`
- return the waiter Effect from the test helper instead of starting a nested runtime
- allocate Convex scheduler fixtures through a named Effect program
- replace generic defects with a tagged test-state defect
- replace Vitest fake timers with the TestClock service supplied by `it.effect`

## Effect v4 basis

This follows vendored Effect RC110 source for `@effect/vitest`, `TestClock`, `Fiber`, `Effect.fn`, `Effect.promise`, and `Effect.flip`. The touched test contains no direct Effect runner, repository testing wrapper, raw async test callback, Promise assertion, generic error, generic throw, or Vitest timer shim.

## Validation

- focused read-model suite: 5 passed
- Backend typecheck: passed with no Effect compiler suggestions
- full Backend suite: 387 files and 1,632 tests passed
- lint, boundaries, test ownership, and Effect source parity: passed
- exact-base replay preserved stable patch identity

A later whole-repository replay ran while unrelated local Next builds and Vitest suites saturated the host and hit five unchanged 5-second backend timeouts. No touched test failed. Exact-head CI remains the release gate.

This is test-only. Production deployment should be skipped by scope classification.