### PR TITLE
test(backend): run deletion billing with Effect Vitest

### DIFF
--- a/packages/backend/convex/customers/deletion/billing.test.ts
+++ b/packages/backend/convex/customers/deletion/billing.test.ts
@@ -1,13 +1,17 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
 import { cleanupDeletedUserBilling } from "@repo/backend/convex/customers/deletion/billing";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const polarGateway = vi.hoisted(() => ({
   deleteCustomer: vi.fn(),
@@ -18,42 +22,64 @@ vi.mock("@repo/backend/convex/customers/polar/live", () => ({
   polarGateway,
 }));
 
-function insertDeletedUser(ctx: MutationCtx, suffix: string) {
-  return ctx.db.insert("users", {
-    authId: `deleted:${suffix}`,
-    credits: 0,
-    creditsResetAt: 1,
-    deletedAt: 1,
-    email: `deleted-${suffix}@example.invalid`,
-    name: "Deleted User",
-    plan: "free",
-  });
-}
+const insertDeletedUser = Effect.fn(
+  "customers.deletion.test.insertDeletedUser"
+)(function* (ctx: MutationCtx, suffix: string) {
+  return yield* Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: `deleted:${suffix}`,
+      credits: 0,
+      creditsResetAt: 1,
+      deletedAt: 1,
+      email: `deleted-${suffix}@example.invalid`,
+      name: "Deleted User",
+      plan: "free",
+    })
+  );
+});
 
-function insertOrphanSubscription(
-  ctx: MutationCtx,
-  userId: Id<"users">,
-  polarCustomerId: string
-) {
-  return ctx.db.insert("subscriptions", {
-    amount: null,
-    cancelAtPeriodEnd: false,
-    checkoutId: null,
-    createdAt: "2026-07-29T00:00:00.000Z",
-    currency: null,
-    currentPeriodEnd: null,
-    currentPeriodStart: "2026-07-29T00:00:00.000Z",
-    customerId: polarCustomerId,
-    endedAt: null,
-    id: `subscription-${userId}`,
-    metadata: {},
-    modifiedAt: null,
-    productId: "product-deleted-user",
-    recurringInterval: null,
-    startedAt: "2026-07-29T00:00:00.000Z",
-    status: "active",
-  });
-}
+const insertOrphanSubscription = Effect.fn(
+  "customers.deletion.test.insertOrphanSubscription"
+)(function* (ctx: MutationCtx, userId: Id<"users">, polarCustomerId: string) {
+  return yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: "2026-07-29T00:00:00.000Z",
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: "2026-07-29T00:00:00.000Z",
+      customerId: polarCustomerId,
+      endedAt: null,
+      id: `subscription-${userId}`,
+      metadata: {},
+      modifiedAt: null,
+      productId: "product-deleted-user",
+      recurringInterval: null,
+      startedAt: "2026-07-29T00:00:00.000Z",
+      status: "active",
+    })
+  );
+});
+
+const readBillingState = Effect.fn("customers.deletion.test.readBillingState")(
+  function* (ctx: QueryCtx, polarCustomerId: string) {
+    const subscriptions = yield* Effect.promise(() =>
+      ctx.db.query("subscriptions").collect()
+    );
+    const tombstone = yield* Effect.promise(() =>
+      ctx.db
+        .query("customerDeletionTombstones")
+        .withIndex("by_polarCustomerId", (query) =>
+          query.eq("polarCustomerId", polarCustomerId)
+        )
+        .unique()
+    );
+
+    return { subscriptions, tombstone };
+  }
+);
 
 describe("customers/deletion/billing", () => {
   beforeEach(() => {
@@ -63,119 +89,162 @@ describe("customers/deletion/billing", () => {
     polarGateway.getCustomerByExternalId.mockReturnValue(Effect.succeed(null));
   });
 
-  it("checkpoints a discovered Polar ID before external deletion", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await insertDeletedUser(ctx, "checkpoint");
-      await insertOrphanSubscription(ctx, insertedUserId, "polar-checkpoint");
-      return insertedUserId;
-    });
+  it.effect("checkpoints a discovered Polar ID before external deletion", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.sync(() => posthogTest.register(t));
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* insertDeletedUser(
+                ctx,
+                "checkpoint"
+              );
+              yield* insertOrphanSubscription(
+                ctx,
+                insertedUserId,
+                "polar-checkpoint"
+              );
+              return insertedUserId;
+            })
+          )
+        )
+      );
 
-    polarGateway.getCustomerByExternalId.mockReturnValue(
-      Effect.succeed({ id: "polar-checkpoint" })
-    );
-    polarGateway.deleteCustomer.mockImplementation((polarCustomerId) =>
-      Effect.tryPromise(async () => {
-        const checkpoint = await t.query((ctx) =>
-          ctx.db
-            .query("customerDeletionTombstones")
-            .withIndex("by_cleanupUserId", (query) =>
-              query.eq("cleanupUserId", userId)
+      polarGateway.getCustomerByExternalId.mockReturnValue(
+        Effect.succeed({ id: "polar-checkpoint" })
+      );
+      polarGateway.deleteCustomer.mockImplementation((polarCustomerId) =>
+        Effect.gen(function* () {
+          const checkpoint = yield* Effect.promise(() =>
+            t.query((ctx) =>
+              runConvexProgram(
+                Effect.promise(() =>
+                  ctx.db
+                    .query("customerDeletionTombstones")
+                    .withIndex("by_cleanupUserId", (query) =>
+                      query.eq("cleanupUserId", userId)
+                    )
+                    .unique()
+                )
+              )
             )
-            .unique()
+          );
+
+          expect(checkpoint).toMatchObject({
+            cleanupUserId: userId,
+            polarCustomerId,
+          });
+          return null;
+        })
+      );
+
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(
+            cleanupDeletedUserBilling(ctx, userId, "original-auth-checkpoint")
+          )
+        )
+      );
+
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(readBillingState(ctx, "polar-checkpoint"))
+        )
+      );
+
+      expect(state.subscriptions).toEqual([]);
+      expect(state.tombstone).toMatchObject({
+        polarCustomerId: "polar-checkpoint",
+      });
+      expect(state.tombstone).not.toHaveProperty("cleanupUserId");
+    })
+  );
+
+  it.effect("resumes local cleanup when Polar is no longer discoverable", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.sync(() => posthogTest.register(t));
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* insertDeletedUser(ctx, "resume");
+              yield* Effect.promise(() =>
+                ctx.db.insert("customerDeletionTombstones", {
+                  cleanupUserId: insertedUserId,
+                  polarCustomerId: "polar-resume",
+                })
+              );
+              yield* insertOrphanSubscription(
+                ctx,
+                insertedUserId,
+                "polar-resume"
+              );
+              return insertedUserId;
+            })
+          )
+        )
+      );
+
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(
+            cleanupDeletedUserBilling(ctx, userId, "original-auth-resume")
+          )
+        )
+      );
+
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(readBillingState(ctx, "polar-resume"))
+        )
+      );
+
+      expect(polarGateway.getCustomerByExternalId).not.toHaveBeenCalled();
+      expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-resume");
+      expect(state.subscriptions).toEqual([]);
+      expect(state.tombstone).not.toHaveProperty("cleanupUserId");
+    })
+  );
+
+  it.effect(
+    "removes a Polar customer created after the first cleanup pass",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.sync(() => posthogTest.register(t));
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertDeletedUser(ctx, "late-polar-sync"))
+          )
+        );
+        polarGateway.getCustomerByExternalId
+          .mockReturnValueOnce(Effect.succeed(null))
+          .mockReturnValueOnce(Effect.succeed({ id: "polar-late-sync" }));
+
+        yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(
+              cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
+            )
+          )
+        );
+        expect(polarGateway.deleteCustomer).not.toHaveBeenCalled();
+
+        yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(
+              cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
+            )
+          )
         );
 
-        expect(checkpoint).toMatchObject({
-          cleanupUserId: userId,
-          polarCustomerId,
-        });
-        return null;
+        expect(polarGateway.deleteCustomer).toHaveBeenCalledOnce();
+        expect(polarGateway.deleteCustomer).toHaveBeenCalledWith(
+          "polar-late-sync"
+        );
       })
-    );
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-checkpoint")
-      )
-    );
-
-    const state = await t.query(async (ctx) => ({
-      subscriptions: await ctx.db.query("subscriptions").collect(),
-      tombstone: await ctx.db
-        .query("customerDeletionTombstones")
-        .withIndex("by_polarCustomerId", (query) =>
-          query.eq("polarCustomerId", "polar-checkpoint")
-        )
-        .unique(),
-    }));
-
-    expect(state.subscriptions).toEqual([]);
-    expect(state.tombstone).toMatchObject({
-      polarCustomerId: "polar-checkpoint",
-    });
-    expect(state.tombstone).not.toHaveProperty("cleanupUserId");
-  });
-
-  it("resumes local cleanup when Polar is no longer discoverable", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await insertDeletedUser(ctx, "resume");
-      await ctx.db.insert("customerDeletionTombstones", {
-        cleanupUserId: insertedUserId,
-        polarCustomerId: "polar-resume",
-      });
-      await insertOrphanSubscription(ctx, insertedUserId, "polar-resume");
-      return insertedUserId;
-    });
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-resume")
-      )
-    );
-
-    const state = await t.query(async (ctx) => ({
-      subscriptions: await ctx.db.query("subscriptions").collect(),
-      tombstone: await ctx.db
-        .query("customerDeletionTombstones")
-        .withIndex("by_polarCustomerId", (query) =>
-          query.eq("polarCustomerId", "polar-resume")
-        )
-        .unique(),
-    }));
-
-    expect(polarGateway.getCustomerByExternalId).not.toHaveBeenCalled();
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-resume");
-    expect(state.subscriptions).toEqual([]);
-    expect(state.tombstone).not.toHaveProperty("cleanupUserId");
-  });
-
-  it("removes a Polar customer created after the first cleanup pass", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation((ctx) =>
-      insertDeletedUser(ctx, "late-polar-sync")
-    );
-    polarGateway.getCustomerByExternalId
-      .mockReturnValueOnce(Effect.succeed(null))
-      .mockReturnValueOnce(Effect.succeed({ id: "polar-late-sync" }));
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
-      )
-    );
-    expect(polarGateway.deleteCustomer).not.toHaveBeenCalled();
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
-      )
-    );
-
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledOnce();
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-late-sync");
-  });
+  );
 });


### PR DESCRIPTION
## Summary

- migrate only `packages/backend/convex/customers/deletion/billing.test.ts`
- import runtime test APIs directly from `@effect/vitest`
- run all three effectful cases through `it.effect`
- model reusable database fixtures and state reads as named `Effect.fn` programs
- suspend PostHog harness registration with `Effect.sync`
- retain `runConvexProgram` only inside real Convex mutation, query, and action callbacks

## Effect v4 basis

This follows the repository-pinned Effect `4.0.0-rc.110` source, `repos/effect/.patterns/testing.md`, direct `@effect/vitest`, and Effect Promise constructor semantics. Convex and component Promises are suspended with `Effect.promise`, while every test-harness callback composes an Effect before its runner boundary. There is no raw async callback, shared testing wrapper, direct Effect runtime call, Promise rejection assertion, generic test error, global Vitest shim, or hard-coded allowlist.

The sole raw Vitest import is local `vi` for `vi.hoisted` and `vi.mock`. A focused run proved that Vitest cannot resolve those transform APIs through the `@effect/vitest` re-export and fails before test collection with its documented instruction to import mocks directly from `vitest`. No runtime test API uses raw Vitest.

## Scope and collision proof

The one touched file had zero matches across all 22 other open PRs. A fresh scan across all 59 other retained worktrees found no committed, staged, unstaged, or untracked overlap. Production billing code, Quran, tryout, signed content runtime, publication, and school assessment paths are untouched.

## Verification

- focused suite: 3/3 passed
- Backend native TypeScript 7 typecheck: passed
- formatting, lint, Effect RC110 source parity, test ownership, boundaries, script typecheck, and 19 script policy tests: passed
- full Backend suite: 386/387 files and 1,640/1,641 tests passed; the only failure was the unrelated signed-content public runtime test hitting its shared 5-second timeout under parallel load
- isolated replay of that exact unrelated file: 1/1 file and 12/12 tests passed
- complete diff and runner-boundary audit: passed

## Identity

Base: `fbf5fe437b52c0dced972966a7fd694f3aee39bf`
Head: `ff2d0d9b3fb231bc56262de09161d2de72366a93`
Tree: `6e42223eef6f305922e96dd5743060b0dc030699`
Patch ID: `2bb81fee37fd38c4d9d1245d31a5e9f8a6135571`

## Release

This is one test-only backend file. No Vercel Preview or Convex deployment is requested. The merge-queue repair and exact #477 canary both merged green. Enqueue only after rechecking the exact head, live collision set, required checks, review threads, and current queue slot.