### PR TITLE
test(backend): make deletion claim test Effect native

### DIFF
--- a/packages/backend/convex/auth/deletion/claim.test.ts
+++ b/packages/backend/convex/auth/deletion/claim.test.ts
@@ -1,5 +1,6 @@
 import { Resend } from "@convex-dev/resend";
 import resendTest from "@convex-dev/resend/test";
+import { describe, expect, it } from "@effect/vitest";
 import { components } from "@repo/backend/convex/_generated/api";
 import { claimAccountDeletion } from "@repo/backend/convex/auth/deletion/claim";
 import { ACCOUNT_DELETION_RECOVERY_DELAY_MS } from "@repo/backend/convex/auth/deletion/constants";
@@ -9,7 +10,8 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 8, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
@@ -19,68 +21,94 @@ const testResend = new Resend(components.resend, {
 });
 
 describe("auth/deletion/claim", () => {
-  it("claims the irreversible phase only from the auth delete hook", async () => {
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, convexModules);
-    resendTest.register(t);
+  it.effect(
+    "claims the irreversible phase only from the auth delete hook",
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() => vi.setSystemTime(NOW));
+        const test = convexTest(schema, convexModules);
+        yield* Effect.sync(() => resendTest.register(test));
 
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "claimed-owner",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "delivered@resend.dev",
-        name: "Claimed Owner",
-        plan: "free",
-      })
-    );
-    const emailId = await t.mutation((ctx) =>
-      testResend.sendEmail(ctx, {
-        from: "Nakafa <nakafa@notifications.nakafa.com>",
-        subject: "Welcome",
-        text: "Welcome",
-        to: "delivered@resend.dev",
-      })
-    );
-    await t.mutation((ctx) =>
-      ctx.db.patch("users", userId, { welcomeEmailId: emailId })
-    );
+        const userId = yield* Effect.promise(() =>
+          test.mutation((ctx) =>
+            ctx.db.insert("users", {
+              authId: "claimed-owner",
+              credits: 0,
+              creditsResetAt: 0,
+              email: "delivered@resend.dev",
+              name: "Claimed Owner",
+              plan: "free",
+            })
+          )
+        );
+        const emailId = yield* Effect.promise(() =>
+          test.mutation((ctx) =>
+            testResend.sendEmail(ctx, {
+              from: "Nakafa <nakafa@notifications.nakafa.com>",
+              subject: "Welcome",
+              text: "Welcome",
+              to: "delivered@resend.dev",
+            })
+          )
+        );
+        yield* Effect.promise(() =>
+          test.mutation((ctx) =>
+            ctx.db.patch("users", userId, { welcomeEmailId: emailId })
+          )
+        );
 
-    const prepared = await t.mutation((ctx) =>
-      runConvexProgram(prepareAccountDeletion(ctx, "claimed-owner", ATTEMPT_ID))
-    );
-    const cancelablePreparation = await t.query((ctx) =>
-      ctx.db.query("accountDeletionPreparations").unique()
-    );
-    const cancelableUser = await t.query((ctx) => ctx.db.get("users", userId));
-    const cancelableEmail = await t.query(components.resend.lib.getStatus, {
-      emailId,
-    });
+        const prepared = yield* Effect.promise(() =>
+          test.mutation((ctx) =>
+            runConvexProgram(
+              prepareAccountDeletion(ctx, "claimed-owner", ATTEMPT_ID)
+            )
+          )
+        );
+        const cancelablePreparation = yield* Effect.promise(() =>
+          test.query((ctx) =>
+            ctx.db.query("accountDeletionPreparations").unique()
+          )
+        );
+        const cancelableUser = yield* Effect.promise(() =>
+          test.query((ctx) => ctx.db.get("users", userId))
+        );
+        const cancelableEmail = yield* Effect.promise(() =>
+          test.query(components.resend.lib.getStatus, { emailId })
+        );
 
-    vi.setSystemTime(NOW + 1000);
-    const claimed = await t.mutation((ctx) =>
-      runConvexProgram(claimAccountDeletion(ctx, "claimed-owner", ATTEMPT_ID))
-    );
-    const committedPreparation = await t.query((ctx) =>
-      ctx.db.query("accountDeletionPreparations").unique()
-    );
-    const committedUser = await t.query((ctx) => ctx.db.get("users", userId));
-    const committedEmail = await t.query(components.resend.lib.getStatus, {
-      emailId,
-    });
+        yield* Effect.sync(() => vi.setSystemTime(NOW + 1000));
+        const claimed = yield* Effect.promise(() =>
+          test.mutation((ctx) =>
+            runConvexProgram(
+              claimAccountDeletion(ctx, "claimed-owner", ATTEMPT_ID)
+            )
+          )
+        );
+        const committedPreparation = yield* Effect.promise(() =>
+          test.query((ctx) =>
+            ctx.db.query("accountDeletionPreparations").unique()
+          )
+        );
+        const committedUser = yield* Effect.promise(() =>
+          test.query((ctx) => ctx.db.get("users", userId))
+        );
+        const committedEmail = yield* Effect.promise(() =>
+          test.query(components.resend.lib.getStatus, { emailId })
+        );
 
-    expect(prepared).toBe(accountDeletionPreparationOutcome.ready);
-    expect(cancelablePreparation).not.toHaveProperty("deletionStartedAt");
-    expect(cancelableUser?.welcomeEmailId).toBe(emailId);
-    expect(cancelableEmail).toMatchObject({ status: "waiting" });
-    expect(claimed).toBe(accountDeletionPreparationOutcome.ready);
-    expect(committedPreparation).toMatchObject({
-      attemptId: ATTEMPT_ID,
-      deletionStartedAt: NOW + 1000,
-      recoveryAt: NOW + 1000 + ACCOUNT_DELETION_RECOVERY_DELAY_MS,
-      recoveryGeneration: 3,
-    });
-    expect(committedUser).not.toHaveProperty("welcomeEmailId");
-    expect(committedEmail).toMatchObject({ status: "cancelled" });
-  });
+        expect(prepared).toBe(accountDeletionPreparationOutcome.ready);
+        expect(cancelablePreparation).not.toHaveProperty("deletionStartedAt");
+        expect(cancelableUser?.welcomeEmailId).toBe(emailId);
+        expect(cancelableEmail).toMatchObject({ status: "waiting" });
+        expect(claimed).toBe(accountDeletionPreparationOutcome.ready);
+        expect(committedPreparation).toMatchObject({
+          attemptId: ATTEMPT_ID,
+          deletionStartedAt: NOW + 1000,
+          recoveryAt: NOW + 1000 + ACCOUNT_DELETION_RECOVERY_DELAY_MS,
+          recoveryGeneration: 3,
+        });
+        expect(committedUser).not.toHaveProperty("welcomeEmailId");
+        expect(committedEmail).toMatchObject({ status: "cancelled" });
+      }).pipe(Effect.ensuring(Effect.sync(() => vi.useRealTimers())))
+  );
 });

--- a/packages/backend/convex/auth/deletion/claim.test.ts
+++ b/packages/backend/convex/auth/deletion/claim.test.ts
@@ -1,6 +1,6 @@
 import { Resend } from "@convex-dev/resend";
 import resendTest from "@convex-dev/resend/test";
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 import { components } from "@repo/backend/convex/_generated/api";
 import { claimAccountDeletion } from "@repo/backend/convex/auth/deletion/claim";
 import { ACCOUNT_DELETION_RECOVERY_DELAY_MS } from "@repo/backend/convex/auth/deletion/constants";
@@ -11,7 +11,6 @@ import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 8, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
@@ -31,29 +30,41 @@ describe("auth/deletion/claim", () => {
 
         const userId = yield* Effect.promise(() =>
           test.mutation((ctx) =>
-            ctx.db.insert("users", {
-              authId: "claimed-owner",
-              credits: 0,
-              creditsResetAt: 0,
-              email: "delivered@resend.dev",
-              name: "Claimed Owner",
-              plan: "free",
-            })
+            runConvexProgram(
+              Effect.promise(() =>
+                ctx.db.insert("users", {
+                  authId: "claimed-owner",
+                  credits: 0,
+                  creditsResetAt: 0,
+                  email: "delivered@resend.dev",
+                  name: "Claimed Owner",
+                  plan: "free",
+                })
+              )
+            )
           )
         );
         const emailId = yield* Effect.promise(() =>
           test.mutation((ctx) =>
-            testResend.sendEmail(ctx, {
-              from: "Nakafa <nakafa@notifications.nakafa.com>",
-              subject: "Welcome",
-              text: "Welcome",
-              to: "delivered@resend.dev",
-            })
+            runConvexProgram(
+              Effect.promise(() =>
+                testResend.sendEmail(ctx, {
+                  from: "Nakafa <nakafa@notifications.nakafa.com>",
+                  subject: "Welcome",
+                  text: "Welcome",
+                  to: "delivered@resend.dev",
+                })
+              )
+            )
           )
         );
         yield* Effect.promise(() =>
           test.mutation((ctx) =>
-            ctx.db.patch("users", userId, { welcomeEmailId: emailId })
+            runConvexProgram(
+              Effect.promise(() =>
+                ctx.db.patch("users", userId, { welcomeEmailId: emailId })
+              )
+            )
           )
         );
 
@@ -66,11 +77,17 @@ describe("auth/deletion/claim", () => {
         );
         const cancelablePreparation = yield* Effect.promise(() =>
           test.query((ctx) =>
-            ctx.db.query("accountDeletionPreparations").unique()
+            runConvexProgram(
+              Effect.promise(() =>
+                ctx.db.query("accountDeletionPreparations").unique()
+              )
+            )
           )
         );
         const cancelableUser = yield* Effect.promise(() =>
-          test.query((ctx) => ctx.db.get("users", userId))
+          test.query((ctx) =>
+            runConvexProgram(Effect.promise(() => ctx.db.get("users", userId)))
+          )
         );
         const cancelableEmail = yield* Effect.promise(() =>
           test.query(components.resend.lib.getStatus, { emailId })
@@ -86,11 +103,17 @@ describe("auth/deletion/claim", () => {
         );
         const committedPreparation = yield* Effect.promise(() =>
           test.query((ctx) =>
-            ctx.db.query("accountDeletionPreparations").unique()
+            runConvexProgram(
+              Effect.promise(() =>
+                ctx.db.query("accountDeletionPreparations").unique()
+              )
+            )
           )
         );
         const committedUser = yield* Effect.promise(() =>
-          test.query((ctx) => ctx.db.get("users", userId))
+          test.query((ctx) =>
+            runConvexProgram(Effect.promise(() => ctx.db.get("users", userId)))
+          )
         );
         const committedEmail = yield* Effect.promise(() =>
           test.query(components.resend.lib.getStatus, { emailId })


### PR DESCRIPTION
## Outcome

Make the account-deletion claim integration test directly native to Effect v4 and upstream `@effect/vitest`.

## Scope

- one owning file: `packages/backend/convex/auth/deletion/claim.test.ts`
- replace raw async test orchestration with `it.effect`
- suspend test and component boundaries with `Effect.promise` and `Effect.sync`
- compose every local Convex database callback through `runConvexProgram`
- guarantee timer restoration with `Effect.ensuring`
- import `vi` directly from the upstream `@effect/vitest` surface
- retain Effect runners only inside real Convex callbacks

## Effect evidence

The implementation follows vendored Effect RC110 and the upstream `@effect/vitest` API. The test has no direct Effect runner, raw Vitest import, raw async callback, or raw local database Promise callback.

## Verification

- focused test: 1 of 1 green
- complete auth-deletion suite: 12 files and 59 of 59 tests green on the final source
- native backend typecheck: green
- full lint: green
- test ownership policy: green
- Effect RC110 source parity: green
- dependency boundaries: green
- clean diff and clean worktree
- exact-head Quality, Required, and Doctor checks passed on `79315c88cc669ef7d077c9522e3b49945a168a2b`; the final exact-head Codex review found no major issues, with zero unresolved review threads

## Exact identity

Head `79315c88cc669ef7d077c9522e3b49945a168a2b`.

## Release

This is test-only, and Production was skipped by policy. No Convex production mutation and no Vercel Preview are involved. The exact #477 canary merged at main `eac90bc83d249f0c1b1979c35b0579c15376534e`; #461 is active, with #475 then #465 queued behind it.