### PR TITLE
test(backend): run deletion commit cases with Effect Vitest

### DIFF
--- a/packages/backend/convex/auth/deletion/commit.test.ts
+++ b/packages/backend/convex/auth/deletion/commit.test.ts
@@ -1,48 +1,51 @@
+import { describe, expect, it, vi } from "@effect/vitest";
 import { continueAccountDeletionCommitProgram } from "@repo/backend/convex/auth/deletion/commit";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
 
 const NOW = Date.UTC(2026, 6, 28, 10, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
 
 function seedStartedDeletion(t: ReturnType<typeof convexTest>, authId: string) {
-  return t.mutation(async (ctx) => {
-    const userId = await ctx.db.insert("users", {
-      authId,
-      credits: 0,
-      creditsResetAt: 0,
-      deletionPreparedAt: NOW,
-      email: `${authId}@example.com`,
-      name: authId,
-      plan: "free",
-    });
-    const preparationId = await ctx.db.insert("accountDeletionPreparations", {
-      attemptId: ATTEMPT_ID,
-      authId,
-      deletionStartedAt: NOW,
-      readyAt: NOW,
-      recoveryAt: NOW,
-      recoveryGeneration: 1,
-      userId,
-    });
-
-    return {
-      expectedPreparation: {
+  return Effect.promise(() =>
+    t.mutation(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        authId,
+        credits: 0,
+        creditsResetAt: 0,
+        deletionPreparedAt: NOW,
+        email: `${authId}@example.com`,
+        name: authId,
+        plan: "free",
+      });
+      const preparationId = await ctx.db.insert("accountDeletionPreparations", {
         attemptId: ATTEMPT_ID,
-        preparationId,
+        authId,
+        deletionStartedAt: NOW,
+        readyAt: NOW,
+        recoveryAt: NOW,
         recoveryGeneration: 1,
-      },
-      preparationId,
-      userId,
-    };
-  });
+        userId,
+      });
+
+      return {
+        expectedPreparation: {
+          attemptId: ATTEMPT_ID,
+          preparationId,
+          recoveryGeneration: 1,
+        },
+        preparationId,
+        userId,
+      };
+    })
+  );
 }
 
 describe("auth/deletion/commit", () => {
-  it.each([
+  it.effect.each([
     {
       accountCount: 0,
       expectedAccountCalls: 0,
@@ -55,88 +58,108 @@ describe("auth/deletion/commit", () => {
       sessionCount: 0,
       stage: "accounts",
     },
-  ])("continues after deleting one bounded $stage page", async (testCase) => {
-    const t = convexTest(schema, convexModules);
-    const seeded = await seedStartedDeletion(t, `${testCase.stage}-owner`);
-    const deleteAccounts = vi.fn(async () => testCase.accountCount);
-    const deleteAuthUser = vi.fn(async () => undefined);
-    const deleteSessions = vi.fn(async () => testCase.sessionCount);
-    const scheduleContinuation = vi.fn(async () => undefined);
+  ])("continues after deleting one bounded $stage page", (testCase) =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const seeded = yield* seedStartedDeletion(t, `${testCase.stage}-owner`);
+      const deleteAccounts = vi.fn(() =>
+        Promise.resolve(testCase.accountCount)
+      );
+      const deleteAuthUser = vi.fn(() => Promise.resolve());
+      const deleteSessions = vi.fn(() =>
+        Promise.resolve(testCase.sessionCount)
+      );
+      const scheduleContinuation = vi.fn(() => Promise.resolve());
 
-    const handled = await t.mutation((ctx) =>
-      runConvexProgram(
-        continueAccountDeletionCommitProgram(
-          ctx,
-          `${testCase.stage}-owner`,
-          seeded.expectedPreparation,
-          {
-            deleteAccounts,
-            deleteAuthUser,
-            deleteSessions,
-            scheduleContinuation,
-          }
+      const handled = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            continueAccountDeletionCommitProgram(
+              ctx,
+              `${testCase.stage}-owner`,
+              seeded.expectedPreparation,
+              {
+                deleteAccounts,
+                deleteAuthUser,
+                deleteSessions,
+                scheduleContinuation,
+              }
+            )
+          )
         )
-      )
-    );
-    const state = await t.query(async (ctx) => ({
-      preparation: await ctx.db.get(
-        "accountDeletionPreparations",
-        seeded.preparationId
-      ),
-      user: await ctx.db.get("users", seeded.userId),
-    }));
+      );
+      const state = yield* Effect.promise(() =>
+        t.query(async (ctx) => ({
+          preparation: await ctx.db.get(
+            "accountDeletionPreparations",
+            seeded.preparationId
+          ),
+          user: await ctx.db.get("users", seeded.userId),
+        }))
+      );
 
-    expect(handled).toBe(true);
-    expect(deleteSessions).toHaveBeenCalledOnce();
-    expect(deleteAccounts).toHaveBeenCalledTimes(testCase.expectedAccountCalls);
-    expect(deleteAuthUser).not.toHaveBeenCalled();
-    expect(scheduleContinuation).toHaveBeenCalledOnce();
-    expect(state.preparation).not.toHaveProperty("finalizedAt");
-    expect(state.user).not.toHaveProperty("deletedAt");
-  });
+      expect(handled).toBe(true);
+      expect(deleteSessions).toHaveBeenCalledOnce();
+      expect(deleteAccounts).toHaveBeenCalledTimes(
+        testCase.expectedAccountCalls
+      );
+      expect(deleteAuthUser).not.toHaveBeenCalled();
+      expect(scheduleContinuation).toHaveBeenCalledOnce();
+      expect(state.preparation).not.toHaveProperty("finalizedAt");
+      expect(state.user).not.toHaveProperty("deletedAt");
+    })
+  );
 
-  it("deletes the auth user and finalizes the app record atomically", async () => {
-    const t = convexTest(schema, convexModules);
-    const seeded = await seedStartedDeletion(t, "final-commit-owner");
-    const deleteAuthUser = vi.fn(async () => undefined);
+  it.effect(
+    "deletes the auth user and finalizes the app record atomically",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const seeded = yield* seedStartedDeletion(t, "final-commit-owner");
+        const deleteAuthUser = vi.fn(() => Promise.resolve());
 
-    const handled = await t.mutation((ctx) =>
-      runConvexProgram(
-        continueAccountDeletionCommitProgram(
-          ctx,
-          "final-commit-owner",
-          seeded.expectedPreparation,
-          {
-            deleteAccounts: vi.fn(async () => 0),
-            deleteAuthUser,
-            deleteSessions: vi.fn(async () => 0),
-            scheduleContinuation: vi.fn(async () => undefined),
-          }
-        )
-      )
-    );
-    const state = await t.query(async (ctx) => ({
-      preparation: await ctx.db.get(
-        "accountDeletionPreparations",
-        seeded.preparationId
-      ),
-      receipt: await ctx.db.query("accountDeletionReceipts").unique(),
-      user: await ctx.db.get("users", seeded.userId),
-    }));
+        const handled = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              continueAccountDeletionCommitProgram(
+                ctx,
+                "final-commit-owner",
+                seeded.expectedPreparation,
+                {
+                  deleteAccounts: vi.fn(() => Promise.resolve(0)),
+                  deleteAuthUser,
+                  deleteSessions: vi.fn(() => Promise.resolve(0)),
+                  scheduleContinuation: vi.fn(() => Promise.resolve()),
+                }
+              )
+            )
+          )
+        );
+        const state = yield* Effect.promise(() =>
+          t.query(async (ctx) => ({
+            preparation: await ctx.db.get(
+              "accountDeletionPreparations",
+              seeded.preparationId
+            ),
+            receipt: await ctx.db.query("accountDeletionReceipts").unique(),
+            user: await ctx.db.get("users", seeded.userId),
+          }))
+        );
 
-    expect(handled).toBe(true);
-    expect(deleteAuthUser).toHaveBeenCalledOnce();
-    expect(state.preparation?.finalizedAt).toEqual(expect.any(Number));
-    expect(state.receipt?.attemptId).toBe(ATTEMPT_ID);
-    expect(state.user).toMatchObject({
-      authId: `deleted:${seeded.userId}`,
-      deletedAt: expect.any(Number),
-      email: `deleted-${seeded.userId}@account.nakafa.invalid`,
-      name: "Deleted user",
-    });
-  });
+        expect(handled).toBe(true);
+        expect(deleteAuthUser).toHaveBeenCalledOnce();
+        expect(state.preparation?.finalizedAt).toEqual(expect.any(Number));
+        expect(state.receipt?.attemptId).toBe(ATTEMPT_ID);
+        expect(state.user).toMatchObject({
+          authId: `deleted:${seeded.userId}`,
+          deletedAt: expect.any(Number),
+          email: `deleted-${seeded.userId}@account.nakafa.invalid`,
+          name: "Deleted user",
+        });
+      })
+  );
 
-  it.each([
+  it.effect.each([
     {
       patch: { deletionStartedAt: undefined },
       state: "before the irreversible claim",
@@ -145,33 +168,43 @@ describe("auth/deletion/commit", () => {
       patch: { cancellationStartedAt: NOW + 1 },
       state: "after cancellation starts",
     },
-  ])("does not touch auth $state", async ({ patch }) => {
-    const t = convexTest(schema, convexModules);
-    const seeded = await seedStartedDeletion(t, "unclaimed-owner");
-    await t.mutation((ctx) =>
-      ctx.db.patch("accountDeletionPreparations", seeded.preparationId, patch)
-    );
-    const deleteAuthUser = vi.fn(async () => undefined);
-    const deleteSessions = vi.fn(async () => 0);
-
-    const handled = await t.mutation((ctx) =>
-      runConvexProgram(
-        continueAccountDeletionCommitProgram(
-          ctx,
-          "unclaimed-owner",
-          seeded.expectedPreparation,
-          {
-            deleteAccounts: vi.fn(async () => 0),
-            deleteAuthUser,
-            deleteSessions,
-            scheduleContinuation: vi.fn(async () => undefined),
-          }
+  ])("does not touch auth $state", ({ patch }) =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const seeded = yield* seedStartedDeletion(t, "unclaimed-owner");
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.patch(
+            "accountDeletionPreparations",
+            seeded.preparationId,
+            patch
+          )
         )
-      )
-    );
+      );
+      const deleteAuthUser = vi.fn(() => Promise.resolve());
+      const deleteSessions = vi.fn(() => Promise.resolve(0));
 
-    expect(handled).toBe(false);
-    expect(deleteSessions).not.toHaveBeenCalled();
-    expect(deleteAuthUser).not.toHaveBeenCalled();
-  });
+      const handled = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            continueAccountDeletionCommitProgram(
+              ctx,
+              "unclaimed-owner",
+              seeded.expectedPreparation,
+              {
+                deleteAccounts: vi.fn(() => Promise.resolve(0)),
+                deleteAuthUser,
+                deleteSessions,
+                scheduleContinuation: vi.fn(() => Promise.resolve()),
+              }
+            )
+          )
+        )
+      );
+
+      expect(handled).toBe(false);
+      expect(deleteSessions).not.toHaveBeenCalled();
+      expect(deleteAuthUser).not.toHaveBeenCalled();
+    })
+  );
 });

--- a/packages/backend/convex/auth/deletion/commit.test.ts
+++ b/packages/backend/convex/auth/deletion/commit.test.ts
@@ -11,36 +11,44 @@ const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
 
 function seedStartedDeletion(t: ReturnType<typeof convexTest>, authId: string) {
   return Effect.promise(() =>
-    t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId,
-        credits: 0,
-        creditsResetAt: 0,
-        deletionPreparedAt: NOW,
-        email: `${authId}@example.com`,
-        name: authId,
-        plan: "free",
-      });
-      const preparationId = await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: ATTEMPT_ID,
-        authId,
-        deletionStartedAt: NOW,
-        readyAt: NOW,
-        recoveryAt: NOW,
-        recoveryGeneration: 1,
-        userId,
-      });
+    t.mutation((ctx) =>
+      runConvexProgram(
+        Effect.gen(function* () {
+          const userId = yield* Effect.promise(() =>
+            ctx.db.insert("users", {
+              authId,
+              credits: 0,
+              creditsResetAt: 0,
+              deletionPreparedAt: NOW,
+              email: `${authId}@example.com`,
+              name: authId,
+              plan: "free",
+            })
+          );
+          const preparationId = yield* Effect.promise(() =>
+            ctx.db.insert("accountDeletionPreparations", {
+              attemptId: ATTEMPT_ID,
+              authId,
+              deletionStartedAt: NOW,
+              readyAt: NOW,
+              recoveryAt: NOW,
+              recoveryGeneration: 1,
+              userId,
+            })
+          );
 
-      return {
-        expectedPreparation: {
-          attemptId: ATTEMPT_ID,
-          preparationId,
-          recoveryGeneration: 1,
-        },
-        preparationId,
-        userId,
-      };
-    })
+          return {
+            expectedPreparation: {
+              attemptId: ATTEMPT_ID,
+              preparationId,
+              recoveryGeneration: 1,
+            },
+            preparationId,
+            userId,
+          };
+        })
+      )
+    )
   );
 }
 
@@ -89,13 +97,20 @@ describe("auth/deletion/commit", () => {
         )
       );
       const state = yield* Effect.promise(() =>
-        t.query(async (ctx) => ({
-          preparation: await ctx.db.get(
-            "accountDeletionPreparations",
-            seeded.preparationId
-          ),
-          user: await ctx.db.get("users", seeded.userId),
-        }))
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const preparation = yield* Effect.promise(() =>
+                ctx.db.get("accountDeletionPreparations", seeded.preparationId)
+              );
+              const user = yield* Effect.promise(() =>
+                ctx.db.get("users", seeded.userId)
+              );
+
+              return { preparation, user };
+            })
+          )
+        )
       );
 
       expect(handled).toBe(true);
@@ -136,14 +151,26 @@ describe("auth/deletion/commit", () => {
           )
         );
         const state = yield* Effect.promise(() =>
-          t.query(async (ctx) => ({
-            preparation: await ctx.db.get(
-              "accountDeletionPreparations",
-              seeded.preparationId
-            ),
-            receipt: await ctx.db.query("accountDeletionReceipts").unique(),
-            user: await ctx.db.get("users", seeded.userId),
-          }))
+          t.query((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const preparation = yield* Effect.promise(() =>
+                  ctx.db.get(
+                    "accountDeletionPreparations",
+                    seeded.preparationId
+                  )
+                );
+                const receipt = yield* Effect.promise(() =>
+                  ctx.db.query("accountDeletionReceipts").unique()
+                );
+                const user = yield* Effect.promise(() =>
+                  ctx.db.get("users", seeded.userId)
+                );
+
+                return { preparation, receipt, user };
+              })
+            )
+          )
         );
 
         expect(handled).toBe(true);
@@ -174,10 +201,14 @@ describe("auth/deletion/commit", () => {
       const seeded = yield* seedStartedDeletion(t, "unclaimed-owner");
       yield* Effect.promise(() =>
         t.mutation((ctx) =>
-          ctx.db.patch(
-            "accountDeletionPreparations",
-            seeded.preparationId,
-            patch
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.patch(
+                "accountDeletionPreparations",
+                seeded.preparationId,
+                patch
+              )
+            )
           )
         )
       );


### PR DESCRIPTION
## Outcome

Migrates the five account-deletion commit cases to direct `@effect/vitest` `it.effect` and `it.effect.each` programs. The test module now has no raw Vitest import, raw async callback, or direct Effect runner.

## Effect v4 basis

- Matches vendored Effect RC110 `packages/vitest/src/index.ts`, which re-exports Vitest and defines `it.effect.each(cases)(name, effect)`.
- Suspends Convex database promises with `Effect.promise` and composes multi-step fixtures and assertions with `Effect.gen`.
- Keeps `runConvexProgram` only at the real Convex mutation and query callback boundaries.
- Uses the direct upstream `@effect/vitest` surface, including `vi`, with no repository wrapper.

## Scope

One package-owned test module only: `packages/backend/convex/auth/deletion/commit.test.ts`. No production behavior, schema, dependency, wrapper, compatibility layer, or Vercel Preview.

## Verification

- Focused file: 5/5 green
- Account-deletion suite: 59/59 green
- Native backend TypeScript typecheck: green
- Root lint: green
- Test ownership policy: green
- Boundaries: green
- Effect source parity: RC110 at `66114151c2b4640bf773f2b3456ce70d679422f6`
- Static scan: zero raw Vitest imports, direct Effect runners, and raw async callbacks
- Clean diff check

## Full-suite observation

Two default-worker backend runs completed 1636/1641 and 1637/1641 tests, with unrelated files changing between exact 5000 ms timeout failures. The first five failed files reran 7/7 green, and the relevant account-deletion suite reran 59/59 green when executed without another Vitest sharing its coverage directory. No timeout was raised and no unrelated test was changed. Exact-head Quality, Required, and Doctor checks passed on `5743ea02cc0e6853b5ac90ae055807f6b06b8f32`; the final exact-head Codex review found no major issues, with zero unresolved review threads.

## Release

Test-only. Required, Doctor, and Quality are green, and no production deployment should be created. The exact #477 canary merged at main `eac90bc83d249f0c1b1979c35b0579c15376534e`; #461 is active, with #475 then #465 queued behind it. Merge only from the exact reviewed head through the protected merge queue when its serialized slot is available.