### PR TITLE
fix(ci): verify merge groups without queue access

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -74,7 +74,7 @@ jobs:
               repo: context.repo.repo,
             })
             if (
-              pull.state !== "OPEN" ||
+              pull.state !== "open" ||
               pull.draft ||
               pull.base.ref !== "main" ||
               pull.base.sha !== mergeGroup.base_sha ||

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -49,89 +49,65 @@ jobs:
               throw new Error("Missing merge group payload.")
             }
 
-            const result = await github.graphql(
-              `query MergeQueueEntry($owner: String!, $name: String!) {
-                repository(owner: $owner, name: $name) {
-                  mergeQueue {
-                    configuration {
-                      maximumEntriesToBuild
-                      maximumEntriesToMerge
-                    }
-                    entries(first: 100) {
-                      nodes {
-                        baseCommit { oid }
-                        enqueuer { login }
-                        headCommit {
-                          oid
-                          tree { oid }
-                        }
-                        pullRequest {
-                          author { login }
-                          baseRefName
-                          baseRefOid
-                          headRefOid
-                          headRepository { nameWithOwner }
-                          number
-                          potentialMergeCommit {
-                            parents(first: 3) { nodes { oid } }
-                            tree { oid }
-                          }
-                          state
-                        }
-                      }
-                    }
-                  }
-                }
-              }`,
-              { name: context.repo.repo, owner: context.repo.owner },
+            const queueRef = /^refs\/heads\/gh-readonly-queue\/main\/pr-(\d+)-([0-9a-f]{40})$/.exec(
+              mergeGroup.head_ref,
             )
-            const queue = result.repository?.mergeQueue
+            if (!queueRef) {
+              throw new Error("Merge group has an invalid queue reference.")
+            }
+            const pullNumber = Number(queueRef[1])
+            const refBaseSha = queueRef[2]
             if (
-              queue?.configuration?.maximumEntriesToBuild !== 1 ||
-              queue.configuration.maximumEntriesToMerge !== 1
+              !Number.isSafeInteger(pullNumber) ||
+              pullNumber <= 0 ||
+              refBaseSha !== mergeGroup.base_sha ||
+              mergeGroup.base_ref !== "refs/heads/main" ||
+              mergeGroup.head_sha !== context.sha ||
+              context.actor !== "nabilfatih"
             ) {
-              throw new Error("Signed acceptance requires a single-entry queue.")
+              throw new Error("Merge group event is not trusted for signed acceptance.")
             }
 
-            const entries = queue.entries?.nodes ?? []
-            const candidates = entries.filter(
-              (entry) =>
-                entry?.baseCommit?.oid === mergeGroup.base_sha &&
-                entry?.headCommit?.oid === mergeGroup.head_sha,
-            )
-            if (candidates.length !== 1) {
-              throw new Error(
-                `Merge group has ${candidates.length} exact queue entries.`,
-              )
-            }
-
-            const [{ enqueuer, headCommit, pullRequest: pull }] = candidates
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              pull_number: pullNumber,
+              repo: context.repo.repo,
+            })
             if (
-              !pull ||
               pull.state !== "OPEN" ||
-              pull.baseRefName !== mergeGroup.base_ref.replace("refs/heads/", "") ||
-              pull.baseRefOid !== mergeGroup.base_sha ||
-              pull.headRepository?.nameWithOwner !== context.payload.repository.full_name ||
-              pull.author?.login !== "nabilfatih" ||
-              enqueuer?.login !== "nabilfatih"
+              pull.draft ||
+              pull.base.ref !== "main" ||
+              pull.base.sha !== mergeGroup.base_sha ||
+              pull.head.repo?.full_name !== context.payload.repository.full_name ||
+              pull.user?.login !== "nabilfatih"
             ) {
               throw new Error("Merge queue entry is not trusted for signed acceptance.")
             }
 
-            // Matching trees proves the event head contains only the admitted
-            // pull request, even if queue settings changed after group creation.
-            const mergeParents = pull.potentialMergeCommit?.parents?.nodes ?? []
-            const expectedParents = [mergeGroup.base_sha, pull.headRefOid].sort()
-            const actualParents = mergeParents.map(({ oid }) => oid).sort()
+            const [{ data: groupCommit }, { data: pullCommit }] = await Promise.all([
+              github.rest.git.getCommit({
+                commit_sha: mergeGroup.head_sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }),
+              github.rest.git.getCommit({
+                commit_sha: pull.head.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }),
+            ])
+            // A one-parent synthetic commit with the exact pull-request tree
+            // proves the queue group contains only this admitted candidate.
             if (
-              actualParents.length !== 2 ||
-              actualParents.some((oid, index) => oid !== expectedParents[index]) ||
-              !pull.potentialMergeCommit?.tree?.oid ||
-              headCommit?.tree?.oid !== pull.potentialMergeCommit.tree.oid
+              groupCommit.sha !== mergeGroup.head_sha ||
+              groupCommit.parents.length !== 1 ||
+              groupCommit.parents[0]?.sha !== mergeGroup.base_sha ||
+              !groupCommit.tree?.sha ||
+              groupCommit.tree.sha !== pullCommit.tree?.sha
             ) {
               throw new Error("Merge group contains changes outside its trusted pull request.")
             }
-            core.info(`Trusted pull request #${pull.number} at ${pull.headRefOid}.`)
+            core.info(`Trusted pull request #${pull.number} at ${pull.head.sha}.`)
 
             return "true"
 

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -109,6 +109,7 @@ describe("GitHub Action policy", () => {
       for (const evidence of [
         "github.rest.pulls.get",
         "github.rest.git.getCommit",
+        'pull.state !== "open"',
         "groupCommit.parents.length !== 1",
         "groupCommit.parents[0]?.sha !== mergeGroup.base_sha",
         "groupCommit.tree.sha !== pullCommit.tree?.sha",

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Result } from "effect";
+import { Effect, FileSystem, Layer, Result } from "effect";
 import {
   HttpClient,
   type HttpClientRequest,
@@ -96,6 +96,27 @@ describe("GitHub Action policy", () => {
       )
     ).toBe(true);
   });
+
+  it.effect("keeps merge-group trust on accessible exact commit evidence", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const workflow = yield* fileSystem.readFileString(
+        `${REPOSITORY_ROOT}/.github/workflows/agent-docs.yml`
+      );
+
+      expect(workflow).not.toContain("mergeQueue");
+      expect(workflow).not.toContain("github.graphql");
+      for (const evidence of [
+        "github.rest.pulls.get",
+        "github.rest.git.getCommit",
+        "groupCommit.parents.length !== 1",
+        "groupCommit.parents[0]?.sha !== mergeGroup.base_sha",
+        "groupCommit.tree.sha !== pullCommit.tree?.sha",
+      ]) {
+        expect(workflow).toContain(evidence);
+      }
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
 
   it.effect("reads release metadata through the Effect HTTP client", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Outcome

Restores protected merge-queue acceptance without querying the inaccessible `repository.mergeQueue` GraphQL field.

## Root cause

Merge-group run 33166146519 failed `Production Scope` because the standard `GITHUB_TOKEN` received `Resource not accessible by integration` for `repository.mergeQueue`. That made `Required` fail for every valid queue candidate.

## Fail-closed replacement

The merge-group gate now uses only accessible pull and commit REST evidence. It requires:

- the exact single-PR queue-ref shape and protected `main` base
- the event head to equal the workflow SHA
- the repository owner as actor and pull author
- one open, non-draft, same-repository pull request on the exact base
- one synthetic commit parent equal to that base
- the synthetic commit tree equal to the exact pull-request head tree

The last two conditions prove the candidate contains exactly the admitted pull request without relying on mutable queue configuration. The regression also locks GitHub REST's lowercase `open` state so pull-request-only CI cannot mask merge-group casing drift.

## Reproduction evidence

Historical candidate `fd7cceb66b7a75bfde365e6d9fc9d7f06b920079` has sole parent `fbf5fe437b52c0dced972966a7fd694f3aee39bf` and tree `e760ca83be1d9e6d6e34ffd86d921c8de07385eb`. PR #470 head `03fe17d0e342a11b765963d8a5d7df5660ac7400` has the identical tree.

## Exact-head verification

Head: `5fe18f4afb8c5d220f802055d99fb8ed3165d00a`

- `pnpm test:scripts`: 4 files, 20 tests
- scripts native TypeScript check
- `actionlint .github/workflows/agent-docs.yml`
- full lint and Effect source parity
- boundaries and security audit
- clean diff and worktree

This PR does not create a Vercel Preview and does not change application or production data.