### PR TITLE
fix(ci): verify merge groups without queue API

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -37,6 +37,11 @@ jobs:
           REQUIRED: ${{ env.DIRECT_TRUSTED_CONTENT_ENVIRONMENT }}
         run: echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
 
+      - if: env.DIRECT_TRUSTED_CONTENT_ENVIRONMENT == 'true' || github.event_name == 'merge_group'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
       - name: Verify merge group provenance
         if: github.event_name == 'merge_group'
         id: merge-group-provenance
@@ -49,91 +54,75 @@ jobs:
               throw new Error("Missing merge group payload.")
             }
 
-            const result = await github.graphql(
-              `query MergeQueueEntry($owner: String!, $name: String!) {
-                repository(owner: $owner, name: $name) {
-                  mergeQueue {
-                    configuration {
-                      maximumEntriesToBuild
-                      maximumEntriesToMerge
-                    }
-                    entries(first: 100) {
-                      nodes {
-                        baseCommit { oid }
-                        enqueuer { login }
-                        headCommit {
-                          oid
-                          tree { oid }
-                        }
-                        pullRequest {
-                          author { login }
-                          baseRefName
-                          baseRefOid
-                          headRefOid
-                          headRepository { nameWithOwner }
-                          number
-                          potentialMergeCommit {
-                            parents(first: 3) { nodes { oid } }
-                            tree { oid }
-                          }
-                          state
-                        }
-                      }
-                    }
-                  }
-                }
-              }`,
-              { name: context.repo.repo, owner: context.repo.owner },
-            )
-            const queue = result.repository?.mergeQueue
+            const baseBranch = mergeGroup.base_ref.replace(/^refs\/heads\//, "")
+            const groupRef = mergeGroup.head_ref.startsWith("refs/heads/")
+              ? mergeGroup.head_ref
+              : `refs/heads/${mergeGroup.head_ref}`
+            const queuePrefix = `refs/heads/gh-readonly-queue/${baseBranch}/pr-`
+            const [pullNumber, refBaseSha, ...unexpected] = groupRef
+              .slice(queuePrefix.length)
+              .split("-")
             if (
-              queue?.configuration?.maximumEntriesToBuild !== 1 ||
-              queue.configuration.maximumEntriesToMerge !== 1
+              !groupRef.startsWith(queuePrefix) ||
+              !/^[1-9][0-9]*$/.test(pullNumber) ||
+              unexpected.length > 0 ||
+              (refBaseSha && refBaseSha !== mergeGroup.base_sha) ||
+              mergeGroup.head_sha !== context.sha ||
+              groupRef !== process.env.GITHUB_REF
             ) {
-              throw new Error("Signed acceptance requires a single-entry queue.")
+              throw new Error("Merge group ref does not identify one pull request.")
             }
 
-            const entries = queue.entries?.nodes ?? []
-            const candidates = entries.filter(
-              (entry) =>
-                entry?.baseCommit?.oid === mergeGroup.base_sha &&
-                entry?.headCommit?.oid === mergeGroup.head_sha,
-            )
-            if (candidates.length !== 1) {
-              throw new Error(
-                `Merge group has ${candidates.length} exact queue entries.`,
-              )
-            }
-
-            const [{ enqueuer, headCommit, pullRequest: pull }] = candidates
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(pullNumber),
+            })
+            const actor = context.payload.sender?.login
             if (
-              !pull ||
-              pull.state !== "OPEN" ||
-              pull.baseRefName !== mergeGroup.base_ref.replace("refs/heads/", "") ||
-              pull.baseRefOid !== mergeGroup.base_sha ||
-              pull.headRepository?.nameWithOwner !== context.payload.repository.full_name ||
-              pull.author?.login !== "nabilfatih" ||
-              enqueuer?.login !== "nabilfatih"
+              pull.state !== "open" ||
+              pull.base.ref !== baseBranch ||
+              pull.base.repo.full_name !== context.payload.repository.full_name ||
+              pull.head.repo?.full_name !== context.payload.repository.full_name ||
+              !actor ||
+              pull.user?.login !== actor ||
+              context.actor !== actor
             ) {
               throw new Error("Merge queue entry is not trusted for signed acceptance.")
             }
 
-            // Matching trees proves the event head contains only the admitted
-            // pull request, even if queue settings changed after group creation.
-            const mergeParents = pull.potentialMergeCommit?.parents?.nodes ?? []
-            const expectedParents = [mergeGroup.base_sha, pull.headRefOid].sort()
-            const actualParents = mergeParents.map(({ oid }) => oid).sort()
-            if (
-              actualParents.length !== 2 ||
-              actualParents.some((oid, index) => oid !== expectedParents[index]) ||
-              !pull.potentialMergeCommit?.tree?.oid ||
-              headCommit?.tree?.oid !== pull.potentialMergeCommit.tree.oid
-            ) {
-              throw new Error("Merge group contains changes outside its trusted pull request.")
-            }
-            core.info(`Trusted pull request #${pull.number} at ${pull.headRefOid}.`)
+            core.setOutput("pull-head", pull.head.sha)
+            core.info(`Admitted pull request #${pull.number} at ${pull.head.sha}.`)
 
             return "true"
+
+      - name: Verify merge group tree
+        if: github.event_name == 'merge_group'
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          GROUP_SHA: ${{ github.event.merge_group.head_sha }}
+          PULL_HEAD: ${{ steps.merge-group-provenance.outputs.pull-head }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin "$BASE_SHA" "$GROUP_SHA" "$PULL_HEAD"
+          actual_head="$(git rev-parse HEAD)"
+          actual_parent="$(git rev-parse "$GROUP_SHA^")"
+          parent_count="$(git rev-list --parents -n 1 "$GROUP_SHA" | wc -w)"
+
+          if [ "$actual_head" != "$GROUP_SHA" ] || \
+            [ "$actual_parent" != "$BASE_SHA" ] || \
+            [ "$parent_count" -ne 2 ]; then
+            echo "Merge group is not a single squash candidate on its declared base." >&2
+            exit 1
+          fi
+
+          expected_tree="$(git merge-tree --write-tree "$BASE_SHA" "$PULL_HEAD")"
+          actual_tree="$(git rev-parse "$GROUP_SHA^{tree}")"
+          if [ "$actual_tree" != "$expected_tree" ]; then
+            echo "Merge group contains changes outside its admitted pull request." >&2
+            exit 1
+          fi
 
       - name: Export content environment trust
         id: trust
@@ -146,11 +135,6 @@ jobs:
             trusted=true
           fi
           echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
-
-      - if: steps.trust.outputs.trusted == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
 
       - name: Setup toolchain
         if: steps.trust.outputs.trusted == 'true'

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -78,15 +78,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: Number(pullNumber),
             })
+            const trustedOwner = "nabilfatih"
             const actor = context.payload.sender?.login
             if (
               pull.state !== "open" ||
               pull.base.ref !== baseBranch ||
               pull.base.repo.full_name !== context.payload.repository.full_name ||
               pull.head.repo?.full_name !== context.payload.repository.full_name ||
-              !actor ||
-              pull.user?.login !== actor ||
-              context.actor !== actor
+              pull.user?.login !== trustedOwner ||
+              actor !== trustedOwner ||
+              context.actor !== trustedOwner
             ) {
               throw new Error("Merge queue entry is not trusted for signed acceptance.")
             }


### PR DESCRIPTION
## Failure evidence

The first real queue canary, PR #477 at synthetic SHA `54f3e103bc7ce89846d7401f34b5258d7eb22baa`, failed only in Production Scope. GitHub returned `Resource not accessible by integration` when the workflow token queried `repository.mergeQueue`. Quality and Doctor were green.

## Root cause

The workflow grants `contents: read` and `pull-requests: read`, but GitHub's merge-queue GraphQL resource requires a separate Merge queues app permission that `GITHUB_TOKEN` does not expose. Retrying the same query cannot succeed.

## Fix

- Read the one PR identified by the official merge-group ref through the permitted Pulls REST endpoint.
- Require an open same-repository PR targeting the declared base.
- Require the PR author, merge-group sender, and workflow actor to be the same authorized user.
- Check out the synthetic SHA before any dependency install or production secret access.
- Require a single-parent squash candidate whose parent is the payload base SHA.
- Reproduce the expected tree with `git merge-tree --write-tree <base> <pull-head>` and require exact equality with the synthetic tree.

This deletes the inaccessible queue GraphQL query and its stale two-parent `potentialMergeCommit` assumption.

## Security invariant

A merge-group run becomes trusted only when the GitHub event, temporary queue ref, Pulls REST record, commit parent, and exact merged tree all agree. Any extra queued change, stale head, foreign repository, different actor, malformed ref, or tree mismatch fails before dependency installation and before the Production job can access secrets.

## Local proof

- The replacement tree proof reproduces the real #477 synthetic tree `10252a7db37934b016886cbbec6490d2b092d98a`.
- `actionlint .github/workflows/agent-docs.yml`
- `pnpm test:scripts`: 19/19
- `pnpm lint`
- `pnpm boundaries`
- `pnpm security:audit`: zero vulnerabilities
- Effect source parity: RC110 at `66114151c2b4640bf773f2b3456ce70d679422f6`
- clean diff check

One first parallel local script run hit the existing 5 second production-acceptance test timeout at 5.012 seconds. The exact file reran green 9/9 in 3.02 seconds, then the complete scripts suite reran green 19/19.

## Release plan

This PR is the self-hosting queue fix. After direct exact-head checks and review are green, enqueue it alone. Its own `merge_group` run must prove the replacement contract before GitHub can merge it. Then re-enqueue test-only canary #477. No Vercel Preview is created.