### PR TITLE
test(www): project structured dates

### DIFF
--- a/apps/www/e2e/content.browser.ts
+++ b/apps/www/e2e/content.browser.ts
@@ -99,7 +99,11 @@ const readJsonLdDates = Effect.fn("NakafaE2E.readJsonLdDates")(function* (
             ) {
               continue;
             }
-            return value;
+            const dateModified = Reflect.get(value, "dateModified");
+            const datePublished = Reflect.get(value, "datePublished");
+            return dateModified === undefined
+              ? { datePublished }
+              : { dateModified, datePublished };
           }
           return null;
         }, jsonLdType),


### PR DESCRIPTION
## Summary

Project the two publication fields from Article and LearningResource JSON-LD before decoding them with the exact Aksara publication-date schema.

## Why

The acceptance test passed the complete JSON-LD object to a schema that intentionally rejects excess properties. Valid fields such as `@type` and `headline` therefore made live EN, ID, and DE checks fail even though production emitted truthful dates.

## Scope

- keep the strict `PublicationDatesSchema`
- select only `datePublished` and optional `dateModified` at the browser evaluation boundary
- preserve absence of `dateModified` instead of manufacturing an undefined field
- change no runtime, UI, route, content, Vercel, Convex, or Gemini behavior

## Exact-head verification

Head `419687e3d9590e9e82d66b4cc49f66afb90c2c45` on current main `26752b972e2fb492994d4f9fdb52d5c3570c0664`. The patch is range-diff identical and the binary diff checksum remains `2d4202e427ad54889fae25236999fa2b39e23aa69d36409412118bc3f8a24543`. Exact-current-base WWW typecheck with repository-owned CI environment values, Ultracite, and diff checks pass. The identical patch passed live production Playwright for article and material contracts across EN, ID, and DE. Fresh protected checks are running.

## Dependency and rollout state

Independent of the signed-runtime contraction stack. No Vercel Preview, manual deployment, Convex write, or content mutation exists.

## Material risks

This is test-only. Its risk is a false positive if projection drops a malformed date, which remains prevented because the exact date schema validates both values and their chronological invariant.