### PR TITLE
refactor(backend): compose customer cleanup queries with Effect

### DIFF
--- a/packages/backend/convex/customers/deletion/billing.ts
+++ b/packages/backend/convex/customers/deletion/billing.ts
@@ -64,22 +64,30 @@ export const cleanupDeletedUserBilling: (
 ) => Effect.Effect<null, DeletedUserBillingCleanupError> = Effect.fn(
   "customers.deletion.cleanupDeletedUserBilling"
 )(function* (ctx: ActionCtx, userId: Id<"users">, authId: string) {
-  const [customer, checkpointPolarCustomerId] = yield* Effect.tryPromise({
-    try: () =>
-      Promise.all([
-        ctx.runQuery(
-          internal.customers.queries.internal.customer.getCustomerByUserId,
-          { userId }
-        ),
-        ctx.runQuery(
-          internal.customers.queries.internal.customer
-            .getCustomerDeletionCheckpoint,
-          { userId }
-        ),
-      ]),
-    catch: (error) =>
-      customerSyncIoError("Failed to load customer cleanup state", error),
-  });
+  const [customer, checkpointPolarCustomerId] = yield* Effect.all(
+    [
+      Effect.tryPromise({
+        try: () =>
+          ctx.runQuery(
+            internal.customers.queries.internal.customer.getCustomerByUserId,
+            { userId }
+          ),
+        catch: (error) =>
+          customerSyncIoError("Failed to load customer cleanup state", error),
+      }),
+      Effect.tryPromise({
+        try: () =>
+          ctx.runQuery(
+            internal.customers.queries.internal.customer
+              .getCustomerDeletionCheckpoint,
+            { userId }
+          ),
+        catch: (error) =>
+          customerSyncIoError("Failed to load customer cleanup state", error),
+      }),
+    ],
+    { concurrency: "unbounded" }
+  );
 
   if (
     checkpointPolarCustomerId &&

--- a/packages/backend/convex/customers/deletion/billingState.ts
+++ b/packages/backend/convex/customers/deletion/billingState.ts
@@ -29,23 +29,28 @@ export const recordCustomerDeletionCheckpointProgram = Effect.fn(
   polarCustomerId: string,
   cleanupUserId?: Id<"users">
 ) {
-  const [customerCheckpoint, polarTombstone] = yield* tryCustomerDeletion(() =>
-    Promise.all([
+  const [customerCheckpoint, polarTombstone] = yield* Effect.all(
+    [
       cleanupUserId
-        ? ctx.db
-            .query("customerDeletionTombstones")
-            .withIndex("by_cleanupUserId", (query) =>
-              query.eq("cleanupUserId", cleanupUserId)
-            )
-            .unique()
-        : Promise.resolve(null),
-      ctx.db
-        .query("customerDeletionTombstones")
-        .withIndex("by_polarCustomerId", (query) =>
-          query.eq("polarCustomerId", polarCustomerId)
-        )
-        .unique(),
-    ])
+        ? tryCustomerDeletion(() =>
+            ctx.db
+              .query("customerDeletionTombstones")
+              .withIndex("by_cleanupUserId", (query) =>
+                query.eq("cleanupUserId", cleanupUserId)
+              )
+              .unique()
+          )
+        : Effect.succeed(null),
+      tryCustomerDeletion(() =>
+        ctx.db
+          .query("customerDeletionTombstones")
+          .withIndex("by_polarCustomerId", (query) =>
+            query.eq("polarCustomerId", polarCustomerId)
+          )
+          .unique()
+      ),
+    ],
+    { concurrency: "unbounded" }
   );
 
   if (


### PR DESCRIPTION
## Summary

- lift each customer and tombstone query into its own typed `Effect.tryPromise`
- combine independent reads with `Effect.all` and unbounded concurrency, preserving the existing `Promise.all` execution behavior
- keep the Convex handler boundary and `CustomerSyncIoError` failure contract unchanged

## Verification

- `pnpm --filter @repo/backend exec vitest run convex/customers/deletion/billing.test.ts`
- `pnpm --filter @repo/backend typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm --filter @repo/backend test` (387 files, 1,632 tests, before the exact-base rebase)
- touched-path scan for raw async, `Promise.all`, raw `try/catch`, generic errors, assertions, environment reads, and Effect runners

The final commit is based directly on `5a5849c868a6fb158188341105bf9137574a9e04`. The stable patch ID remained `75504de70e0c13e5885b3c2a94bf25028d7a533e` across the one-time rebase.