### PR TITLE
test(backend): run deletion workflow with Effect Vitest

### DIFF
--- a/packages/backend/convex/customers/deletion/workflow.test.ts
+++ b/packages/backend/convex/customers/deletion/workflow.test.ts
@@ -1,11 +1,10 @@
-import { assert, describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, it, vi } from "@effect/vitest";
 import { launchDeletedUserCleanupProgram } from "@repo/backend/convex/customers/deletion/workflow";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Clock, Data, Effect } from "effect";
-import { vi } from "vitest";
 
 class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
   readonly message: string;
@@ -157,15 +156,19 @@ describe("customers/deletion/workflow", () => {
       const deletedAt = yield* Clock.currentTimeMillis;
       const userId = yield* Effect.promise(() =>
         t.mutation((ctx) =>
-          ctx.db.insert("users", {
-            authId: "failing-auth-user",
-            credits: 0,
-            creditsResetAt: 0,
-            deletedAt,
-            email: "failing@example.com",
-            name: "Failing User",
-            plan: "free",
-          })
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("users", {
+                authId: "failing-auth-user",
+                credits: 0,
+                creditsResetAt: 0,
+                deletedAt,
+                email: "failing@example.com",
+                name: "Failing User",
+                plan: "free",
+              })
+            )
+          )
         )
       );
 
@@ -196,7 +199,9 @@ describe("customers/deletion/workflow", () => {
       });
 
       const user = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.get("users", userId))
+        t.query((ctx) =>
+          runConvexProgram(Effect.promise(() => ctx.db.get("users", userId)))
+        )
       );
 
       expect(starters.startAnalytics).toHaveBeenCalledOnce();

--- a/packages/backend/convex/customers/deletion/workflow.test.ts
+++ b/packages/backend/convex/customers/deletion/workflow.test.ts
@@ -1,156 +1,209 @@
+import { assert, describe, expect, it } from "@effect/vitest";
 import { launchDeletedUserCleanupProgram } from "@repo/backend/convex/customers/deletion/workflow";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Clock, Data, Effect } from "effect";
+import { vi } from "vitest";
+
+class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
+  readonly message: string;
+}> {}
+
+class CleanupMutationRejected extends Data.TaggedError(
+  "CleanupMutationRejected"
+)<{
+  readonly cause: unknown;
+}> {}
+
+/** Creates isolated adapters for the four independent cleanup workflows. */
+function createCleanupStarters() {
+  return {
+    startAnalytics: vi.fn(() => Promise.resolve()),
+    startAuth: vi.fn(() => Promise.resolve()),
+    startCustomer: vi.fn(() => Promise.resolve()),
+    startData: vi.fn(() => Promise.resolve()),
+  };
+}
 
 describe("customers/deletion/workflow", () => {
-  it("starts cleanup for the matching app user", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () => undefined);
-    const deletedAt = Date.now();
+  it.effect("starts cleanup for the matching app user", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      const deletedAt = yield* Clock.currentTimeMillis;
 
-    const user = await t.mutation(async (ctx) => {
-      const insertedUserId = await ctx.db.insert("users", {
-        authId: "deleted-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        deletedAt,
-        email: "deleted@example.com",
-        name: "Deleted User",
-        plan: "free",
-      });
-      await ctx.db.insert("accountDeletionPreparations", {
-        authId: "deleted-auth-user",
-        finalizedAt: Date.now(),
-        recoveryGeneration: 0,
-        userId: insertedUserId,
-      });
+      const user = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* Effect.promise(() =>
+                ctx.db.insert("users", {
+                  authId: "deleted-auth-user",
+                  credits: 0,
+                  creditsResetAt: 0,
+                  deletedAt,
+                  email: "deleted@example.com",
+                  name: "Deleted User",
+                  plan: "free",
+                })
+              );
+              yield* Effect.promise(() =>
+                ctx.db.insert("accountDeletionPreparations", {
+                  authId: "deleted-auth-user",
+                  finalizedAt: deletedAt,
+                  recoveryGeneration: 0,
+                  userId: insertedUserId,
+                })
+              );
 
-      await runConvexProgram(
-        launchDeletedUserCleanupProgram(
-          ctx,
-          "deleted-auth-user",
-          insertedUserId,
-          { startAnalytics, startAuth, startCustomer, startData }
+              yield* launchDeletedUserCleanupProgram(
+                ctx,
+                "deleted-auth-user",
+                insertedUserId,
+                starters
+              );
+
+              return yield* Effect.promise(() =>
+                ctx.db.get("users", insertedUserId)
+              );
+            })
+          )
         )
       );
 
-      return await ctx.db.get("users", insertedUserId);
-    });
+      assert(user !== null);
+      expect(user.deletionCleanupStartedAt).toEqual(expect.any(Number));
+      expect(starters.startAnalytics).toHaveBeenCalledOnce();
+      expect(starters.startAuth).toHaveBeenCalledOnce();
+      expect(starters.startCustomer).toHaveBeenCalledOnce();
+      expect(starters.startData).toHaveBeenCalledOnce();
+      const expectedIdentity = {
+        authId: "deleted-auth-user",
+        userId: user._id,
+      };
+      expect(starters.startAnalytics).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startAuth).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startCustomer).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startData).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+    })
+  );
 
-    expect(user?.deletionCleanupStartedAt).toEqual(expect.any(Number));
-    expect(startAnalytics).toHaveBeenCalledOnce();
-    expect(startAuth).toHaveBeenCalledOnce();
-    expect(startCustomer).toHaveBeenCalledOnce();
-    expect(startData).toHaveBeenCalledOnce();
-    const expectedIdentity = {
-      authId: "deleted-auth-user",
-      userId: user?._id,
-    };
-    expect(startAnalytics).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startAuth).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startCustomer).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startData).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-  });
-
-  it("does nothing when the app user is already absent", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () => undefined);
-    const missingUserId = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "removed-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "removed@example.com",
-        name: "Removed User",
-        plan: "free",
-      });
-      await ctx.db.delete("users", userId);
-      return userId;
-    });
-
-    await t.mutation((ctx) =>
-      runConvexProgram(
-        launchDeletedUserCleanupProgram(
-          ctx,
-          "missing-auth-user",
-          missingUserId,
-          { startAnalytics, startAuth, startCustomer, startData }
-        )
-      )
-    );
-
-    expect(startAnalytics).not.toHaveBeenCalled();
-    expect(startAuth).not.toHaveBeenCalled();
-    expect(startCustomer).not.toHaveBeenCalled();
-    expect(startData).not.toHaveBeenCalled();
-  });
-
-  it("returns a typed failure when any workflow cannot start", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () =>
-      Promise.reject(new Error("workflow unavailable"))
-    );
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "failing-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        deletedAt: Date.now(),
-        email: "failing@example.com",
-        name: "Failing User",
-        plan: "free",
-      })
-    );
-
-    await expect(
-      t.mutation(
-        async (ctx) =>
-          await runConvexProgram(
-            launchDeletedUserCleanupProgram(ctx, "failing-auth-user", userId, {
-              startAnalytics,
-              startAuth,
-              startCustomer,
-              startData,
+  it.effect("does nothing when the app user is already absent", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      const missingUserId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const userId = yield* Effect.promise(() =>
+                ctx.db.insert("users", {
+                  authId: "removed-auth-user",
+                  credits: 0,
+                  creditsResetAt: 0,
+                  email: "removed@example.com",
+                  name: "Removed User",
+                  plan: "free",
+                })
+              );
+              yield* Effect.promise(() => ctx.db.delete("users", userId));
+              return userId;
             })
           )
-      )
-    ).rejects.toMatchObject({
-      data: {
-        code: "USER_CLEANUP_FAILED",
-        message: "workflow unavailable",
-      },
-    });
+        )
+      );
 
-    const user = await t.query(async (ctx) => await ctx.db.get(userId));
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            launchDeletedUserCleanupProgram(
+              ctx,
+              "missing-auth-user",
+              missingUserId,
+              starters
+            )
+          )
+        )
+      );
 
-    expect(startAnalytics).toHaveBeenCalledOnce();
-    expect(startAuth).toHaveBeenCalledOnce();
-    expect(startCustomer).toHaveBeenCalledOnce();
-    expect(startData).toHaveBeenCalledOnce();
-    expect(user).not.toHaveProperty("deletionCleanupStartedAt");
-  });
+      expect(starters.startAnalytics).not.toHaveBeenCalled();
+      expect(starters.startAuth).not.toHaveBeenCalled();
+      expect(starters.startCustomer).not.toHaveBeenCalled();
+      expect(starters.startData).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("returns a typed failure when any workflow cannot start", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      starters.startData.mockRejectedValue(
+        new WorkflowUnavailable({ message: "workflow unavailable" })
+      );
+      const deletedAt = yield* Clock.currentTimeMillis;
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "failing-auth-user",
+            credits: 0,
+            creditsResetAt: 0,
+            deletedAt,
+            email: "failing@example.com",
+            name: "Failing User",
+            plan: "free",
+          })
+        )
+      );
+
+      const failure = yield* Effect.flip(
+        Effect.tryPromise({
+          catch: (cause) => new CleanupMutationRejected({ cause }),
+          try: () =>
+            t.mutation((ctx) =>
+              runConvexProgram(
+                launchDeletedUserCleanupProgram(
+                  ctx,
+                  "failing-auth-user",
+                  userId,
+                  starters
+                )
+              )
+            ),
+        })
+      );
+      expect(failure).toMatchObject({
+        _tag: "CleanupMutationRejected",
+        cause: {
+          data: {
+            code: "USER_CLEANUP_FAILED",
+            message: "workflow unavailable",
+          },
+        },
+      });
+
+      const user = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.get("users", userId))
+      );
+
+      expect(starters.startAnalytics).toHaveBeenCalledOnce();
+      expect(starters.startAuth).toHaveBeenCalledOnce();
+      expect(starters.startCustomer).toHaveBeenCalledOnce();
+      expect(starters.startData).toHaveBeenCalledOnce();
+      expect(user).not.toHaveProperty("deletionCleanupStartedAt");
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate only `packages/backend/convex/customers/deletion/workflow.test.ts`
- import `assert`, `describe`, `expect`, `it`, and `vi` directly from `@effect/vitest`
- run all three asynchronous cases through `it.effect`
- suspend infallible Convex framework Promises with `Effect.promise`
- lift the intentional rejecting mutation with `Effect.tryPromise`
- retain `runConvexProgram` only inside real Convex test callbacks

## Effect v4 basis

This follows the repository-pinned Effect `4.0.0-rc.110` source, `repos/effect/.patterns/testing.md`, the direct `@effect/vitest` implementation, and Effect Promise constructor semantics. Every Convex test callback composes database and domain work as an Effect before the runner boundary. The expected workflow failure and rejected Convex mutation have specific tagged errors, with the rejection asserted through `Effect.flip`. There is no raw Vitest import, shared testing wrapper, raw async test callback, raw database Promise callback, generic `Error`, Promise rejection assertion, direct test runner, global Vitest shim, or hard-coded allowlist.

## Scope and collision proof

The one touched file had zero matches across all 20 other open PRs. A fresh scan across all 56 other retained worktrees found no committed, staged, unstaged, or untracked overlap. Quran, tryout, signed content runtime, publication, and school assessment paths are excluded.

## Verification

- exact-head focused suite: 3/3 passed
- exact-head Backend native TypeScript 7 typecheck: passed
- exact-head complete Backend suite: 387/387 files and 1,641/1,641 tests passed
- exact-head formatting, lint, Effect RC110 source parity, test ownership, and boundaries: passed
- complete diff and runner-boundary audit: passed

## Identity

Base: `fbf5fe437b52c0dced972966a7fd694f3aee39bf`
Head: `142eb9651bee17416de09bdf0f5401c2b918c7af`
Tree: `a045d8962842cae24dd43a70d45159af01e93ccf`
Patch ID: `0af3b06b3542ee9052ae568a6b54b407a39870ba`

## Release

This is one test-only backend file. No Vercel Preview or Convex deployment is requested. The merge-queue repair and exact #477 canary both merged green. Enqueue only after rechecking the exact head, live collision set, required checks, review threads, and current queue slot.