### PR TITLE
test(backend): run deletion successor with Effect Vitest

### DIFF
--- a/packages/backend/convex/auth/deletion/successor.test.ts
+++ b/packages/backend/convex/auth/deletion/successor.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE } from "@repo/backend/convex/auth/deletion/constants";
 import { findSchoolOwnershipSuccessorPage } from "@repo/backend/convex/auth/deletion/successor";
@@ -5,105 +6,121 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
 
 const NOW = Date.UTC(2026, 6, 28, 8, 0, 0);
 
-async function insertUser(
-  ctx: MutationCtx,
-  suffix: string,
-  deletedAt?: number
-) {
-  return await ctx.db.insert("users", {
-    authId: `successor-${suffix}`,
-    credits: 0,
-    creditsResetAt: 0,
-    deletedAt,
-    email: `successor-${suffix}@example.com`,
-    name: `Successor ${suffix}`,
-    plan: "free",
-  });
+function insertUser(ctx: MutationCtx, suffix: string, deletedAt?: number) {
+  return Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: `successor-${suffix}`,
+      credits: 0,
+      creditsResetAt: 0,
+      deletedAt,
+      email: `successor-${suffix}@example.com`,
+      name: `Successor ${suffix}`,
+      plan: "free",
+    })
+  );
 }
 
 describe("auth/deletion/successor", () => {
-  it("continues past a full page of deleting members", async () => {
-    const t = convexTest(schema, convexModules);
-    const seeded = await t.mutation(async (ctx) => {
-      const ownerId = await insertUser(ctx, "owner");
-      const schoolId = await ctx.db.insert("schools", {
-        city: "Jakarta",
-        createdBy: ownerId,
-        currentStudents: ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE + 1,
-        currentTeachers: 0,
-        email: "successor-school@example.com",
-        name: "Successor School",
-        province: "DKI Jakarta",
-        slug: "successor-school",
-        type: "high-school",
-        updatedAt: NOW,
-      });
+  it.effect("continues past a full page of deleting members", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const seeded = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const ownerId = yield* insertUser(ctx, "owner");
+              const schoolId = yield* Effect.promise(() =>
+                ctx.db.insert("schools", {
+                  city: "Jakarta",
+                  createdBy: ownerId,
+                  currentStudents: ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE + 1,
+                  currentTeachers: 0,
+                  email: "successor-school@example.com",
+                  name: "Successor School",
+                  province: "DKI Jakarta",
+                  slug: "successor-school",
+                  type: "high-school",
+                  updatedAt: NOW,
+                })
+              );
 
-      for (
-        let index = 0;
-        index < ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE;
-        index += 1
-      ) {
-        const userId = await insertUser(ctx, `deleting-${index}`, NOW);
-        await ctx.db.insert("schoolMembers", {
-          joinedAt: NOW,
-          role: "student",
-          schoolId,
-          status: "active",
-          updatedAt: NOW,
-          userId,
-        });
+              for (
+                let index = 0;
+                index < ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE;
+                index += 1
+              ) {
+                const userId = yield* insertUser(ctx, `deleting-${index}`, NOW);
+                yield* Effect.promise(() =>
+                  ctx.db.insert("schoolMembers", {
+                    joinedAt: NOW,
+                    role: "student",
+                    schoolId,
+                    status: "active",
+                    updatedAt: NOW,
+                    userId,
+                  })
+                );
+              }
+
+              const successorId = yield* insertUser(ctx, "active");
+              const successorMembershipId = yield* Effect.promise(() =>
+                ctx.db.insert("schoolMembers", {
+                  joinedAt: NOW,
+                  role: "student",
+                  schoolId,
+                  status: "active",
+                  updatedAt: NOW,
+                  userId: successorId,
+                })
+              );
+
+              return { ownerId, schoolId, successorMembershipId };
+            })
+          )
+        )
+      );
+      const firstPage = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            findSchoolOwnershipSuccessorPage(
+              ctx,
+              seeded.schoolId,
+              seeded.ownerId,
+              null
+            )
+          )
+        )
+      );
+
+      expect(firstPage.kind).toBe("continue");
+
+      if (firstPage.kind !== "continue") {
+        return;
       }
 
-      const successorId = await insertUser(ctx, "active");
-      const successorMembershipId = await ctx.db.insert("schoolMembers", {
-        joinedAt: NOW,
-        role: "student",
-        schoolId,
-        status: "active",
-        updatedAt: NOW,
-        userId: successorId,
+      const secondPage = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            findSchoolOwnershipSuccessorPage(
+              ctx,
+              seeded.schoolId,
+              seeded.ownerId,
+              firstPage.cursor
+            )
+          )
+        )
+      );
+
+      expect(secondPage).toMatchObject({
+        kind: "found",
+        successorMembership: {
+          _id: seeded.successorMembershipId,
+        },
       });
-
-      return { ownerId, schoolId, successorMembershipId };
-    });
-    const firstPage = await t.mutation((ctx) =>
-      runConvexProgram(
-        findSchoolOwnershipSuccessorPage(
-          ctx,
-          seeded.schoolId,
-          seeded.ownerId,
-          null
-        )
-      )
-    );
-
-    expect(firstPage.kind).toBe("continue");
-
-    if (firstPage.kind !== "continue") {
-      return;
-    }
-
-    const secondPage = await t.mutation((ctx) =>
-      runConvexProgram(
-        findSchoolOwnershipSuccessorPage(
-          ctx,
-          seeded.schoolId,
-          seeded.ownerId,
-          firstPage.cursor
-        )
-      )
-    );
-
-    expect(secondPage).toMatchObject({
-      kind: "found",
-      successorMembership: {
-        _id: seeded.successorMembershipId,
-      },
-    });
-  });
+    })
+  );
 });


### PR DESCRIPTION
## Outcome

Migrates the school-ownership successor pagination test to direct Effect v4 Vitest orchestration.

## Effect v4 basis

- Uses direct `@effect/vitest` `it.effect` from vendored RC110.
- Models fixture writes and Convex Promise boundaries with `Effect.promise` and `Effect.gen`.
- Keeps `runConvexProgram` only at real Convex mutation callback boundaries.
- Removes the raw `vitest` import and every raw async helper or test callback.

## Scope

One package-owned test module only: `packages/backend/convex/auth/deletion/successor.test.ts`. No production behavior, dependency, wrapper, compatibility layer, or Vercel Preview.

## Verification

- Focused test: 1/1 green
- Native backend TypeScript typecheck: green
- Root lint: green
- Test ownership policy: green
- Boundaries: green
- Effect source parity: RC110 at `66114151c2b4640bf773f2b3456ce70d679422f6`
- No direct Effect runner, raw Vitest import, or async callback remains
- Clean diff check

## Release

Test-only. Merge only from its exact reviewed head through the protected merge queue after Required, Doctor, and Quality are green. No production deployment should be created.