### PR TITLE
fix(migration): decode stored snapshot envelope

### DIFF
--- a/apps/www/e2e/marketing.browser.ts
+++ b/apps/www/e2e/marketing.browser.ts
@@ -231,7 +231,7 @@ const verifyContributorPayloads = Effect.fn(
   // div without a tooltip role. The trigger's aria-label owns its identity.
   // @see https://base-ui.com/react/components/tooltip
   const tooltip = page.locator(
-    '[data-slot="tooltip-content"][data-open]:not([data-ending-style])'
+    '[data-slot="tooltip-content"][data-open]:not([data-starting-style]):not([data-ending-style])'
   );
   yield* Effect.promise(() =>
     expect(tooltip).toHaveText(firstContributor.name)

--- a/packages/backend/convex/tryouts/migration/evidence.test.ts
+++ b/packages/backend/convex/tryouts/migration/evidence.test.ts
@@ -1,0 +1,50 @@
+import { assert, describe, it } from "@effect/vitest";
+import { TryoutHistoryMigrationSourceSchema } from "@nakafa/aksara-contracts/transport/migration/tryout/response";
+import { decodeMigrationSnapshot } from "@repo/backend/convex/tryouts/migration/evidence";
+import { Effect, Schema } from "effect";
+
+const digest = (digit: string) => `sha256:${digit.repeat(64)}`;
+const snapshot = Schema.decodeSync(
+  TryoutHistoryMigrationSourceSchema.fields.evidence.fields.snapshot
+)({
+  catalogDigest: digest("1"),
+  counts: { country: 1, exam: 2, section: 3, set: 4, track: 5 },
+  format: "tryout-v1",
+  locales: ["en", "id"],
+  placementCount: 6,
+  placementDigest: digest("2"),
+  routeCount: 7,
+  snapshotId: digest("3"),
+});
+
+describe("tryouts/migration/evidence", () => {
+  it.effect(
+    "extracts the authenticated manifest from its stored envelope",
+    () =>
+      Effect.gen(function* () {
+        const decoded = yield* decodeMigrationSnapshot(
+          JSON.stringify({ family: "tryout", manifest: snapshot })
+        );
+
+        assert.deepStrictEqual(decoded, snapshot);
+      })
+  );
+
+  it.effect("rejects bare, foreign, and extended snapshot envelopes", () =>
+    Effect.gen(function* () {
+      const invalid = [
+        snapshot,
+        { family: "page", manifest: snapshot },
+        { extra: true, family: "tryout", manifest: snapshot },
+      ];
+
+      for (const value of invalid) {
+        const error = yield* decodeMigrationSnapshot(
+          JSON.stringify(value)
+        ).pipe(Effect.flip);
+
+        assert.strictEqual(error.code, "CONTENT_RELEASE_INTEGRITY");
+      }
+    })
+  );
+});

--- a/packages/backend/convex/tryouts/migration/evidence.ts
+++ b/packages/backend/convex/tryouts/migration/evidence.ts
@@ -55,6 +55,10 @@ const PrivateAttemptSchema = Schema.Struct({
     tryoutSnapshotId: Schema.String,
   }),
 });
+const StoredTryoutSnapshotSchema = Schema.Struct({
+  family: Schema.Literal("tryout"),
+  manifest: TryoutHistoryMigrationSourceSchema.fields.evidence.fields.snapshot,
+});
 
 /** Produces a private domain-separated digest without exposing its identities. */
 function digestPrivateInventory(domain: string, inventoryJson: string) {
@@ -74,6 +78,21 @@ const decodePrivateAttempts = Effect.fn(
     Effect.flatMap(
       Schema.decodeUnknownEffect(Schema.Array(PrivateAttemptSchema))
     ),
+    Effect.mapError(contractFailure)
+  )
+);
+
+/** Decodes the stored Convex envelope into its authenticated manifest. */
+export const decodeMigrationSnapshot = Effect.fn(
+  "tryouts.migration.decodeSnapshot"
+)((snapshotJson: string) =>
+  parseStoredJson(snapshotJson, "Retained try-out snapshot").pipe(
+    Effect.flatMap(
+      Schema.decodeUnknownEffect(StoredTryoutSnapshotSchema, {
+        onExcessProperty: "error",
+      })
+    ),
+    Effect.map(({ manifest }) => manifest),
     Effect.mapError(contractFailure)
   )
 );
@@ -141,10 +160,7 @@ export const readMigrationSource = Effect.fn(
       "Retained try-out scale count changed after its audit."
     );
   }
-  const snapshot = yield* parseStoredJson(
-    bytes.snapshotJson,
-    "Retained try-out snapshot"
-  );
+  const snapshot = yield* decodeMigrationSnapshot(bytes.snapshotJson);
   const rendererManifest = yield* parseStoredJson(
     bytes.rendererJson,
     "Retained try-out renderer"


### PR DESCRIPTION
## Summary

Decode the retained tryout-history snapshot using its exact stored `{ family, manifest }` envelope, then pass only the authenticated historical manifest to the migration contract.

## Why

Aksara migration run 33152508928 failed before any migration write because Effect Schema rejected excess path `evidence.snapshot.family`. Production still has no migration target or history residue. The first PR Production run later exposed an unrelated tooltip locator race after 59 browser tests passed; the retry passed.

## Scope

- strictly decode the stored historical snapshot envelope
- preserve the authenticated manifest and downstream hash checks
- exclude both entering and exiting tooltip transition states from one production browser locator
- do not mutate production, migration tables, Vercel, workflows, or Gemini routing

## Exact-head verification

Exact head: `eefcb6fa07abd733d4268d5b9fa88c1dbcd51e5a`, rebased patch-equivalently onto protected main `75cad2b60174b1fd9e2b45f7ee7ecda81c6d3de1`.

Focused Effect Vitest 2/2, backend and WWW typechecks, five repeated production contributor browser cases, lint, boundaries, security audit, Effect 4 RC110 source parity, and diff check passed locally. Fresh Required and Doctor are running.

## Rollout state

This PR only fixes the fail-closed migration reader and browser acceptance harness. The protected Aksara workflow will be dispatched only after this exact head is merged and exact-main GitHub, Vercel, and Convex production are verified.

## Material risks

The retained source is the historical `tryout-v1` contract, not a generic localized snapshot. Accepting a broader shape would weaken integrity. Any new Production failure blocks merge and must be classified from exact logs.