### PR TITLE
test(backend): make program bucket tests Effect native

### DIFF
--- a/packages/backend/convex/contentRelease/program/bucket.test.ts
+++ b/packages/backend/convex/contentRelease/program/bucket.test.ts
@@ -5,7 +5,11 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
+
+class ProgramBucketMutationRejected extends Data.TaggedError(
+  "ProgramBucketMutationRejected"
+)<{ readonly cause: unknown }> {}
 
 describe("contentRelease/program/bucket", () => {
   it.effect("creates and increments one snapshot-local sitemap partition", () =>
@@ -28,7 +32,11 @@ describe("contentRelease/program/bucket", () => {
       );
 
       const bucket = yield* Effect.promise(() =>
-        target.run((ctx) => ctx.db.query("programBuckets").unique())
+        target.run((ctx) =>
+          runConvexProgram(
+            Effect.promise(() => ctx.db.query("programBuckets").unique())
+          )
+        )
       );
       expect(bucket).toMatchObject({
         appLocale: "en",
@@ -44,40 +52,46 @@ describe("contentRelease/program/bucket", () => {
     Effect.gen(function* () {
       const target = convexTest(schema, convexModules);
 
-      yield* Effect.promise(() =>
-        expect(
+      const invalidPartition = yield* Effect.tryPromise({
+        try: () =>
           target.mutation((ctx) =>
             runConvexProgram(
               addProgramBucketRoute(ctx, "snapshot", 0, "en", "invalid")
             )
-          )
-        ).rejects.toMatchObject({
-          data: { code: "CONTENT_RELEASE_INTEGRITY" },
-        })
-      );
+          ),
+        catch: (cause) => new ProgramBucketMutationRejected({ cause }),
+      }).pipe(Effect.flip);
+      expect(invalidPartition.cause).toMatchObject({
+        data: { code: "CONTENT_RELEASE_INTEGRITY" },
+      });
 
       yield* Effect.promise(() =>
         target.mutation((ctx) =>
-          ctx.db.insert("programBuckets", {
-            appLocale: "en",
-            bucket: "abc",
-            index: 0,
-            routeCount: CONTENT_BUCKET_SIZE,
-            snapshotId: "snapshot",
-          })
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("programBuckets", {
+                appLocale: "en",
+                bucket: "abc",
+                index: 0,
+                routeCount: CONTENT_BUCKET_SIZE,
+                snapshotId: "snapshot",
+              })
+            )
+          )
         )
       );
-      yield* Effect.promise(() =>
-        expect(
+      const overflowingPartition = yield* Effect.tryPromise({
+        try: () =>
           target.mutation((ctx) =>
             runConvexProgram(
               addProgramBucketRoute(ctx, "snapshot", 1, "en", "abc")
             )
-          )
-        ).rejects.toMatchObject({
-          data: { code: "CONTENT_RELEASE_LIMIT" },
-        })
-      );
+          ),
+        catch: (cause) => new ProgramBucketMutationRejected({ cause }),
+      }).pipe(Effect.flip);
+      expect(overflowingPartition.cause).toMatchObject({
+        data: { code: "CONTENT_RELEASE_LIMIT" },
+      });
     })
   );
 });

--- a/packages/backend/convex/contentRelease/program/bucket.test.ts
+++ b/packages/backend/convex/contentRelease/program/bucket.test.ts
@@ -1,61 +1,83 @@
+import { describe, expect, it } from "@effect/vitest";
 import { CONTENT_BUCKET_SIZE } from "@repo/backend/convex/contentRelease/bucket";
 import { addProgramBucketRoute } from "@repo/backend/convex/contentRelease/program/bucket";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
 
 describe("contentRelease/program/bucket", () => {
-  it("creates and increments one snapshot-local sitemap partition", async () => {
-    const target = convexTest(schema, convexModules);
+  it.effect("creates and increments one snapshot-local sitemap partition", () =>
+    Effect.gen(function* () {
+      const target = convexTest(schema, convexModules);
 
-    await target.mutation((ctx) =>
-      runConvexProgram(addProgramBucketRoute(ctx, "snapshot", 4, "en", "abc"))
-    );
-    await target.mutation((ctx) =>
-      runConvexProgram(addProgramBucketRoute(ctx, "snapshot", 9, "en", "abc"))
-    );
-
-    await expect(
-      target.run((ctx) => ctx.db.query("programBuckets").unique())
-    ).resolves.toMatchObject({
-      appLocale: "en",
-      bucket: "abc",
-      index: 4,
-      routeCount: 2,
-      snapshotId: "snapshot",
-    });
-  });
-
-  it("rejects invalid and overflowing sitemap partitions", async () => {
-    const target = convexTest(schema, convexModules);
-
-    await expect(
-      target.mutation((ctx) =>
-        runConvexProgram(
-          addProgramBucketRoute(ctx, "snapshot", 0, "en", "invalid")
+      yield* Effect.promise(() =>
+        target.mutation((ctx) =>
+          runConvexProgram(
+            addProgramBucketRoute(ctx, "snapshot", 4, "en", "abc")
+          )
         )
-      )
-    ).rejects.toMatchObject({
-      data: { code: "CONTENT_RELEASE_INTEGRITY" },
-    });
+      );
+      yield* Effect.promise(() =>
+        target.mutation((ctx) =>
+          runConvexProgram(
+            addProgramBucketRoute(ctx, "snapshot", 9, "en", "abc")
+          )
+        )
+      );
 
-    await target.mutation((ctx) =>
-      ctx.db.insert("programBuckets", {
+      const bucket = yield* Effect.promise(() =>
+        target.run((ctx) => ctx.db.query("programBuckets").unique())
+      );
+      expect(bucket).toMatchObject({
         appLocale: "en",
         bucket: "abc",
-        index: 0,
-        routeCount: CONTENT_BUCKET_SIZE,
+        index: 4,
+        routeCount: 2,
         snapshotId: "snapshot",
-      })
-    );
-    await expect(
-      target.mutation((ctx) =>
-        runConvexProgram(addProgramBucketRoute(ctx, "snapshot", 1, "en", "abc"))
-      )
-    ).rejects.toMatchObject({
-      data: { code: "CONTENT_RELEASE_LIMIT" },
-    });
-  });
+      });
+    })
+  );
+
+  it.effect("rejects invalid and overflowing sitemap partitions", () =>
+    Effect.gen(function* () {
+      const target = convexTest(schema, convexModules);
+
+      yield* Effect.promise(() =>
+        expect(
+          target.mutation((ctx) =>
+            runConvexProgram(
+              addProgramBucketRoute(ctx, "snapshot", 0, "en", "invalid")
+            )
+          )
+        ).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+
+      yield* Effect.promise(() =>
+        target.mutation((ctx) =>
+          ctx.db.insert("programBuckets", {
+            appLocale: "en",
+            bucket: "abc",
+            index: 0,
+            routeCount: CONTENT_BUCKET_SIZE,
+            snapshotId: "snapshot",
+          })
+        )
+      );
+      yield* Effect.promise(() =>
+        expect(
+          target.mutation((ctx) =>
+            runConvexProgram(
+              addProgramBucketRoute(ctx, "snapshot", 1, "en", "abc")
+            )
+          )
+        ).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_LIMIT" },
+        })
+      );
+    })
+  );
 });


### PR DESCRIPTION
## Outcome

Migrates the program bucket behavior tests directly to Effect v4 through `@effect/vitest` and `it.effect`.

## Typed failure semantics

Expected Convex rejections cross `Effect.tryPromise`, map to the specific private `ProgramBucketMutationRejected` tagged error, and are asserted from the typed error channel with `Effect.flip`. The tests no longer hide expected rejected Promises inside `Effect.promise`.

## Convex boundaries

Database reads and inserts compose through `Effect.promise` inside `runConvexProgram`. Runners remain only in the real `convex-test` callback boundaries. There are no raw async tests, direct Effect runners, adapter imports, raw Vitest imports, global Vitest APIs, or Promise assertion chains.

## Scope

One file only: `packages/backend/convex/contentRelease/program/bucket.test.ts`.

Exact head: `6e7532698a89e7f11647dd68c863ac129f9d36a8`
Tree: `cdd18eee3d25cde6b68e7f5a52ef608d9635ec3a`
Stable branch patch: `a084d602427834780e5a24168d1687b17d8132d4`

## Verification

- focused program-bucket tests: 2/2
- complete content-release program test directory: 8 files and 33/33 tests
- backend native TypeScript 7 typecheck
- repository format and lint
- test ownership policy
- Effect RC110 vendored-source parity
- package boundaries
- diff and raw-boundary scans
- exact-head GitHub CI and review are running

## Release

This is test-only. It changes no production behavior, signed content, Quran, tryout, dependency, Convex deployment, or Vercel configuration. No Vercel Preview is created.