### PR TITLE
ci: prepare required checks for merge queue

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -53,6 +53,7 @@ jobs:
               `query MergeQueueEntry($owner: String!, $name: String!) {
                 repository(owner: $owner, name: $name) {
                   mergeQueue {
+                    configuration { maximumEntriesToMerge }
                     entries(first: 100) {
                       nodes {
                         baseCommit { oid }
@@ -71,9 +72,14 @@ jobs:
                   }
                 }
               }`,
-              context.repo,
+              { name: context.repo.repo, owner: context.repo.owner },
             )
-            const entries = result.repository?.mergeQueue?.entries?.nodes ?? []
+            const queue = result.repository?.mergeQueue
+            if (queue?.configuration?.maximumEntriesToMerge !== 1) {
+              throw new Error("Signed acceptance requires one pull request per merge group.")
+            }
+
+            const entries = queue.entries?.nodes ?? []
             const candidates = entries.filter(
               (entry) =>
                 entry?.baseCommit?.oid === mergeGroup.base_sha &&

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -11,12 +11,13 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   # Pull request heads supersede their own predecessor runs. Protected-main
-  # runs use the immutable commit SHA so a later independent merge cannot
-  # cancel an already-admitted production acceptance.
-  group: Agent-Friendly Docs-${{ github.event_name == 'push' && github.sha || github.ref }}
+  # and merge-group runs use the immutable commit SHA so a later independent
+  # change cannot cancel an already-admitted production acceptance.
+  group: Agent-Friendly Docs-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -25,38 +26,120 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
+      DIRECT_TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
     outputs:
       required: ${{ steps.classify.outputs.required || steps.default.outputs.required }}
-      trusted: ${{ steps.default.outputs.trusted }}
+      trusted: ${{ steps.trust.outputs.trusted }}
     steps:
       - name: Set fail-closed default
         id: default
         env:
-          REQUIRED: ${{ env.TRUSTED_CONTENT_ENVIRONMENT }}
-          TRUSTED: ${{ env.TRUSTED_CONTENT_ENVIRONMENT }}
-        run: |
-          echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
-          echo "trusted=$TRUSTED" >> "$GITHUB_OUTPUT"
+          REQUIRED: ${{ env.DIRECT_TRUSTED_CONTENT_ENVIRONMENT }}
+        run: echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
 
-      - if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+      - name: Verify merge group provenance
+        if: github.event_name == 'merge_group'
+        id: merge-group-provenance
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const mergeGroup = context.payload.merge_group
+            if (!mergeGroup) {
+              throw new Error("Missing merge group payload.")
+            }
+
+            const baseBranch = mergeGroup.base_ref.replace("refs/heads/", "")
+            const candidateHeads = []
+            const visited = new Set()
+            let cursor = mergeGroup.head_sha
+
+            while (cursor !== mergeGroup.base_sha) {
+              if (visited.has(cursor) || candidateHeads.length >= 100) {
+                throw new Error("Invalid merge group commit chain.")
+              }
+              visited.add(cursor)
+
+              const { data: commit } = await github.rest.git.getCommit({
+                ...context.repo,
+                commit_sha: cursor,
+              })
+              if (commit.parents.length !== 2) {
+                throw new Error(`Merge group commit ${cursor} is not a two-parent merge.`)
+              }
+
+              const [queueParent, candidateParent] = commit.parents
+              candidateHeads.push(candidateParent.sha)
+              cursor = queueParent.sha
+            }
+
+            if (candidateHeads.length === 0) {
+              throw new Error("Merge group contains no pull request commits.")
+            }
+
+            for (const candidateHead of candidateHeads) {
+              const pulls = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                {
+                  ...context.repo,
+                  commit_sha: candidateHead,
+                  per_page: 100,
+                },
+              )
+              const candidates = pulls.filter(
+                (pull) =>
+                  pull.state === "open" &&
+                  pull.base.ref === baseBranch &&
+                  pull.head.sha === candidateHead,
+              )
+              if (candidates.length !== 1) {
+                throw new Error(
+                  `Merge group commit ${candidateHead} has ${candidates.length} matching pull requests.`,
+                )
+              }
+
+              const [pull] = candidates
+              if (
+                pull.head.repo?.full_name !== context.payload.repository.full_name ||
+                pull.user?.login !== "nabilfatih"
+              ) {
+                throw new Error(`Pull request #${pull.number} is not trusted for signed acceptance.`)
+              }
+              core.info(`Trusted pull request #${pull.number} at ${candidateHead}.`)
+            }
+
+            return "true"
+
+      - name: Export content environment trust
+        id: trust
+        env:
+          DIRECT_TRUST: ${{ env.DIRECT_TRUSTED_CONTENT_ENVIRONMENT }}
+          MERGE_GROUP_TRUST: ${{ steps.merge-group-provenance.outputs.result }}
+        run: |
+          trusted=false
+          if [ "$DIRECT_TRUST" = "true" ] || [ "$MERGE_GROUP_TRUST" = "true" ]; then
+            trusted=true
+          fi
+          echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
+
+      - if: steps.trust.outputs.trusted == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup toolchain
-        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: steps.trust.outputs.trusted == 'true'
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           cache: true
           install: false
 
       - name: Install dependencies
-        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: steps.trust.outputs.trusted == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Classify production acceptance
-        if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
+        if: steps.trust.outputs.trusted == 'true'
         id: classify
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -53,18 +53,29 @@ jobs:
               `query MergeQueueEntry($owner: String!, $name: String!) {
                 repository(owner: $owner, name: $name) {
                   mergeQueue {
-                    configuration { maximumEntriesToMerge }
+                    configuration {
+                      maximumEntriesToBuild
+                      maximumEntriesToMerge
+                    }
                     entries(first: 100) {
                       nodes {
                         baseCommit { oid }
                         enqueuer { login }
-                        headCommit { oid }
+                        headCommit {
+                          oid
+                          tree { oid }
+                        }
                         pullRequest {
                           author { login }
                           baseRefName
+                          baseRefOid
                           headRefOid
                           headRepository { nameWithOwner }
                           number
+                          potentialMergeCommit {
+                            parents(first: 3) { nodes { oid } }
+                            tree { oid }
+                          }
                           state
                         }
                       }
@@ -75,8 +86,11 @@ jobs:
               { name: context.repo.repo, owner: context.repo.owner },
             )
             const queue = result.repository?.mergeQueue
-            if (queue?.configuration?.maximumEntriesToMerge !== 1) {
-              throw new Error("Signed acceptance requires one pull request per merge group.")
+            if (
+              queue?.configuration?.maximumEntriesToBuild !== 1 ||
+              queue.configuration.maximumEntriesToMerge !== 1
+            ) {
+              throw new Error("Signed acceptance requires a single-entry queue.")
             }
 
             const entries = queue.entries?.nodes ?? []
@@ -91,16 +105,31 @@ jobs:
               )
             }
 
-            const [{ enqueuer, pullRequest: pull }] = candidates
+            const [{ enqueuer, headCommit, pullRequest: pull }] = candidates
             if (
               !pull ||
               pull.state !== "OPEN" ||
               pull.baseRefName !== mergeGroup.base_ref.replace("refs/heads/", "") ||
+              pull.baseRefOid !== mergeGroup.base_sha ||
               pull.headRepository?.nameWithOwner !== context.payload.repository.full_name ||
               pull.author?.login !== "nabilfatih" ||
               enqueuer?.login !== "nabilfatih"
             ) {
               throw new Error("Merge queue entry is not trusted for signed acceptance.")
+            }
+
+            // Matching trees proves the event head contains only the admitted
+            // pull request, even if queue settings changed after group creation.
+            const mergeParents = pull.potentialMergeCommit?.parents?.nodes ?? []
+            const expectedParents = [mergeGroup.base_sha, pull.headRefOid].sort()
+            const actualParents = mergeParents.map(({ oid }) => oid).sort()
+            if (
+              actualParents.length !== 2 ||
+              actualParents.some((oid, index) => oid !== expectedParents[index]) ||
+              !pull.potentialMergeCommit?.tree?.oid ||
+              headCommit?.tree?.oid !== pull.potentialMergeCommit.tree.oid
+            ) {
+              throw new Error("Merge group contains changes outside its trusted pull request.")
             }
             core.info(`Trusted pull request #${pull.number} at ${pull.headRefOid}.`)
 

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -49,64 +49,54 @@ jobs:
               throw new Error("Missing merge group payload.")
             }
 
-            const baseBranch = mergeGroup.base_ref.replace("refs/heads/", "")
-            const candidateHeads = []
-            const visited = new Set()
-            let cursor = mergeGroup.head_sha
-
-            while (cursor !== mergeGroup.base_sha) {
-              if (visited.has(cursor) || candidateHeads.length >= 100) {
-                throw new Error("Invalid merge group commit chain.")
-              }
-              visited.add(cursor)
-
-              const { data: commit } = await github.rest.git.getCommit({
-                ...context.repo,
-                commit_sha: cursor,
-              })
-              if (commit.parents.length !== 2) {
-                throw new Error(`Merge group commit ${cursor} is not a two-parent merge.`)
-              }
-
-              const [queueParent, candidateParent] = commit.parents
-              candidateHeads.push(candidateParent.sha)
-              cursor = queueParent.sha
-            }
-
-            if (candidateHeads.length === 0) {
-              throw new Error("Merge group contains no pull request commits.")
-            }
-
-            for (const candidateHead of candidateHeads) {
-              const pulls = await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit,
-                {
-                  ...context.repo,
-                  commit_sha: candidateHead,
-                  per_page: 100,
-                },
+            const result = await github.graphql(
+              `query MergeQueueEntry($owner: String!, $name: String!) {
+                repository(owner: $owner, name: $name) {
+                  mergeQueue {
+                    entries(first: 100) {
+                      nodes {
+                        baseCommit { oid }
+                        enqueuer { login }
+                        headCommit { oid }
+                        pullRequest {
+                          author { login }
+                          baseRefName
+                          headRefOid
+                          headRepository { nameWithOwner }
+                          number
+                          state
+                        }
+                      }
+                    }
+                  }
+                }
+              }`,
+              context.repo,
+            )
+            const entries = result.repository?.mergeQueue?.entries?.nodes ?? []
+            const candidates = entries.filter(
+              (entry) =>
+                entry?.baseCommit?.oid === mergeGroup.base_sha &&
+                entry?.headCommit?.oid === mergeGroup.head_sha,
+            )
+            if (candidates.length !== 1) {
+              throw new Error(
+                `Merge group has ${candidates.length} exact queue entries.`,
               )
-              const candidates = pulls.filter(
-                (pull) =>
-                  pull.state === "open" &&
-                  pull.base.ref === baseBranch &&
-                  pull.head.sha === candidateHead,
-              )
-              if (candidates.length !== 1) {
-                throw new Error(
-                  `Merge group commit ${candidateHead} has ${candidates.length} matching pull requests.`,
-                )
-              }
-
-              const [pull] = candidates
-              if (
-                pull.head.repo?.full_name !== context.payload.repository.full_name ||
-                pull.user?.login !== "nabilfatih"
-              ) {
-                throw new Error(`Pull request #${pull.number} is not trusted for signed acceptance.`)
-              }
-              core.info(`Trusted pull request #${pull.number} at ${candidateHead}.`)
             }
+
+            const [{ enqueuer, pullRequest: pull }] = candidates
+            if (
+              !pull ||
+              pull.state !== "OPEN" ||
+              pull.baseRefName !== mergeGroup.base_ref.replace("refs/heads/", "") ||
+              pull.headRepository?.nameWithOwner !== context.payload.repository.full_name ||
+              pull.author?.login !== "nabilfatih" ||
+              enqueuer?.login !== "nabilfatih"
+            ) {
+              throw new Error("Merge queue entry is not trusted for signed acceptance.")
+            }
+            core.info(`Trusted pull request #${pull.number} at ${pull.headRefOid}.`)
 
             return "true"
 

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
   push:
     branches: [main]
 
@@ -22,15 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
+      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
     outputs:
       required: ${{ steps.classify.outputs.required || steps.default.outputs.required }}
+      trusted: ${{ steps.default.outputs.trusted }}
     steps:
       - name: Set fail-closed default
         id: default
         env:
           REQUIRED: ${{ env.TRUSTED_CONTENT_ENVIRONMENT }}
-        run: echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
+          TRUSTED: ${{ env.TRUSTED_CONTENT_ENVIRONMENT }}
+        run: |
+          echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
+          echo "trusted=$TRUSTED" >> "$GITHUB_OUTPUT"
 
       - if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,8 +59,8 @@ jobs:
         if: env.TRUSTED_CONTENT_ENVIRONMENT == 'true'
         id: classify
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
         run: pnpm ci:production-acceptance
 
   quality:
@@ -92,7 +99,7 @@ jobs:
     # same-repository candidates with production-relevant changes. In-place
     # test-only candidates retain Quality while Production is skipped.
     needs: production-scope
-    if: needs.production-scope.outputs.required == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih'))
+    if: needs.production-scope.outputs.required == 'true' && needs.production-scope.outputs.trusted == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -466,7 +473,7 @@ jobs:
       PRODUCTION_REQUIRED: ${{ needs.production-scope.outputs.required }}
       PRODUCTION_SCOPE_RESULT: ${{ needs.production-scope.result }}
       QUALITY_RESULT: ${{ needs.quality.result }}
-      TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
+      TRUSTED_CONTENT_ENVIRONMENT: ${{ needs.production-scope.outputs.trusted }}
     steps:
       - name: Verify acceptance jobs
         run: |

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,6 +3,9 @@ name: React
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
   push:
     branches: [main]
 
@@ -10,8 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: react-doctor-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   react-doctor:
@@ -29,8 +32,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run React Doctor for candidate
-        if: github.event_name == 'pull_request'
-        run: pnpm run doctor --verbose --scope changed --base origin/main --include-untracked --blocking warning
+        if: github.event_name != 'push'
+        env:
+          DOCTOR_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || 'origin/main' }}
+        run: pnpm run doctor --verbose --scope changed --base "$DOCTOR_BASE" --include-untracked --blocking warning
       - name: Run React Doctor for push
         if: github.event_name == 'push'
         run: pnpm run doctor --verbose --scope full --blocking warning

--- a/scripts/github-action-policy.ts
+++ b/scripts/github-action-policy.ts
@@ -36,6 +36,13 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     reason: "Checkout is pinned to the latest reviewed stable release.",
   },
   {
+    action: "actions/github-script",
+    approvedSha: "3a2844b7e9c422d3c10d287c895573f7108da1b3",
+    expectedTag: "v9.0.0",
+    expectedUsages: 1,
+    reason: "Merge groups verify every candidate through the GitHub API.",
+  },
+  {
     action: "pnpm/setup",
     approvedSha: "84cb39b217b10273981911c288cd62326dc7c6d2",
     expectedInputs: { cache: "true", install: "false" },


### PR DESCRIPTION
## Outcome

Prepare Nakafa's required CI and Doctor workflows for GitHub's protected merge queue so independent ready pull requests no longer need repeated manual rebases and full production reruns.

- trigger both required workflows on `merge_group: checks_requested`
- classify the candidate from its exact queue base and synthetic head
- run Doctor against the immutable merge-group base
- key PR cancellation by PR number and queue or main runs by immutable commit SHA

## Security

Signed-content secrets remain fail closed. Before dependency execution, a pinned and policy-reviewed `actions/github-script` reads GitHub's live merge queue and requires:

- queue build and merge concurrency both equal to one
- exactly one entry matching the webhook's GitHub-owned base and synthetic head
- an open `main` PR from `nakafaai/nakafa.com`
- PR author and queue enqueuer both equal to `nabilfatih`
- the PR's GitHub-generated potential merge commit has exactly the webhook base and current PR head as parents
- the potential merge tree equals the exact synthetic merge-group tree

The tree equality is the immutable membership proof. A batched group, stale base, replaced head, configuration race, fork, different author, different enqueuer, or any extra code changes the tree or parent set and fails Production Scope before checkout, install, or secret-bearing Production.

## Exact scope

- `.github/workflows/agent-docs.yml`
- `.github/workflows/react-doctor.yml`
- `scripts/github-action-policy.ts`

Base `586ff21e003d51364b8693539e8583d581b39e6e`, head `fb2794f366932a3b2b13d743e23462b4f68f8c79`, tree `84e9897086b81a38ffc104aac2dee9220c5b148d`, complete patch `6539f5639dcc7e876f5a17ccc7d145fa30122c0e`.

## Verification

- live Aksara queue, GraphQL schema, and synthetic commit topology inspection
- accepted, duplicate, stale-base, wrong-parent, changed-tree, different-enqueuer, and batched-configuration semantic mocks
- `actionlint` on both workflows
- extracted GitHub Script syntax check
- native script typecheck and 19 policy tests
- full lint, security audit, test ownership, Effect RC110 source parity, and dependency boundaries
- Doctor correctly skips when no WWW source changed
- complete diff check

## Rollout

This PR does not mutate repository rules. After protected merge, the ruleset will retain Required, Doctor, pull-request and thread protections, deletion protection, and force-push protection while adding the merge queue. Initial configuration is squash, one candidate building and merging at a time, a 45-minute response timeout, and no artificial wait.

A fully green test-only PR will be the first queue canary, proving the real `merge_group` event without exposing production secrets. Exact-main Production will continue under its immutable SHA. Production-affecting candidates will enter only after that protected-main proof is green. The queue serializes only the shared signed-production proof while implementation, review, and pull-request checks continue independently.

No bypass is added and no Vercel Preview is created.