### PR TITLE
refactor(email): compose welcome rendering with Effect

### DIFF
--- a/packages/email/templates/welcome.tsx
+++ b/packages/email/templates/welcome.tsx
@@ -216,24 +216,30 @@ export function Welcome({
 }
 
 /** Renders the production HTML and text bodies from one source template. */
-export const renderWelcomeEmail = Effect.fn("email.welcome.render")(
-  (props: WelcomeProps) =>
-    Effect.tryPromise({
-      catch: () =>
-        new WelcomeEmailRenderError({
-          code: "WELCOME_EMAIL_RENDER_FAILED",
-          message: "Unable to render the welcome email.",
-        }),
-      try: async () => {
-        const email = <Welcome {...props} />;
-        const [html, text] = await Promise.all([
-          render(email),
-          render(email, { plainText: true }),
-        ]);
-        return { html, text };
-      },
-    })
-);
+export const renderWelcomeEmail = Effect.fn("email.welcome.render")(function* (
+  props: WelcomeProps
+) {
+  const email = <Welcome {...props} />;
+  const renderFailure = () =>
+    new WelcomeEmailRenderError({
+      code: "WELCOME_EMAIL_RENDER_FAILED",
+      message: "Unable to render the welcome email.",
+    });
+  const [html, text] = yield* Effect.all(
+    [
+      Effect.tryPromise({
+        catch: renderFailure,
+        try: () => render(email),
+      }),
+      Effect.tryPromise({
+        catch: renderFailure,
+        try: () => render(email, { plainText: true }),
+      }),
+    ],
+    { concurrency: "unbounded" }
+  );
+  return { html, text };
+});
 
 Welcome.PreviewProps = {
   name: "Nabil Fatih",


### PR DESCRIPTION
## Description

- Replace the raw async and Promise.all welcome-render seam with RC110 Effect.tryPromise and Effect.all composition.
- Preserve concurrent HTML and plain-text rendering, the typed WelcomeEmailRenderError channel, the public result shape, and the existing backend framework boundary.

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Performance

## Testing

- [x] Focused delivery behavior: pnpm --filter @repo/backend exec vitest run convex/emails/delivery.test.ts
- [x] Email typecheck: pnpm --filter @repo/email typecheck
- [x] Lint: pnpm lint
- [x] Boundaries: pnpm boundaries
- [x] Formatting: pnpm exec ultracite check packages/email/templates/welcome.tsx
- [x] Effect source parity: pnpm effect:source:check
- [x] React Doctor changed-file scan: zero diagnostics
- [x] Contribution terms reviewed: LICENSE, CONTENT_LICENSE.md, and TRADEMARKS.md

## Related Issues

None.

## Additional Context

The package has no email-local test script, so the existing backend delivery test is the nearest production behavior proof. A deterministic render probe produced byte-identical pre-change and exact-head results: HTML length 11,316 with SHA-256 6ee47e63b1069b605f36b128f0899b7e194bf86dc5a0d66824d06393d6709bbc, and text length 889 with SHA-256 f2df325cb7a23036cf5f6644b19f9b704560eca5474bbae7e6291b7205c1726f.