### PR TITLE
test(www): run public source checks with Effect Vitest

### DIFF
--- a/apps/www/lib/routing/public/source.test.ts
+++ b/apps/www/lib/routing/public/source.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readSourceBackedHtmlRouteRejection } from "@/lib/routing/public/source";
 
 const publishedMocks = vi.hoisted(() => ({
@@ -52,323 +53,342 @@ describe("public HTML route rejection", () => {
     previewMocks.matchesPreviewRoute.mockReturnValue(Effect.succeed(false));
   });
 
-  it("rejects stale public namespaces and invisible route groups", async () => {
-    const paths = [
-      ["/id/curricula/merdeka", "id"],
-      ["/id/subjects/matematika/integral", "id"],
-      ["/en/kurikulum/merdeka/kelas-10", "en"],
-      ["/en/materi/mathematics/integral", "en"],
-      ["/learn", "en"],
-    ] as const;
+  it.effect("rejects stale public namespaces and invisible route groups", () =>
+    Effect.gen(function* () {
+      const paths = [
+        ["/id/curricula/merdeka", "id"],
+        ["/id/subjects/matematika/integral", "id"],
+        ["/en/kurikulum/merdeka/kelas-10", "en"],
+        ["/en/materi/mathematics/integral", "en"],
+        ["/learn", "en"],
+      ] as const;
 
-    for (const [pathname, locale] of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(locale);
-    }
-  });
+      for (const [pathname, locale] of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBe(locale);
+      }
+    })
+  );
 
-  it("rejects impossible Quran and article HTML paths", async () => {
-    const paths = [
-      "/id/quran/999",
-      "/id/quran/abc",
-      "/id/quran/01",
-      "/id/quran/1/extra",
-      "/en/articles/Invalid_Category",
-      "/en/articles/politics/Invalid_Slug",
-      "/en/articles/politics/article/extra",
-    ];
+  it.effect("rejects impossible Quran and article HTML paths", () =>
+    Effect.gen(function* () {
+      const paths = [
+        "/id/quran/999",
+        "/id/quran/abc",
+        "/id/quran/01",
+        "/id/quran/1/extra",
+        "/en/articles/Invalid_Category",
+        "/en/articles/politics/Invalid_Slug",
+        "/en/articles/politics/article/extra",
+      ];
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(pathname.startsWith("/id/") ? "id" : "en");
-    }
-  });
+      for (const pathname of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBe(pathname.startsWith("/id/") ? "id" : "en");
+      }
+    })
+  );
 
-  it("accepts signed articles and rejects missing or unmanaged routes", async () => {
-    publishedMocks.readActiveContentRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
+  it.effect(
+    "accepts signed articles and rejects missing or unmanaged routes",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.readActiveContentRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "found",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "missing",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "unmanaged",
+            })
+          );
+
+        const paths = [
+          "/en/articles/public-affairs/new-article",
+          "/en/articles/public-affairs/deleted-article",
+          "/en/articles/public-affairs/unmanaged-article",
+        ];
+        const results = yield* Effect.all(
+          paths.map((pathname) =>
+            readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
+          ),
+          { concurrency: "unbounded" }
+        );
+
+        expect(results).toEqual([null, "en", "en"]);
+        expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
           activeReleaseId: "release-active",
-          kind: "found",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "missing",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "unmanaged",
-        })
-      );
+          appLocale: "en",
+          family: "article",
+          publicPath: "articles/public-affairs/new-article",
+        });
+      })
+  );
 
-    const paths = [
-      "/en/articles/public-affairs/new-article",
-      "/en/articles/public-affairs/deleted-article",
-      "/en/articles/public-affairs/unmanaged-article",
-    ];
-    const results = await Promise.all(
-      paths.map((pathname) =>
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      )
-    );
+  it.effect(
+    "accepts signed Pages and rejects missing or unmanaged Page routes",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.readActiveContentRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "found",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "missing",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "unmanaged",
+            })
+          );
 
-    expect(results).toEqual([null, "en", "en"]);
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId: "release-active",
-      appLocale: "en",
-      family: "article",
-      publicPath: "articles/public-affairs/new-article",
-    });
-  });
-
-  it("accepts signed Pages and rejects missing or unmanaged Page routes", async () => {
-    publishedMocks.readActiveContentRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "found",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "missing",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "unmanaged",
-        })
-      );
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        const found = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/impressum",
-        })
-      )
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        });
+        const missing = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/fabricated-page",
-        })
-      )
-    ).resolves.toBe("de");
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        });
+        const unmanaged = yield* readSourceBackedHtmlRouteRejection({
           method: "HEAD",
           pathname: "/en/missing/page",
-        })
-      )
-    ).resolves.toBe("en");
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenNthCalledWith(1, {
-      activeReleaseId: "release-active",
-      appLocale: "de",
-      family: "page",
-      publicPath: "impressum",
-    });
-  });
+        });
 
-  it("accepts the exact selected local preview before publication lookup", async () => {
-    previewMocks.matchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
+        expect(found).toBeNull();
+        expect(missing).toBe("de");
+        expect(unmanaged).toBe("en");
+        expect(publishedMocks.readActiveContentRoute).toHaveBeenNthCalledWith(
+          1,
+          {
+            activeReleaseId: "release-active",
+            appLocale: "de",
+            family: "page",
+            publicPath: "impressum",
+          }
+        );
+      })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+  it.effect(
+    "accepts the exact selected local preview before publication lookup",
+    () =>
+      Effect.gen(function* () {
+        previewMocks.matchesPreviewRoute.mockReturnValueOnce(
+          Effect.succeed(true)
+        );
+
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/en/articles/public-affairs/new-preview",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
-      appLocale: "en",
-      publicPath: "articles/public-affairs/new-preview",
-    });
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+        });
+        expect(rejection).toBeNull();
+        expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
+          appLocale: "en",
+          publicPath: "articles/public-affairs/new-preview",
+        });
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
 
-  it("accepts the exact selected Page preview before publication lookup", async () => {
-    previewMocks.matchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
+  it.effect(
+    "accepts the exact selected Page preview before publication lookup",
+    () =>
+      Effect.gen(function* () {
+        previewMocks.matchesPreviewRoute.mockReturnValueOnce(
+          Effect.succeed(true)
+        );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/neue-rechtliche-seite",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
-      appLocale: "de",
-      publicPath: "neue-rechtliche-seite",
-    });
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+        });
+        expect(rejection).toBeNull();
+        expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
+          appLocale: "de",
+          publicPath: "neue-rechtliche-seite",
+        });
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
 
-  it("rejects article details when no active publication exists", async () => {
-    publishedMocks.readActiveContentIdentity.mockReturnValueOnce(
-      Effect.succeed(null)
-    );
-    publishedMocks.readActiveContentRoute.mockReturnValueOnce(
-      Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
-    );
+  it.effect("rejects article details when no active publication exists", () =>
+    Effect.gen(function* () {
+      publishedMocks.readActiveContentIdentity.mockReturnValueOnce(
+        Effect.succeed(null)
+      );
+      publishedMocks.readActiveContentRoute.mockReturnValueOnce(
+        Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
+      );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/public-affairs/unmanaged-article",
-        })
-      )
-    ).resolves.toBe("en");
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId: null,
-      appLocale: "en",
-      family: "article",
-      publicPath: "articles/public-affairs/unmanaged-article",
-    });
-  });
-
-  it("uses exact signed ownership for category pages", async () => {
-    publishedMocks.hasArticleCategory
-      .mockReturnValueOnce(Effect.succeed(true))
-      .mockReturnValueOnce(Effect.succeed(false));
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/public-affairs",
-        })
-      )
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/deleted-category",
-        })
-      )
-    ).resolves.toBe("en");
-  });
-
-  it("propagates signed article lookup failures", async () => {
-    publishedMocks.readActiveContentRoute.mockReturnValueOnce(
-      Effect.fail(
-        new TestPublishedRouteError({ message: "publication unavailable" })
-      )
-    );
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "HEAD",
-          pathname: "/en/articles/politics/published-article",
-        })
-      )
-    ).rejects.toThrow("publication unavailable");
-  });
-
-  it("delegates indexes, markdown, and non-read requests", async () => {
-    const requests = [
-      { method: "GET", pathname: "/id/quran" },
-      { method: "GET", pathname: "/en/articles" },
-      { method: "GET", pathname: "/id/quran/1.md" },
-      {
+      const rejection = yield* readSourceBackedHtmlRouteRejection({
         method: "GET",
-        pathname: "/en/articles/politics/published-article.md",
-      },
-      { method: "GET", pathname: "/de/datenschutz.md" },
-      { method: "POST", pathname: "/en/articles/politics/not-a-read-check" },
-    ];
+        pathname: "/en/articles/public-affairs/unmanaged-article",
+      });
+      expect(rejection).toBe("en");
+      expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
+        activeReleaseId: null,
+        appLocale: "en",
+        family: "article",
+        publicPath: "articles/public-affairs/unmanaged-article",
+      });
+    })
+  );
 
-    for (const request of requests) {
-      await expect(
-        Effect.runPromise(readSourceBackedHtmlRouteRejection(request))
-      ).resolves.toBeNull();
-    }
-    expect(publishedMocks.hasArticleCategory).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+  it.effect("uses exact signed ownership for category pages", () =>
+    Effect.gen(function* () {
+      publishedMocks.hasArticleCategory
+        .mockReturnValueOnce(Effect.succeed(true))
+        .mockReturnValueOnce(Effect.succeed(false));
 
-  it("delegates concrete application roots without Page lookups", async () => {
-    const paths = [
-      "/de",
-      "/de/search",
-      "/de/chat/new",
-      "/de/lehrplaene/merdeka",
-      "/de/faecher/mathematik/algebra",
-      "/de/try-out/indonesien/snbt",
-      "/en/school/onboarding",
-    ];
+      const found = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/en/articles/public-affairs",
+      });
+      const missing = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/en/articles/deleted-category",
+      });
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
+      expect(found).toBeNull();
+      expect(missing).toBe("en");
+    })
+  );
+
+  it.effect("propagates signed article lookup failures", () =>
+    Effect.gen(function* () {
+      publishedMocks.readActiveContentRoute.mockReturnValueOnce(
+        Effect.fail(
+          new TestPublishedRouteError({ message: "publication unavailable" })
         )
-      ).resolves.toBeNull();
-    }
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+      );
 
-  it("rejects invalid descendants inside reserved application roots", async () => {
-    const paths = [
-      "/de/search/fabricated",
-      "/de/auth/fabricated",
-      "/de/onboarding/fabricated",
-      "/de/home/fabricated",
-      "/de/contributor/fabricated",
-      "/de/user",
-      "/de/user/settings/fabricated",
-      "/en/school/select/fabricated",
-      "/de/og",
-      "/de/faecher",
-      "/en/subjects/mathematics",
-      "/de/try-out/a/b/c/d/e/f",
-    ];
+      const failure = yield* readSourceBackedHtmlRouteRejection({
+        method: "HEAD",
+        pathname: "/en/articles/politics/published-article",
+      }).pipe(Effect.flip);
+      expect(failure).toMatchObject({
+        _tag: "TestPublishedRouteError",
+        message: "publication unavailable",
+      });
+    })
+  );
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(pathname.startsWith("/en/") ? "en" : "de");
-    }
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
-
-  it("rejects malformed Page paths without a publication lookup", async () => {
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+  it.effect("delegates indexes, markdown, and non-read requests", () =>
+    Effect.gen(function* () {
+      const requests = [
+        { method: "GET", pathname: "/id/quran" },
+        { method: "GET", pathname: "/en/articles" },
+        { method: "GET", pathname: "/id/quran/1.md" },
+        {
           method: "GET",
-          pathname: "/de/Invalid_Page",
-        })
-      )
-    ).resolves.toBe("de");
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+          pathname: "/en/articles/politics/published-article.md",
+        },
+        { method: "GET", pathname: "/de/datenschutz.md" },
+        {
+          method: "POST",
+          pathname: "/en/articles/politics/not-a-read-check",
+        },
+      ];
+
+      for (const request of requests) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection(request);
+        expect(rejection).toBeNull();
+      }
+      expect(publishedMocks.hasArticleCategory).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("delegates concrete application roots without Page lookups", () =>
+    Effect.gen(function* () {
+      const paths = [
+        "/de",
+        "/de/search",
+        "/de/chat/new",
+        "/de/lehrplaene/merdeka",
+        "/de/faecher/mathematik/algebra",
+        "/de/try-out/indonesien/snbt",
+        "/en/school/onboarding",
+      ];
+
+      for (const pathname of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBeNull();
+      }
+      expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "rejects invalid descendants inside reserved application roots",
+    () =>
+      Effect.gen(function* () {
+        const paths = [
+          "/de/search/fabricated",
+          "/de/auth/fabricated",
+          "/de/onboarding/fabricated",
+          "/de/home/fabricated",
+          "/de/contributor/fabricated",
+          "/de/user",
+          "/de/user/settings/fabricated",
+          "/en/school/select/fabricated",
+          "/de/og",
+          "/de/faecher",
+          "/en/subjects/mathematics",
+          "/de/try-out/a/b/c/d/e/f",
+        ];
+
+        for (const pathname of paths) {
+          const rejection = yield* readSourceBackedHtmlRouteRejection({
+            method: "GET",
+            pathname,
+          });
+          expect(rejection).toBe(pathname.startsWith("/en/") ? "en" : "de");
+        }
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
+
+  it.effect("rejects malformed Page paths without a publication lookup", () =>
+    Effect.gen(function* () {
+      const rejection = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/de/Invalid_Page",
+      });
+      expect(rejection).toBe("de");
+      expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
 });


### PR DESCRIPTION
## Summary

Migrates the existing public HTML source rejection tests directly to Effect v4 RC110 Vitest.

## Architecture

- Imports test primitives from `@effect/vitest`.
- Runs all 13 effectful cases with `it.effect`.
- Composes concurrent lookups with `Effect.all`.
- Asserts the typed tagged failure with `Effect.flip`.
- Retains raw Vitest only for the required `vi` transform APIs.

## Scope

Exactly one test file changes: `apps/www/lib/routing/public/source.test.ts`. Production source and behavior remain unchanged. The separate unmerged `developers` behavior assertion is intentionally excluded.

## Identity

- Base: `ce8d944e328ed2d2cd7bbf5544f1d4bdf9d14490`
- Head: `d08818759c01196809d2e214beca4058ab3886e6`
- Tree: `938c8ad99c10e6c8b47feff91111c06563a8e86b`
- Stable patch: `f8083f1f8f0b71cab49c69923752207ed82a0e26`

## Validation

- Focused test: 13 passed
- Scoped owning source coverage: 100% statements, branches, functions, and lines
- Full WWW suite: 209 files and 1,518 tests passed, 100% all coverage metrics
- Native TypeScript 7 WWW typecheck
- Format and lint
- Effect RC110 source parity and test policies
- Boundaries
- Script typecheck and 19 script tests
- React Doctor: 100/100

## Release

Test-only checkpoint. Production and dependency files are unchanged. No Vercel Preview or deployment is required.