### PR TITLE
refactor(content): switch canonical runtime

### DIFF
--- a/packages/backend/client/content/public.test.ts
+++ b/packages/backend/client/content/public.test.ts
@@ -19,8 +19,8 @@ import {
 import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
-  TRANSITION_PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
-  TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH,
+  PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
+  PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
 import { testArtifactJson } from "@repo/backend/test/content/artifact";
 import { testProjectionJson } from "@repo/backend/test/content/material";
@@ -34,8 +34,8 @@ import {
 import { Effect } from "effect";
 import { vi } from "vitest";
 
-const endpoint = `https://example.convex.site${TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH}`;
-const batchEndpoint = `https://example.convex.site${TRANSITION_PUBLIC_CONTENT_RUNTIME_BATCH_PATH}`;
+const endpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_PATH}`;
+const batchEndpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_BATCH_PATH}`;
 const target = {
   siteUrl: "https://example.convex.site/ignored/path",
   token: "runtime-test-token",

--- a/packages/backend/client/content/public.ts
+++ b/packages/backend/client/content/public.ts
@@ -31,8 +31,8 @@ import {
   PublicContentRuntimeBatchResponseSchema,
 } from "@repo/backend/content/batch";
 import {
-  TRANSITION_PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
-  TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH,
+  PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
+  PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
 import { contentKeyResolver } from "@repo/backend/content/trust";
 import { Effect, Schema } from "effect";
@@ -128,7 +128,7 @@ const readPublicContentProgram = Effect.fn(
   );
   const endpoint = yield* createContentEndpoint(
     target.siteUrl,
-    TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH
+    PUBLIC_CONTENT_RUNTIME_PATH
   );
   const { response, value: decoded } = yield* requestContentResponse(
     { endpoint, source, target },
@@ -198,7 +198,7 @@ export const readPublicContentEvidenceBatch = Effect.fn(
   );
   const endpoint = yield* createContentEndpoint(
     target.siteUrl,
-    TRANSITION_PUBLIC_CONTENT_RUNTIME_BATCH_PATH
+    PUBLIC_CONTENT_RUNTIME_BATCH_PATH
   );
   const { response, value: decoded } = yield* requestContentResponse(
     { endpoint, source, target },

--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -13,13 +13,13 @@ import {
 import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
-  TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH,
+  PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
 import { Duration, Effect, Fiber, Logger } from "effect";
 import { TestClock } from "effect/testing";
 import { vi } from "vitest";
 
-const endpoint = `https://example.convex.site${TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH}`;
+const endpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_PATH}`;
 const target = {
   siteUrl: "https://example.convex.site",
   token: "runtime-test-token",
@@ -100,15 +100,15 @@ describe("content runtime transport", () => {
       expect(
         yield* createContentEndpoint(
           "https://example.convex.site/ignored",
-          TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH
+          PUBLIC_CONTENT_RUNTIME_PATH
         )
       ).toBe(endpoint);
       expect(
         yield* createContentEndpoint(
           "http://localhost:3211/ignored",
-          TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH
+          PUBLIC_CONTENT_RUNTIME_PATH
         )
-      ).toBe(`http://localhost:3211${TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH}`);
+      ).toBe(`http://localhost:3211${PUBLIC_CONTENT_RUNTIME_PATH}`);
 
       for (const siteUrl of [
         "not a URL",
@@ -119,7 +119,7 @@ describe("content runtime transport", () => {
         expect(
           yield* createContentEndpoint(
             siteUrl,
-            TRANSITION_PUBLIC_CONTENT_RUNTIME_PATH
+            PUBLIC_CONTENT_RUNTIME_PATH
           ).pipe(Effect.flip)
         ).toEqual(new ContentTransportError({ reason: "url" }));
       }


### PR DESCRIPTION
## Summary

Switch every controlled signed-content client from temporary `/internal/content/runtime/v2` routes to the canonical unversioned singular and batch endpoints deployed by #461.

## Why

The durable private transport is unversioned. Keeping current clients on `/v2` after the additive backend expansion would preserve migration debt and block final contraction.

## Scope

- use canonical singular and batch constants
- update the owning transport and client tests
- retain temporary backend `/v2` routes only until #434 deletes them

## Exact-head verification

Exact head `ff1b2b52840798afc4b70f2ee09e3e6a2bf8f07c` is based directly on protected main `b8e917905cfb732b00be2406538a0f1ed81c1ae8`. The one-commit range-diff is identical to prior reviewed head `83941b7359909ee92cd740c201105306e9a202ea`, and the rebased tree equals the clean merge-tree `6a686a29edb757c2d0f62b56779dbdc634202137`. The diff remains exactly three files with 14 insertions and 14 deletions. Local proof passes 2 files and 24 tests, backend typecheck, lint, Effect RC110 source identity, import, and diff checks. Fresh exact-head Required, Doctor, signed Production, Browser, AFDocs, runtime verification, cleanup, and review are running.

## Dependency and rollout state

#461 is protected-merged. Exact-main Vercel deployment `dpl_AG8cZTVfwhagVXmidC5WKJiotPno` is READY with no error or fatal logs. Convex production exposes current `read` and `readBatch`, has removed public singular, batch, and history markers, and retains only the separate protected marker. No Preview or branch production write exists.

## Material risks

Merging before the additive #461 surface reached production would have broken current clients; that gate is satisfied. #434 removes temporary `/v2` endpoints immediately after this switch.