### PR TITLE
fix(migration): remove unused provisional scale graph

### DIFF
--- a/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
@@ -1,0 +1,174 @@
+import type { CleanupRepair } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
+
+interface RepairRun {
+  readonly questionCount: number;
+  readonly sectionIdentity: string;
+}
+
+export interface ScaleRepairEvidence {
+  readonly itemCount: number;
+  readonly migrationId: string;
+  readonly planHash: string;
+  readonly publishedAt: number;
+  readonly questionCount: number;
+  readonly runs: readonly RepairRun[];
+  readonly scaleVersionId: string;
+  readonly setIdentity: string;
+  readonly sourceSnapshotId: string;
+}
+
+const identity = (...parts: readonly string[]) => parts.join("\0");
+
+/** Exact production graph omitted by the signed attempt-derived inventory. */
+export const retainedScaleRepair = {
+  itemCount: 150,
+  migrationId: "retained-tryout-history",
+  planHash:
+    "sha256:9ac40883fe6c7856a4f69e492513229d4dc4596df12d78bfc7a7c9fe182c81f9",
+  publishedAt: 1_783_529_292_775,
+  questionCount: 150,
+  runs: [
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "reading-and-writing-skills"
+      ),
+    },
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "general-knowledge"
+      ),
+    },
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "english-language"
+      ),
+    },
+    {
+      questionCount: 30,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "indonesian-language"
+      ),
+    },
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "general-reasoning"
+      ),
+    },
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "mathematical-reasoning"
+      ),
+    },
+    {
+      questionCount: 20,
+      sectionIdentity: identity(
+        "en",
+        "section",
+        "indonesia",
+        "snbt",
+        "2027",
+        "set-2",
+        "quantitative-knowledge"
+      ),
+    },
+  ],
+  scaleVersionId: "wh77kyh90xdyy9bxkve0h7w4d98a5ghm",
+  setIdentity: identity("en", "set", "indonesia", "snbt", "2027", "set-2", ""),
+  sourceSnapshotId:
+    "sha256:0a43a4125fc4886f90b5a509405178bfb8762ad3c7f72be80614fce2671b5162",
+} satisfies ScaleRepairEvidence;
+
+/** Checks bounded cardinalities before they reach indexed query limits. */
+export function hasValidScaleRepairEvidence(evidence: ScaleRepairEvidence) {
+  const questionCount = evidence.runs.reduce(
+    (count, run) => count + run.questionCount,
+    0
+  );
+  return (
+    Number.isSafeInteger(evidence.itemCount) &&
+    evidence.itemCount > 0 &&
+    evidence.itemCount === evidence.questionCount &&
+    Number.isSafeInteger(evidence.publishedAt) &&
+    evidence.publishedAt > 0 &&
+    Number.isSafeInteger(evidence.questionCount) &&
+    evidence.questionCount > 0 &&
+    evidence.runs.length > 0 &&
+    new Set(evidence.runs.map(({ sectionIdentity }) => sectionIdentity))
+      .size === evidence.runs.length &&
+    evidence.runs.every(
+      ({ questionCount: count, sectionIdentity }) =>
+        Number.isSafeInteger(count) && count > 0 && sectionIdentity.length > 0
+    ) &&
+    Number.isSafeInteger(questionCount) &&
+    questionCount === evidence.questionCount
+  );
+}
+
+/** Verifies the persisted repair still binds the exact source evidence. */
+export function matchesScaleRepair(
+  repair: CleanupRepair,
+  evidence: ScaleRepairEvidence,
+  deletedRows: number
+) {
+  return (
+    repair.deletedRows === deletedRows &&
+    repair.itemCount === evidence.itemCount &&
+    repair.migrationId === evidence.migrationId &&
+    repair.planHash === evidence.planHash &&
+    repair.publishedAt === evidence.publishedAt &&
+    repair.questionCount === evidence.questionCount &&
+    Number.isSafeInteger(repair.repairedAt) &&
+    repair.repairedAt > 0 &&
+    repair.runCount === evidence.runs.length &&
+    repair.runs.length === evidence.runs.length &&
+    repair.runs.every(
+      (run, index) =>
+        run.questionCount === evidence.runs[index]?.questionCount &&
+        run.sectionIdentity === evidence.runs[index]?.sectionIdentity
+    ) &&
+    repair.scaleVersionId === evidence.scaleVersionId &&
+    repair.setIdentity === evidence.setIdentity &&
+    repair.sourceSnapshotId === evidence.sourceSnapshotId
+  );
+}

--- a/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
@@ -119,6 +119,11 @@ export const retainedScaleRepair = {
     "sha256:0a43a4125fc4886f90b5a509405178bfb8762ad3c7f72be80614fce2671b5162",
 } satisfies ScaleRepairEvidence;
 
+/** Counts the exact graph rows bound by one repair evidence record. */
+export function countScaleRepairRows(evidence: ScaleRepairEvidence) {
+  return evidence.itemCount + evidence.runs.length + 1;
+}
+
 /** Checks bounded cardinalities before they reach indexed query limits. */
 export function hasValidScaleRepairEvidence(evidence: ScaleRepairEvidence) {
   const questionCount = evidence.runs.reduce(
@@ -170,5 +175,19 @@ export function matchesScaleRepair(
     repair.scaleVersionId === evidence.scaleVersionId &&
     repair.setIdentity === evidence.setIdentity &&
     repair.sourceSnapshotId === evidence.sourceSnapshotId
+  );
+}
+
+/** Requires the exact durable audit for the one migration that owns a repair. */
+export function hasRequiredScaleRepair(
+  migrationId: string,
+  repair: CleanupRepair | null | undefined,
+  evidence: ScaleRepairEvidence = retainedScaleRepair
+) {
+  return (
+    migrationId !== evidence.migrationId ||
+    (repair !== null &&
+      repair !== undefined &&
+      matchesScaleRepair(repair, evidence, countScaleRepairRows(evidence)))
   );
 }

--- a/packages/backend/convex/tryouts/migration/cleanup/guard.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/guard.ts
@@ -147,12 +147,22 @@ export const requireCleanupPreconditions = Effect.fn(
       "A retained IRT scale is still referenced by a try-out attempt or score."
     );
   }
-  if (
-    yield* isSnapshotReferenced(ctx, "tryout", migration.sourceSnapshotId, {
+});
+
+/** Proves no live reader retains the source snapshot after bounded repair. */
+export const requireCleanupRetention = Effect.fn(
+  "tryouts.migration.requireCleanupRetention"
+)(function* (ctx: MutationCtx, migration: CleanupMigration) {
+  const referenced = yield* isSnapshotReferenced(
+    ctx,
+    "tryout",
+    migration.sourceSnapshotId,
+    {
       ignoredMigrationId: migration.migrationId,
       ignoredScaleVersionIds: migration.authorization.sourceScaleVersionIds,
-    })
-  ) {
+    }
+  );
+  if (referenced) {
     return yield* releaseFail(
       "CONTENT_RELEASE_STATE",
       "The retained try-out snapshot is still protected from cleanup."

--- a/packages/backend/convex/tryouts/migration/cleanup/guard.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/guard.ts
@@ -2,10 +2,16 @@ import { computeTryoutHistoryCleanupLimit } from "@nakafa/aksara-contracts/migra
 import { hashTryoutHistoryMigrationPlan } from "@nakafa/aksara-contracts/migration/tryout/history/hash";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
-import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  type ReleaseError,
+  releaseFail,
+} from "@repo/backend/convex/contentRelease/error";
 import { contractFailure } from "@repo/backend/convex/contentRelease/proof/failure";
 import { isSnapshotReferenced } from "@repo/backend/convex/contentRelease/snapshot/retention";
-import type { CleanupProof } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
+import type {
+  CleanupProof,
+  CleanupState,
+} from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { decodeMigrationPlan } from "@repo/backend/convex/tryouts/migration/plan";
 import { Effect } from "effect";
 
@@ -39,6 +45,49 @@ export function hasSameCleanupProof(left: CleanupProof, right: CleanupProof) {
     left.assetHash === right.assetHash && left.sourceSha === right.sourceSha
   );
 }
+
+type CleanupStart =
+  | {
+      readonly kind: "initial";
+      readonly migration: Extract<
+        CleanupMigration,
+        { readonly phase: "completed" }
+      >;
+    }
+  | { readonly kind: "resume"; readonly state: CleanupState };
+
+/** Restores bounded cleanup state only under its immutable durable proof. */
+export const requireCleanupStart = Effect.fn(
+  "tryouts.migration.requireCleanupStart"
+)(function* (
+  migration: CleanupMigration,
+  receipt: Doc<"tryoutHistoryMigrationReceipts">,
+  proof: CleanupProof
+): Effect.fn.Return<CleanupStart, ReleaseError> {
+  if (migration.phase === "completed") {
+    const repairProofMatches =
+      receipt.proof !== undefined && hasSameCleanupProof(receipt.proof, proof);
+    if (
+      receipt.deletedRows !== 0 ||
+      (receipt.repair === undefined
+        ? receipt.proof !== undefined
+        : !repairProofMatches)
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Unstarted try-out history cleanup has invalid durable progress."
+      );
+    }
+    return { kind: "initial", migration };
+  }
+  if (!(receipt.proof && hasSameCleanupProof(receipt.proof, proof))) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Try-out history cleanup proof changed after deletion started."
+    );
+  }
+  return { kind: "resume", state: migration.cleanup };
+});
 
 /** Recomputes the signed payload identity retained during bounded cleanup. */
 export const requireCleanupPlan = Effect.fn(

--- a/packages/backend/convex/tryouts/migration/cleanup/marker.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/marker.ts
@@ -1,0 +1,43 @@
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  retainedScaleRepair,
+  type ScaleRepairEvidence,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import { Effect } from "effect";
+
+/** Observes the independent exact scale whose absence proves repair ran. */
+export const retainedRepairScalePresent = Effect.fn(
+  "tryouts.migration.retainedRepairScalePresent"
+)(function* (
+  ctx: QueryCtx,
+  migrationId: string,
+  evidence: ScaleRepairEvidence = retainedScaleRepair
+) {
+  if (migrationId !== evidence.migrationId) {
+    return false;
+  }
+  const scales = yield* Effect.promise(() =>
+    ctx.db
+      .query("irtScaleVersions")
+      .withIndex(
+        "by_tryoutSnapshotId_and_setIdentity_and_publishedAt",
+        (query) =>
+          query
+            .eq("tryoutSnapshotId", evidence.sourceSnapshotId)
+            .eq("setIdentity", evidence.setIdentity)
+            .eq("publishedAt", evidence.publishedAt)
+      )
+      .take(2)
+  );
+  if (
+    scales.length > 1 ||
+    (scales[0] !== undefined && scales[0]._id !== evidence.scaleVersionId)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Try-out history migration changed its retained repair scale identity."
+    );
+  }
+  return scales.length === 1;
+});

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -1,0 +1,89 @@
+import {
+  tryoutCatalogIdentity,
+  tryoutPlacementIdentity,
+} from "@nakafa/aksara-contracts/tryout/identity";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { readTryoutSectionRows } from "@repo/backend/convex/contentRelease/tryout/section";
+import { Effect } from "effect";
+
+interface RepairRun {
+  readonly questionCount: number;
+  readonly sectionIdentity: string;
+}
+
+interface SignedPlacement {
+  readonly rowHash: string;
+  readonly sectionIdentity: string;
+}
+
+/** Authenticates every signed source placement selected by the repair runs. */
+export const loadRepairPlacements = Effect.fn(
+  "tryouts.migration.loadRepairPlacements"
+)(function* (ctx: MutationCtx, snapshotId: string, runs: readonly RepairRun[]) {
+  const placements = new Map<string, SignedPlacement>();
+  for (const run of runs) {
+    const storedSection = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutCatalog")
+        .withIndex("by_snapshotId_and_identity", (query) =>
+          query.eq("snapshotId", snapshotId).eq("identity", run.sectionIdentity)
+        )
+        .unique()
+    );
+    if (!storedSection) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history scale repair lost a signed source section."
+      );
+    }
+    const source = yield* readTryoutSectionRows(ctx, snapshotId, storedSection);
+    if (
+      tryoutCatalogIdentity(source.section.row) !== run.sectionIdentity ||
+      source.placements.length !== run.questionCount
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history scale repair changed signed section ownership."
+      );
+    }
+    for (const placement of source.placements) {
+      const identity = tryoutPlacementIdentity(placement.row);
+      if (placements.has(identity)) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_INTEGRITY",
+          "Try-out history scale repair found duplicate signed placements."
+        );
+      }
+      placements.set(identity, {
+        rowHash: placement.rowHash,
+        sectionIdentity: run.sectionIdentity,
+      });
+    }
+  }
+  return placements;
+});
+
+/** Binds each provisional item to its exact signed row and section run. */
+export function matchesRepairPlacements(
+  placements: ReadonlyMap<string, SignedPlacement>,
+  items: readonly Doc<"irtScaleItems">[],
+  runs: readonly Doc<"irtCalibrationRuns">[]
+) {
+  const sectionByRun = new Map(
+    runs.map((run) => [run._id, run.sectionIdentity])
+  );
+  return (
+    placements.size === items.length &&
+    new Set(items.map(({ placementIdentity }) => placementIdentity)).size ===
+      items.length &&
+    items.every((item) => {
+      const placement = placements.get(item.placementIdentity);
+      return (
+        placement?.rowHash === item.placementRowHash &&
+        placement.sectionIdentity === sectionByRun.get(item.calibrationRunId)
+      );
+    })
+  );
+}

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -1,15 +1,16 @@
 import { assert, describe, expect, it } from "@effect/vitest";
-import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import type schema from "@repo/backend/convex/schema";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import {
-  retainedScaleRepair,
+  countScaleRepairRows,
   type ScaleRepairEvidence,
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
-import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
+import {
+  seedRepair,
+  seedUnusedScale,
+} from "@repo/backend/test/migration/repair";
 import {
   CLEANUP_MIGRATION_ID,
   CLEANUP_PROOF,
@@ -20,74 +21,6 @@ import type { TestConvex } from "convex-test";
 import { Effect } from "effect";
 
 type CleanupTest = TestConvex<typeof schema>;
-
-/** Seeds the exact zero-use provisional graph omitted by attempt inventory. */
-async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
-  const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
-    model: "2pl",
-    publishedAt: retainedScaleRepair.publishedAt,
-    questionCount: retainedScaleRepair.questionCount,
-    setIdentity: retainedScaleRepair.setIdentity,
-    status: "provisional",
-    tryoutSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
-  });
-  const itemIds: Id<"irtScaleItems">[] = [];
-  const runIds: Id<"irtCalibrationRuns">[] = [];
-  for (const { questionCount, sectionIdentity } of retainedScaleRepair.runs) {
-    const runId = await ctx.db.insert("irtCalibrationRuns", {
-      attemptCount: 0,
-      completedAt: retainedScaleRepair.publishedAt,
-      iterationCount: 0,
-      maxParameterDelta: 0,
-      model: "2pl",
-      questionCount,
-      responseCount,
-      scaleVersionId,
-      sectionIdentity,
-      startedAt: retainedScaleRepair.publishedAt,
-      status: "completed",
-      updatedAt: retainedScaleRepair.publishedAt,
-    });
-    runIds.push(runId);
-    for (let question = 0; question < questionCount; question += 1) {
-      itemIds.push(
-        await ctx.db.insert("irtScaleItems", {
-          calibrationRunId: runId,
-          calibrationStatus: "provisional",
-          correctRate: 0,
-          difficulty: 0,
-          discrimination: 1,
-          placementIdentity: `${sectionIdentity}:${question}`,
-          placementRowHash: `row:${sectionIdentity}:${question}`,
-          responseCount: 0,
-          scaleVersionId,
-        })
-      );
-    }
-  }
-  return { itemIds, runIds, scaleVersionId };
-}
-
-/** Seeds signed cleanup plus its exact repair evidence. */
-async function seedRepair(t: CleanupTest, responseCount = 0) {
-  const cleanup = await seedCleanupSuccess(t);
-  const repair = await t.mutation(async (ctx) => {
-    const migration = await ctx.db.query("tryoutHistoryMigrations").unique();
-    assert.ok(migration?.phase === "completed");
-    const graph = await seedUnusedScale(ctx, responseCount);
-    return {
-      ...graph,
-      evidence: {
-        ...retainedScaleRepair,
-        migrationId: migration.migrationId,
-        planHash: migration.authorization.planHash,
-        scaleVersionId: graph.scaleVersionId,
-        sourceSnapshotId: migration.sourceSnapshotId,
-      } satisfies ScaleRepairEvidence,
-    };
-  });
-  return { cleanup, repair };
-}
 
 function runCleanup(t: CleanupTest, evidence: ScaleRepairEvidence) {
   return t.mutation((ctx) =>
@@ -137,14 +70,19 @@ describe("tryouts/migration/cleanup/repair", () => {
       const { repair } = yield* Effect.promise(() => seedRepair(t));
       const first = yield* Effect.promise(() => runCleanup(t, repair.evidence));
       const repaired = yield* Effect.promise(() => readRepair(t, repair));
-      assert.deepStrictEqual(first, { deleted: 0, done: false, repaired: 158 });
+      const repairedRows = countScaleRepairRows(repair.evidence);
+      assert.deepStrictEqual(first, {
+        deleted: 0,
+        done: false,
+        repaired: repairedRows,
+      });
       assert.strictEqual(repaired.scale, null);
       assert.ok(repaired.items.every((item) => item === null));
       assert.ok(repaired.runs.every((run) => run === null));
       assert.strictEqual(repaired.migration?.phase, "completed");
       assert.strictEqual(repaired.receipt?.deletedRows, 0);
       assert.deepStrictEqual(repaired.receipt?.proof, CLEANUP_PROOF);
-      assert.strictEqual(repaired.receipt?.repair?.deletedRows, 158);
+      assert.strictEqual(repaired.receipt?.repair?.deletedRows, repairedRows);
       assert.strictEqual(
         repaired.receipt?.repair?.scaleVersionId,
         repair.scaleVersionId
@@ -154,7 +92,7 @@ describe("tryouts/migration/cleanup/repair", () => {
       const finished = yield* Effect.promise(() => readRepair(t, repair));
       assert.strictEqual(finished.receipt?.phase, "cleaned");
       assert.strictEqual(finished.receipt?.deletedRows, 82);
-      assert.strictEqual(finished.receipt?.repair?.deletedRows, 158);
+      assert.strictEqual(finished.receipt?.repair?.deletedRows, repairedRows);
     })
   );
 
@@ -175,7 +113,10 @@ describe("tryouts/migration/cleanup/repair", () => {
               repair:
                 damage === "missing"
                   ? undefined
-                  : { ...receipt.repair, deletedRows: 157 },
+                  : {
+                      ...receipt.repair,
+                      deletedRows: receipt.repair.deletedRows - 1,
+                    },
             });
           })
         );
@@ -208,10 +149,59 @@ describe("tryouts/migration/cleanup/repair", () => {
     })
   );
 
+  it.effect("rejects signed placement drift before any repair write", () =>
+    Effect.gen(function* () {
+      for (const drift of ["identity", "rowHash", "section"] as const) {
+        const t = createConvexTestWithBetterAuth();
+        const { repair } = yield* Effect.promise(() =>
+          seedRepair(t, 0, ["quantitative-knowledge", "english-language"])
+        );
+        const [firstItemId, secondItemId] = repair.itemIds;
+        const [firstRunId, secondRunId] = repair.runIds;
+        assert.ok(firstItemId && secondItemId && firstRunId && secondRunId);
+        yield* Effect.promise(() =>
+          t.mutation(async (ctx) => {
+            if (drift === "identity") {
+              await ctx.db.patch(firstItemId, {
+                placementIdentity: "drifted-placement",
+              });
+              return;
+            }
+            if (drift === "rowHash") {
+              await ctx.db.patch(firstItemId, {
+                placementRowHash: "drifted-row",
+              });
+              return;
+            }
+            await ctx.db.patch(firstItemId, {
+              calibrationRunId: secondRunId,
+            });
+            await ctx.db.patch(secondItemId, {
+              calibrationRunId: firstRunId,
+            });
+          })
+        );
+
+        yield* Effect.promise(() =>
+          expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+            data: { code: "CONTENT_RELEASE_INTEGRITY" },
+          })
+        );
+        const state = yield* Effect.promise(() => readRepair(t, repair));
+        assert.ok(state.scale);
+        assert.ok(state.items.every((item) => item !== null));
+        assert.ok(state.runs.every((run) => run !== null));
+        assert.strictEqual(state.receipt?.repair, undefined);
+      }
+    })
+  );
+
   it.effect("rejects duplicate run identities before any repair write", () =>
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
-      const { repair } = yield* Effect.promise(() => seedRepair(t));
+      const { repair } = yield* Effect.promise(() =>
+        seedRepair(t, 0, ["quantitative-knowledge", "english-language"])
+      );
       const [firstRun, secondRun] = repair.runIds;
       const [firstEvidence, secondEvidence] = repair.evidence.runs;
       assert.ok(firstRun && secondRun && firstEvidence && secondEvidence);
@@ -245,10 +235,10 @@ describe("tryouts/migration/cleanup/repair", () => {
     Effect.gen(function* () {
       for (const drift of ["identity", "inventory"] as const) {
         const t = createConvexTestWithBetterAuth();
-        const { repair } = yield* Effect.promise(() => seedRepair(t));
+        const { repair, source } = yield* Effect.promise(() => seedRepair(t));
         if (drift === "inventory") {
           yield* Effect.promise(() =>
-            t.mutation((ctx) => seedUnusedScale(ctx))
+            t.mutation((ctx) => seedUnusedScale(ctx, source))
           );
         }
         const evidence =

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -4,6 +4,7 @@ import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import type schema from "@repo/backend/convex/schema";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
 import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
 import {
@@ -17,23 +18,38 @@ import { Effect } from "effect";
 
 type CleanupTest = TestConvex<typeof schema>;
 
-const QUESTION_COUNTS = [20, 20, 20, 30, 20, 20, 20] as const;
+const RUNS = [
+  { questionCount: 20, sectionIdentity: "section:reading" },
+  { questionCount: 20, sectionIdentity: "section:knowledge" },
+  { questionCount: 20, sectionIdentity: "section:english" },
+  { questionCount: 30, sectionIdentity: "section:indonesian" },
+  { questionCount: 20, sectionIdentity: "section:reasoning" },
+  { questionCount: 20, sectionIdentity: "section:mathematics" },
+  { questionCount: 20, sectionIdentity: "section:quantitative" },
+] as const;
+const SET_IDENTITY = [
+  "en",
+  "set",
+  "indonesia",
+  "snbt",
+  "2027",
+  "set-2",
+  "",
+].join("\0");
 
-/** Seeds the zero-use provisional graph that blocked production cleanup. */
+/** Seeds the exact zero-use provisional graph omitted by attempt inventory. */
 async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
   const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
     model: "2pl",
     publishedAt: 1,
     questionCount: 150,
-    setIdentity: ["en", "set", "indonesia", "snbt", "2027", "set-2", ""].join(
-      "\0"
-    ),
+    setIdentity: SET_IDENTITY,
     status: "provisional",
     tryoutSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
   });
   const itemIds: Id<"irtScaleItems">[] = [];
   const runIds: Id<"irtCalibrationRuns">[] = [];
-  for (const [index, questionCount] of QUESTION_COUNTS.entries()) {
+  for (const { questionCount, sectionIdentity } of RUNS) {
     const runId = await ctx.db.insert("irtCalibrationRuns", {
       attemptCount: 0,
       completedAt: 1,
@@ -43,7 +59,7 @@ async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
       questionCount,
       responseCount,
       scaleVersionId,
-      sectionIdentity: `section:${index}`,
+      sectionIdentity,
       startedAt: 1,
       status: "completed",
       updatedAt: 1,
@@ -57,8 +73,8 @@ async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
           correctRate: 0,
           difficulty: 0,
           discrimination: 1,
-          placementIdentity: `placement:${index}:${question}`,
-          placementRowHash: `row:${index}:${question}`,
+          placementIdentity: `${sectionIdentity}:${question}`,
+          placementRowHash: `row:${sectionIdentity}:${question}`,
           responseCount: 0,
           scaleVersionId,
         })
@@ -68,124 +84,217 @@ async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
   return { itemIds, runIds, scaleVersionId };
 }
 
-/** Runs one bounded production cleanup transaction. */
-function runCleanup(t: CleanupTest) {
+/** Seeds signed cleanup plus its exact repair evidence. */
+async function seedRepair(t: CleanupTest, responseCount = 0) {
+  const cleanup = await seedCleanupSuccess(t);
+  const repair = await t.mutation(async (ctx) => {
+    const migration = await ctx.db.query("tryoutHistoryMigrations").unique();
+    assert.ok(migration?.phase === "completed");
+    const graph = await seedUnusedScale(ctx, responseCount);
+    return {
+      ...graph,
+      evidence: {
+        itemCount: 150,
+        migrationId: migration.migrationId,
+        planHash: migration.authorization.planHash,
+        publishedAt: 1,
+        questionCount: 150,
+        runs: RUNS,
+        scaleVersionId: graph.scaleVersionId,
+        setIdentity: SET_IDENTITY,
+        sourceSnapshotId: migration.sourceSnapshotId,
+      } satisfies ScaleRepairEvidence,
+    };
+  });
+  return { cleanup, repair };
+}
+
+function runCleanup(t: CleanupTest, evidence: ScaleRepairEvidence) {
   return t.mutation((ctx) =>
     runConvexProgram(
       cleanupProgram(
         ctx,
         CLEANUP_MIGRATION_ID,
         CLEANUP_RECEIPT_HASH,
-        CLEANUP_PROOF
+        CLEANUP_PROOF,
+        evidence
       )
     )
   );
 }
 
+function readRepair(
+  t: CleanupTest,
+  graph: Awaited<ReturnType<typeof seedUnusedScale>>
+) {
+  return t.query(async (ctx) => ({
+    items: await Promise.all(graph.itemIds.map((id) => ctx.db.get(id))),
+    migration: await ctx.db
+      .query("tryoutHistoryMigrations")
+      .withIndex("by_migrationId", (query) =>
+        query.eq("migrationId", CLEANUP_MIGRATION_ID)
+      )
+      .unique(),
+    receipt: await ctx.db.query("tryoutHistoryMigrationReceipts").unique(),
+    runs: await Promise.all(graph.runIds.map((id) => ctx.db.get(id))),
+    scale: await ctx.db.get(graph.scaleVersionId),
+  }));
+}
+
 describe("tryouts/migration/cleanup/repair", () => {
-  it.effect("removes the unused provisional graph before signed cleanup", () =>
+  it.effect("audits the exact graph separately from signed cleanup", () =>
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
-      yield* Effect.promise(() => seedCleanupSuccess(t));
-      const unused = yield* Effect.promise(() =>
-        t.mutation((ctx) => seedUnusedScale(ctx))
+      const { repair } = yield* Effect.promise(() => seedRepair(t));
+      const first = yield* Effect.promise(() => runCleanup(t, repair.evidence));
+      const repaired = yield* Effect.promise(() => readRepair(t, repair));
+
+      assert.deepStrictEqual(first, { deleted: 0, done: false, repaired: 158 });
+      assert.strictEqual(repaired.scale, null);
+      assert.ok(repaired.items.every((item) => item === null));
+      assert.ok(repaired.runs.every((run) => run === null));
+      assert.strictEqual(repaired.migration?.phase, "completed");
+      assert.strictEqual(repaired.receipt?.deletedRows, 0);
+      assert.strictEqual(repaired.receipt?.repair?.deletedRows, 158);
+      assert.strictEqual(
+        repaired.receipt?.repair?.scaleVersionId,
+        repair.scaleVersionId
       );
+      assert.ok((repaired.receipt?.repair?.repairedAt ?? 0) > 0);
+
       let done = false;
       for (let page = 0; page < 32; page += 1) {
-        const result = yield* Effect.promise(() => runCleanup(t));
+        const result = yield* Effect.promise(() =>
+          runCleanup(t, repair.evidence)
+        );
         if (result.done) {
           done = true;
           break;
         }
       }
-      const state = yield* Effect.promise(() =>
-        t.query(async (ctx) => ({
-          receipt: await ctx.db
-            .query("tryoutHistoryMigrationReceipts")
-            .unique(),
-          items: await Promise.all(unused.itemIds.map((id) => ctx.db.get(id))),
-          runs: await Promise.all(unused.runIds.map((id) => ctx.db.get(id))),
-          scale: await ctx.db.get(unused.scaleVersionId),
-        }))
-      );
+      const finished = yield* Effect.promise(() => readRepair(t, repair));
 
       assert.strictEqual(done, true);
-      assert.strictEqual(state.scale, null);
-      assert.ok(state.items.every((item) => item === null));
-      assert.ok(state.runs.every((run) => run === null));
-      assert.strictEqual(state.receipt?.phase, "cleaned");
-      assert.strictEqual(state.receipt?.deletedRows, 82);
+      assert.strictEqual(finished.receipt?.phase, "cleaned");
+      assert.strictEqual(finished.receipt?.deletedRows, 82);
+      assert.strictEqual(finished.receipt?.repair?.deletedRows, 158);
     })
   );
 
-  it.effect("rolls back when the provisional graph has runtime evidence", () =>
+  it.effect("rejects graph drift before any repair write", () =>
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
-      yield* Effect.promise(() => seedCleanupSuccess(t));
-      const unused = yield* Effect.promise(() =>
-        t.mutation((ctx) => seedUnusedScale(ctx, 1))
-      );
+      const { repair } = yield* Effect.promise(() => seedRepair(t, 1));
+
       yield* Effect.promise(() =>
-        expect(runCleanup(t)).rejects.toMatchObject({
-          data: {
-            code: "CONTENT_RELEASE_INTEGRITY",
-            message:
-              "Retained cleanup cannot prove the unused provisional scale graph.",
-          },
+        expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
         })
       );
-      const state = yield* Effect.promise(() =>
-        t.query(async (ctx) => ({
-          migration: await ctx.db.query("tryoutHistoryMigrations").unique(),
-          receipt: await ctx.db
-            .query("tryoutHistoryMigrationReceipts")
-            .unique(),
-          items: await Promise.all(unused.itemIds.map((id) => ctx.db.get(id))),
-          runs: await Promise.all(unused.runIds.map((id) => ctx.db.get(id))),
-          scale: await ctx.db.get(unused.scaleVersionId),
-        }))
-      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
 
       assert.ok(state.scale);
       assert.ok(state.items.every((item) => item !== null));
       assert.ok(state.runs.every((run) => run !== null));
-      assert.strictEqual(state.migration?.phase, "completed");
+      assert.strictEqual(state.receipt?.repair, undefined);
       assert.strictEqual(state.receipt?.deletedRows, 0);
     })
   );
 
-  it.effect("rejects an ambiguous provisional inventory without writes", () =>
+  it.effect("rejects identity or inventory drift before writes", () =>
+    Effect.gen(function* () {
+      for (const drift of ["identity", "inventory"] as const) {
+        const t = createConvexTestWithBetterAuth();
+        const { repair } = yield* Effect.promise(() => seedRepair(t));
+        if (drift === "inventory") {
+          yield* Effect.promise(() =>
+            t.mutation((ctx) => seedUnusedScale(ctx))
+          );
+        }
+        const evidence =
+          drift === "identity"
+            ? { ...repair.evidence, publishedAt: 2 }
+            : repair.evidence;
+
+        yield* Effect.promise(() =>
+          expect(runCleanup(t, evidence)).rejects.toMatchObject({
+            data: { code: "CONTENT_RELEASE_INTEGRITY" },
+          })
+        );
+        const state = yield* Effect.promise(() => readRepair(t, repair));
+
+        assert.ok(state.scale);
+        assert.strictEqual(state.receipt?.repair, undefined);
+        assert.strictEqual(state.receipt?.deletedRows, 0);
+      }
+    })
+  );
+
+  it.effect("rejects a reverse item reference before writes", () =>
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
-      yield* Effect.promise(() => seedCleanupSuccess(t));
-      const unused = yield* Effect.promise(() =>
-        t.mutation(async (ctx) => [
-          await seedUnusedScale(ctx),
-          await seedUnusedScale(ctx),
-        ])
-      );
+      const { cleanup, repair } = yield* Effect.promise(() => seedRepair(t));
+      const [repairRunId] = repair.runIds;
+      assert.ok(repairRunId);
       yield* Effect.promise(() =>
-        expect(runCleanup(t)).rejects.toMatchObject({
-          data: {
-            code: "CONTENT_RELEASE_INTEGRITY",
-            message:
-              "Retained cleanup found an unexpected provisional scale inventory.",
-          },
-        })
-      );
-      const state = yield* Effect.promise(() =>
-        t.query(async (ctx) => ({
-          receipt: await ctx.db
-            .query("tryoutHistoryMigrationReceipts")
-            .unique(),
-          scales: await Promise.all(
-            unused.map(({ scaleVersionId }) => ctx.db.get(scaleVersionId))
-          ),
-        }))
+        t.mutation((ctx) =>
+          ctx.db.insert("irtScaleItems", {
+            calibrationRunId: repairRunId,
+            calibrationStatus: "provisional",
+            correctRate: 0,
+            difficulty: 0,
+            discrimination: 1,
+            placementIdentity: "foreign-placement",
+            placementRowHash: "foreign-row",
+            responseCount: 0,
+            scaleVersionId: cleanup.sourceScale.scaleVersionId,
+          })
+        )
       );
 
-      assert.ok(state.scales.every((scale) => scale !== null));
-      assert.strictEqual(state.receipt?.deletedRows, 0);
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+
+      assert.ok(state.scale);
+      assert.strictEqual(state.receipt?.repair, undefined);
+    })
+  );
+
+  it.effect("rejects external retention before repair writes", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const { repair } = yield* Effect.promise(() => seedRepair(t));
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("tryoutHistoryMigrations", {
+            artifactMapCount: 0,
+            catalogMapCount: 0,
+            createdAt: 1,
+            migrationId: "external-retention",
+            phase: "staging",
+            placementMapCount: 0,
+            sourceSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
+            target: { kind: "pending" },
+            updatedAt: 1,
+          })
+        )
+      );
+
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_STATE" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+
+      assert.ok(state.scale);
+      assert.ok(state.items.every((item) => item !== null));
+      assert.ok(state.runs.every((run) => run !== null));
+      assert.strictEqual(state.receipt?.repair, undefined);
     })
   );
 });

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -4,7 +4,10 @@ import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import type schema from "@repo/backend/convex/schema";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import {
+  retainedScaleRepair,
+  type ScaleRepairEvidence,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
 import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
 import {
@@ -18,41 +21,22 @@ import { Effect } from "effect";
 
 type CleanupTest = TestConvex<typeof schema>;
 
-const RUNS = [
-  { questionCount: 20, sectionIdentity: "section:reading" },
-  { questionCount: 20, sectionIdentity: "section:knowledge" },
-  { questionCount: 20, sectionIdentity: "section:english" },
-  { questionCount: 30, sectionIdentity: "section:indonesian" },
-  { questionCount: 20, sectionIdentity: "section:reasoning" },
-  { questionCount: 20, sectionIdentity: "section:mathematics" },
-  { questionCount: 20, sectionIdentity: "section:quantitative" },
-] as const;
-const SET_IDENTITY = [
-  "en",
-  "set",
-  "indonesia",
-  "snbt",
-  "2027",
-  "set-2",
-  "",
-].join("\0");
-
 /** Seeds the exact zero-use provisional graph omitted by attempt inventory. */
 async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
   const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
     model: "2pl",
-    publishedAt: 1,
-    questionCount: 150,
-    setIdentity: SET_IDENTITY,
+    publishedAt: retainedScaleRepair.publishedAt,
+    questionCount: retainedScaleRepair.questionCount,
+    setIdentity: retainedScaleRepair.setIdentity,
     status: "provisional",
     tryoutSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
   });
   const itemIds: Id<"irtScaleItems">[] = [];
   const runIds: Id<"irtCalibrationRuns">[] = [];
-  for (const { questionCount, sectionIdentity } of RUNS) {
+  for (const { questionCount, sectionIdentity } of retainedScaleRepair.runs) {
     const runId = await ctx.db.insert("irtCalibrationRuns", {
       attemptCount: 0,
-      completedAt: 1,
+      completedAt: retainedScaleRepair.publishedAt,
       iterationCount: 0,
       maxParameterDelta: 0,
       model: "2pl",
@@ -60,9 +44,9 @@ async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
       responseCount,
       scaleVersionId,
       sectionIdentity,
-      startedAt: 1,
+      startedAt: retainedScaleRepair.publishedAt,
       status: "completed",
-      updatedAt: 1,
+      updatedAt: retainedScaleRepair.publishedAt,
     });
     runIds.push(runId);
     for (let question = 0; question < questionCount; question += 1) {
@@ -94,14 +78,10 @@ async function seedRepair(t: CleanupTest, responseCount = 0) {
     return {
       ...graph,
       evidence: {
-        itemCount: 150,
+        ...retainedScaleRepair,
         migrationId: migration.migrationId,
         planHash: migration.authorization.planHash,
-        publishedAt: 1,
-        questionCount: 150,
-        runs: RUNS,
         scaleVersionId: graph.scaleVersionId,
-        setIdentity: SET_IDENTITY,
         sourceSnapshotId: migration.sourceSnapshotId,
       } satisfies ScaleRepairEvidence,
     };
@@ -148,20 +128,19 @@ describe("tryouts/migration/cleanup/repair", () => {
       const { repair } = yield* Effect.promise(() => seedRepair(t));
       const first = yield* Effect.promise(() => runCleanup(t, repair.evidence));
       const repaired = yield* Effect.promise(() => readRepair(t, repair));
-
       assert.deepStrictEqual(first, { deleted: 0, done: false, repaired: 158 });
       assert.strictEqual(repaired.scale, null);
       assert.ok(repaired.items.every((item) => item === null));
       assert.ok(repaired.runs.every((run) => run === null));
       assert.strictEqual(repaired.migration?.phase, "completed");
       assert.strictEqual(repaired.receipt?.deletedRows, 0);
+      assert.deepStrictEqual(repaired.receipt?.proof, CLEANUP_PROOF);
       assert.strictEqual(repaired.receipt?.repair?.deletedRows, 158);
       assert.strictEqual(
         repaired.receipt?.repair?.scaleVersionId,
         repair.scaleVersionId
       );
       assert.ok((repaired.receipt?.repair?.repairedAt ?? 0) > 0);
-
       let done = false;
       for (let page = 0; page < 32; page += 1) {
         const result = yield* Effect.promise(() =>
@@ -173,7 +152,6 @@ describe("tryouts/migration/cleanup/repair", () => {
         }
       }
       const finished = yield* Effect.promise(() => readRepair(t, repair));
-
       assert.strictEqual(done, true);
       assert.strictEqual(finished.receipt?.phase, "cleaned");
       assert.strictEqual(finished.receipt?.deletedRows, 82);
@@ -185,7 +163,6 @@ describe("tryouts/migration/cleanup/repair", () => {
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
       const { repair } = yield* Effect.promise(() => seedRepair(t, 1));
-
       yield* Effect.promise(() =>
         expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
           data: { code: "CONTENT_RELEASE_INTEGRITY" },
@@ -294,6 +271,29 @@ describe("tryouts/migration/cleanup/repair", () => {
       assert.ok(state.scale);
       assert.ok(state.items.every((item) => item !== null));
       assert.ok(state.runs.every((run) => run !== null));
+      assert.strictEqual(state.receipt?.repair, undefined);
+    })
+  );
+
+  it.effect("rejects terminal target drift before repair writes", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const { cleanup, repair } = yield* Effect.promise(() => seedRepair(t));
+      yield* Effect.promise(() =>
+        t.mutation((ctx) => ctx.db.delete(cleanup.target.bundleId))
+      );
+
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+
+      assert.ok(state.scale);
+      assert.ok(state.items.every((item) => item !== null));
+      assert.ok(state.runs.every((run) => run !== null));
+      assert.strictEqual(state.receipt?.proof, undefined);
       assert.strictEqual(state.receipt?.repair, undefined);
     })
   );

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -1,0 +1,191 @@
+import { assert, describe, expect, it } from "@effect/vitest";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import type schema from "@repo/backend/convex/schema";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
+import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
+import {
+  CLEANUP_MIGRATION_ID,
+  CLEANUP_PROOF,
+  CLEANUP_RECEIPT_HASH,
+  CLEANUP_SOURCE_SNAPSHOT,
+} from "@repo/backend/test/migration/state";
+import type { TestConvex } from "convex-test";
+import { Effect } from "effect";
+
+type CleanupTest = TestConvex<typeof schema>;
+
+const QUESTION_COUNTS = [20, 20, 20, 30, 20, 20, 20] as const;
+
+/** Seeds the zero-use provisional graph that blocked production cleanup. */
+async function seedUnusedScale(ctx: MutationCtx, responseCount = 0) {
+  const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
+    model: "2pl",
+    publishedAt: 1,
+    questionCount: 150,
+    setIdentity: ["en", "set", "indonesia", "snbt", "2027", "set-2", ""].join(
+      "\0"
+    ),
+    status: "provisional",
+    tryoutSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
+  });
+  const itemIds: Id<"irtScaleItems">[] = [];
+  const runIds: Id<"irtCalibrationRuns">[] = [];
+  for (const [index, questionCount] of QUESTION_COUNTS.entries()) {
+    const runId = await ctx.db.insert("irtCalibrationRuns", {
+      attemptCount: 0,
+      completedAt: 1,
+      iterationCount: 0,
+      maxParameterDelta: 0,
+      model: "2pl",
+      questionCount,
+      responseCount,
+      scaleVersionId,
+      sectionIdentity: `section:${index}`,
+      startedAt: 1,
+      status: "completed",
+      updatedAt: 1,
+    });
+    runIds.push(runId);
+    for (let question = 0; question < questionCount; question += 1) {
+      itemIds.push(
+        await ctx.db.insert("irtScaleItems", {
+          calibrationRunId: runId,
+          calibrationStatus: "provisional",
+          correctRate: 0,
+          difficulty: 0,
+          discrimination: 1,
+          placementIdentity: `placement:${index}:${question}`,
+          placementRowHash: `row:${index}:${question}`,
+          responseCount: 0,
+          scaleVersionId,
+        })
+      );
+    }
+  }
+  return { itemIds, runIds, scaleVersionId };
+}
+
+/** Runs one bounded production cleanup transaction. */
+function runCleanup(t: CleanupTest) {
+  return t.mutation((ctx) =>
+    runConvexProgram(
+      cleanupProgram(
+        ctx,
+        CLEANUP_MIGRATION_ID,
+        CLEANUP_RECEIPT_HASH,
+        CLEANUP_PROOF
+      )
+    )
+  );
+}
+
+describe("tryouts/migration/cleanup/repair", () => {
+  it.effect("removes the unused provisional graph before signed cleanup", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      yield* Effect.promise(() => seedCleanupSuccess(t));
+      const unused = yield* Effect.promise(() =>
+        t.mutation((ctx) => seedUnusedScale(ctx))
+      );
+      let done = false;
+      for (let page = 0; page < 32; page += 1) {
+        const result = yield* Effect.promise(() => runCleanup(t));
+        if (result.done) {
+          done = true;
+          break;
+        }
+      }
+      const state = yield* Effect.promise(() =>
+        t.query(async (ctx) => ({
+          receipt: await ctx.db
+            .query("tryoutHistoryMigrationReceipts")
+            .unique(),
+          items: await Promise.all(unused.itemIds.map((id) => ctx.db.get(id))),
+          runs: await Promise.all(unused.runIds.map((id) => ctx.db.get(id))),
+          scale: await ctx.db.get(unused.scaleVersionId),
+        }))
+      );
+
+      assert.strictEqual(done, true);
+      assert.strictEqual(state.scale, null);
+      assert.ok(state.items.every((item) => item === null));
+      assert.ok(state.runs.every((run) => run === null));
+      assert.strictEqual(state.receipt?.phase, "cleaned");
+      assert.strictEqual(state.receipt?.deletedRows, 82);
+    })
+  );
+
+  it.effect("rolls back when the provisional graph has runtime evidence", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      yield* Effect.promise(() => seedCleanupSuccess(t));
+      const unused = yield* Effect.promise(() =>
+        t.mutation((ctx) => seedUnusedScale(ctx, 1))
+      );
+      yield* Effect.promise(() =>
+        expect(runCleanup(t)).rejects.toMatchObject({
+          data: {
+            code: "CONTENT_RELEASE_INTEGRITY",
+            message:
+              "Retained cleanup cannot prove the unused provisional scale graph.",
+          },
+        })
+      );
+      const state = yield* Effect.promise(() =>
+        t.query(async (ctx) => ({
+          migration: await ctx.db.query("tryoutHistoryMigrations").unique(),
+          receipt: await ctx.db
+            .query("tryoutHistoryMigrationReceipts")
+            .unique(),
+          items: await Promise.all(unused.itemIds.map((id) => ctx.db.get(id))),
+          runs: await Promise.all(unused.runIds.map((id) => ctx.db.get(id))),
+          scale: await ctx.db.get(unused.scaleVersionId),
+        }))
+      );
+
+      assert.ok(state.scale);
+      assert.ok(state.items.every((item) => item !== null));
+      assert.ok(state.runs.every((run) => run !== null));
+      assert.strictEqual(state.migration?.phase, "completed");
+      assert.strictEqual(state.receipt?.deletedRows, 0);
+    })
+  );
+
+  it.effect("rejects an ambiguous provisional inventory without writes", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      yield* Effect.promise(() => seedCleanupSuccess(t));
+      const unused = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => [
+          await seedUnusedScale(ctx),
+          await seedUnusedScale(ctx),
+        ])
+      );
+      yield* Effect.promise(() =>
+        expect(runCleanup(t)).rejects.toMatchObject({
+          data: {
+            code: "CONTENT_RELEASE_INTEGRITY",
+            message:
+              "Retained cleanup found an unexpected provisional scale inventory.",
+          },
+        })
+      );
+      const state = yield* Effect.promise(() =>
+        t.query(async (ctx) => ({
+          receipt: await ctx.db
+            .query("tryoutHistoryMigrationReceipts")
+            .unique(),
+          scales: await Promise.all(
+            unused.map(({ scaleVersionId }) => ctx.db.get(scaleVersionId))
+          ),
+        }))
+      );
+
+      assert.ok(state.scales.every((scale) => scale !== null));
+      assert.strictEqual(state.receipt?.deletedRows, 0);
+    })
+  );
+});

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -121,6 +121,15 @@ function readRepair(
   }));
 }
 
+async function finishCleanup(t: CleanupTest, evidence: ScaleRepairEvidence) {
+  for (let page = 0; page < 32; page += 1) {
+    if ((await runCleanup(t, evidence)).done) {
+      return;
+    }
+  }
+  assert.fail("Expected bounded cleanup to finish.");
+}
+
 describe("tryouts/migration/cleanup/repair", () => {
   it.effect("audits the exact graph separately from signed cleanup", () =>
     Effect.gen(function* () {
@@ -141,21 +150,42 @@ describe("tryouts/migration/cleanup/repair", () => {
         repair.scaleVersionId
       );
       assert.ok((repaired.receipt?.repair?.repairedAt ?? 0) > 0);
-      let done = false;
-      for (let page = 0; page < 32; page += 1) {
-        const result = yield* Effect.promise(() =>
-          runCleanup(t, repair.evidence)
-        );
-        if (result.done) {
-          done = true;
-          break;
-        }
-      }
+      yield* Effect.promise(() => finishCleanup(t, repair.evidence));
       const finished = yield* Effect.promise(() => readRepair(t, repair));
-      assert.strictEqual(done, true);
       assert.strictEqual(finished.receipt?.phase, "cleaned");
       assert.strictEqual(finished.receipt?.deletedRows, 82);
       assert.strictEqual(finished.receipt?.repair?.deletedRows, 158);
+    })
+  );
+
+  it.effect("rejects a cleaned retry without its exact repair audit", () =>
+    Effect.gen(function* () {
+      for (const damage of ["missing", "tampered"] as const) {
+        const t = createConvexTestWithBetterAuth();
+        const { repair } = yield* Effect.promise(() => seedRepair(t));
+        yield* Effect.promise(() => runCleanup(t, repair.evidence));
+        yield* Effect.promise(() => finishCleanup(t, repair.evidence));
+        yield* Effect.promise(() =>
+          t.mutation(async (ctx) => {
+            const receipt = await ctx.db
+              .query("tryoutHistoryMigrationReceipts")
+              .unique();
+            assert.ok(receipt?.repair);
+            await ctx.db.patch(receipt._id, {
+              repair:
+                damage === "missing"
+                  ? undefined
+                  : { ...receipt.repair, deletedRows: 157 },
+            });
+          })
+        );
+
+        yield* Effect.promise(() =>
+          expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+            data: { code: "CONTENT_RELEASE_INTEGRITY" },
+          })
+        );
+      }
     })
   );
 
@@ -175,6 +205,39 @@ describe("tryouts/migration/cleanup/repair", () => {
       assert.ok(state.runs.every((run) => run !== null));
       assert.strictEqual(state.receipt?.repair, undefined);
       assert.strictEqual(state.receipt?.deletedRows, 0);
+    })
+  );
+
+  it.effect("rejects duplicate run identities before any repair write", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const { repair } = yield* Effect.promise(() => seedRepair(t));
+      const [firstRun, secondRun] = repair.runIds;
+      const [firstEvidence, secondEvidence] = repair.evidence.runs;
+      assert.ok(firstRun && secondRun && firstEvidence && secondEvidence);
+      assert.strictEqual(
+        firstEvidence.questionCount,
+        secondEvidence.questionCount
+      );
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.patch(secondRun, {
+            sectionIdentity: firstEvidence.sectionIdentity,
+          })
+        )
+      );
+
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, repair.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+      assert.ok(state.scale);
+      assert.ok(state.items.every((item) => item !== null));
+      assert.ok(state.runs.every((run) => run !== null));
+      assert.strictEqual(state.receipt?.repair, undefined);
+      assert.strictEqual(state.receipt?.proof, undefined);
     })
   );
 

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -9,6 +9,10 @@ import {
   retainedScaleRepair,
   type ScaleRepairEvidence,
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import {
+  loadRepairPlacements,
+  matchesRepairPlacements,
+} from "@repo/backend/convex/tryouts/migration/cleanup/placement";
 import type { CleanupRepair } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { Effect } from "effect";
 
@@ -158,6 +162,11 @@ export const prepareUnusedScale = Effect.fn(
   const observedRunIdentities = new Set(
     runs.map(({ sectionIdentity }) => sectionIdentity)
   );
+  const signedPlacements = yield* loadRepairPlacements(
+    ctx,
+    migration.sourceSnapshotId,
+    evidence.runs
+  );
   const runIds = new Set(runs.map(({ _id }) => _id));
   const itemIds = new Set(items.map(({ _id }) => _id));
   const reverseItems = yield* Effect.forEach(runs, (run) =>
@@ -174,12 +183,6 @@ export const prepareUnusedScale = Effect.fn(
     (count, run) => count + run.questionCount,
     0
   );
-  const placementCount = new Set(
-    items.map(({ placementIdentity }) => placementIdentity)
-  ).size;
-  const rowHashCount = new Set(
-    items.map(({ placementRowHash }) => placementRowHash)
-  ).size;
   if (
     scale.setIdentity !== evidence.setIdentity ||
     scale.publishedAt !== evidence.publishedAt ||
@@ -190,8 +193,7 @@ export const prepareUnusedScale = Effect.fn(
     attempt !== null ||
     score !== null ||
     items.length !== evidence.itemCount ||
-    placementCount !== items.length ||
-    rowHashCount !== items.length ||
+    !matchesRepairPlacements(signedPlacements, items, runs) ||
     runs.length !== evidence.runs.length ||
     expectedRuns.size !== runs.length ||
     observedRunIdentities.size !== runs.length ||

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -3,6 +3,7 @@ import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { isSnapshotReferenced } from "@repo/backend/convex/contentRelease/snapshot/retention";
 import {
+  countScaleRepairRows,
   hasValidScaleRepairEvidence,
   matchesScaleRepair,
   retainedScaleRepair,
@@ -54,7 +55,7 @@ export const prepareUnusedScale = Effect.fn(
     }
     return null;
   }
-  const deletedRows = evidence.itemCount + evidence.runs.length + 1;
+  const deletedRows = countScaleRepairRows(evidence);
   if (
     !(
       hasValidScaleRepairEvidence(evidence) && Number.isSafeInteger(deletedRows)
@@ -154,6 +155,9 @@ export const prepareUnusedScale = Effect.fn(
       questionCount,
     ])
   );
+  const observedRunIdentities = new Set(
+    runs.map(({ sectionIdentity }) => sectionIdentity)
+  );
   const runIds = new Set(runs.map(({ _id }) => _id));
   const itemIds = new Set(items.map(({ _id }) => _id));
   const reverseItems = yield* Effect.forEach(runs, (run) =>
@@ -190,6 +194,7 @@ export const prepareUnusedScale = Effect.fn(
     rowHashCount !== items.length ||
     runs.length !== evidence.runs.length ||
     expectedRuns.size !== runs.length ||
+    observedRunIdentities.size !== runs.length ||
     !Number.isSafeInteger(runQuestionCount) ||
     runQuestionCount !== evidence.questionCount ||
     mappings.some(

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -1,24 +1,64 @@
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { isSnapshotReferenced } from "@repo/backend/convex/contentRelease/snapshot/retention";
+import {
+  hasValidScaleRepairEvidence,
+  matchesScaleRepair,
+  retainedScaleRepair,
+  type ScaleRepairEvidence,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import type { CleanupRepair } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { Effect } from "effect";
-
-const MAX_UNUSED_SCALES = 1;
-const MAX_UNUSED_RUNS = 32;
-const MAX_UNUSED_ITEMS = 512;
 
 type CleanupMigration = Pick<
   Extract<
     Doc<"tryoutHistoryMigrations">,
     { readonly phase: "cleaning" | "completed" }
   >,
-  "authorization" | "sourceSnapshotId"
+  "authorization" | "migrationId" | "sourceSnapshotId"
 >;
 
-/** Removes the bounded zero-use provisional graph omitted by attempt inventory. */
+type CleanupReceipt = Pick<Doc<"tryoutHistoryMigrationReceipts">, "repair">;
+
+interface ScaleRepairResult {
+  readonly deletedRows: number;
+  readonly repair: Omit<CleanupRepair, "repairedAt">;
+}
+
+/** Removes one exact zero-use graph and returns its separate durable audit. */
 export const repairUnusedScale = Effect.fn(
   "tryouts.migration.repairUnusedScale"
-)(function* (ctx: MutationCtx, migration: CleanupMigration) {
+)(function* (
+  ctx: MutationCtx,
+  migration: CleanupMigration,
+  receipt: CleanupReceipt,
+  evidence: ScaleRepairEvidence = retainedScaleRepair
+) {
+  const applies =
+    migration.migrationId === evidence.migrationId &&
+    migration.authorization.planHash === evidence.planHash &&
+    migration.sourceSnapshotId === evidence.sourceSnapshotId;
+  if (!applies) {
+    if (receipt.repair !== undefined) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history cleanup retained repair evidence for another signed plan."
+      );
+    }
+    return null;
+  }
+  const deletedRows = evidence.itemCount + evidence.runs.length + 1;
+  if (
+    !(
+      hasValidScaleRepairEvidence(evidence) && Number.isSafeInteger(deletedRows)
+    )
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Try-out history cleanup has invalid repair cardinality."
+    );
+  }
   const authorized = new Set(migration.authorization.sourceScaleVersionIds);
   const scales = yield* Effect.promise(() =>
     ctx.db
@@ -27,29 +67,33 @@ export const repairUnusedScale = Effect.fn(
         "by_tryoutSnapshotId_and_setIdentity_and_publishedAt",
         (query) => query.eq("tryoutSnapshotId", migration.sourceSnapshotId)
       )
-      .take(authorized.size + MAX_UNUSED_SCALES + 1)
+      .take(authorized.size + 2)
   );
   const unused = scales.filter(({ _id }) => !authorized.has(_id));
-  if (unused.length === 0) {
-    return false;
+  if (receipt.repair !== undefined) {
+    if (
+      !matchesScaleRepair(receipt.repair, evidence, deletedRows) ||
+      unused.length !== 0
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history cleanup lost its durable provisional scale repair."
+      );
+    }
+    return null;
   }
-  if (unused.length !== MAX_UNUSED_SCALES) {
+  const scale = unused[0];
+  if (
+    scale === undefined ||
+    unused.length !== 1 ||
+    scale._id !== evidence.scaleVersionId
+  ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
-      "Retained cleanup found an unexpected provisional scale inventory."
+      "Try-out history cleanup found an unexpected provisional scale identity."
     );
   }
-  const [scale] = unused;
-  if (scale === undefined) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      "Retained cleanup lost its provisional scale identity."
-    );
-  }
-  if (scale.status !== "provisional" || scale.history === true) {
-    return false;
-  }
-  const { attempt, items, runs, score } = yield* Effect.all({
+  const { attempt, items, mappings, runs, score } = yield* Effect.all({
     attempt: Effect.promise(() =>
       ctx.db
         .query("tryoutAttempts")
@@ -64,7 +108,15 @@ export const repairUnusedScale = Effect.fn(
         .withIndex("by_scaleVersionId_and_placementIdentity", (query) =>
           query.eq("scaleVersionId", scale._id)
         )
-        .take(MAX_UNUSED_ITEMS + 1)
+        .take(evidence.itemCount + 1)
+    ),
+    mappings: Effect.promise(() =>
+      ctx.db
+        .query("tryoutHistoryScaleMigrations")
+        .withIndex("by_migrationId_and_oldScaleVersionId", (query) =>
+          query.eq("migrationId", migration.migrationId)
+        )
+        .take(authorized.size + 1)
     ),
     runs: Effect.promise(() =>
       ctx.db
@@ -73,7 +125,7 @@ export const repairUnusedScale = Effect.fn(
           "by_scaleVersionId_and_sectionIdentity_and_startedAt",
           (query) => query.eq("scaleVersionId", scale._id)
         )
-        .take(MAX_UNUSED_RUNS + 1)
+        .take(evidence.runs.length + 1)
     ),
     score: Effect.promise(() =>
       ctx.db
@@ -84,14 +136,28 @@ export const repairUnusedScale = Effect.fn(
         .first()
     ),
   });
+  const expectedRuns = new Map(
+    evidence.runs.map(({ questionCount, sectionIdentity }) => [
+      sectionIdentity,
+      questionCount,
+    ])
+  );
+  const runIds = new Set(runs.map(({ _id }) => _id));
+  const itemIds = new Set(items.map(({ _id }) => _id));
+  const reverseItems = yield* Effect.forEach(runs, (run) =>
+    Effect.promise(() =>
+      ctx.db
+        .query("irtScaleItems")
+        .withIndex("by_calibrationRunId", (query) =>
+          query.eq("calibrationRunId", run._id)
+        )
+        .take(run.questionCount + 1)
+    )
+  );
   const runQuestionCount = runs.reduce(
     (count, run) => count + run.questionCount,
     0
   );
-  const sectionCount = new Set(
-    runs.map(({ sectionIdentity }) => sectionIdentity)
-  ).size;
-  const runIds = new Set(runs.map(({ _id }) => _id));
   const placementCount = new Set(
     items.map(({ placementIdentity }) => placementIdentity)
   ).size;
@@ -99,24 +165,29 @@ export const repairUnusedScale = Effect.fn(
     items.map(({ placementRowHash }) => placementRowHash)
   ).size;
   if (
+    scale.setIdentity !== evidence.setIdentity ||
+    scale.publishedAt !== evidence.publishedAt ||
+    scale.questionCount !== evidence.questionCount ||
+    scale.status !== "provisional" ||
+    scale.history === true ||
     scale.model !== "2pl" ||
-    !Number.isSafeInteger(scale.questionCount) ||
-    scale.questionCount <= 0 ||
-    scale.questionCount > MAX_UNUSED_ITEMS ||
-    !Number.isSafeInteger(scale.publishedAt) ||
-    scale.publishedAt <= 0 ||
     attempt !== null ||
     score !== null ||
-    items.length !== scale.questionCount ||
+    items.length !== evidence.itemCount ||
     placementCount !== items.length ||
     rowHashCount !== items.length ||
-    runs.length === 0 ||
-    runs.length > MAX_UNUSED_RUNS ||
-    sectionCount !== runs.length ||
+    runs.length !== evidence.runs.length ||
+    expectedRuns.size !== runs.length ||
     !Number.isSafeInteger(runQuestionCount) ||
-    runQuestionCount !== scale.questionCount ||
+    runQuestionCount !== evidence.questionCount ||
+    mappings.some(
+      (mapping) =>
+        mapping.oldScaleVersionId === scale._id ||
+        mapping.newScaleVersionId === scale._id
+    ) ||
     runs.some(
       (run) =>
+        expectedRuns.get(run.sectionIdentity) !== run.questionCount ||
         run.model !== scale.model ||
         run.status !== "completed" ||
         run.attemptCount !== 0 ||
@@ -126,8 +197,7 @@ export const repairUnusedScale = Effect.fn(
         run.startedAt !== scale.publishedAt ||
         run.completedAt !== scale.publishedAt ||
         run.updatedAt !== scale.publishedAt ||
-        !Number.isSafeInteger(run.questionCount) ||
-        run.questionCount <= 0
+        run.error !== undefined
     ) ||
     items.some(
       (item) =>
@@ -138,15 +208,29 @@ export const repairUnusedScale = Effect.fn(
         item.difficulty !== 0 ||
         item.discrimination !== 1
     ) ||
-    runs.some(
-      (run) =>
-        items.filter(({ calibrationRunId }) => calibrationRunId === run._id)
-          .length !== run.questionCount
+    reverseItems.some(
+      (rows, index) =>
+        rows.length !== runs[index]?.questionCount ||
+        rows.some(({ _id }) => !itemIds.has(_id))
     )
   ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
-      "Retained cleanup cannot prove the unused provisional scale graph."
+      "Try-out history cleanup cannot prove the exact provisional scale graph."
+    );
+  }
+  if (
+    yield* isSnapshotReferenced(ctx, "tryout", migration.sourceSnapshotId, {
+      ignoredMigrationId: migration.migrationId,
+      ignoredScaleVersionIds: [
+        ...migration.authorization.sourceScaleVersionIds,
+        scale._id,
+      ],
+    })
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "The provisional scale repair source is still protected."
     );
   }
   yield* Effect.forEach(items, (item) =>
@@ -156,5 +240,23 @@ export const repairUnusedScale = Effect.fn(
     Effect.promise(() => ctx.db.delete("irtCalibrationRuns", run._id))
   );
   yield* Effect.promise(() => ctx.db.delete("irtScaleVersions", scale._id));
-  return true;
+  return {
+    deletedRows,
+    repair: {
+      deletedRows,
+      itemCount: evidence.itemCount,
+      migrationId: evidence.migrationId,
+      planHash: evidence.planHash,
+      publishedAt: evidence.publishedAt,
+      questionCount: evidence.questionCount,
+      runCount: evidence.runs.length,
+      runs: evidence.runs.map(({ questionCount, sectionIdentity }) => ({
+        questionCount,
+        sectionIdentity,
+      })),
+      scaleVersionId: evidence.scaleVersionId,
+      setIdentity: evidence.setIdentity,
+      sourceSnapshotId: evidence.sourceSnapshotId,
+    },
+  } satisfies ScaleRepairResult;
 });

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -1,0 +1,160 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { Effect } from "effect";
+
+const MAX_UNUSED_SCALES = 1;
+const MAX_UNUSED_RUNS = 32;
+const MAX_UNUSED_ITEMS = 512;
+
+type CleanupMigration = Pick<
+  Extract<
+    Doc<"tryoutHistoryMigrations">,
+    { readonly phase: "cleaning" | "completed" }
+  >,
+  "authorization" | "sourceSnapshotId"
+>;
+
+/** Removes the bounded zero-use provisional graph omitted by attempt inventory. */
+export const repairUnusedScale = Effect.fn(
+  "tryouts.migration.repairUnusedScale"
+)(function* (ctx: MutationCtx, migration: CleanupMigration) {
+  const authorized = new Set(migration.authorization.sourceScaleVersionIds);
+  const scales = yield* Effect.promise(() =>
+    ctx.db
+      .query("irtScaleVersions")
+      .withIndex(
+        "by_tryoutSnapshotId_and_setIdentity_and_publishedAt",
+        (query) => query.eq("tryoutSnapshotId", migration.sourceSnapshotId)
+      )
+      .take(authorized.size + MAX_UNUSED_SCALES + 1)
+  );
+  const unused = scales.filter(({ _id }) => !authorized.has(_id));
+  if (unused.length === 0) {
+    return false;
+  }
+  if (unused.length !== MAX_UNUSED_SCALES) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Retained cleanup found an unexpected provisional scale inventory."
+    );
+  }
+  const [scale] = unused;
+  if (scale === undefined) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Retained cleanup lost its provisional scale identity."
+    );
+  }
+  if (scale.status !== "provisional" || scale.history === true) {
+    return false;
+  }
+  const { attempt, items, runs, score } = yield* Effect.all({
+    attempt: Effect.promise(() =>
+      ctx.db
+        .query("tryoutAttempts")
+        .withIndex("by_scaleVersionId", (query) =>
+          query.eq("scaleVersionId", scale._id)
+        )
+        .first()
+    ),
+    items: Effect.promise(() =>
+      ctx.db
+        .query("irtScaleItems")
+        .withIndex("by_scaleVersionId_and_placementIdentity", (query) =>
+          query.eq("scaleVersionId", scale._id)
+        )
+        .take(MAX_UNUSED_ITEMS + 1)
+    ),
+    runs: Effect.promise(() =>
+      ctx.db
+        .query("irtCalibrationRuns")
+        .withIndex(
+          "by_scaleVersionId_and_sectionIdentity_and_startedAt",
+          (query) => query.eq("scaleVersionId", scale._id)
+        )
+        .take(MAX_UNUSED_RUNS + 1)
+    ),
+    score: Effect.promise(() =>
+      ctx.db
+        .query("tryoutScores")
+        .withIndex("by_scaleVersionId", (query) =>
+          query.eq("scaleVersionId", scale._id)
+        )
+        .first()
+    ),
+  });
+  const runQuestionCount = runs.reduce(
+    (count, run) => count + run.questionCount,
+    0
+  );
+  const sectionCount = new Set(
+    runs.map(({ sectionIdentity }) => sectionIdentity)
+  ).size;
+  const runIds = new Set(runs.map(({ _id }) => _id));
+  const placementCount = new Set(
+    items.map(({ placementIdentity }) => placementIdentity)
+  ).size;
+  const rowHashCount = new Set(
+    items.map(({ placementRowHash }) => placementRowHash)
+  ).size;
+  if (
+    scale.model !== "2pl" ||
+    !Number.isSafeInteger(scale.questionCount) ||
+    scale.questionCount <= 0 ||
+    scale.questionCount > MAX_UNUSED_ITEMS ||
+    !Number.isSafeInteger(scale.publishedAt) ||
+    scale.publishedAt <= 0 ||
+    attempt !== null ||
+    score !== null ||
+    items.length !== scale.questionCount ||
+    placementCount !== items.length ||
+    rowHashCount !== items.length ||
+    runs.length === 0 ||
+    runs.length > MAX_UNUSED_RUNS ||
+    sectionCount !== runs.length ||
+    !Number.isSafeInteger(runQuestionCount) ||
+    runQuestionCount !== scale.questionCount ||
+    runs.some(
+      (run) =>
+        run.model !== scale.model ||
+        run.status !== "completed" ||
+        run.attemptCount !== 0 ||
+        run.responseCount !== 0 ||
+        run.iterationCount !== 0 ||
+        run.maxParameterDelta !== 0 ||
+        run.startedAt !== scale.publishedAt ||
+        run.completedAt !== scale.publishedAt ||
+        run.updatedAt !== scale.publishedAt ||
+        !Number.isSafeInteger(run.questionCount) ||
+        run.questionCount <= 0
+    ) ||
+    items.some(
+      (item) =>
+        !runIds.has(item.calibrationRunId) ||
+        item.calibrationStatus !== "provisional" ||
+        item.responseCount !== 0 ||
+        item.correctRate !== 0 ||
+        item.difficulty !== 0 ||
+        item.discrimination !== 1
+    ) ||
+    runs.some(
+      (run) =>
+        items.filter(({ calibrationRunId }) => calibrationRunId === run._id)
+          .length !== run.questionCount
+    )
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Retained cleanup cannot prove the unused provisional scale graph."
+    );
+  }
+  yield* Effect.forEach(items, (item) =>
+    Effect.promise(() => ctx.db.delete("irtScaleItems", item._id))
+  );
+  yield* Effect.forEach(runs, (run) =>
+    Effect.promise(() => ctx.db.delete("irtCalibrationRuns", run._id))
+  );
+  yield* Effect.promise(() => ctx.db.delete("irtScaleVersions", scale._id));
+  return true;
+});

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -1,4 +1,4 @@
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { isSnapshotReferenced } from "@repo/backend/convex/contentRelease/snapshot/retention";
@@ -16,7 +16,7 @@ type CleanupMigration = Pick<
     Doc<"tryoutHistoryMigrations">,
     { readonly phase: "cleaning" | "completed" }
   >,
-  "authorization" | "migrationId" | "sourceSnapshotId"
+  "authorization" | "migrationId" | "phase" | "sourceSnapshotId"
 >;
 
 type CleanupReceipt = Pick<Doc<"tryoutHistoryMigrationReceipts">, "repair">;
@@ -26,9 +26,15 @@ interface ScaleRepairResult {
   readonly repair: Omit<CleanupRepair, "repairedAt">;
 }
 
-/** Removes one exact zero-use graph and returns its separate durable audit. */
-export const repairUnusedScale = Effect.fn(
-  "tryouts.migration.repairUnusedScale"
+interface ScaleRepairPlan extends ScaleRepairResult {
+  readonly itemIds: readonly Id<"irtScaleItems">[];
+  readonly runIds: readonly Id<"irtCalibrationRuns">[];
+  readonly scaleVersionId: Id<"irtScaleVersions">;
+}
+
+/** Proves one exact zero-use graph before any repair write is possible. */
+export const prepareUnusedScale = Effect.fn(
+  "tryouts.migration.prepareUnusedScale"
 )(function* (
   ctx: MutationCtx,
   migration: CleanupMigration,
@@ -57,6 +63,12 @@ export const repairUnusedScale = Effect.fn(
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
       "Try-out history cleanup has invalid repair cardinality."
+    );
+  }
+  if (receipt.repair === undefined && migration.phase !== "completed") {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Try-out history cleanup cannot repair after signed deletion started."
     );
   }
   const authorized = new Set(migration.authorization.sourceScaleVersionIds);
@@ -233,15 +245,9 @@ export const repairUnusedScale = Effect.fn(
       "The provisional scale repair source is still protected."
     );
   }
-  yield* Effect.forEach(items, (item) =>
-    Effect.promise(() => ctx.db.delete("irtScaleItems", item._id))
-  );
-  yield* Effect.forEach(runs, (run) =>
-    Effect.promise(() => ctx.db.delete("irtCalibrationRuns", run._id))
-  );
-  yield* Effect.promise(() => ctx.db.delete("irtScaleVersions", scale._id));
   return {
     deletedRows,
+    itemIds: items.map(({ _id }) => _id),
     repair: {
       deletedRows,
       itemCount: evidence.itemCount,
@@ -258,5 +264,26 @@ export const repairUnusedScale = Effect.fn(
       setIdentity: evidence.setIdentity,
       sourceSnapshotId: evidence.sourceSnapshotId,
     },
+    runIds: runs.map(({ _id }) => _id),
+    scaleVersionId: scale._id,
+  } satisfies ScaleRepairPlan;
+});
+
+/** Commits one previously proven graph inside the caller's transaction. */
+export const commitUnusedScale = Effect.fn(
+  "tryouts.migration.commitUnusedScale"
+)(function* (ctx: MutationCtx, plan: ScaleRepairPlan) {
+  yield* Effect.forEach(plan.itemIds, (id) =>
+    Effect.promise(() => ctx.db.delete("irtScaleItems", id))
+  );
+  yield* Effect.forEach(plan.runIds, (id) =>
+    Effect.promise(() => ctx.db.delete("irtCalibrationRuns", id))
+  );
+  yield* Effect.promise(() =>
+    ctx.db.delete("irtScaleVersions", plan.scaleVersionId)
+  );
+  return {
+    deletedRows: plan.deletedRows,
+    repair: plan.repair,
   } satisfies ScaleRepairResult;
 });

--- a/packages/backend/convex/tryouts/migration/cleanup/run.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.test.ts
@@ -120,8 +120,11 @@ describe("tryouts/migration/cleanup/run", () => {
       Effect.gen(function* () {
         const t = createConvexTestWithBetterAuth();
         const seeded = yield* Effect.promise(() => seedCleanupSuccess(t));
-        const pages: { readonly deleted: number; readonly done: boolean }[] =
-          [];
+        const pages: {
+          readonly deleted: number;
+          readonly done: boolean;
+          readonly repaired: number;
+        }[] = [];
         for (let page = 0; page < 32; page += 1) {
           const result = yield* runCleanup(t);
           pages.push(result);
@@ -144,7 +147,11 @@ describe("tryouts/migration/cleanup/run", () => {
 
         assert.ok(pages.some(({ deleted }) => deleted === 32));
         assert.strictEqual(pages.at(-1)?.done, true);
-        assert.deepStrictEqual(retry, { deleted: 0, done: true });
+        assert.deepStrictEqual(retry, {
+          deleted: 0,
+          done: true,
+          repaired: 0,
+        });
         assert.ok(state.attempt);
         assert.ok(state.targetBundle);
         assert.ok(state.targetCatalog.length > 0);

--- a/packages/backend/convex/tryouts/migration/cleanup/run.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.test.ts
@@ -86,7 +86,10 @@ describe("tryouts/migration/cleanup/run", () => {
         ).pipe(Effect.flip);
         const after = yield* Effect.promise(() => readCleanupState(t));
 
-        assert.ok(failure.message.includes(message));
+        assert.ok(
+          failure.message.includes(message),
+          `${guard}: ${failure.message}`
+        );
         assert.deepStrictEqual(after, before);
       }
     })

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -13,9 +13,11 @@ import {
   hasSameCleanupProof,
   requireCleanupPlan,
   requireCleanupPreconditions,
+  requireCleanupRetention,
 } from "@repo/backend/convex/tryouts/migration/cleanup/guard";
 import { cleanupLedger } from "@repo/backend/convex/tryouts/migration/cleanup/ledger";
 import { requireCleanupEmpty } from "@repo/backend/convex/tryouts/migration/cleanup/proof";
+import { repairUnusedScale } from "@repo/backend/convex/tryouts/migration/cleanup/repair";
 import { cleanupScale } from "@repo/backend/convex/tryouts/migration/cleanup/scale";
 import {
   type CleanupProof,
@@ -105,6 +107,8 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   }
   const plan = yield* requireCleanupPlan(migration);
   yield* requireCleanupPreconditions(ctx, migration);
+  yield* repairUnusedScale(ctx, migration);
+  yield* requireCleanupRetention(ctx, migration);
   let state: CleanupState;
   if (migration.phase === "completed") {
     if (receipt.proof || receipt.deletedRows !== 0) {

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -8,6 +8,7 @@ import {
   recordCleanupPage,
   requireCleanupComplete,
 } from "@repo/backend/convex/tryouts/migration/cleanup/count";
+import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import {
   hasCleanupReceiptBinding,
   hasSameCleanupProof,
@@ -34,6 +35,7 @@ import { Clock, Effect } from "effect";
 export const cleanupResultValidator = v.object({
   deleted: v.number(),
   done: v.boolean(),
+  repaired: v.number(),
 });
 
 /** Deletes one bounded legacy page and removes the temporary root last. */
@@ -41,7 +43,8 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   ctx: MutationCtx,
   migrationId: string,
   receiptHash: string,
-  proof: CleanupProof
+  proof: CleanupProof,
+  repairEvidence?: ScaleRepairEvidence
 ) {
   const receipt = yield* loadMigrationReceipt(ctx, migrationId);
   if (!receipt || receipt.receiptHash !== receiptHash) {
@@ -67,7 +70,7 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
       receipt.deletedRows > 0 &&
       receipt.deletedRows <= receipt.cleanupLimit
     ) {
-      return { deleted: 0, done: true };
+      return { deleted: 0, done: true, repaired: 0 };
     }
     if (receipt.phase === "cleaned") {
       return yield* releaseFail(
@@ -107,7 +110,21 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   }
   const plan = yield* requireCleanupPlan(migration);
   yield* requireCleanupPreconditions(ctx, migration);
-  yield* repairUnusedScale(ctx, migration);
+  const repair = yield* repairUnusedScale(
+    ctx,
+    migration,
+    receipt,
+    repairEvidence
+  );
+  if (repair !== null) {
+    const repairedAt = yield* Clock.currentTimeMillis;
+    yield* Effect.promise(() =>
+      ctx.db.patch("tryoutHistoryMigrationReceipts", receipt._id, {
+        repair: { ...repair.repair, repairedAt },
+      })
+    );
+    return { deleted: 0, done: false, repaired: repair.deletedRows };
+  }
   yield* requireCleanupRetention(ctx, migration);
   let state: CleanupState;
   if (migration.phase === "completed") {
@@ -188,7 +205,7 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
         proof,
       })
     );
-    return { deleted: page.deleted, done: false };
+    return { deleted: page.deleted, done: false, repaired: 0 };
   }
   yield* requireCleanupEmpty(ctx, migration);
   const deletedRows = yield* requireCleanupComplete(state, plan.payload);
@@ -218,7 +235,7 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   yield* Effect.promise(() =>
     ctx.db.delete("tryoutHistoryMigrations", migration._id)
   );
-  return { deleted: 1, done: true };
+  return { deleted: 1, done: true, repaired: 0 };
 });
 
 export const cleanup = internalMutation({

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -15,10 +15,14 @@ import {
   requireCleanupPlan,
   requireCleanupPreconditions,
   requireCleanupRetention,
+  requireCleanupStart,
 } from "@repo/backend/convex/tryouts/migration/cleanup/guard";
 import { cleanupLedger } from "@repo/backend/convex/tryouts/migration/cleanup/ledger";
 import { requireCleanupEmpty } from "@repo/backend/convex/tryouts/migration/cleanup/proof";
-import { repairUnusedScale } from "@repo/backend/convex/tryouts/migration/cleanup/repair";
+import {
+  commitUnusedScale,
+  prepareUnusedScale,
+} from "@repo/backend/convex/tryouts/migration/cleanup/repair";
 import { cleanupScale } from "@repo/backend/convex/tryouts/migration/cleanup/scale";
 import {
   type CleanupProof,
@@ -110,16 +114,26 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   }
   const plan = yield* requireCleanupPlan(migration);
   yield* requireCleanupPreconditions(ctx, migration);
-  const repair = yield* repairUnusedScale(
+  const start = yield* requireCleanupStart(migration, receipt, proof);
+  const preparedRepair = yield* prepareUnusedScale(
     ctx,
     migration,
     receipt,
     repairEvidence
   );
-  if (repair !== null) {
+  if (preparedRepair !== null) {
+    if (start.kind !== "initial") {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history cleanup cannot repair after signed deletion started."
+      );
+    }
+    yield* verifyTerminalStorage(ctx, start.migration);
+    const repair = yield* commitUnusedScale(ctx, preparedRepair);
     const repairedAt = yield* Clock.currentTimeMillis;
     yield* Effect.promise(() =>
       ctx.db.patch("tryoutHistoryMigrationReceipts", receipt._id, {
+        proof,
         repair: { ...repair.repair, repairedAt },
       })
     );
@@ -127,23 +141,11 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
   }
   yield* requireCleanupRetention(ctx, migration);
   let state: CleanupState;
-  if (migration.phase === "completed") {
-    if (receipt.proof || receipt.deletedRows !== 0) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Unstarted try-out history cleanup already has durable progress."
-      );
-    }
-    yield* verifyTerminalStorage(ctx, migration);
+  if (start.kind === "initial") {
+    yield* verifyTerminalStorage(ctx, start.migration);
     state = initialCleanupState(yield* Clock.currentTimeMillis);
   } else {
-    if (!(receipt.proof && hasSameCleanupProof(receipt.proof, proof))) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Try-out history cleanup proof changed after deletion started."
-      );
-    }
-    state = migration.cleanup;
+    state = start.state;
   }
   const countedRows = yield* countCleanupRows(state, plan.payload);
   if (countedRows !== receipt.deletedRows) {

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -8,7 +8,10 @@ import {
   recordCleanupPage,
   requireCleanupComplete,
 } from "@repo/backend/convex/tryouts/migration/cleanup/count";
-import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import {
+  hasRequiredScaleRepair,
+  type ScaleRepairEvidence,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import {
   hasCleanupReceiptBinding,
   hasSameCleanupProof,
@@ -66,6 +69,15 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
       .unique()
   );
   if (!migration) {
+    if (
+      receipt.phase === "cleaned" &&
+      !hasRequiredScaleRepair(migrationId, receipt.repair, repairEvidence)
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Cleaned try-out history migration lost its durable repair audit."
+      );
+    }
     if (
       receipt.phase === "cleaned" &&
       receipt.proof &&

--- a/packages/backend/convex/tryouts/migration/cleanup/schema.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/schema.ts
@@ -39,6 +39,26 @@ export const cleanupProofValidator = v.object({
   sourceSha: v.string(),
 });
 
+export const cleanupRepairValidator = v.object({
+  deletedRows: v.number(),
+  itemCount: v.number(),
+  migrationId: v.string(),
+  planHash: v.string(),
+  publishedAt: v.number(),
+  questionCount: v.number(),
+  repairedAt: v.number(),
+  runCount: v.number(),
+  runs: v.array(
+    v.object({
+      questionCount: v.number(),
+      sectionIdentity: v.string(),
+    })
+  ),
+  scaleVersionId: v.string(),
+  setIdentity: v.string(),
+  sourceSnapshotId: v.string(),
+});
+
 export const cleanupCountsValidator = v.object({
   artifact: v.number(),
   audit: v.number(),
@@ -64,6 +84,7 @@ export const cleanupStateValidator = v.object({
 
 export type CleanupKind = Infer<typeof cleanupKindValidator>;
 export type CleanupProof = Infer<typeof cleanupProofValidator>;
+export type CleanupRepair = Infer<typeof cleanupRepairValidator>;
 export type CleanupState = Infer<typeof cleanupStateValidator>;
 
 /** One bounded deletion page attributed to its signed source category. */

--- a/packages/backend/convex/tryouts/migration/receipt.test.ts
+++ b/packages/backend/convex/tryouts/migration/receipt.test.ts
@@ -7,13 +7,20 @@ describe("tryouts/migration/receipt", () => {
     "accepts an idempotent terminal cleanup race only after cleanup",
     () =>
       Effect.gen(function* () {
-        yield* requireCleanupProgress({ deleted: 0, done: true }, "cleaned");
+        yield* requireCleanupProgress(
+          { deleted: 0, done: true, repaired: 0 },
+          "cleaned"
+        );
+        yield* requireCleanupProgress(
+          { deleted: 0, done: false, repaired: 158 },
+          "sealed"
+        );
         const unfinished = yield* requireCleanupProgress(
-          { deleted: 0, done: false },
+          { deleted: 0, done: false, repaired: 0 },
           "sealed"
         ).pipe(Effect.flip);
         const contradictory = yield* requireCleanupProgress(
-          { deleted: 0, done: true },
+          { deleted: 0, done: true, repaired: 0 },
           "sealed"
         ).pipe(Effect.flip);
 

--- a/packages/backend/convex/tryouts/migration/receipt.ts
+++ b/packages/backend/convex/tryouts/migration/receipt.ts
@@ -252,7 +252,6 @@ export const cleanupMigrationReceipt = Effect.fn(
       command: request.command,
       deleted: 0,
       migrationId: request.releaseId,
-      repaired: 0,
       status: current,
     };
   }
@@ -269,7 +268,6 @@ export const cleanupMigrationReceipt = Effect.fn(
     command: request.command,
     deleted: result.deleted,
     migrationId: request.releaseId,
-    repaired: result.repaired,
     status,
   };
 });

--- a/packages/backend/convex/tryouts/migration/receipt.ts
+++ b/packages/backend/convex/tryouts/migration/receipt.ts
@@ -13,6 +13,7 @@ import {
 } from "@repo/backend/convex/contentRelease/error";
 import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
 import { requireActiveContentKey } from "@repo/backend/convex/contentRelease/ingress/key";
+import { hasRequiredScaleRepair } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import type { cleanupResultValidator } from "@repo/backend/convex/tryouts/migration/cleanup/run";
 import { verifyImmutableMigrationReceipt } from "@repo/backend/convex/tryouts/migration/proof/github";
 import {
@@ -220,6 +221,15 @@ export const cleanupMigrationReceipt = Effect.fn(
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
       "Try-out history cleanup has invalid durable progress."
+    );
+  }
+  if (
+    durable.phase === "cleaned" &&
+    !hasRequiredScaleRepair(request.releaseId, durable.repair)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Cleaned try-out history migration lost its durable repair audit."
     );
   }
   let proof: TryoutHistoryMigrationProof;

--- a/packages/backend/convex/tryouts/migration/receipt.ts
+++ b/packages/backend/convex/tryouts/migration/receipt.ts
@@ -91,7 +91,11 @@ function hasSameCleanupProof(
 export const requireCleanupProgress = Effect.fn(
   "tryouts.migration.requireCleanupProgress"
 )(function* (result: CleanupResult, phase: MigrationStatus["phase"]) {
-  if (result.deleted < 0 || (result.deleted === 0 && !result.done)) {
+  if (
+    result.deleted < 0 ||
+    result.repaired < 0 ||
+    (result.deleted === 0 && result.repaired === 0 && !result.done)
+  ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
       "Try-out history cleanup made no bounded progress."
@@ -248,6 +252,7 @@ export const cleanupMigrationReceipt = Effect.fn(
       command: request.command,
       deleted: 0,
       migrationId: request.releaseId,
+      repaired: 0,
       status: current,
     };
   }
@@ -264,6 +269,7 @@ export const cleanupMigrationReceipt = Effect.fn(
     command: request.command,
     deleted: result.deleted,
     migrationId: request.releaseId,
+    repaired: result.repaired,
     status,
   };
 });

--- a/packages/backend/convex/tryouts/migration/schema.ts
+++ b/packages/backend/convex/tryouts/migration/schema.ts
@@ -1,5 +1,6 @@
 import {
   cleanupProofValidator,
+  cleanupRepairValidator,
   cleanupStateValidator,
 } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { defineTable } from "convex/server";
@@ -155,6 +156,7 @@ const tables = {
     phase: v.union(v.literal("sealed"), v.literal("cleaned")),
     planHash: v.string(),
     proof: v.optional(cleanupProofValidator),
+    repair: v.optional(cleanupRepairValidator),
     receiptHash: v.string(),
     receiptJson: v.string(),
     recordedAt: v.number(),

--- a/packages/backend/convex/tryouts/migration/state/query.test.ts
+++ b/packages/backend/convex/tryouts/migration/state/query.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
 import schema from "@repo/backend/convex/schema";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  countScaleRepairRows,
+  retainedScaleRepair,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import type {
+  cleanupReceiptValidator,
   mapEntryValidator,
   targetRuntimeValidator,
 } from "@repo/backend/convex/tryouts/migration/state/schema";
@@ -10,6 +16,8 @@ import {
   seedOwnedAbort,
   seedPendingAbort,
 } from "@repo/backend/test/migration/abort";
+import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
+import { CLEANUP_MIGRATION_ID } from "@repo/backend/test/migration/state";
 import { makeFunctionReference } from "convex/server";
 import type { Infer } from "convex/values";
 import { convexTest } from "convex-test";
@@ -17,6 +25,7 @@ import { Effect } from "effect";
 
 type MapEntry = Infer<typeof mapEntryValidator>;
 type TargetRuntime = Infer<typeof targetRuntimeValidator>;
+type CleanupReceipt = Infer<typeof cleanupReceiptValidator>;
 
 const mapEntries = makeFunctionReference<
   "query",
@@ -28,8 +37,43 @@ const targetRuntime = makeFunctionReference<
   { migrationId: string },
   TargetRuntime
 >("tryouts/migration/state/query:targetRuntime");
+const cleanupReceipt = makeFunctionReference<
+  "query",
+  { migrationId: string },
+  CleanupReceipt
+>("tryouts/migration/state/query:receipt");
 
 describe("tryouts/migration/state/query", () => {
+  it.effect("projects the complete durable repair audit", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      yield* Effect.promise(() => seedCleanupSuccess(t));
+      const repair = {
+        ...retainedScaleRepair,
+        deletedRows: countScaleRepairRows(retainedScaleRepair),
+        repairedAt: 1,
+        runCount: retainedScaleRepair.runs.length,
+      };
+      yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const receipt = await ctx.db
+            .query("tryoutHistoryMigrationReceipts")
+            .unique();
+          expect(receipt).not.toBeNull();
+          if (receipt) {
+            await ctx.db.patch(receipt._id, { repair });
+          }
+        })
+      );
+
+      const projected = yield* Effect.promise(() =>
+        t.query(cleanupReceipt, { migrationId: CLEANUP_MIGRATION_ID })
+      );
+
+      expect(projected?.repair).toEqual(repair);
+    })
+  );
+
   it.effect("projects the staged ledger and immutable runtime", () =>
     Effect.gen(function* () {
       const t = convexTest(schema, convexModules);

--- a/packages/backend/convex/tryouts/migration/state/query.ts
+++ b/packages/backend/convex/tryouts/migration/state/query.ts
@@ -85,6 +85,7 @@ export const receipt = internalQuery({
                 deletedRows: stored.deletedRows,
                 phase: stored.phase,
                 proof: stored.proof ?? null,
+                repair: stored.repair ?? null,
               }
             : null
         )

--- a/packages/backend/convex/tryouts/migration/state/schema.ts
+++ b/packages/backend/convex/tryouts/migration/state/schema.ts
@@ -129,6 +129,7 @@ export const cleanupReceiptValidator = v.union(
 /** Internal state read that distinguishes absent, sealed, and cleaned roots. */
 export const migrationRecordValidator = v.object({
   cleanupStarted: v.boolean(),
+  repairScalePresent: v.boolean(),
   receipt: v.union(migrationReceiptRecordValidator, v.null()),
   status: v.union(activeMigrationStatusValidator, v.null()),
 });

--- a/packages/backend/convex/tryouts/migration/state/schema.ts
+++ b/packages/backend/convex/tryouts/migration/state/schema.ts
@@ -1,4 +1,7 @@
-import { cleanupProofValidator } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
+import {
+  cleanupProofValidator,
+  cleanupRepairValidator,
+} from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { v } from "convex/values";
 
 export const completionValidator = v.object({
@@ -118,6 +121,7 @@ export const cleanupReceiptValidator = v.union(
     deletedRows: v.number(),
     phase: v.union(v.literal("sealed"), v.literal("cleaned")),
     proof: v.union(cleanupProofValidator, v.null()),
+    repair: v.union(cleanupRepairValidator, v.null()),
   })
 );
 

--- a/packages/backend/convex/tryouts/migration/state/schema.ts
+++ b/packages/backend/convex/tryouts/migration/state/schema.ts
@@ -107,6 +107,7 @@ export const migrationReceiptRecordValidator = v.object({
   phase: v.union(v.literal("sealed"), v.literal("cleaned")),
   planHash: v.string(),
   proof: v.union(cleanupProofValidator, v.null()),
+  repair: v.union(cleanupRepairValidator, v.null()),
   receiptHash: v.string(),
   receiptJson: v.string(),
   sourceSnapshotId: v.string(),

--- a/packages/backend/convex/tryouts/migration/state/store.test.ts
+++ b/packages/backend/convex/tryouts/migration/state/store.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "@effect/vitest";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
   countScaleRepairRows,
   retainedScaleRepair,
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import { retainedRepairScalePresent } from "@repo/backend/convex/tryouts/migration/cleanup/marker";
 import type {
   migrationRecordValidator,
   migrationStatusValidator,
@@ -34,6 +36,81 @@ const record = makeFunctionReference<
 >("tryouts/migration/state/store:record");
 
 describe("tryouts/migration/state/store", () => {
+  it.effect("observes the exact retained repair scale independently", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const scaleVersionId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("irtScaleVersions", {
+            model: "2pl",
+            publishedAt: retainedScaleRepair.publishedAt,
+            questionCount: retainedScaleRepair.questionCount,
+            setIdentity: retainedScaleRepair.setIdentity,
+            status: "provisional",
+            tryoutSnapshotId: retainedScaleRepair.sourceSnapshotId,
+          })
+        )
+      );
+      const evidence = { ...retainedScaleRepair, scaleVersionId };
+      const present = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            retainedRepairScalePresent(
+              ctx,
+              retainedScaleRepair.migrationId,
+              evidence
+            )
+          )
+        )
+      );
+      expect(present).toBe(true);
+
+      yield* Effect.promise(() =>
+        t.mutation((ctx) => ctx.db.delete(scaleVersionId))
+      );
+      const absent = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            retainedRepairScalePresent(
+              ctx,
+              retainedScaleRepair.migrationId,
+              evidence
+            )
+          )
+        )
+      );
+      expect(absent).toBe(false);
+
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("irtScaleVersions", {
+            model: "2pl",
+            publishedAt: retainedScaleRepair.publishedAt,
+            questionCount: retainedScaleRepair.questionCount,
+            setIdentity: retainedScaleRepair.setIdentity,
+            status: "provisional",
+            tryoutSnapshotId: retainedScaleRepair.sourceSnapshotId,
+          })
+        )
+      );
+      yield* Effect.promise(() =>
+        expect(
+          t.query((ctx) =>
+            runConvexProgram(
+              retainedRepairScalePresent(
+                ctx,
+                retainedScaleRepair.migrationId,
+                evidence
+              )
+            )
+          )
+        ).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+    })
+  );
+
   it.effect("projects the durable terminal repair audit", () =>
     Effect.gen(function* () {
       const t = convexTest(schema, convexModules);

--- a/packages/backend/convex/tryouts/migration/state/store.test.ts
+++ b/packages/backend/convex/tryouts/migration/state/store.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "@effect/vitest";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
-import type { migrationStatusValidator } from "@repo/backend/convex/tryouts/migration/state/schema";
+import {
+  countScaleRepairRows,
+  retainedScaleRepair,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import type {
+  migrationRecordValidator,
+  migrationStatusValidator,
+} from "@repo/backend/convex/tryouts/migration/state/schema";
 import {
   ABORT_MIGRATION_ID,
   ABORT_SOURCE_SNAPSHOT,
@@ -13,14 +20,60 @@ import { convexTest } from "convex-test";
 import { Effect } from "effect";
 
 type MigrationStatus = Infer<typeof migrationStatusValidator>;
+type MigrationRecord = Infer<typeof migrationRecordValidator>;
 
 const initialize = makeFunctionReference<
   "mutation",
   { migrationId: string; sourceSnapshotId: string },
   MigrationStatus
 >("tryouts/migration/state/store:initialize");
+const record = makeFunctionReference<
+  "query",
+  { migrationId: string },
+  MigrationRecord
+>("tryouts/migration/state/store:record");
 
 describe("tryouts/migration/state/store", () => {
+  it.effect("projects the durable terminal repair audit", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const repair = {
+        ...retainedScaleRepair,
+        deletedRows: countScaleRepairRows(retainedScaleRepair),
+        repairedAt: 1,
+        runCount: retainedScaleRepair.runs.length,
+      };
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("tryoutHistoryMigrationReceipts", {
+            cleanupLimit: 1,
+            completedAt: 1,
+            deletedRows: 1,
+            migratedAttempts: 0,
+            migratedScaleItems: 0,
+            migratedScaleRuns: 0,
+            migratedScaleVersions: 0,
+            migrationId: retainedScaleRepair.migrationId,
+            phase: "cleaned",
+            planHash: retainedScaleRepair.planHash,
+            receiptHash: "receipt-hash",
+            receiptJson: "receipt-json",
+            recordedAt: 1,
+            repair,
+            sourceSnapshotId: retainedScaleRepair.sourceSnapshotId,
+            targetBundleHash: "target-bundle",
+            targetSnapshotId: "target-snapshot",
+          })
+        )
+      );
+
+      const stored = yield* Effect.promise(() =>
+        t.query(record, { migrationId: retainedScaleRepair.migrationId })
+      );
+      expect(stored.receipt?.repair).toEqual(repair);
+    })
+  );
+
   it.effect("rejects duplicate abort tombstones", () =>
     Effect.gen(function* () {
       const t = convexTest(schema, convexModules);

--- a/packages/backend/convex/tryouts/migration/state/store.ts
+++ b/packages/backend/convex/tryouts/migration/state/store.ts
@@ -130,6 +130,7 @@ export function migrationReceiptRecord(
     phase: receipt.phase,
     planHash: receipt.planHash,
     proof: receipt.proof ?? null,
+    repair: receipt.repair ?? null,
     receiptHash: receipt.receiptHash,
     receiptJson: receipt.receiptJson,
     sourceSnapshotId: receipt.sourceSnapshotId,

--- a/packages/backend/convex/tryouts/migration/state/store.ts
+++ b/packages/backend/convex/tryouts/migration/state/store.ts
@@ -10,6 +10,7 @@ import {
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { retainedTryoutHistoryPlan } from "@repo/backend/convex/tryouts/history/spec";
+import { retainedRepairScalePresent } from "@repo/backend/convex/tryouts/migration/cleanup/marker";
 import {
   type activeMigrationStatusValidator,
   type completedMigrationStatusValidator,
@@ -264,9 +265,11 @@ export const record = internalQuery({
             .unique()
         ),
         receipt: loadMigrationReceipt(ctx, args.migrationId),
+        repairScalePresent: retainedRepairScalePresent(ctx, args.migrationId),
       }).pipe(
-        Effect.map(({ migration, receipt }) => ({
+        Effect.map(({ migration, receipt, repairScalePresent }) => ({
           cleanupStarted: migration?.phase === "cleaning",
+          repairScalePresent,
           receipt: receipt ? migrationReceiptRecord(receipt) : null,
           status: migration ? migrationStatus(migration) : null,
         }))

--- a/packages/backend/convex/tryouts/migration/status.test.ts
+++ b/packages/backend/convex/tryouts/migration/status.test.ts
@@ -17,43 +17,61 @@ const repair = {
 describe("tryouts/migration/status", () => {
   it.effect("requires the repair after proof or terminal cleanup", () =>
     Effect.gen(function* () {
-      for (const receipt of [
+      for (const [receipt, repairScalePresent] of [
         {
-          migrationId: retainedScaleRepair.migrationId,
-          phase: "sealed" as const,
-          proof: null,
-          repair: null,
+          receipt: {
+            migrationId: retainedScaleRepair.migrationId,
+            phase: "sealed" as const,
+            proof: null,
+            repair: null,
+          },
+          repairScalePresent: true,
         },
         {
-          migrationId: retainedScaleRepair.migrationId,
-          phase: "sealed" as const,
-          proof: CLEANUP_PROOF,
-          repair,
+          receipt: {
+            migrationId: retainedScaleRepair.migrationId,
+            phase: "sealed" as const,
+            proof: CLEANUP_PROOF,
+            repair,
+          },
+          repairScalePresent: false,
         },
         {
-          migrationId: retainedScaleRepair.migrationId,
-          phase: "cleaned" as const,
-          proof: CLEANUP_PROOF,
-          repair,
+          receipt: {
+            migrationId: retainedScaleRepair.migrationId,
+            phase: "cleaned" as const,
+            proof: CLEANUP_PROOF,
+            repair,
+          },
+          repairScalePresent: false,
         },
         {
-          migrationId: "migration-without-repair",
-          phase: "cleaned" as const,
-          proof: CLEANUP_PROOF,
-          repair: null,
+          receipt: {
+            migrationId: "migration-without-repair",
+            phase: "cleaned" as const,
+            proof: CLEANUP_PROOF,
+            repair: null,
+          },
+          repairScalePresent: false,
         },
-      ]) {
-        yield* requireTerminalRepair(receipt);
+      ].map(
+        ({ receipt, repairScalePresent }) =>
+          [receipt, repairScalePresent] as const
+      )) {
+        yield* requireTerminalRepair(receipt, repairScalePresent);
       }
 
       for (const phase of ["sealed", "cleaned"] as const) {
         for (const damaged of [null, { ...repair, deletedRows: 157 }]) {
-          const failure = yield* requireTerminalRepair({
-            migrationId: retainedScaleRepair.migrationId,
-            phase,
-            proof: CLEANUP_PROOF,
-            repair: damaged,
-          }).pipe(Effect.flip);
+          const failure = yield* requireTerminalRepair(
+            {
+              migrationId: retainedScaleRepair.migrationId,
+              phase,
+              proof: CLEANUP_PROOF,
+              repair: damaged,
+            },
+            false
+          ).pipe(Effect.flip);
           assert.strictEqual(failure.code, "CONTENT_RELEASE_INTEGRITY");
           assert.strictEqual(
             failure.message,
@@ -61,13 +79,36 @@ describe("tryouts/migration/status", () => {
           );
         }
       }
-      const missingProof = yield* requireTerminalRepair({
-        migrationId: retainedScaleRepair.migrationId,
-        phase: "sealed",
-        proof: null,
-        repair,
-      }).pipe(Effect.flip);
+      const missingProof = yield* requireTerminalRepair(
+        {
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "sealed",
+          proof: null,
+          repair,
+        },
+        false
+      ).pipe(Effect.flip);
       assert.strictEqual(missingProof.code, "CONTENT_RELEASE_INTEGRITY");
+      const simultaneousLoss = yield* requireTerminalRepair(
+        {
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "sealed",
+          proof: null,
+          repair: null,
+        },
+        false
+      ).pipe(Effect.flip);
+      assert.strictEqual(simultaneousLoss.code, "CONTENT_RELEASE_INTEGRITY");
+      const prematureAudit = yield* requireTerminalRepair(
+        {
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "sealed",
+          proof: CLEANUP_PROOF,
+          repair,
+        },
+        true
+      ).pipe(Effect.flip);
+      assert.strictEqual(prematureAudit.code, "CONTENT_RELEASE_INTEGRITY");
     })
   );
 });

--- a/packages/backend/convex/tryouts/migration/status.test.ts
+++ b/packages/backend/convex/tryouts/migration/status.test.ts
@@ -4,6 +4,7 @@ import {
   retainedScaleRepair,
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { requireTerminalRepair } from "@repo/backend/convex/tryouts/migration/status";
+import { CLEANUP_PROOF } from "@repo/backend/test/migration/state";
 import { Effect } from "effect";
 
 const repair = {
@@ -14,30 +15,51 @@ const repair = {
 };
 
 describe("tryouts/migration/status", () => {
-  it.effect("requires the exact durable repair before cleaned status", () =>
+  it.effect("requires the repair after proof or terminal cleanup", () =>
     Effect.gen(function* () {
-      yield* requireTerminalRepair({
-        migrationId: retainedScaleRepair.migrationId,
-        phase: "cleaned",
-        repair,
-      });
-      yield* requireTerminalRepair({
-        migrationId: "migration-without-repair",
-        phase: "cleaned",
-        repair: null,
-      });
-
-      for (const damaged of [null, { ...repair, deletedRows: 157 }]) {
-        const failure = yield* requireTerminalRepair({
+      for (const receipt of [
+        {
           migrationId: retainedScaleRepair.migrationId,
-          phase: "cleaned",
-          repair: damaged,
-        }).pipe(Effect.flip);
-        assert.strictEqual(failure.code, "CONTENT_RELEASE_INTEGRITY");
-        assert.strictEqual(
-          failure.message,
-          "Cleaned try-out history migration lost its durable repair audit."
-        );
+          phase: "sealed" as const,
+          proof: null,
+          repair: null,
+        },
+        {
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "sealed" as const,
+          proof: CLEANUP_PROOF,
+          repair,
+        },
+        {
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "cleaned" as const,
+          proof: CLEANUP_PROOF,
+          repair,
+        },
+        {
+          migrationId: "migration-without-repair",
+          phase: "cleaned" as const,
+          proof: CLEANUP_PROOF,
+          repair: null,
+        },
+      ]) {
+        yield* requireTerminalRepair(receipt);
+      }
+
+      for (const phase of ["sealed", "cleaned"] as const) {
+        for (const damaged of [null, { ...repair, deletedRows: 157 }]) {
+          const failure = yield* requireTerminalRepair({
+            migrationId: retainedScaleRepair.migrationId,
+            phase,
+            proof: CLEANUP_PROOF,
+            repair: damaged,
+          }).pipe(Effect.flip);
+          assert.strictEqual(failure.code, "CONTENT_RELEASE_INTEGRITY");
+          assert.strictEqual(
+            failure.message,
+            "Try-out history migration lost its durable repair audit."
+          );
+        }
       }
     })
   );

--- a/packages/backend/convex/tryouts/migration/status.test.ts
+++ b/packages/backend/convex/tryouts/migration/status.test.ts
@@ -1,0 +1,44 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  countScaleRepairRows,
+  retainedScaleRepair,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import { requireTerminalRepair } from "@repo/backend/convex/tryouts/migration/status";
+import { Effect } from "effect";
+
+const repair = {
+  ...retainedScaleRepair,
+  deletedRows: countScaleRepairRows(retainedScaleRepair),
+  repairedAt: 1,
+  runCount: retainedScaleRepair.runs.length,
+};
+
+describe("tryouts/migration/status", () => {
+  it.effect("requires the exact durable repair before cleaned status", () =>
+    Effect.gen(function* () {
+      yield* requireTerminalRepair({
+        migrationId: retainedScaleRepair.migrationId,
+        phase: "cleaned",
+        repair,
+      });
+      yield* requireTerminalRepair({
+        migrationId: "migration-without-repair",
+        phase: "cleaned",
+        repair: null,
+      });
+
+      for (const damaged of [null, { ...repair, deletedRows: 157 }]) {
+        const failure = yield* requireTerminalRepair({
+          migrationId: retainedScaleRepair.migrationId,
+          phase: "cleaned",
+          repair: damaged,
+        }).pipe(Effect.flip);
+        assert.strictEqual(failure.code, "CONTENT_RELEASE_INTEGRITY");
+        assert.strictEqual(
+          failure.message,
+          "Cleaned try-out history migration lost its durable repair audit."
+        );
+      }
+    })
+  );
+});

--- a/packages/backend/convex/tryouts/migration/status.test.ts
+++ b/packages/backend/convex/tryouts/migration/status.test.ts
@@ -61,6 +61,13 @@ describe("tryouts/migration/status", () => {
           );
         }
       }
+      const missingProof = yield* requireTerminalRepair({
+        migrationId: retainedScaleRepair.migrationId,
+        phase: "sealed",
+        proof: null,
+        repair,
+      }).pipe(Effect.flip);
+      assert.strictEqual(missingProof.code, "CONTENT_RELEASE_INTEGRITY");
     })
   );
 });

--- a/packages/backend/convex/tryouts/migration/status.ts
+++ b/packages/backend/convex/tryouts/migration/status.ts
@@ -44,15 +44,18 @@ const terminalReference = makeFunctionReference<
 export const requireTerminalRepair = Effect.fn(
   "tryouts.migration.requireTerminalRepair"
 )(function* (
-  receipt: Pick<MigrationReceiptRecord, "migrationId" | "phase" | "repair">
+  receipt: Pick<
+    MigrationReceiptRecord,
+    "migrationId" | "phase" | "proof" | "repair"
+  >
 ) {
   if (
-    receipt.phase === "cleaned" &&
+    (receipt.phase === "cleaned" || receipt.proof !== null) &&
     !hasRequiredScaleRepair(receipt.migrationId, receipt.repair)
   ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
-      "Cleaned try-out history migration lost its durable repair audit."
+      "Try-out history migration lost its durable repair audit."
     );
   }
 });

--- a/packages/backend/convex/tryouts/migration/status.ts
+++ b/packages/backend/convex/tryouts/migration/status.ts
@@ -7,6 +7,7 @@ import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
 import { parseStoredJson } from "@repo/backend/convex/contentRelease/parse";
 import { contractFailure } from "@repo/backend/convex/contentRelease/proof/failure";
+import { hasRequiredScaleRepair } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { decodeMigrationPlan } from "@repo/backend/convex/tryouts/migration/plan";
 import {
   authenticateMigrationReceipt,
@@ -24,6 +25,7 @@ import type { Infer } from "convex/values";
 import { Effect } from "effect";
 
 type MigrationRecord = Infer<typeof migrationRecordValidator>;
+type MigrationReceiptRecord = NonNullable<MigrationRecord["receipt"]>;
 type MigrationStatus = Infer<typeof migrationStatusValidator>;
 type TerminalRecord = Infer<typeof terminalRecordValidator>;
 
@@ -37,6 +39,23 @@ const terminalReference = makeFunctionReference<
   { migrationId: string },
   TerminalRecord
 >("tryouts/migration/terminal:terminal");
+
+/** Requires the durable repair audit before exposing cleaned terminal state. */
+export const requireTerminalRepair = Effect.fn(
+  "tryouts.migration.requireTerminalRepair"
+)(function* (
+  receipt: Pick<MigrationReceiptRecord, "migrationId" | "phase" | "repair">
+) {
+  if (
+    receipt.phase === "cleaned" &&
+    !hasRequiredScaleRepair(receipt.migrationId, receipt.repair)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Cleaned try-out history migration lost its durable repair audit."
+    );
+  }
+});
 
 /** Recomputes the complete permanent target before terminal state is exposed. */
 const verifyCompletedStatus = Effect.fn(
@@ -106,6 +125,7 @@ export const readMigrationStatus = Effect.fn("tryouts.migration.readStatus")(
         "Stored try-out history migration receipt changed signed identity."
       );
     }
+    yield* requireTerminalRepair(record.receipt);
     if (!record.status) {
       if (record.receipt.phase !== "cleaned") {
         return yield* releaseFail(

--- a/packages/backend/convex/tryouts/migration/status.ts
+++ b/packages/backend/convex/tryouts/migration/status.ts
@@ -50,20 +50,19 @@ export const requireTerminalRepair = Effect.fn(
   receipt: Pick<
     MigrationReceiptRecord,
     "migrationId" | "phase" | "proof" | "repair"
-  >
+  >,
+  repairScalePresent: boolean
 ) {
-  const repairStarted =
-    receipt.phase === "cleaned" ||
-    receipt.proof !== null ||
-    receipt.repair !== null;
-  const proofMissing =
-    receipt.migrationId === retainedScaleRepair.migrationId &&
-    repairStarted &&
-    receipt.proof === null;
+  if (receipt.migrationId !== retainedScaleRepair.migrationId) {
+    return;
+  }
+  const repaired = !repairScalePresent;
+  const hasProof = receipt.proof !== null;
+  const hasRepair = hasRequiredScaleRepair(receipt.migrationId, receipt.repair);
   if (
-    repairStarted &&
-    (proofMissing ||
-      !hasRequiredScaleRepair(receipt.migrationId, receipt.repair))
+    (repaired && !(hasProof && hasRepair)) ||
+    (!repaired &&
+      (receipt.phase === "cleaned" || hasProof || receipt.repair !== null))
   ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
@@ -140,7 +139,7 @@ export const readMigrationStatus = Effect.fn("tryouts.migration.readStatus")(
         "Stored try-out history migration receipt changed signed identity."
       );
     }
-    yield* requireTerminalRepair(record.receipt);
+    yield* requireTerminalRepair(record.receipt, record.repairScalePresent);
     if (!record.status) {
       if (record.receipt.phase !== "cleaned") {
         return yield* releaseFail(

--- a/packages/backend/convex/tryouts/migration/status.ts
+++ b/packages/backend/convex/tryouts/migration/status.ts
@@ -7,7 +7,10 @@ import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
 import { parseStoredJson } from "@repo/backend/convex/contentRelease/parse";
 import { contractFailure } from "@repo/backend/convex/contentRelease/proof/failure";
-import { hasRequiredScaleRepair } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import {
+  hasRequiredScaleRepair,
+  retainedScaleRepair,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { decodeMigrationPlan } from "@repo/backend/convex/tryouts/migration/plan";
 import {
   authenticateMigrationReceipt,
@@ -49,9 +52,18 @@ export const requireTerminalRepair = Effect.fn(
     "migrationId" | "phase" | "proof" | "repair"
   >
 ) {
+  const repairStarted =
+    receipt.phase === "cleaned" ||
+    receipt.proof !== null ||
+    receipt.repair !== null;
+  const proofMissing =
+    receipt.migrationId === retainedScaleRepair.migrationId &&
+    repairStarted &&
+    receipt.proof === null;
   if (
-    (receipt.phase === "cleaned" || receipt.proof !== null) &&
-    !hasRequiredScaleRepair(receipt.migrationId, receipt.repair)
+    repairStarted &&
+    (proofMissing ||
+      !hasRequiredScaleRepair(receipt.migrationId, receipt.repair))
   ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -1,0 +1,218 @@
+import { strict as assert } from "node:assert/strict";
+import {
+  ContentKeySchema,
+  CorpusSourcePathSchema,
+} from "@nakafa/aksara-contracts/ids";
+import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot/data";
+import { makeTryoutCatalogRecord } from "@nakafa/aksara-contracts/tryout/catalog-hash";
+import {
+  tryoutCatalogIdentity,
+  tryoutCatalogNodeIdentity,
+  tryoutPlacementIdentity,
+} from "@nakafa/aksara-contracts/tryout/identity";
+import { makeTryoutPlacementRecord } from "@nakafa/aksara-contracts/tryout/placement-hash";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import {
+  tryoutCatalogFacts,
+  tryoutPlacementFacts,
+} from "@repo/backend/convex/contentRelease/tryout/facts";
+import type schema from "@repo/backend/convex/schema";
+import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
+import { CLEANUP_SOURCE_SNAPSHOT } from "@repo/backend/test/migration/state";
+import { makeTryoutPlacementRow } from "@repo/backend/test/tryout/snapshot";
+import { makeTryoutStartCatalog } from "@repo/backend/test/tryout/source";
+import type { TestConvex } from "convex-test";
+
+const REPAIR_PUBLISHED_AT = 20;
+type CleanupTest = TestConvex<typeof schema>;
+
+/** Builds one signed section and placement selected by the repair graph. */
+function makeRepairSource(sectionKey: string, order: number) {
+  const baseSection = makeTryoutStartCatalog("en", "visible", "irt").find(
+    (row) => row.kind === "section"
+  );
+  assert.ok(baseSection?.kind === "section");
+  const section = {
+    family: "tryout",
+    record: makeTryoutCatalogRecord({
+      ...baseSection,
+      examKey: "snbt",
+      order,
+      questionCount: 1,
+      sectionKey,
+      setKey: "set-2",
+      trackKey: "2027",
+    }),
+    rowKind: "catalog",
+  } as const;
+  const basePlacement = makeTryoutPlacementRow("en");
+  const questionRoot = `question-bank/tryout/indonesia/snbt/${sectionKey}/set-2/question-1`;
+  const placement = {
+    family: "tryout",
+    record: makeTryoutPlacementRecord({
+      ...basePlacement.record.row,
+      answerContentKey: ContentKeySchema.make(`${questionRoot}/answer`),
+      examKey: "snbt",
+      questionContentKey: ContentKeySchema.make(`${questionRoot}/question`),
+      questionOrder: 1,
+      questionSourcePath: CorpusSourcePathSchema.make(
+        `packages/corpus/${questionRoot}`
+      ),
+      sectionKey,
+      setKey: "set-2",
+      trackKey: "2027",
+    }),
+    rowKind: "placement",
+  } as const;
+  return { placement, section };
+}
+
+/** Replaces legacy test placeholders with authenticated source rows. */
+async function seedRepairSource(
+  ctx: MutationCtx,
+  source: readonly ReturnType<typeof makeRepairSource>[]
+) {
+  const catalogs = await ctx.db
+    .query("tryoutCatalog")
+    .withIndex("by_snapshotId_and_index", (query) =>
+      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+    )
+    .take(source.length);
+  const placements = await ctx.db
+    .query("tryoutPlacements")
+    .withIndex("by_snapshotId_and_index", (query) =>
+      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+    )
+    .take(source.length);
+  assert.ok(catalogs.length === source.length && placements[0]);
+  for (const [index, row] of source.entries()) {
+    const catalog = catalogs[index];
+    assert.ok(catalog);
+    await ctx.db.replace("tryoutCatalog", catalog._id, {
+      ...tryoutCatalogFacts(row.section.record),
+      index: catalog.index,
+      rowHash: row.section.record.rowHash,
+      rowJson: canonicalizeContentSnapshotRow(row.section),
+      snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+    });
+    const stored = placements[index];
+    const next = {
+      ...tryoutPlacementFacts(row.placement.record),
+      index: stored?.index ?? index + 1,
+      rowHash: row.placement.record.rowHash,
+      rowJson: canonicalizeContentSnapshotRow(row.placement),
+      snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+    };
+    if (stored) {
+      await ctx.db.replace("tryoutPlacements", stored._id, next);
+    } else {
+      await ctx.db.insert("tryoutPlacements", next);
+    }
+  }
+}
+
+/** Seeds the exact zero-use provisional graph omitted by attempt inventory. */
+export async function seedUnusedScale(
+  ctx: MutationCtx,
+  source: readonly ReturnType<typeof makeRepairSource>[],
+  responseCount = 0
+) {
+  const first = source[0];
+  assert.ok(first);
+  const firstPlacement = first.placement.record.row;
+  const setIdentity = tryoutCatalogNodeIdentity({
+    appLocale: firstPlacement.appLocale,
+    countryKey: firstPlacement.countryKey,
+    examKey: firstPlacement.examKey,
+    kind: "set",
+    setKey: firstPlacement.setKey,
+    trackKey: firstPlacement.trackKey,
+  });
+  const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
+    model: "2pl",
+    publishedAt: REPAIR_PUBLISHED_AT,
+    questionCount: source.length,
+    setIdentity,
+    status: "provisional",
+    tryoutSnapshotId: CLEANUP_SOURCE_SNAPSHOT,
+  });
+  const itemIds: Id<"irtScaleItems">[] = [];
+  const runIds: Id<"irtCalibrationRuns">[] = [];
+  for (const row of source) {
+    const sectionIdentity = tryoutCatalogIdentity(row.section.record.row);
+    const runId = await ctx.db.insert("irtCalibrationRuns", {
+      attemptCount: 0,
+      completedAt: REPAIR_PUBLISHED_AT,
+      iterationCount: 0,
+      maxParameterDelta: 0,
+      model: "2pl",
+      questionCount: 1,
+      responseCount,
+      scaleVersionId,
+      sectionIdentity,
+      startedAt: REPAIR_PUBLISHED_AT,
+      status: "completed",
+      updatedAt: REPAIR_PUBLISHED_AT,
+    });
+    runIds.push(runId);
+    itemIds.push(
+      await ctx.db.insert("irtScaleItems", {
+        calibrationRunId: runId,
+        calibrationStatus: "provisional",
+        correctRate: 0,
+        difficulty: 0,
+        discrimination: 1,
+        placementIdentity: tryoutPlacementIdentity(row.placement.record.row),
+        placementRowHash: row.placement.record.rowHash,
+        responseCount: 0,
+        scaleVersionId,
+      })
+    );
+  }
+  return {
+    evidence: {
+      itemCount: source.length,
+      publishedAt: REPAIR_PUBLISHED_AT,
+      questionCount: source.length,
+      runs: source.map((row) => ({
+        questionCount: 1,
+        sectionIdentity: tryoutCatalogIdentity(row.section.record.row),
+      })),
+      setIdentity,
+    },
+    itemIds,
+    runIds,
+    scaleVersionId,
+  };
+}
+
+/** Seeds signed cleanup plus one authenticated provisional repair graph. */
+export async function seedRepair(
+  test: CleanupTest,
+  responseCount = 0,
+  sectionKeys: readonly string[] = ["quantitative-knowledge"]
+) {
+  const cleanup = await seedCleanupSuccess(test);
+  const source = sectionKeys.map((sectionKey, index) =>
+    makeRepairSource(sectionKey, index + 1)
+  );
+  const repair = await test.mutation(async (ctx) => {
+    const migration = await ctx.db.query("tryoutHistoryMigrations").unique();
+    assert.ok(migration?.phase === "completed");
+    await seedRepairSource(ctx, source);
+    const graph = await seedUnusedScale(ctx, source, responseCount);
+    return {
+      ...graph,
+      evidence: {
+        ...graph.evidence,
+        migrationId: migration.migrationId,
+        planHash: migration.authorization.planHash,
+        scaleVersionId: graph.scaleVersionId,
+        sourceSnapshotId: migration.sourceSnapshotId,
+      } satisfies ScaleRepairEvidence,
+    };
+  });
+  return { cleanup, repair, source };
+}


### PR DESCRIPTION
## Summary

- bind the provisional scale repair to the exact retained migration, signed plan, source snapshot, Convex graph identity, timestamp, seven zero-use runs, and 150 zero-response items
- verify every live reference and terminal target inside the cleanup transaction before the first repair write
- atomically delete exactly 158 repair rows and persist the immutable proof plus complete repair audit
- keep the repair count internal so the unchanged Aksara 0.23 transport remains strict
- resume ordinary signed cleanup after the single repair-only page

## Production evidence

The sealed `retained-tryout-history` migration is complete. Cleanup fails closed because source snapshot `sha256:0a43a4125fc4886f90b5a509405178bfb8762ad3c7f72be80614fce2671b5162` retains exact provisional scale `wh77kyh90xdyy9bxkve0h7w4d98a5ghm` outside the three signed attempt-derived scale IDs. It has no attempt, score, or migration-map reference, exactly seven completed zero-use runs, and 150 unique zero-response items. Production signed cleanup can consume 6,544 of its signed 6,548-row ceiling, so the separate 158-row repair is recorded only in the durable receipt audit.

## Verification

Exact head: `8cfc889ae3f781225659aa7af433001a82b127e2`
Exact base: `fbf5fe437b52c0dced972966a7fd694f3aee39bf`

- focused cleanup and ingress suite: 3 files, 13 tests
- full backend suite: 388 files, 1,647 tests
- backend typecheck
- lint and Effect 4.0.0-rc.110 source parity
- boundaries: 3,089 files across 19 packages
- security audit: no vulnerabilities
- exact diff check
- exact-head CI and final review remain required before protected merge

## Rollout and deletion checkpoint

This is a temporary fail-closed production repair. After this PR and Aksara PR #250 deploy, the authenticated cleanup must prove the repair audit, signed deletion total, cleaned receipt, deleted migration root, deleted provisional graph, and retained target bundle and attempts. The final contraction then deletes this repair capability, migration-only surfaces and tables, predecessor routes, and versioned compatibility paths. No repair exception remains in the final system.