### PR TITLE
refactor(backend): compose email retention with Effect

### DIFF
--- a/packages/backend/convex/emails/retention.test.ts
+++ b/packages/backend/convex/emails/retention.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
@@ -16,7 +17,11 @@ describe("emails/retention", () => {
 
       const scheduledJobs = yield* Effect.promise(() =>
         test.query((ctx) =>
-          ctx.db.system.query("_scheduled_functions").collect()
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.system.query("_scheduled_functions").collect()
+            )
+          )
         )
       );
 

--- a/packages/backend/convex/emails/retention.test.ts
+++ b/packages/backend/convex/emails/retention.test.ts
@@ -1,28 +1,35 @@
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
 
 describe("emails/retention", () => {
-  it("schedules both component-owned retention sweeps", async () => {
-    const t = convexTest(schema, convexModules);
+  it.effect("schedules both component-owned retention sweeps", () =>
+    Effect.gen(function* () {
+      const test = convexTest(schema, convexModules);
 
-    await t.mutation(internal.emails.retention.cleanupRetainedEmailData, {});
+      yield* Effect.promise(() =>
+        test.mutation(internal.emails.retention.cleanupRetainedEmailData, {})
+      );
 
-    const scheduledJobs = await t.query((ctx) =>
-      ctx.db.system.query("_scheduled_functions").collect()
-    );
+      const scheduledJobs = yield* Effect.promise(() =>
+        test.query((ctx) =>
+          ctx.db.system.query("_scheduled_functions").collect()
+        )
+      );
 
-    expect(scheduledJobs).toEqual([
-      expect.objectContaining({
-        args: [{}],
-        name: expect.stringContaining("cleanupOldEmails"),
-      }),
-      expect.objectContaining({
-        args: [{}],
-        name: expect.stringContaining("cleanupAbandonedEmails"),
-      }),
-    ]);
-  });
+      expect(scheduledJobs).toEqual([
+        expect.objectContaining({
+          args: [{}],
+          name: expect.stringContaining("cleanupOldEmails"),
+        }),
+        expect.objectContaining({
+          args: [{}],
+          name: expect.stringContaining("cleanupAbandonedEmails"),
+        }),
+      ]);
+    })
+  );
 });

--- a/packages/backend/convex/emails/retention.ts
+++ b/packages/backend/convex/emails/retention.ts
@@ -1,6 +1,22 @@
 import { components } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/functions";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { v } from "convex/values";
+import { Effect } from "effect";
+
+const scheduleRetainedEmailCleanup = Effect.fn(
+  "emails.retention.scheduleCleanup"
+)(function* (ctx: MutationCtx) {
+  yield* Effect.promise(() =>
+    ctx.scheduler.runAfter(0, components.resend.lib.cleanupOldEmails, {})
+  );
+  yield* Effect.promise(() =>
+    ctx.scheduler.runAfter(0, components.resend.lib.cleanupAbandonedEmails, {})
+  );
+
+  return null;
+});
 
 /**
  * Applies the Resend component's bounded retention policy.
@@ -12,14 +28,5 @@ import { v } from "convex/values";
 export const cleanupRetainedEmailData = internalMutation({
   args: {},
   returns: v.null(),
-  handler: async (ctx) => {
-    await ctx.scheduler.runAfter(0, components.resend.lib.cleanupOldEmails, {});
-    await ctx.scheduler.runAfter(
-      0,
-      components.resend.lib.cleanupAbandonedEmails,
-      {}
-    );
-
-    return null;
-  },
+  handler: (ctx) => runConvexProgram(scheduleRetainedEmailCleanup(ctx)),
 });


### PR DESCRIPTION
## Summary

- name the retained-email scheduler as one `Effect.fn` program
- execute it only at the existing Convex framework boundary
- migrate the effectful retention test directly to `@effect/vitest` and `it.effect`
- compose scheduled-job inspection through the real Convex query boundary

## Architecture

Scheduler operations stay composable inside Effect and execute only through `runConvexProgram` at real internal mutation and test query callbacks. No testing wrapper, raw async callback, direct test runner, global `vi`, compatibility layer, or dependency change is introduced.

## Verification

- focused retention test: 1/1 passed on final source
- backend native TypeScript typecheck: passed
- lint, Effect RC110 source parity, and test ownership policy: passed
- workspace boundaries: passed
- complete diff check: passed
- exact-head GitHub Quality, Production, Required, Doctor, and review remain required before merge

## Exact identity

Head `e389ef5a8b59e3cd7aa6f23987f8dc997dd49afb`.

## Release

This is an independent production-code checkpoint. It creates no Vercel Preview and does not change any signed content, Quran, tryout, or publication contract. Merge only through the protected queue after exact-head production acceptance.