### PR TITLE
test(backend): run customer integrity with Effect Vitest

### DIFF
--- a/packages/backend/convex/customers/integrity/internal.test.ts
+++ b/packages/backend/convex/customers/integrity/internal.test.ts
@@ -1,120 +1,154 @@
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
 
 const NOW = new Date(Date.UTC(2026, 3, 5, 12, 0, 0)).toISOString();
 
+const seedCustomerIntegrityState = Effect.fn(
+  "customers.integrity.test.seedState"
+)(function* (ctx: MutationCtx) {
+  const userId = yield* Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: "auth-customer-integrity",
+      credits: 10,
+      creditsResetAt: 1,
+      email: "integrity@example.com",
+      name: "Integrity User",
+      plan: "free",
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("customers", {
+      id: "polar-integrity",
+      externalId: "auth-customer-integrity",
+      metadata: { userId },
+      userId,
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: NOW,
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: NOW,
+      customerCancellationComment: null,
+      customerCancellationReason: null,
+      customerId: "polar-integrity",
+      endedAt: null,
+      id: "active-subscription",
+      metadata: {},
+      modifiedAt: null,
+      productId: "pro-product",
+      recurringInterval: null,
+      startedAt: NOW,
+      status: "active",
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: NOW,
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: NOW,
+      customerCancellationComment: null,
+      customerCancellationReason: null,
+      customerId: "polar-integrity",
+      endedAt: null,
+      id: "canceled-subscription",
+      metadata: {},
+      modifiedAt: null,
+      productId: "pro-product",
+      recurringInterval: null,
+      startedAt: NOW,
+      status: "canceled",
+    })
+  );
+
+  return userId;
+});
+
 describe("customers/integrity/internal", () => {
-  it("lists integrity pages for users, customers, and active subscriptions", async () => {
-    const t = convexTest(schema, convexModules);
+  it.effect(
+    "lists integrity pages for users, customers, and active subscriptions",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(seedCustomerIntegrityState(ctx)))
+        );
 
-    const state = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "auth-customer-integrity",
-        credits: 10,
-        creditsResetAt: 1,
-        email: "integrity@example.com",
-        name: "Integrity User",
-        plan: "free",
-      });
-
-      await ctx.db.insert("customers", {
-        id: "polar-integrity",
-        externalId: "auth-customer-integrity",
-        metadata: { userId },
-        userId,
-      });
-
-      await ctx.db.insert("subscriptions", {
-        amount: null,
-        cancelAtPeriodEnd: false,
-        checkoutId: null,
-        createdAt: NOW,
-        currency: null,
-        currentPeriodEnd: null,
-        currentPeriodStart: NOW,
-        customerCancellationComment: null,
-        customerCancellationReason: null,
-        customerId: "polar-integrity",
-        endedAt: null,
-        id: "active-subscription",
-        metadata: {},
-        modifiedAt: null,
-        productId: "pro-product",
-        recurringInterval: null,
-        startedAt: NOW,
-        status: "active",
-      });
-      await ctx.db.insert("subscriptions", {
-        amount: null,
-        cancelAtPeriodEnd: false,
-        checkoutId: null,
-        createdAt: NOW,
-        currency: null,
-        currentPeriodEnd: null,
-        currentPeriodStart: NOW,
-        customerCancellationComment: null,
-        customerCancellationReason: null,
-        customerId: "polar-integrity",
-        endedAt: null,
-        id: "canceled-subscription",
-        metadata: {},
-        modifiedAt: null,
-        productId: "pro-product",
-        recurringInterval: null,
-        startedAt: NOW,
-        status: "canceled",
-      });
-
-      return userId;
-    });
-
-    const [users, customers, subscriptions] = await Promise.all([
-      t.query(
-        internal.customers.integrity.internal.listUsersForCustomerIntegrity,
-        {
-          paginationOpts: {
-            cursor: null,
-            numItems: 100,
+        const { customers, subscriptions, users } = yield* Effect.all(
+          {
+            customers: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal.listCustomersForIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
+            subscriptions: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal
+                  .listActiveSubscriptionsForIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
+            users: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal
+                  .listUsersForCustomerIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
           },
-        }
-      ),
-      t.query(internal.customers.integrity.internal.listCustomersForIntegrity, {
-        paginationOpts: {
-          cursor: null,
-          numItems: 100,
-        },
-      }),
-      t.query(
-        internal.customers.integrity.internal
-          .listActiveSubscriptionsForIntegrity,
-        {
-          paginationOpts: {
-            cursor: null,
-            numItems: 100,
-          },
-        }
-      ),
-    ]);
+          { concurrency: "unbounded" }
+        );
 
-    expect(users.page).toEqual([
-      expect.objectContaining({
-        userId: state,
-      }),
-    ]);
-    expect(customers.page).toEqual([
-      expect.objectContaining({
-        polarCustomerId: "polar-integrity",
-        userId: state,
-      }),
-    ]);
-    expect(subscriptions.page).toEqual([
-      expect.objectContaining({
-        customerId: "polar-integrity",
-        subscriptionId: "active-subscription",
-      }),
-    ]);
-  });
+        expect(users.page).toEqual([
+          expect.objectContaining({
+            userId,
+          }),
+        ]);
+        expect(customers.page).toEqual([
+          expect.objectContaining({
+            polarCustomerId: "polar-integrity",
+            userId,
+          }),
+        ]);
+        expect(subscriptions.page).toEqual([
+          expect.objectContaining({
+            customerId: "polar-integrity",
+            subscriptionId: "active-subscription",
+          }),
+        ]);
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- Migrate `packages/backend/convex/customers/integrity/internal.test.ts` from raw async Vitest orchestration to direct `@effect/vitest` `it.effect`.
- Keep the patch to one backend test file. No production source, dependency, config, generated file, deployment, or global test behavior changes.

## Effect v4 boundary

- Model the database fixture as a named `Effect.fn` program.
- Wrap Convex database and test-client promises with `Effect.promise`.
- Retain `runConvexProgram` only at the real `t.mutation` callback boundary.
- Replace `Promise.all` with `Effect.all(..., { concurrency: "unbounded" })`, preserving the original concurrent query behavior.
- Use direct `@effect/vitest`; no wrapper, raw async, raw Vitest import, global `vi`, generic error, direct Effect runner, or hard-coded policy allowance remains.

## Source evidence

Validated against vendored Effect RC110 source and installed `@effect/vitest@4.0.0-rc.110`. `Effect.all` accepts structured effects and an explicit concurrency option; `it.effect` owns test runtime execution.

## Verification

- Focused test: 1 file, 1 test passed.
- Focused source coverage: 100% statements, branches, functions, and lines.
- Full backend rerun: 387 files and 1,641 tests passed.
- An earlier full run had one unrelated 5-second timeout in `classes/forums/attachments/route.test.ts`; isolated replay passed 9 of 9 in 2.4 seconds before the clean full rerun.
- Backend native TypeScript 7 typecheck passed.
- `pnpm lint`, `pnpm boundaries`, `pnpm check:tests`, `pnpm test:scripts`, and RC110 source parity passed.
- Complete diff and invariant scans passed.

## Identity and ownership

- Base: `9e9b3bf65231072c55dc05477035cbd046f08298`
- Head: `c1beeda51d5d914aaf043ffcb0a79f069e263e6b`
- Tree: `fdf707f497ba3818a42f01de62f74827a701ad45`
- Stable patch ID: `4ee79f5503c48152955aded0759b438ce0c5b653`
- Zero collision across all open PR files and every other retained worktree's committed, staged, unstaged, and untracked paths.

## Release

Exact-head Quality, Required, and Doctor checks passed on `c1beeda51d5d914aaf043ffcb0a79f069e263e6b`; the final exact-head Codex review found no major issues, with zero unresolved review threads. This is test-only, so Production was skipped. No Vercel Preview or Convex deployment was created. The exact #477 canary merged at main `eac90bc83d249f0c1b1979c35b0579c15376534e`; #461 is active, with #475 then #465 queued behind it. Keep this PR out of the merge queue until its serialized slot is available.