### PR TITLE
test(www): run material reads with Effect Vitest

### DIFF
--- a/apps/www/lib/content/material/discovery.test.ts
+++ b/apps/www/lib/content/material/discovery.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
-import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Data, Effect } from "effect";
+import { vi } from "vitest";
 import {
   readPublishedLatestMaterials,
   readPublishedMaterialBucket,
@@ -14,6 +15,12 @@ const publicPath =
 const sourcePath =
   "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx";
 const activeReleaseId = ReleaseIdSchema.make("release-material");
+
+class TestMaterialRuntimeUnavailable extends Data.TaggedError(
+  "TestMaterialRuntimeUnavailable"
+)<{
+  readonly operation: "query";
+}> {}
 
 vi.mock("@/lib/content/runtime/query", async () => {
   const { createTestRuntimeQuery } = await import("@/test/runtime-query");
@@ -38,136 +45,144 @@ describe("published material discovery", () => {
     runtimeQueryMock.mockReset();
   });
 
-  it("rejects unmanaged buckets and reads complete signed buckets", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: false,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId: null,
-        managed: true,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [summary],
-      });
+  it.effect("rejects unmanaged buckets and reads complete signed buckets", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: false,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId: null,
+          managed: true,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: [summary],
+        });
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "abc").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "def").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(readPublishedMaterialBucket("en", "ghi"))
-    ).resolves.toEqual({ activeReleaseId, materials: null });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "jkl", activeReleaseId)
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      materials: [
-        {
-          publicPath,
-          sourcePath,
-        },
-      ],
-    });
-  });
-
-  it.each(["en", "id", "de"] as const)(
-    "decodes newest %s materials from the expected release",
-    async (appLocale) => {
-      const {
-        dateModified: _dateModified,
-        description: _description,
-        ...publishedOnly
-      } = summary;
-      runtimeQueryMock.mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [publishedOnly],
-      });
-
-      const result = await Effect.runPromise(
-        readPublishedLatestMaterials(appLocale, 10, activeReleaseId)
+      const unmanaged = yield* readPublishedMaterialBucket("en", "abc").pipe(
+        Effect.flip
       );
-      expect(result).toMatchObject({
+      const inactive = yield* readPublishedMaterialBucket("en", "def").pipe(
+        Effect.flip
+      );
+      const absent = yield* readPublishedMaterialBucket("en", "ghi");
+      const published = yield* readPublishedMaterialBucket(
+        "en",
+        "jkl",
+        activeReleaseId
+      );
+
+      expect(unmanaged).toMatchObject({ _tag: "PublishedProjectionError" });
+      expect(inactive).toMatchObject({ _tag: "PublishedProjectionError" });
+      expect(absent).toEqual({ activeReleaseId, materials: null });
+      expect(published).toMatchObject({
         activeReleaseId,
-        materials: [{ datePublished: summary.datePublished, sourcePath }],
+        materials: [
+          {
+            publicPath,
+            sourcePath,
+          },
+        ],
       });
-      expect(result.materials[0]).not.toHaveProperty("description");
-      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-        appLocale,
-        limit: 10,
-      });
-    }
+    })
   );
 
-  it("rejects malformed summaries, unmanaged results, and runtime failures", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [{ ...summary, sourcePath: "" }],
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: false,
-        materials: [],
-      })
-      .mockRejectedValueOnce(new Error("runtime unavailable"));
+  it.effect.each(["en", "id", "de"] as const)(
+    "decodes newest %s materials from the expected release",
+    (appLocale) =>
+      Effect.gen(function* () {
+        const {
+          dateModified: _dateModified,
+          description: _description,
+          ...publishedOnly
+        } = summary;
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: [publishedOnly],
+        });
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "abc").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedLatestMaterials("en", 10).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedLatestMaterials("en", 10).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "TestRuntimeQueryError" });
-  });
+        const result = yield* readPublishedLatestMaterials(
+          appLocale,
+          10,
+          activeReleaseId
+        );
+        expect(result).toMatchObject({
+          activeReleaseId,
+          materials: [{ datePublished: summary.datePublished, sourcePath }],
+        });
+        expect(result.materials[0]).not.toHaveProperty("description");
+        expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+          appLocale,
+          limit: 10,
+        });
+      })
+  );
 
-  it.each(["en", "id", "de"] as const)(
+  it.effect(
+    "rejects malformed summaries, unmanaged results, and runtime failures",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock
+          .mockResolvedValueOnce({
+            activeReleaseId,
+            managed: true,
+            materials: [{ ...summary, sourcePath: "" }],
+          })
+          .mockResolvedValueOnce({
+            activeReleaseId,
+            managed: false,
+            materials: [],
+          })
+          .mockRejectedValueOnce(
+            new TestMaterialRuntimeUnavailable({ operation: "query" })
+          );
+
+        const malformed = yield* readPublishedMaterialBucket("en", "abc").pipe(
+          Effect.flip
+        );
+        const unmanaged = yield* readPublishedLatestMaterials("en", 10).pipe(
+          Effect.flip
+        );
+        const unavailable = yield* readPublishedLatestMaterials("en", 10).pipe(
+          Effect.flip
+        );
+
+        expect(malformed).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(unmanaged).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(unavailable).toMatchObject({ _tag: "TestRuntimeQueryError" });
+      })
+  );
+
+  it.effect.each(["en", "id", "de"] as const)(
     "rejects a %s material bucket from a different active release",
-    async (appLocale) => {
-      runtimeQueryMock.mockResolvedValueOnce({
-        activeReleaseId: ReleaseIdSchema.make("release-next"),
-        managed: true,
-        materials: [summary],
-      });
+    (appLocale) =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId: ReleaseIdSchema.make("release-next"),
+          managed: true,
+          materials: [summary],
+        });
 
-      await expect(
-        Effect.runPromise(
-          readPublishedMaterialBucket(appLocale, "abc", activeReleaseId).pipe(
-            Effect.flip
-          )
-        )
-      ).resolves.toMatchObject({
-        _tag: "PublishedReleaseMismatchError",
-        expectedReleaseId: activeReleaseId,
-      });
-    }
+        const mismatch = yield* readPublishedMaterialBucket(
+          appLocale,
+          "abc",
+          activeReleaseId
+        ).pipe(Effect.flip);
+        expect(mismatch).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+          expectedReleaseId: activeReleaseId,
+        });
+      })
   );
 });

--- a/apps/www/lib/content/material/route.test.ts
+++ b/apps/www/lib/content/material/route.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedMaterialRoute,
   readPublishedMaterialRoute,
@@ -91,82 +92,95 @@ beforeEach(() => {
 });
 
 describe("published material route", () => {
-  it("decodes one complete signed route, locale set, and sibling group", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
+  it.effect(
+    "decodes one complete signed route, locale set, and sibling group",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      getPublishedMaterialRoute("en", previewProjection.publicPath)
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      alternates: [previewProjection, previewIdProjection, previewDeProjection],
-      projection: previewProjection,
-      rendererDomain: "mathematics",
-      siblings: [previewProjection, previewNextProjection],
-      sourceRevision,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledOnce();
-    expect(cacheMock).toHaveBeenCalledOnce();
-  });
+        const route = yield* Effect.tryPromise(() =>
+          getPublishedMaterialRoute("en", previewProjection.publicPath)
+        );
+        expect(route).toMatchObject({
+          activeReleaseId,
+          alternates: [
+            previewProjection,
+            previewIdProjection,
+            previewDeProjection,
+          ],
+          projection: previewProjection,
+          rendererDomain: "mathematics",
+          siblings: [previewProjection, previewNextProjection],
+          sourceRevision,
+        });
+        expect(runtimeQueryMock).toHaveBeenCalledOnce();
+        expect(cacheMock).toHaveBeenCalledOnce();
+      })
+  );
 
-  it("pins a route read to the expected active release", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
+  it.effect("pins a route read to the expected active release", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      getPublishedMaterialRoute(
-        "en",
-        previewProjection.publicPath,
-        activeReleaseId
-      )
-    ).resolves.toMatchObject({ activeReleaseId });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
-    );
-  });
-
-  it("preserves an active release mismatch for pinned callers", async () => {
-    const expectedReleaseId = ReleaseIdSchema.make("release-previous");
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute(
+      const route = yield* Effect.tryPromise(() =>
+        getPublishedMaterialRoute(
           "en",
           previewProjection.publicPath,
-          expectedReleaseId
-        ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: activeReleaseId,
-      expectedReleaseId,
-    });
-  });
+          activeReleaseId
+        )
+      );
+      expect(route).toMatchObject({ activeReleaseId });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
+      );
+    })
+  );
 
-  it("preserves a signed missing-route tombstone", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(
-      foundModel({
-        alternateJson: [],
-        projectionJson: null,
-        rendererDomain: null,
-        siblingJson: [],
+  it.effect("preserves an active release mismatch for pinned callers", () =>
+    Effect.gen(function* () {
+      const expectedReleaseId = ReleaseIdSchema.make("release-previous");
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
+
+      const mismatch = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath,
+        expectedReleaseId
+      ).pipe(Effect.flip);
+      expect(mismatch).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: activeReleaseId,
+        expectedReleaseId,
+      });
+    })
+  );
+
+  it.effect("preserves a signed missing-route tombstone", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(
+        foundModel({
+          alternateJson: [],
+          projectionJson: null,
+          rendererDomain: null,
+          siblingJson: [],
+          sourcePath: null,
+        })
+      );
+
+      const route = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath
+      );
+      expect(route).toMatchObject({
+        activeReleaseId,
+        alternates: [],
+        projection: null,
         sourcePath: null,
-      })
-    );
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute("en", previewProjection.publicPath)
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      alternates: [],
-      projection: null,
-      sourcePath: null,
-    });
-  });
-
-  it.each([
+  it.effect.each([
     ["active manifest", foundModel({ activeManifestHash: "invalid" })],
     ["missing manifest", foundModel({ activeManifestHash: null })],
     ["active locales", foundModel({ activeAppLocales: ["id", "en", "de"] })],
@@ -219,15 +233,15 @@ describe("published material route", () => {
     ["projection JSON", foundModel({ projectionJson: "{}" })],
     ["alternate JSON", foundModel({ alternateJson: ["{}"] })],
     ["sibling JSON", foundModel({ siblingJson: ["{}"] })],
-  ])("rejects an invalid %s", async (_label, result) => {
-    runtimeQueryMock.mockResolvedValueOnce(result);
+  ])("rejects an invalid %s", ([, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(result);
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute("en", previewProjection.publicPath).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      const failure = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath
+      ).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });


### PR DESCRIPTION
## Summary

Migrate the two material read test modules directly to Effect v4 Vitest.

- Effectful cases now return Effects through `it.effect`.
- Direct `Effect.runPromise`, raw async assertions, and generic expected errors are removed.
- Raw Vitest remains only for the required `vi.hoisted` and `vi.mock` transform APIs.

## Architecture

This follows the vendored Effect 4.0.0-rc.110 `@effect/vitest` implementation and testing pattern. Material read programs compose directly in the Effect runtime. The cached Next.js Promise boundary is lifted with `Effect.tryPromise` only where that framework API is under test.

## Scope

Only these package-owned tests change:

- `apps/www/lib/content/material/discovery.test.ts`
- `apps/www/lib/content/material/route.test.ts`

No runtime, dependency, lockfile, Quran, tryout, or content-release backend code changes.

## Exact identity

- Base: `eac90bc83d249f0c1b1979c35b0579c15376534e`
- Head: `30b5f2f7cb3de117a22a89b4a665346e1a937c66`
- Tree: `427c622125022fe37fc5811d9e894e1f274c18c3`
- Stable patch ID: `9f37b9b2977762fd4dcb5e82af49052a0a54d101`

## Verification

- Focused tests: 2 files, 30 tests
- Focused owning-module coverage: 100% statements, branches, functions, and lines
- Full WWW: 209 files, 1,518 tests, 100% coverage
- Native TypeScript 7 WWW typecheck
- Format and lint
- Effect source parity at 4.0.0-rc.110
- Test and patch policies
- Script typecheck and 19 policy tests
- Package boundaries
- React Doctor changed scope: 100/100

## Release

This is test-only. It does not request a Vercel Preview or production deployment.