### PR TITLE
refactor(backend): derive credit grant contract

### DIFF
--- a/packages/backend/convex/credits/constants.ts
+++ b/packages/backend/convex/credits/constants.ts
@@ -1,9 +1,5 @@
+import type { CreditGrantType } from "@repo/backend/convex/credits/schema";
 import type { UserPlan } from "@repo/backend/convex/users/schema";
-
-/**
- * Grant types for credit reset (subset of CreditTransactionType).
- */
-type CreditGrantType = "daily-grant" | "monthly-grant";
 
 /**
  * Credit grant configuration per plan.

--- a/packages/backend/convex/credits/schema.ts
+++ b/packages/backend/convex/credits/schema.ts
@@ -18,6 +18,8 @@ export type CreditTransactionType = Infer<
   typeof creditTransactionTypeValidator
 >;
 
+export type CreditGrantType = Extract<CreditTransactionType, `${string}-grant`>;
+
 /** Scalar audit values allowed on credit transaction metadata. */
 export const creditTransactionMetadataValueValidator = v.union(
   v.string(),


### PR DESCRIPTION
## Summary

- derive `CreditGrantType` from the validator-owned `CreditTransactionType` contract
- remove the duplicate hand-written grant union from plan constants
- preserve the runtime validator and generated Convex types

## Scope

Two package-owned files:

- `packages/backend/convex/credits/constants.ts`
- `packages/backend/convex/credits/schema.ts`

## Exact-base verification

- focused credit suite: 2 files, 17 tests passed
- Backend native TypeScript typecheck passed with zero Effect suggestions
- full lint, Effect RC110 source parity, test ownership policy, and boundaries passed
- the stable patch already passed Quality, production build, browser acceptance, AFDocs, final fingerprint, Required, and Doctor before strict protection required this current-base refresh

## Base proof

- parent: `cd66fb113bb526bfd81aee0f90b7b6a009f29627`
- head: `df6915724e6e43b20ab9d8951aa1ac8f54230024`
- stable patch ID: `42d5831bb0840d71cfcac5ab99859cf3249bfbf4`