### PR TITLE
test(www): run content core with Effect Vitest

### DIFF
--- a/apps/www/lib/content/material/sitemap.test.ts
+++ b/apps/www/lib/content/material/sitemap.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   readPublishedMaterialBuckets,
   readPublishedMaterialSitemap,
@@ -23,63 +24,64 @@ beforeEach(() => {
 });
 
 describe("published material sitemap", () => {
-  it("decodes the release identity and reads one sitemap page", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
+  it.effect("decodes the release identity and reads one sitemap page", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          buckets: ["abc"],
+          managed: true,
+          materialCount: 1,
+        })
+        .mockResolvedValueOnce({
+          routes: [
+            {
+              lastModified: "2025-04-27",
+              publicPath:
+                "subjects/mathematics/function-composition-inverse-function/function-concept",
+            },
+          ],
+        });
+
+      expect(yield* readPublishedMaterialBuckets("en")).toEqual({
         activeReleaseId,
         buckets: ["abc"],
-        managed: true,
         materialCount: 1,
-      })
-      .mockResolvedValueOnce({
-        routes: [
-          {
-            lastModified: "2025-04-27",
-            publicPath:
-              "subjects/mathematics/function-composition-inverse-function/function-concept",
-          },
-        ],
       });
-
-    await expect(
-      Effect.runPromise(readPublishedMaterialBuckets("en"))
-    ).resolves.toEqual({
-      activeReleaseId,
-      buckets: ["abc"],
-      materialCount: 1,
-    });
-    await expect(
-      Effect.runPromise(readPublishedMaterialSitemap("en", "abc"))
-    ).resolves.toMatchObject({
-      routes: [{ lastModified: "2025-04-27" }],
-    });
-  });
-
-  it("rejects invalid and unmanaged material inventories", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId: "",
-        buckets: [],
-        managed: false,
-        materialCount: 0,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        buckets: [],
-        managed: false,
-        materialCount: 0,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId: null,
-        buckets: [],
-        managed: true,
-        materialCount: 0,
+      expect(yield* readPublishedMaterialSitemap("en", "abc")).toMatchObject({
+        routes: [{ lastModified: "2025-04-27" }],
       });
+    })
+  );
 
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      await expect(
-        Effect.runPromise(readPublishedMaterialBuckets("en").pipe(Effect.flip))
-      ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    }
-  });
+  it.effect("rejects invalid and unmanaged material inventories", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          activeReleaseId: "",
+          buckets: [],
+          managed: false,
+          materialCount: 0,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          buckets: [],
+          managed: false,
+          materialCount: 0,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId: null,
+          buckets: [],
+          managed: true,
+          materialCount: 0,
+        });
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const failure = yield* readPublishedMaterialBuckets("en").pipe(
+          Effect.flip
+        );
+        expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+      }
+    })
+  );
 });

--- a/apps/www/lib/content/material/trust.test.ts
+++ b/apps/www/lib/content/material/trust.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedTrustLesson,
   readPublishedTrustLesson,
@@ -27,53 +28,59 @@ describe("published marketing trust lesson", () => {
     cacheMock.mockReset();
   });
 
-  it("resolves the current signed route from its stable lesson identity", async () => {
-    runtimeQueryMock.mockResolvedValueOnce({
-      activeReleaseId: "release-material",
-      managed: true,
-      publicPath:
-        "subjects/mathematics/exponential-logarithm/current-basic-concept",
-    });
+  it.effect(
+    "resolves the current signed route from its stable lesson identity",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId: "release-material",
+          managed: true,
+          publicPath:
+            "subjects/mathematics/exponential-logarithm/current-basic-concept",
+        });
 
-    await expect(getPublishedTrustLesson("en")).resolves.toEqual({
-      lessonHref:
-        "/en/subjects/mathematics/exponential-logarithm/current-basic-concept",
-      sourceHref:
-        "/en/subjects/mathematics/exponential-logarithm/current-basic-concept.md",
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(
-      api.contentRelease.material.identity,
-      {
-        contentKey:
-          "material/lesson/mathematics/exponential-logarithm/basic-concept",
-        appLocale: "en",
-        expectedMaterialKey: "lesson.mathematics.exponential-logarithm",
-        expectedSectionKey: "basic-concept",
-      }
-    );
-    expect(cacheMock).toHaveBeenCalledWith("material");
-  });
+        expect(
+          yield* Effect.promise(() => getPublishedTrustLesson("en"))
+        ).toEqual({
+          lessonHref:
+            "/en/subjects/mathematics/exponential-logarithm/current-basic-concept",
+          sourceHref:
+            "/en/subjects/mathematics/exponential-logarithm/current-basic-concept.md",
+        });
+        expect(runtimeQueryMock).toHaveBeenCalledWith(
+          api.contentRelease.material.identity,
+          {
+            contentKey:
+              "material/lesson/mathematics/exponential-logarithm/basic-concept",
+            appLocale: "en",
+            expectedMaterialKey: "lesson.mathematics.exponential-logarithm",
+            expectedSectionKey: "basic-concept",
+          }
+        );
+        expect(cacheMock).toHaveBeenCalledWith("material");
+      })
+  );
 
-  it.each([
+  it.effect.each([
     ["unmanaged", false, null],
     ["missing", true, null],
     ["malformed", true, "/copied/path"],
-  ])(
+  ] as const)(
     "rejects a %s signed identity without a copied route",
-    async (_name, managed, publicPath) => {
-      runtimeQueryMock.mockResolvedValueOnce({
-        activeReleaseId: managed ? "release-material" : null,
-        managed,
-        publicPath,
-      });
+    ([_name, managed, publicPath]) =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId: managed ? "release-material" : null,
+          managed,
+          publicPath,
+        });
 
-      await expect(
-        Effect.runPromise(readPublishedTrustLesson("en").pipe(Effect.flip))
-      ).resolves.toMatchObject({
-        _tag: "PublishedProjectionError",
-        appLocale: "en",
-        publicPath: "marketing/trust",
-      });
-    }
+        const failure = yield* readPublishedTrustLesson("en").pipe(Effect.flip);
+        expect(failure).toMatchObject({
+          _tag: "PublishedProjectionError",
+          appLocale: "en",
+          publicPath: "marketing/trust",
+        });
+      })
   );
 });

--- a/apps/www/lib/content/runtime/query.test.ts
+++ b/apps/www/lib/content/runtime/query.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 const { readMock, runtimeUrl } = vi.hoisted(() => ({
@@ -21,53 +22,54 @@ vi.mock("@/env", () => ({
 }));
 
 describe("content runtime query", () => {
-  it("maps the Effect runtime query into the typed data-read channel", async () => {
-    readMock.mockReturnValueOnce(Effect.succeed(42));
-    await expect(
-      Effect.runPromise(
-        readRuntimeQuery(api.contentRelease.reference.read, {
-          input: {
-            appLocale: "en",
-            kind: "route",
-            publicPath: "articles/politics/test",
-          },
-        })
-      )
-    ).resolves.toBe(42);
-
-    const runtimeError = new ConvexRuntimeQueryError({
-      networkCodes: ["EPIPE"],
-      query: "contentRelease.material.route",
-      reason: "transport",
-    });
-    readMock.mockReturnValueOnce(Effect.fail(runtimeError));
-    await expect(
-      Effect.runPromise(
-        Effect.flip(
-          readRuntimeQuery(api.contentRelease.reference.read, {
+  it.effect(
+    "maps the Effect runtime query into the typed data-read channel",
+    () =>
+      Effect.gen(function* () {
+        readMock.mockReturnValueOnce(Effect.succeed(42));
+        expect(
+          yield* readRuntimeQuery(api.contentRelease.reference.read, {
             input: {
               appLocale: "en",
               kind: "route",
               publicPath: "articles/politics/test",
             },
           })
-        )
-      )
-    ).resolves.toMatchObject({
-      cause: runtimeError.message,
-      message:
-        "Unable to read Nakafa runtime content query: contentRelease.material.route.",
-    });
-    expect(readMock).toHaveBeenCalledWith(
-      runtimeUrl,
-      api.contentRelease.reference.read,
-      {
-        input: {
-          appLocale: "en",
-          kind: "route",
-          publicPath: "articles/politics/test",
-        },
-      }
-    );
-  });
+        ).toBe(42);
+
+        const runtimeError = new ConvexRuntimeQueryError({
+          networkCodes: ["EPIPE"],
+          query: "contentRelease.material.route",
+          reason: "transport",
+        });
+        readMock.mockReturnValueOnce(Effect.fail(runtimeError));
+        const failure = yield* readRuntimeQuery(
+          api.contentRelease.reference.read,
+          {
+            input: {
+              appLocale: "en",
+              kind: "route",
+              publicPath: "articles/politics/test",
+            },
+          }
+        ).pipe(Effect.flip);
+
+        expect(failure).toMatchObject({
+          cause: runtimeError.message,
+          message:
+            "Unable to read Nakafa runtime content query: contentRelease.material.route.",
+        });
+        expect(readMock).toHaveBeenCalledWith(
+          runtimeUrl,
+          api.contentRelease.reference.read,
+          {
+            input: {
+              appLocale: "en",
+              kind: "route",
+              publicPath: "articles/politics/test",
+            },
+          }
+        );
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate the material trust, material sitemap, and content runtime query tests directly to @effect/vitest
- return Effect programs from it.effect and it.effect.each instead of running Effect inside async Vitest tests
- keep Vitest mocking primitives direct and retain the existing cache, projection, and typed failure assertions

## Verification

- pnpm --filter www exec vitest run --coverage.enabled=false lib/content/material/trust.test.ts lib/content/material/sitemap.test.ts lib/content/runtime/query.test.ts
- pnpm --filter www typecheck with schema-valid non-secret local environment values, zero Effect compiler suggestions
- pnpm lint
- pnpm boundaries
- pnpm effect:source:check
- pnpm run doctor --verbose --scope changed --base origin/main --include-untracked, score 100

The full repository suite was not started because concurrent host-wide Vitest runs were producing false five-second timeouts. Exact-head CI remains the full-suite gate. No Vercel Preview was created.