### PR TITLE
refactor(www): keep learning selection Effect native

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/home/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(core)/home/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "@repo/internationalization/src/navigation";
 import type { PublicAppLocale } from "@repo/internationalization/src/routing";
+import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { HomeContinueLearning } from "@/components/home/continue-learning";
@@ -11,8 +12,8 @@ import { isActiveLocale } from "@/lib/i18n/active";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { shouldRequireLearningProgramOnboarding } from "@/lib/programs/catalog";
 import {
-  getActiveLearningSelection,
   getLearningProgramOnboardingCatalog,
+  readActiveLearningSelection,
 } from "@/lib/programs/server";
 
 /** Routes authenticated users through canonical learning selection. */
@@ -45,7 +46,9 @@ async function AuthenticatedHome({
     return null;
   }
 
-  const learningSelection = await getActiveLearningSelection(token, locale);
+  const learningSelection = await Effect.runPromise(
+    readActiveLearningSelection(token, locale)
+  );
   if (!learningSelection) {
     const programs = await getLearningProgramOnboardingCatalog(locale);
 

--- a/apps/www/app/[locale]/(app)/(shared)/onboarding/focus/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/onboarding/focus/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "@repo/internationalization/src/navigation";
 import type { PublicAppLocale } from "@repo/internationalization/src/routing";
+import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { FocusStepForm } from "@/components/programs/onboarding/focus";
@@ -9,8 +10,8 @@ import { getToken } from "@/lib/auth/server";
 import { isActiveLocale } from "@/lib/i18n/active";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import {
-  getActiveLearningSelection,
   getLearningProgramOnboardingCatalog,
+  readActiveLearningSelection,
 } from "@/lib/programs/server";
 
 /** Renders the route-owned focus form step for normal Nakafa onboarding. */
@@ -47,7 +48,9 @@ async function FocusStepRuntime({ locale }: { locale: PublicAppLocale }) {
     return null;
   }
 
-  const activeSelection = await getActiveLearningSelection(token, locale);
+  const activeSelection = await Effect.runPromise(
+    readActiveLearningSelection(token, locale)
+  );
 
   return (
     <FocusStepForm activeSelection={activeSelection} programs={programs} />

--- a/apps/www/lib/programs/server.ts
+++ b/apps/www/lib/programs/server.ts
@@ -4,15 +4,12 @@ import { api } from "@repo/backend/convex/_generated/api";
 import type { PublicAppLocale } from "@repo/internationalization/src/routing";
 import { fetchQuery } from "convex/nextjs";
 import { Effect, Schema } from "effect";
-import type {
-  ActiveLearningSelection,
-  LearningProgramCatalog,
-} from "@/components/programs/contract";
+import type { LearningProgramCatalog } from "@/components/programs/contract";
 import { applyContentRuntimeCache } from "@/lib/content/cache";
 import { filterOnboardingPrograms } from "@/lib/programs/catalog";
 
 /** Expected failure while reading the current user's learning selection. */
-class ActiveLearningSelectionReadError extends Schema.TaggedError<ActiveLearningSelectionReadError>()(
+export class ActiveLearningSelectionReadError extends Schema.TaggedError<ActiveLearningSelectionReadError>()(
   "ActiveLearningSelectionReadError",
   {
     cause: Schema.Unknown,
@@ -21,7 +18,7 @@ class ActiveLearningSelectionReadError extends Schema.TaggedError<ActiveLearning
 ) {}
 
 /** Reads the authenticated user's canonical learning selection. */
-const readActiveLearningSelection = Effect.fn(
+export const readActiveLearningSelection = Effect.fn(
   "www.learningPrograms.activeSelection"
 )(function* (token: string, locale: PublicAppLocale) {
   return yield* Effect.tryPromise({
@@ -66,12 +63,4 @@ export async function getLearningProgramOnboardingCatalog(
   const catalog = await getLearningProgramCatalog(locale);
 
   return filterOnboardingPrograms(catalog);
-}
-
-/** Reads the active learning selection for the authenticated request token. */
-export async function getActiveLearningSelection(
-  token: string,
-  locale: PublicAppLocale
-): Promise<ActiveLearningSelection> {
-  return await Effect.runPromise(readActiveLearningSelection(token, locale));
 }


### PR DESCRIPTION
## Scope

- Export the active learning-selection read as a named Effect v4 program with its tagged error.
- Delete the Promise facade and its internal Effect.runPromise.
- Execute the program only at the authenticated home and onboarding Server Component seams.

## Architecture

The cross-module fallible interface now remains Effect-native. The two Next.js rendering seams own execution, matching the repository Effect v4 standard and the pinned RC110 runtime guidance. The change is net negative: 13 insertions and 18 deletions.

## Exact proof

- Base: 586ff21e003d51364b8693539e8583d581b39e6e
- Head: 8282c23b77ba9ec6f19085b29c18bc0795828dbf
- Tree: 0846b05f6ea4084d48475e4af4c0ad2ce31ea063
- Stable patch: f23046f061e71abf24f3b1868d778a3f7d222fd8
- The prior reviewed head was superseded only to absorb current protected main. The stable patch is unchanged.
- Collision scan: zero overlap across 12 open PRs and 47 other retained worktrees.

## Verification

- Current-base focused program and onboarding tests: 18 passed.
- Exact-head WWW suite: 1,518 passed across 209 files with coverage policy green.
- Native WWW typecheck: passed with schema-valid non-secret local config values.
- Lint, Effect RC110 source parity, test ownership policy, and boundaries: passed.
- React Doctor changed scope: 100/100.
- Exact-head CI run 33161227456: Production Scope, Quality, complete production build, browser acceptance, AFDocs, final signed-runtime fingerprint, and Required passed.
- Exact-head Codex review: no major issues; zero review threads.
- Diff check and clean worktree: passed.

No Vercel Preview was created.