### PR TITLE
test(www): run renderer checks with Effect Vitest

### DIFF
--- a/apps/www/lib/content/renderer/components.test.ts
+++ b/apps/www/lib/content/renderer/components.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
 
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import { semanticMdxComponents } from "@repo/design-system/lib/markdown/semantic";
-import { Effect } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { Data, Effect } from "effect";
+import { vi } from "vitest";
 
 vi.mock("@repo/internationalization/src/navigation", () => ({
   getPathname: vi.fn(),
@@ -19,6 +20,12 @@ vi.mock("next-intl", () => ({
 
 const contentKey = ContentKeySchema.make("test:renderer-components");
 
+class RendererFixtureUnavailable extends Data.TaggedError(
+  "RendererFixtureUnavailable"
+)<{
+  readonly resource: "component" | "domain";
+}> {}
+
 afterEach(() => {
   vi.doUnmock("@repo/design-system/lib/markdown/semantic");
   vi.doUnmock("@/lib/content/renderer/domain/site");
@@ -26,173 +33,188 @@ afterEach(() => {
 });
 
 describe("renderer components", () => {
-  it("loads semantic HTML plus exactly the signed custom requirements", async () => {
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
-    const components = await Effect.runPromise(
-      resolveRendererComponents({
-        contentKey,
-        rendererDomain: "snbt-plain",
-        requiredComponents: [{ name: "InlineMath", version: 1 }],
+  it.effect(
+    "loads semantic HTML plus exactly the signed custom requirements",
+    () =>
+      Effect.gen(function* () {
+        const { resolveRendererComponents } = yield* Effect.promise(
+          () => import("@/lib/content/renderer/components")
+        );
+        const components = yield* resolveRendererComponents({
+          contentKey,
+          rendererDomain: "snbt-plain",
+          requiredComponents: [{ name: "InlineMath", version: 1 }],
+        });
+
+        expect(components).toMatchObject(semanticMdxComponents);
+        expect(Object.keys(components).sort()).toEqual(
+          [...Object.keys(semanticMdxComponents), "InlineMath"].sort()
+        );
+        expect(components).not.toHaveProperty("BlockMath");
+        expect(components).not.toHaveProperty("Mermaid");
       })
-    );
+  );
 
-    expect(components).toMatchObject(semanticMdxComponents);
-    expect(Object.keys(components).sort()).toEqual(
-      [...Object.keys(semanticMdxComponents), "InlineMath"].sort()
-    );
-    expect(components).not.toHaveProperty("BlockMath");
-    expect(components).not.toHaveProperty("Mermaid");
-  });
-
-  it("fails with the signed identity when an implementation is missing", async () => {
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
-
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
+  it.effect(
+    "fails with the signed identity when an implementation is missing",
+    () =>
+      Effect.gen(function* () {
+        const { resolveRendererComponents } = yield* Effect.promise(
+          () => import("@/lib/content/renderer/components")
+        );
+        const failure = yield* resolveRendererComponents({
           contentKey,
           rendererDomain: "site",
           requiredComponents: [{ name: "MissingRenderer", version: 1 }],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererImplementationMissing",
-      componentName: "MissingRenderer",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
+        }).pipe(Effect.flip);
 
-  it("fails when semantic ownership and implementation coverage drift", async () => {
-    vi.doMock("@repo/design-system/lib/markdown/semantic", () => ({
-      semanticMdxComponents: {},
-    }));
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
+        expect(failure).toMatchObject({
+          _tag: "RendererImplementationMissing",
+          componentName: "MissingRenderer",
+          contentKey,
+          rendererDomain: "site",
+        });
+      })
+  );
 
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
+  it.effect(
+    "fails when semantic ownership and implementation coverage drift",
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() =>
+          vi.doMock("@repo/design-system/lib/markdown/semantic", () => ({
+            semanticMdxComponents: {},
+          }))
+        );
+        const { resolveRendererComponents } = yield* Effect.promise(
+          () => import("@/lib/content/renderer/components")
+        );
+        const failure = yield* resolveRendererComponents({
           contentKey,
           rendererDomain: "site",
           requiredComponents: [{ name: "p", version: 1 }],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererImplementationMissing",
-      componentName: "p",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
+        }).pipe(Effect.flip);
 
-  it("rejects a base and selected-domain ownership collision", async () => {
-    vi.doMock("@/lib/content/renderer/domain/site", () => ({
-      domainComponentLoaders: [
-        { load: () => Promise.resolve(() => null), name: "InlineMath" },
-      ],
-    }));
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
-
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
+        expect(failure).toMatchObject({
+          _tag: "RendererImplementationMissing",
+          componentName: "p",
           contentKey,
           rendererDomain: "site",
-          requiredComponents: [{ name: "InlineMath", version: 1 }],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererComponentCollision",
-      componentName: "InlineMath",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
+        });
+      })
+  );
 
-  it("rejects duplicate implementations inside the selected domain", async () => {
-    vi.doMock("@/lib/content/renderer/domain/site", () => ({
-      domainComponentLoaders: [
-        { load: () => Promise.resolve(() => null), name: "SiteWidget" },
-        { load: () => Promise.resolve(() => null), name: "SiteWidget" },
-      ],
-    }));
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
+  it.effect("rejects a base and selected-domain ownership collision", () =>
+    Effect.gen(function* () {
+      yield* Effect.sync(() =>
+        vi.doMock("@/lib/content/renderer/domain/site", () => ({
+          domainComponentLoaders: [
+            { load: () => Promise.resolve(() => null), name: "InlineMath" },
+          ],
+        }))
+      );
+      const { resolveRendererComponents } = yield* Effect.promise(
+        () => import("@/lib/content/renderer/components")
+      );
+      const failure = yield* resolveRendererComponents({
+        contentKey,
+        rendererDomain: "site",
+        requiredComponents: [{ name: "InlineMath", version: 1 }],
+      }).pipe(Effect.flip);
 
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
-          contentKey,
-          rendererDomain: "site",
-          requiredComponents: [{ name: "SiteWidget", version: 1 }],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererComponentCollision",
-      componentName: "SiteWidget",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
+      expect(failure).toMatchObject({
+        _tag: "RendererComponentCollision",
+        componentName: "InlineMath",
+        contentKey,
+        rendererDomain: "site",
+      });
+    })
+  );
 
-  it("preserves domain import failures in the typed error channel", async () => {
-    vi.doMock("@/lib/content/renderer/domain/site", () => {
-      throw new Error("domain unavailable");
-    });
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
-
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
-          contentKey,
-          rendererDomain: "site",
-          requiredComponents: [],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererDomainLoadError",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
-
-  it("identifies the component whose implementation import failed", async () => {
-    vi.doMock("@/lib/content/renderer/domain/site", () => ({
-      domainComponentLoaders: [
-        {
-          load: () => Promise.reject(new Error("component unavailable")),
-          name: "SiteWidget",
-        },
-      ],
-    }));
-    const { resolveRendererComponents } = await import(
-      "@/lib/content/renderer/components"
-    );
-
-    await expect(
-      Effect.runPromise(
-        resolveRendererComponents({
+  it.effect(
+    "rejects duplicate implementations inside the selected domain",
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() =>
+          vi.doMock("@/lib/content/renderer/domain/site", () => ({
+            domainComponentLoaders: [
+              { load: () => Promise.resolve(() => null), name: "SiteWidget" },
+              { load: () => Promise.resolve(() => null), name: "SiteWidget" },
+            ],
+          }))
+        );
+        const { resolveRendererComponents } = yield* Effect.promise(
+          () => import("@/lib/content/renderer/components")
+        );
+        const failure = yield* resolveRendererComponents({
           contentKey,
           rendererDomain: "site",
           requiredComponents: [{ name: "SiteWidget", version: 1 }],
-        }).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "RendererDomainLoadError",
-      componentName: "SiteWidget",
-      contentKey,
-      rendererDomain: "site",
-    });
-  });
+        }).pipe(Effect.flip);
+
+        expect(failure).toMatchObject({
+          _tag: "RendererComponentCollision",
+          componentName: "SiteWidget",
+          contentKey,
+          rendererDomain: "site",
+        });
+      })
+  );
+
+  it.effect("preserves domain import failures in the typed error channel", () =>
+    Effect.gen(function* () {
+      yield* Effect.sync(() =>
+        vi.doMock("@/lib/content/renderer/domain/site", () => {
+          throw new RendererFixtureUnavailable({ resource: "domain" });
+        })
+      );
+      const { resolveRendererComponents } = yield* Effect.promise(
+        () => import("@/lib/content/renderer/components")
+      );
+      const failure = yield* resolveRendererComponents({
+        contentKey,
+        rendererDomain: "site",
+        requiredComponents: [],
+      }).pipe(Effect.flip);
+
+      expect(failure).toMatchObject({
+        _tag: "RendererDomainLoadError",
+        contentKey,
+        rendererDomain: "site",
+      });
+    })
+  );
+
+  it.effect("identifies the component whose implementation import failed", () =>
+    Effect.gen(function* () {
+      yield* Effect.sync(() =>
+        vi.doMock("@/lib/content/renderer/domain/site", () => ({
+          domainComponentLoaders: [
+            {
+              load: () =>
+                Promise.reject(
+                  new RendererFixtureUnavailable({ resource: "component" })
+                ),
+              name: "SiteWidget",
+            },
+          ],
+        }))
+      );
+      const { resolveRendererComponents } = yield* Effect.promise(
+        () => import("@/lib/content/renderer/components")
+      );
+      const failure = yield* resolveRendererComponents({
+        contentKey,
+        rendererDomain: "site",
+        requiredComponents: [{ name: "SiteWidget", version: 1 }],
+      }).pipe(Effect.flip);
+
+      expect(failure).toMatchObject({
+        _tag: "RendererDomainLoadError",
+        componentName: "SiteWidget",
+        contentKey,
+        rendererDomain: "site",
+      });
+    })
+  );
 });

--- a/apps/www/lib/content/renderer/manifest.test.ts
+++ b/apps/www/lib/content/renderer/manifest.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { describe, expect, it } from "@effect/vitest";
 import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import {
   canonicalizeRendererManifestContract,
@@ -11,7 +12,7 @@ import {
 } from "@nakafa/aksara-contracts/renderer/manifest";
 import { semanticComponentNames } from "@repo/design-system/lib/markdown/names";
 import { Effect, Exit, Schema } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { baseComponentLoaders } from "@/lib/content/renderer/domain/base";
 import { loadRendererDomainModule } from "@/lib/content/renderer/selection";
 
@@ -28,119 +29,130 @@ vi.mock("next-intl", () => ({
 }));
 
 describe("renderer manifest", () => {
-  it("authenticates the canonical renderer contract", async () => {
-    const { rendererManifest } = await import(
-      "@/lib/content/renderer/manifest"
-    );
-    const manifest = await Effect.runPromise(rendererManifest);
-
-    await expect(
-      Effect.runPromise(validateRendererManifestHash(manifest))
-    ).resolves.toEqual(manifest);
-    expect(manifest.domains.map(({ name }) => name)).toEqual(RENDERER_DOMAINS);
-    expect(manifest.publishedDomains).toEqual(RENDERER_DOMAINS);
-  });
-
-  it("accepts historical domain subsets only as frozen evidence", async () => {
-    const { rendererManifest } = await import(
-      "@/lib/content/renderer/manifest"
-    );
-    const manifest = await Effect.runPromise(rendererManifest);
-    const domains = manifest.domains.filter(({ name }) => name !== "site");
-    const publishedDomains = manifest.publishedDomains.filter(
-      (name) => name !== "site"
-    );
-    const canonicalContract = canonicalizeRendererManifestContract({
-      base: manifest.base,
-      domains,
-      publishedDomains,
-    });
-    const hash = `sha256:${createHash("sha256")
-      .update(canonicalContract)
-      .digest("hex")}`;
-    const historicalManifest = Schema.decodeSync(
-      RendererManifestEnvelopeSchema
-    )({
-      ...manifest,
-      domains,
-      hash,
-      publishedDomains,
-    });
-
-    expect(historicalManifest.hash).toBe(
-      "sha256:e06c5326020aeb0c43c0c565948b18a111a4df009ff3b3fe5cd827f35f9275e7"
-    );
-
-    await expect(
-      Effect.runPromise(validateRendererManifestHash(historicalManifest))
-    ).resolves.toEqual(historicalManifest);
-
-    const liveValidation = await Effect.runPromiseExit(
-      validateLiveRendererManifestHash(historicalManifest)
-    );
-    expect(Exit.isFailure(liveValidation)).toBe(true);
-  });
-
-  it("matches every manifest requirement to one physical implementation", async () => {
-    const [{ resolveRendererComponents }, { rendererManifest }] =
-      await Promise.all([
-        import("@/lib/content/renderer/components"),
-        import("@/lib/content/renderer/manifest"),
-      ]);
-    const manifest = await Effect.runPromise(rendererManifest);
-    const contentKey = ContentKeySchema.make("test:renderer-manifest");
-
-    for (const domain of manifest.domains) {
-      const requiredComponents = [
-        ...manifest.base.supportedComponents,
-        ...domain.supportedComponents,
-      ];
-      const components = await Effect.runPromise(
-        resolveRendererComponents({
-          contentKey,
-          rendererDomain: domain.name,
-          requiredComponents,
-        })
+  it.effect("authenticates the canonical renderer contract", () =>
+    Effect.gen(function* () {
+      const { rendererManifest } = yield* Effect.promise(
+        () => import("@/lib/content/renderer/manifest")
       );
-      const expectedNames = [
-        ...new Set(requiredComponents.map(({ name }) => name)),
-      ].sort();
+      const manifest = yield* rendererManifest;
 
-      expect(Object.keys(components).sort()).toEqual(expectedNames);
-    }
-  }, 120_000);
-
-  it("keeps every literal loader registry exactly aligned with the manifest", async () => {
-    const { rendererManifest } = await import(
-      "@/lib/content/renderer/manifest"
-    );
-    const manifest = await Effect.runPromise(rendererManifest);
-    const contentKey = ContentKeySchema.make("test:renderer-loaders");
-    const semanticNames = new Set<string>(semanticComponentNames);
-    const expectedBaseNames = manifest.base.supportedComponents
-      .map(({ name }) => name)
-      .filter((name) => !semanticNames.has(name))
-      .sort();
-
-    expect(baseComponentLoaders.map(({ name }) => name).sort()).toEqual(
-      expectedBaseNames
-    );
-
-    for (const domain of manifest.domains) {
-      const domainModule = await Effect.runPromise(
-        loadRendererDomainModule({
-          contentKey,
-          rendererDomain: domain.name,
-          requiredComponents: [],
-        })
+      expect(yield* validateRendererManifestHash(manifest)).toEqual(manifest);
+      expect(manifest.domains.map(({ name }) => name)).toEqual(
+        RENDERER_DOMAINS
       );
-      const expectedDomainNames = domain.supportedComponents
-        .map(({ name }) => name)
-        .sort();
+      expect(manifest.publishedDomains).toEqual(RENDERER_DOMAINS);
+    })
+  );
 
-      expect(
-        domainModule.domainComponentLoaders.map(({ name }) => name).sort()
-      ).toEqual(expectedDomainNames);
-    }
-  });
+  it.effect("accepts historical domain subsets only as frozen evidence", () =>
+    Effect.gen(function* () {
+      const { rendererManifest } = yield* Effect.promise(
+        () => import("@/lib/content/renderer/manifest")
+      );
+      const manifest = yield* rendererManifest;
+      const domains = manifest.domains.filter(({ name }) => name !== "site");
+      const publishedDomains = manifest.publishedDomains.filter(
+        (name) => name !== "site"
+      );
+      const canonicalContract = canonicalizeRendererManifestContract({
+        base: manifest.base,
+        domains,
+        publishedDomains,
+      });
+      const hash = `sha256:${createHash("sha256")
+        .update(canonicalContract)
+        .digest("hex")}`;
+      const historicalManifest = yield* Schema.decodeEffect(
+        RendererManifestEnvelopeSchema
+      )({
+        ...manifest,
+        domains,
+        hash,
+        publishedDomains,
+      });
+
+      expect(historicalManifest.hash).toBe(
+        "sha256:e06c5326020aeb0c43c0c565948b18a111a4df009ff3b3fe5cd827f35f9275e7"
+      );
+      expect(yield* validateRendererManifestHash(historicalManifest)).toEqual(
+        historicalManifest
+      );
+
+      const liveValidation = yield* Effect.exit(
+        validateLiveRendererManifestHash(historicalManifest)
+      );
+      expect(Exit.isFailure(liveValidation)).toBe(true);
+    })
+  );
+
+  it.effect(
+    "matches every manifest requirement to one physical implementation",
+    () =>
+      Effect.gen(function* () {
+        const [{ resolveRendererComponents }, { rendererManifest }] =
+          yield* Effect.all(
+            [
+              Effect.promise(() => import("@/lib/content/renderer/components")),
+              Effect.promise(() => import("@/lib/content/renderer/manifest")),
+            ],
+            { concurrency: "unbounded" }
+          );
+        const manifest = yield* rendererManifest;
+        const contentKey = ContentKeySchema.make("test:renderer-manifest");
+
+        for (const domain of manifest.domains) {
+          const requiredComponents = [
+            ...manifest.base.supportedComponents,
+            ...domain.supportedComponents,
+          ];
+          const components = yield* resolveRendererComponents({
+            contentKey,
+            rendererDomain: domain.name,
+            requiredComponents,
+          });
+          const expectedNames = [
+            ...new Set(requiredComponents.map(({ name }) => name)),
+          ].sort();
+
+          expect(Object.keys(components).sort()).toEqual(expectedNames);
+        }
+      }),
+    120_000
+  );
+
+  it.effect(
+    "keeps every literal loader registry exactly aligned with the manifest",
+    () =>
+      Effect.gen(function* () {
+        const { rendererManifest } = yield* Effect.promise(
+          () => import("@/lib/content/renderer/manifest")
+        );
+        const manifest = yield* rendererManifest;
+        const contentKey = ContentKeySchema.make("test:renderer-loaders");
+        const semanticNames = new Set<string>(semanticComponentNames);
+        const expectedBaseNames = manifest.base.supportedComponents
+          .map(({ name }) => name)
+          .filter((name) => !semanticNames.has(name))
+          .sort();
+
+        expect(baseComponentLoaders.map(({ name }) => name).sort()).toEqual(
+          expectedBaseNames
+        );
+
+        for (const domain of manifest.domains) {
+          const domainModule = yield* loadRendererDomainModule({
+            contentKey,
+            rendererDomain: domain.name,
+            requiredComponents: [],
+          });
+          const expectedDomainNames = domain.supportedComponents
+            .map(({ name }) => name)
+            .sort();
+
+          expect(
+            domainModule.domainComponentLoaders.map(({ name }) => name).sort()
+          ).toEqual(expectedDomainNames);
+        }
+      })
+  );
 });


### PR DESCRIPTION
## Outcome

Migrate the renderer component and manifest suites directly to Effect v4's upstream Vitest integration.

- import test APIs from `@effect/vitest`
- return Effects through `it.effect`
- compose dynamic imports, typed failures, and exits without direct runtime runners
- retain Vitest only for the `vi` module-mocking seam
- keep production code unchanged

## Exact scope

- `apps/www/lib/content/renderer/components.test.ts`
- `apps/www/lib/content/renderer/manifest.test.ts`

Base `6a7c171a4c8b904994d4f9fdb52d5c3570c0664`, head `53d7880be11a12bd4d2c2f3c277ff7b468efb014`, patch `ee7d6a5de3527daf95883d0dcf25eb4efff26573`.

## Effect v4 evidence

The migration follows the vendored RC110 `@effect/vitest` implementation and repository Effect guidance. Effectful tests return Effects through `it.effect`; dynamic imports use `Effect.promise`; failure assertions remain in the typed Effect channel; pure mocking stays at Vitest's `vi` boundary.

## Verification

- focused renderer suites: 11/11, 100% coverage
- full WWW suite: 1,517/1,517, 100% statements, branches, functions, and lines
- native WWW typecheck with validated local environment
- root lint, Effect RC110 source parity, test ownership, dependency boundaries
- React Doctor: 100/100
- clean worktree and diff
- no direct Effect runners in either changed test

Production acceptance should classify this as test-only. No Vercel Preview is created.