### PR TITLE
test(backend): run deletion receipt with Effect Vitest

### DIFF
--- a/packages/backend/convex/auth/deletion/receipt.test.ts
+++ b/packages/backend/convex/auth/deletion/receipt.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE } from "@repo/backend/convex/auth/deletion/constants";
 import {
@@ -10,7 +11,7 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
 
 const COMMITTED_ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";
 const PENDING_ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0621";
@@ -19,136 +20,183 @@ const UNKNOWN_ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0623";
 const FINALIZED_ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0624";
 
 function insertUser(ctx: MutationCtx, authId: string) {
-  return ctx.db.insert("users", {
-    authId,
-    credits: 0,
-    creditsResetAt: 0,
-    email: `${authId}@example.com`,
-    name: authId,
-    plan: "free",
-  });
+  return Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId,
+      credits: 0,
+      creditsResetAt: 0,
+      email: `${authId}@example.com`,
+      name: authId,
+      plan: "free",
+    })
+  );
 }
 
 describe("auth/deletion/receipt", () => {
-  it("distinguishes committed, pending, and unknown browser attempts", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation(async (ctx) => {
-      const pendingUserId = await insertUser(ctx, "pending-auth");
-      const deletedAuthUserId = await insertUser(ctx, "deleted-auth");
+  it.effect(
+    "distinguishes committed, pending, and unknown browser attempts",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const pendingUserId = yield* insertUser(ctx, "pending-auth");
+                const deletedAuthUserId = yield* insertUser(
+                  ctx,
+                  "deleted-auth"
+                );
 
-      await ctx.db.insert("accountDeletionReceipts", {
-        attemptId: COMMITTED_ATTEMPT_ID,
-        committedAt: 1,
-      });
-      await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: PENDING_ATTEMPT_ID,
-        authId: "pending-auth",
-        recoveryGeneration: 0,
-        userId: pendingUserId,
-      });
-      await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: DELETED_AUTH_ATTEMPT_ID,
-        authId: "deleted-auth",
-        recoveryGeneration: 0,
-        userId: deletedAuthUserId,
-      });
-      await ctx.db.insert("accountDeletionPreparations", {
-        attemptId: FINALIZED_ATTEMPT_ID,
-        authId: "pending-auth",
-        finalizedAt: 1,
-        recoveryGeneration: 0,
-        userId: pendingUserId,
-      });
-    });
-    const authUserExists = vi.fn(async (authId: string) =>
-      Promise.resolve(authId === "pending-auth")
-    );
-    const getStatus = (attemptId: string) =>
-      t.query((ctx) =>
-        runConvexProgram(
-          getAccountDeletionAttemptStatusProgram(ctx, attemptId, authUserExists)
+                yield* Effect.promise(() =>
+                  ctx.db.insert("accountDeletionReceipts", {
+                    attemptId: COMMITTED_ATTEMPT_ID,
+                    committedAt: 1,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("accountDeletionPreparations", {
+                    attemptId: PENDING_ATTEMPT_ID,
+                    authId: "pending-auth",
+                    recoveryGeneration: 0,
+                    userId: pendingUserId,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("accountDeletionPreparations", {
+                    attemptId: DELETED_AUTH_ATTEMPT_ID,
+                    authId: "deleted-auth",
+                    recoveryGeneration: 0,
+                    userId: deletedAuthUserId,
+                  })
+                );
+                yield* Effect.promise(() =>
+                  ctx.db.insert("accountDeletionPreparations", {
+                    attemptId: FINALIZED_ATTEMPT_ID,
+                    authId: "pending-auth",
+                    finalizedAt: 1,
+                    recoveryGeneration: 0,
+                    userId: pendingUserId,
+                  })
+                );
+              })
+            )
+          )
+        );
+        const authUserExists = vi.fn((authId: string) =>
+          Promise.resolve(authId === "pending-auth")
+        );
+        const getStatus = (attemptId: string) =>
+          Effect.promise(() =>
+            t.query((ctx) =>
+              runConvexProgram(
+                getAccountDeletionAttemptStatusProgram(
+                  ctx,
+                  attemptId,
+                  authUserExists
+                )
+              )
+            )
+          );
+
+        expect(yield* getStatus(COMMITTED_ATTEMPT_ID)).toBe(
+          accountDeletionAttemptStatus.committed
+        );
+        expect(yield* getStatus(PENDING_ATTEMPT_ID)).toBe(
+          accountDeletionAttemptStatus.pending
+        );
+        expect(yield* getStatus(DELETED_AUTH_ATTEMPT_ID)).toBe(
+          accountDeletionAttemptStatus.committed
+        );
+        expect(yield* getStatus(FINALIZED_ATTEMPT_ID)).toBe(
+          accountDeletionAttemptStatus.committed
+        );
+        expect(yield* getStatus(UNKNOWN_ATTEMPT_ID)).toBe(
+          accountDeletionAttemptStatus.unknown
+        );
+        expect(authUserExists).toHaveBeenCalledTimes(2);
+      })
+  );
+
+  it.effect("records one idempotent privacy-minimal receipt", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              yield* recordAccountDeletionReceipt(ctx, COMMITTED_ATTEMPT_ID, 1);
+              yield* recordAccountDeletionReceipt(ctx, COMMITTED_ATTEMPT_ID, 2);
+              yield* recordAccountDeletionReceipt(ctx, undefined, 3);
+            })
+          )
+        )
+      );
+      const receipts = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.query("accountDeletionReceipts").collect())
+      );
+
+      expect(receipts).toEqual([
+        expect.objectContaining({
+          attemptId: COMMITTED_ATTEMPT_ID,
+          committedAt: 1,
+        }),
+      ]);
+    })
+  );
+
+  it.effect("deletes expired receipts in bounded pages", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              for (
+                let index = 0;
+                index <= ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE;
+                index += 1
+              ) {
+                yield* Effect.promise(() =>
+                  ctx.db.insert("accountDeletionReceipts", {
+                    attemptId: `expired-${index}`,
+                    committedAt: 0,
+                  })
+                );
+              }
+              yield* Effect.promise(() =>
+                ctx.db.insert("accountDeletionReceipts", {
+                  attemptId: "future",
+                  committedAt: Number.MAX_SAFE_INTEGER,
+                })
+              );
+            })
+          )
         )
       );
 
-    await expect(getStatus(COMMITTED_ATTEMPT_ID)).resolves.toBe(
-      accountDeletionAttemptStatus.committed
-    );
-    await expect(getStatus(PENDING_ATTEMPT_ID)).resolves.toBe(
-      accountDeletionAttemptStatus.pending
-    );
-    await expect(getStatus(DELETED_AUTH_ATTEMPT_ID)).resolves.toBe(
-      accountDeletionAttemptStatus.committed
-    );
-    await expect(getStatus(FINALIZED_ATTEMPT_ID)).resolves.toBe(
-      accountDeletionAttemptStatus.committed
-    );
-    await expect(getStatus(UNKNOWN_ATTEMPT_ID)).resolves.toBe(
-      accountDeletionAttemptStatus.unknown
-    );
-    expect(authUserExists).toHaveBeenCalledTimes(2);
-  });
-
-  it("records one idempotent privacy-minimal receipt", async () => {
-    const t = convexTest(schema, convexModules);
-
-    await t.mutation(async (ctx) => {
-      await runConvexProgram(
-        recordAccountDeletionReceipt(ctx, COMMITTED_ATTEMPT_ID, 1)
+      const firstSweep = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(sweepAccountDeletionReceiptsProgram(ctx))
+        )
       );
-      await runConvexProgram(
-        recordAccountDeletionReceipt(ctx, COMMITTED_ATTEMPT_ID, 2)
+      const secondSweep = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(sweepAccountDeletionReceiptsProgram(ctx))
+        )
       );
-      await runConvexProgram(recordAccountDeletionReceipt(ctx, undefined, 3));
-    });
-    const receipts = await t.query((ctx) =>
-      ctx.db.query("accountDeletionReceipts").collect()
-    );
+      const receipts = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.query("accountDeletionReceipts").collect())
+      );
 
-    expect(receipts).toEqual([
-      expect.objectContaining({
-        attemptId: COMMITTED_ATTEMPT_ID,
-        committedAt: 1,
-      }),
-    ]);
-  });
-
-  it("deletes expired receipts in bounded pages", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation(async (ctx) => {
-      for (
-        let index = 0;
-        index <= ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE;
-        index += 1
-      ) {
-        await ctx.db.insert("accountDeletionReceipts", {
-          attemptId: `expired-${index}`,
-          committedAt: 0,
-        });
-      }
-      await ctx.db.insert("accountDeletionReceipts", {
-        attemptId: "future",
-        committedAt: Number.MAX_SAFE_INTEGER,
-      });
-    });
-
-    await expect(
-      t.mutation((ctx) =>
-        runConvexProgram(sweepAccountDeletionReceiptsProgram(ctx))
-      )
-    ).resolves.toBe(true);
-    await expect(
-      t.mutation((ctx) =>
-        runConvexProgram(sweepAccountDeletionReceiptsProgram(ctx))
-      )
-    ).resolves.toBe(false);
-    const receipts = await t.query((ctx) =>
-      ctx.db.query("accountDeletionReceipts").collect()
-    );
-
-    expect(receipts).toEqual([
-      expect.objectContaining({
-        attemptId: "future",
-      }),
-    ]);
-  });
+      expect(firstSweep).toBe(true);
+      expect(secondSweep).toBe(false);
+      expect(receipts).toEqual([
+        expect.objectContaining({
+          attemptId: "future",
+        }),
+      ]);
+    })
+  );
 });

--- a/packages/backend/convex/auth/deletion/receipt.test.ts
+++ b/packages/backend/convex/auth/deletion/receipt.test.ts
@@ -134,7 +134,13 @@ describe("auth/deletion/receipt", () => {
         )
       );
       const receipts = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.query("accountDeletionReceipts").collect())
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.query("accountDeletionReceipts").collect()
+            )
+          )
+        )
       );
 
       expect(receipts).toEqual([
@@ -187,7 +193,13 @@ describe("auth/deletion/receipt", () => {
         )
       );
       const receipts = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.query("accountDeletionReceipts").collect())
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.query("accountDeletionReceipts").collect()
+            )
+          )
+        )
       );
 
       expect(firstSweep).toBe(true);


### PR DESCRIPTION
## Outcome

Migrates account-deletion receipt status, idempotency, and bounded-sweep tests to direct Effect v4 Vitest orchestration.

## Effect v4 basis

- Uses direct `@effect/vitest` `it.effect` from vendored RC110.
- Models fixture writes, queries, mutations, and adapter callbacks with `Effect.gen` and `Effect.promise`.
- Composes receipt programs inside one Convex runtime boundary instead of running them individually.
- Removes the raw `vitest` import and every raw async helper or test callback.

## Scope

One package-owned test module only: `packages/backend/convex/auth/deletion/receipt.test.ts`. No production behavior, dependency, wrapper, compatibility layer, or Vercel Preview.

## Verification

- Focused tests: 3/3 green
- Native backend TypeScript typecheck: green
- Root lint: green
- Test ownership policy: green
- Boundaries: green
- Effect source parity: RC110 at `66114151c2b4640bf773f2b3456ce70d679422f6`
- No direct Effect runner, raw Vitest import, or async callback remains
- Clean diff check

## Release

Test-only. Merge only from its exact reviewed head through the protected merge queue after Required, Doctor, and Quality are green. No production deployment should be created.