### PR TITLE
refactor(api): keep Effect runner at route boundary

### DIFF
--- a/apps/api/app/contents/[locale]/material/[...slug]/route.ts
+++ b/apps/api/app/contents/[locale]/material/[...slug]/route.ts
@@ -37,47 +37,29 @@ export async function GET(
   }
 
   const prefix = `material/${slug.join("/")}`;
-  return runMaterialApiRead(
+  return Effect.runPromise(
     getMaterialApiContentPage({
       ...pageParams,
       appLocale: validLocale,
       prefix,
-    }),
-    { locale, slug }
-  );
-}
-
-/** Converts one content-runtime read into the shared material API response shape. */
-function runMaterialApiRead(
-  apiRead: ReturnType<typeof getMaterialApiContentPage>,
-  {
-    locale,
-    slug,
-  }: {
-    locale: string;
-    slug: readonly string[];
-  }
-) {
-  const onError = (error: Parameters<typeof logError>[0]) =>
-    Effect.gen(function* () {
-      yield* logError(error, {
-        service: "api-contents",
-        locale,
-        basePath: slug.join("/") || "/",
-        slugLength: slug.length,
-        message: "Failed to fetch contents.",
-      });
-
-      return NextResponse.json(
-        { error: "Failed to fetch contents." },
-        { status: 500 }
-      );
-    });
-
-  return Effect.runPromise(
-    apiRead.pipe(
+    }).pipe(
       Effect.map((data): Response => NextResponse.json(data)),
-      Effect.catch(onError)
+      Effect.catch((error) =>
+        Effect.gen(function* () {
+          yield* logError(error, {
+            service: "api-contents",
+            locale,
+            basePath: slug.join("/") || "/",
+            slugLength: slug.length,
+            message: "Failed to fetch contents.",
+          });
+
+          return NextResponse.json(
+            { error: "Failed to fetch contents." },
+            { status: 500 }
+          );
+        })
+      )
     )
   );
 }


### PR DESCRIPTION
## Problem

The material content route started its Effect runtime inside a private one-use helper. That hid the imperative runner one level below the actual Next.js framework boundary and duplicated the response adapter structure already kept directly in the article route.

## Change

Inline the material read, response mapping, typed Effect recovery, and `Effect.runPromise` call into the exported `GET` handler. Delete the shallow helper. Runtime behavior and response contracts are unchanged.

## Effect v4 evidence

The vendored Effect 4 RC110 source defines `Effect.runPromise` as Promise interoperability. The installed Next.js 16.3.2 route module requires a route handler to return a `Response` or a thenable resolving to a `Response`. After this change, all three direct runners across `apps/api` and `apps/mcp` sit directly in exported API `GET` handlers. `apps/mcp` contains no runner.

## Scope and ownership

This changes one API route file only. A fresh open-PR and retained-worktree scan found no owner or overlap. It does not touch Convex data, Quran, tryouts, history, migrations, signed publication, dependencies, or deployment configuration.

## Verification

- Focused material route: 7 tests passed
- Full API suite: 51 tests passed with 100% statements, branches, functions, and lines
- API native TypeScript typecheck passed with TypeScript 7.0.2 plus effect-tsgo 0.36.5
- Root lint passed
- Repository boundaries passed
- Test ownership policy passed
- Vendored Effect parity passed for effect 4.0.0-rc.110 at 66114151c2b4640bf773f2b3456ce70d679422f6
- API production build completed with non-secret local validation environment values

## Release

Ready for review. Exact-head Production and Required are green. This PR has not been enqueued or merged. PR #477 merged to main as `eac90bc83d249f0c1b1979c35b0579c15376534e`. PR #461 is now the active merge-group candidate at synthetic head `ce8d944e328ed2d2cd7bbf5544f1d4bdf9d14490`. PR #475 and PR #465 are queued behind it in that order.
