### PR TITLE
test(backend): run analytics erasure request with Effect Vitest

### DIFF
--- a/packages/backend/convex/analytics/erasure/request.test.ts
+++ b/packages/backend/convex/analytics/erasure/request.test.ts
@@ -1,57 +1,110 @@
+import workflowTest from "@convex-dev/workflow/test";
+import { assert, describe, expect, it } from "@effect/vitest";
 import { requestAnalyticsErasure } from "@repo/backend/convex/analytics/erasure/request";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Cause, Data, Effect, Exit, Result } from "effect";
+import { vi } from "vitest";
+
+class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
+  readonly message: string;
+}> {}
 
 describe("analytics erasure request", () => {
-  it("admits erasure from the action boundary", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "erasure-request-user",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "erasure-request@example.com",
-        name: "Erasure Request",
-        plan: "free",
-      })
-    );
-    const startErasure = vi.fn(async () => undefined);
+  it.effect("admits erasure from the action boundary", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "erasure-request-user",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "erasure-request@example.com",
+            name: "Erasure Request",
+            plan: "free",
+          })
+        )
+      );
+      const startErasure = vi.fn(() => Promise.resolve(undefined));
 
-    await t.action((ctx) =>
-      runConvexProgram(requestAnalyticsErasure(ctx, userId, startErasure))
-    );
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(requestAnalyticsErasure(ctx, userId, startErasure))
+        )
+      );
 
-    expect(startErasure).toHaveBeenCalledWith(expect.any(Object), userId);
-  });
+      expect(startErasure).toHaveBeenCalledWith(expect.any(Object), userId);
+    })
+  );
 
-  it("surfaces a typed failure when workflow admission fails", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "failed-erasure-request-user",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "failed-erasure-request@example.com",
-        name: "Failed Erasure Request",
-        plan: "free",
-      })
-    );
-    const startErasure = vi.fn(async () =>
-      Promise.reject(new Error("workflow unavailable"))
-    );
+  it.effect("starts the durable erasure workflow", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      workflowTest.register(t);
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "durable-erasure-request-user",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "durable-erasure-request@example.com",
+            name: "Durable Erasure Request",
+            plan: "free",
+          })
+        )
+      );
 
-    await expect(
-      t.action((ctx) =>
-        runConvexProgram(requestAnalyticsErasure(ctx, userId, startErasure))
-      )
-    ).rejects.toMatchObject({
-      data: {
-        code: "ANALYTICS_ERASURE_REQUEST_FAILED",
-        message: expect.stringContaining("workflow unavailable"),
-      },
-    });
-  });
+      expect(
+        yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(requestAnalyticsErasure(ctx, userId))
+          )
+        )
+      ).toBeNull();
+    })
+  );
+
+  it.effect("surfaces a typed failure when workflow admission fails", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "failed-erasure-request-user",
+            credits: 0,
+            creditsResetAt: 0,
+            email: "failed-erasure-request@example.com",
+            name: "Failed Erasure Request",
+            plan: "free",
+          })
+        )
+      );
+      const startErasure = vi.fn(() =>
+        Promise.reject(
+          new WorkflowUnavailable({ message: "workflow unavailable" })
+        )
+      );
+
+      const exit = yield* Effect.exit(
+        Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(requestAnalyticsErasure(ctx, userId, startErasure))
+          )
+        )
+      );
+      assert(Exit.isFailure(exit));
+
+      const defect = Cause.findDefect(exit.cause);
+      assert(Result.isSuccess(defect));
+      expect(defect.success).toMatchObject({
+        data: {
+          code: "ANALYTICS_ERASURE_REQUEST_FAILED",
+          message: expect.stringContaining("workflow unavailable"),
+        },
+      });
+    })
+  );
 });

--- a/packages/backend/convex/analytics/erasure/request.test.ts
+++ b/packages/backend/convex/analytics/erasure/request.test.ts
@@ -1,15 +1,25 @@
 import workflowTest from "@convex-dev/workflow/test";
-import { assert, describe, expect, it } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
+import { internal } from "@repo/backend/convex/_generated/api";
 import { requestAnalyticsErasure } from "@repo/backend/convex/analytics/erasure/request";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { cleanupSource } from "@repo/backend/convex/privacy/spec";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
+import { workflow } from "@repo/backend/convex/workflow";
+import { getFunctionName } from "convex/server";
 import { convexTest } from "convex-test";
-import { Cause, Data, Effect, Exit, Result } from "effect";
+import { Data, Effect } from "effect";
 import { vi } from "vitest";
 
 class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
   readonly message: string;
+}> {}
+
+class AnalyticsErasureActionRejected extends Data.TaggedError(
+  "AnalyticsErasureActionRejected"
+)<{
+  readonly cause: unknown;
 }> {}
 
 describe("analytics erasure request", () => {
@@ -57,13 +67,25 @@ describe("analytics erasure request", () => {
         )
       );
 
-      expect(
-        yield* Effect.promise(() =>
-          t.action((ctx) =>
-            runConvexProgram(requestAnalyticsErasure(ctx, userId))
-          )
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(requestAnalyticsErasure(ctx, userId))
         )
-      ).toBeNull();
+      );
+
+      const admittedWorkflows = yield* Effect.promise(() =>
+        t.action((ctx) => workflow.list(ctx))
+      );
+
+      expect(admittedWorkflows.page).toEqual([
+        expect.objectContaining({
+          args: { userId },
+          context: { source: cleanupSource.consentOverlap },
+          name: getFunctionName(
+            internal.analytics.erasure.workflow.eraseConsentOverlap
+          ),
+        }),
+      ]);
     })
   );
 
@@ -88,21 +110,24 @@ describe("analytics erasure request", () => {
         )
       );
 
-      const exit = yield* Effect.exit(
-        Effect.promise(() =>
-          t.action((ctx) =>
-            runConvexProgram(requestAnalyticsErasure(ctx, userId, startErasure))
-          )
-        )
+      const failure = yield* Effect.flip(
+        Effect.tryPromise({
+          catch: (cause) => new AnalyticsErasureActionRejected({ cause }),
+          try: () =>
+            t.action((ctx) =>
+              runConvexProgram(
+                requestAnalyticsErasure(ctx, userId, startErasure)
+              )
+            ),
+        })
       );
-      assert(Exit.isFailure(exit));
-
-      const defect = Cause.findDefect(exit.cause);
-      assert(Result.isSuccess(defect));
-      expect(defect.success).toMatchObject({
-        data: {
-          code: "ANALYTICS_ERASURE_REQUEST_FAILED",
-          message: expect.stringContaining("workflow unavailable"),
+      expect(failure).toMatchObject({
+        _tag: "AnalyticsErasureActionRejected",
+        cause: {
+          data: {
+            code: "ANALYTICS_ERASURE_REQUEST_FAILED",
+            message: expect.stringContaining("workflow unavailable"),
+          },
         },
       });
     })

--- a/packages/backend/convex/analytics/erasure/request.test.ts
+++ b/packages/backend/convex/analytics/erasure/request.test.ts
@@ -1,5 +1,5 @@
 import workflowTest from "@convex-dev/workflow/test";
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { requestAnalyticsErasure } from "@repo/backend/convex/analytics/erasure/request";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -10,7 +10,6 @@ import { workflow } from "@repo/backend/convex/workflow";
 import { getFunctionName } from "convex/server";
 import { convexTest } from "convex-test";
 import { Data, Effect } from "effect";
-import { vi } from "vitest";
 
 class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
   readonly message: string;
@@ -28,14 +27,18 @@ describe("analytics erasure request", () => {
       const t = convexTest(schema, convexModules);
       const userId = yield* Effect.promise(() =>
         t.mutation((ctx) =>
-          ctx.db.insert("users", {
-            authId: "erasure-request-user",
-            credits: 0,
-            creditsResetAt: 0,
-            email: "erasure-request@example.com",
-            name: "Erasure Request",
-            plan: "free",
-          })
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("users", {
+                authId: "erasure-request-user",
+                credits: 0,
+                creditsResetAt: 0,
+                email: "erasure-request@example.com",
+                name: "Erasure Request",
+                plan: "free",
+              })
+            )
+          )
         )
       );
       const startErasure = vi.fn(() => Promise.resolve(undefined));
@@ -56,14 +59,18 @@ describe("analytics erasure request", () => {
       yield* Effect.sync(() => workflowTest.register(t));
       const userId = yield* Effect.promise(() =>
         t.mutation((ctx) =>
-          ctx.db.insert("users", {
-            authId: "durable-erasure-request-user",
-            credits: 0,
-            creditsResetAt: 0,
-            email: "durable-erasure-request@example.com",
-            name: "Durable Erasure Request",
-            plan: "free",
-          })
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("users", {
+                authId: "durable-erasure-request-user",
+                credits: 0,
+                creditsResetAt: 0,
+                email: "durable-erasure-request@example.com",
+                name: "Durable Erasure Request",
+                plan: "free",
+              })
+            )
+          )
         )
       );
 
@@ -74,7 +81,9 @@ describe("analytics erasure request", () => {
       );
 
       const admittedWorkflows = yield* Effect.promise(() =>
-        t.action((ctx) => workflow.list(ctx))
+        t.action((ctx) =>
+          runConvexProgram(Effect.promise(() => workflow.list(ctx)))
+        )
       );
 
       expect(admittedWorkflows.page).toEqual([
@@ -94,14 +103,18 @@ describe("analytics erasure request", () => {
       const t = convexTest(schema, convexModules);
       const userId = yield* Effect.promise(() =>
         t.mutation((ctx) =>
-          ctx.db.insert("users", {
-            authId: "failed-erasure-request-user",
-            credits: 0,
-            creditsResetAt: 0,
-            email: "failed-erasure-request@example.com",
-            name: "Failed Erasure Request",
-            plan: "free",
-          })
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("users", {
+                authId: "failed-erasure-request-user",
+                credits: 0,
+                creditsResetAt: 0,
+                email: "failed-erasure-request@example.com",
+                name: "Failed Erasure Request",
+                plan: "free",
+              })
+            )
+          )
         )
       );
       const startErasure = vi.fn(() =>

--- a/packages/backend/convex/analytics/erasure/request.test.ts
+++ b/packages/backend/convex/analytics/erasure/request.test.ts
@@ -53,7 +53,7 @@ describe("analytics erasure request", () => {
   it.effect("starts the durable erasure workflow", () =>
     Effect.gen(function* () {
       const t = convexTest(schema, convexModules);
-      workflowTest.register(t);
+      yield* Effect.sync(() => workflowTest.register(t));
       const userId = yield* Effect.promise(() =>
         t.mutation((ctx) =>
           ctx.db.insert("users", {


### PR DESCRIPTION
## Summary

- migrate only `packages/backend/convex/analytics/erasure/request.test.ts`
- import the complete test API directly from `@effect/vitest`
- run all three asynchronous cases through `it.effect`
- suspend infallible Convex framework Promises with `Effect.promise`
- suspend synchronous test-harness registration with `Effect.sync`
- retain `runConvexProgram` only inside real Convex action and mutation callbacks
- prove injected success, typed rejection, and actual durable Workflow admission

## Effect v4 basis

This follows the repository-pinned Effect `4.0.0-rc.110` source, `repos/effect/.patterns/testing.md`, the direct `@effect/vitest` implementation, Effect Promise constructor semantics, and the installed Workflow test adapter implementation. Every Convex test callback composes database, component, or domain work as an Effect before the runner boundary. Expected action rejection is lifted with `Effect.tryPromise` into the specific `AnalyticsErasureActionRejected` channel and asserted through `Effect.flip`. The synchronously mutating `workflowTest.register` call is suspended with `Effect.sync`. There is no raw Vitest import, testing wrapper, raw async test callback, raw framework Promise callback, direct Effect runtime call, Promise rejection assertion, generic test error, global Vitest shim, or hard-coded allowlist.

## Scope and collision proof

The one touched file had zero matches across every other open PR. A fresh scan across every retained worktree found no committed, staged, unstaged, or untracked overlap outside this task worktree. Quran, tryout, signed content runtime, publication, and school assessment paths are excluded.

## Verification

- exact-head focused suite: 3/3 passed
- exact-head focused `request.ts` coverage: 100% statements, branches, functions, and lines
- exact-head Backend native TypeScript 7 typecheck: passed
- exact-head complete Backend suite: 387/387 files and 1,642/1,642 tests passed
- exact-head formatting, lint, Effect RC110 source parity, patch policy, test ownership, and boundaries: passed
- complete diff and runner-boundary audit: passed
- exact-head Quality, Required, and Doctor checks passed on `59443664d95bdc5197bf964433e9d69e9a947c31`; the final exact-head Codex review found no major issues, and every review thread is resolved

## Identity

Base: `586ff21e003d51364b8693539e8583d581b39e6e`
Head: `59443664d95bdc5197bf964433e9d69e9a947c31`
Tree: `abc78be67ed8738653b09ce3d3ca4484dd046cea`
Patch ID: `3a48250a5251fec19c6f92af2dfbf112ce1f4b30`

## Release

This is one test-only backend file. No Vercel Preview or Convex deployment is requested. The merge-queue repair and exact #477 canary merged green at main `eac90bc83d249f0c1b1979c35b0579c15376534e`. #461 is active, with #475 then #465 queued behind it. Enqueue only after rechecking the exact head, live collision set, required checks, review threads, and current queue slot.