### PR TITLE
refactor(ai): keep stream error logging Effect native

### DIFF
--- a/packages/ai/nina/runtime/error.ts
+++ b/packages/ai/nina/runtime/error.ts
@@ -3,32 +3,30 @@ import type { LogContext } from "@repo/utilities/logging/types";
 import { Effect } from "effect";
 
 /** Formats AI SDK stream errors while preserving server-side diagnostics. */
-export function formatNinaStreamError({
-  error,
-  logContext,
-  turn,
-}: {
-  readonly error: unknown;
-  readonly logContext: LogContext;
-  readonly turn: NinaTurn;
-}) {
-  if (error instanceof Error) {
-    if (error.message.includes("Rate limit")) {
-      Effect.runFork(
-        Effect.logWarning("Rate limit exceeded in Nina stream").pipe(
+export const formatNinaStreamError = Effect.fn("nina.stream.formatError")(
+  function* ({
+    error,
+    logContext,
+    turn,
+  }: {
+    readonly error: unknown;
+    readonly logContext: LogContext;
+    readonly turn: NinaTurn;
+  }) {
+    if (error instanceof Error) {
+      if (error.message.includes("Rate limit")) {
+        yield* Effect.logWarning("Rate limit exceeded in Nina stream").pipe(
           Effect.annotateLogs(logContext)
-        )
-      );
-      return turn.copy.rateLimitMessage;
+        );
+        return turn.copy.rateLimitMessage;
+      }
+
+      return error.message;
     }
 
-    return error.message;
-  }
-
-  Effect.runFork(
-    Effect.logError("Unknown error in Nina stream").pipe(
+    yield* Effect.logError("Unknown error in Nina stream").pipe(
       Effect.annotateLogs(logContext)
-    )
-  );
-  return turn.copy.errorMessage;
-}
+    );
+    return turn.copy.errorMessage;
+  }
+);

--- a/packages/ai/nina/runtime/stream.ts
+++ b/packages/ai/nina/runtime/stream.ts
@@ -54,6 +54,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
     const services = yield* Effect.context<never>();
     const runFork = Effect.runForkWith(services);
     const runPromise = Effect.runPromiseWith(services);
+    const runSync = Effect.runSyncWith(services);
     const messages = yield* store.loadMessages;
     const logContext = createNinaLogContext(turn);
     const originalMessageCount = messages.length;
@@ -147,7 +148,7 @@ export const createNinaStreamResponse = Effect.fn("nina.stream.response")(
       generateId: () => responseMessageId,
       onError: (error) => {
         scheduleAssistantFailure(error, "createUIMessageStream");
-        return formatNinaStreamError({ error, logContext, turn });
+        return runSync(formatNinaStreamError({ error, logContext, turn }));
       },
       onEnd: ({
         finishReason,
@@ -261,11 +262,13 @@ const runNinaWriterTurn = Effect.fn("nina.stream.writer")(function* ({
     },
     stream: {
       formatError: (error) =>
-        formatNinaStreamError({
-          error,
-          logContext,
-          turn: { page, runtime, user, copy },
-        }),
+        runSync(
+          formatNinaStreamError({
+            error,
+            logContext,
+            turn: { page, runtime, user, copy },
+          })
+        ),
       onError: onStreamError,
       readFinishMetadata: (mainUsage) =>
         runSync(


### PR DESCRIPTION
## Problem

`formatNinaStreamError` started two Effect fibers inside a formatting helper. That hid runtime execution below the synchronous AI SDK error callback seam and made logging timing independent from the returned fallback text.

## Change

- make error formatting a named `Effect.fn("nina.stream.formatError")`
- compose rate-limit and unknown-error logging in that Effect
- execute the formatter with `Effect.runSyncWith` only at the two AI SDK callbacks that must return a string
- keep the existing durable failure scheduler unchanged because it is the shared adapter used exclusively by AI SDK `onError` and `onEnd` callbacks

The patch changes two Nina runtime files with 32 additions and 31 deletions. Runtime response contracts are unchanged.

## Effect v4 evidence

Vendored Effect 4.0.0-rc.110 defines `Effect.fn` for named Effect programs and `Effect.runSyncWith(context)` for synchronous interoperability. Installed AI SDK 7.0.77 defines both relevant `onError` callbacks as `(error: unknown) => string`, so those callbacks are the required imperative seams.

## Scope and ownership

A fresh scan covered all 24 open PRs and every retained worktree. Neither changed file has another owner or overlap. No email runner exists, and all other direct AI runners were verified as provider callback adapters. This PR does not touch Convex data, Quran, tryouts, history, migrations, signed publication, dependencies, or deployment configuration.

## Verification

- focused Nina stream and agent suites: 8 of 8 passed
- full AI suite: 62 files, 377 tests, 100% statements, branches, functions, and lines
- AI native TypeScript typecheck passed with TypeScript 7.0.2 plus effect-tsgo 0.36.5
- root format and lint passed
- dependency boundaries passed
- test ownership policy passed
- vendored Effect parity passed for RC110 at `66114151c2b4640bf773f2b3456ce70d679422f6`
- diff check and clean committed worktree passed

## Release

Ready for review. Exact-head Production and Required are green. Head `a160074a7955d7eca13f7fb6cc13593375af4728` was validated from base `9e9b3bf65231072c55dc05477035cbd046f08298`. This PR has not been enqueued or merged. PR #477 merged to main as `eac90bc83d249f0c1b1979c35b0579c15376534e`. PR #461 is now the active merge-group candidate at synthetic head `ce8d944e328ed2d2cd7bbf5544f1d4bdf9d14490`. PR #475 and PR #465 are queued behind it in that order. No Vercel Preview or Convex mutation was created.