### PR TITLE
test(www): run auth server checks with Effect Vitest

### DIFF
--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -9,13 +9,13 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "@effect/vitest";
 import { Effect } from "effect";
 import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
 import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
 import { createRequestStore } from "next/dist/server/async-storage/request-store";
 import { createWorkStore } from "next/dist/server/async-storage/work-store";
-import { vi } from "vitest";
 
 const CONVEX_SITE_URL = "https://test.convex.site";
 
@@ -23,10 +23,9 @@ const loadAuthServer = Effect.fn("auth.server.test.load")(() =>
   Effect.tryPromise(() => import("./server"))
 );
 
-const runWithRequestHeaders = (
-  headers: Headers,
-  getToken: typeof import("./server")["getToken"]
-) => {
+const runWithRequestHeaders = Effect.fn(
+  "auth.server.test.runWithRequestHeaders"
+)((headers: Headers, getToken: typeof import("./server")["getToken"]) => {
   const requestStore = createRequestStore({
     fallbackParams: null,
     headers,
@@ -74,7 +73,7 @@ const runWithRequestHeaders = (
       workUnitAsyncStorage.run(requestStore, getToken)
     )
   );
-};
+});
 
 beforeAll(() => {
   vi.stubEnv("INTERNAL_CONTENT_API_KEY", "test-content-key");

--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -19,10 +19,14 @@ import { vi } from "vitest";
 
 const CONVEX_SITE_URL = "https://test.convex.site";
 
-let handler: typeof import("./server")["handler"];
-let getToken: typeof import("./server")["getToken"];
+const loadAuthServer = Effect.fn("auth.server.test.load")(() =>
+  Effect.tryPromise(() => import("./server"))
+);
 
-const runWithRequestHeaders = (headers: Headers) => {
+const runWithRequestHeaders = (
+  headers: Headers,
+  getToken: typeof import("./server")["getToken"]
+) => {
   const requestStore = createRequestStore({
     fallbackParams: null,
     headers,
@@ -72,14 +76,12 @@ const runWithRequestHeaders = (headers: Headers) => {
   );
 };
 
-beforeAll(async () => {
+beforeAll(() => {
   vi.stubEnv("INTERNAL_CONTENT_API_KEY", "test-content-key");
   vi.stubEnv("NEXT_PUBLIC_CONVEX_URL", "https://test.convex.cloud");
   vi.stubEnv("NEXT_PUBLIC_CONVEX_SITE_URL", CONVEX_SITE_URL);
   vi.stubEnv("NEXT_PUBLIC_MCP_URL", "https://test.example.com/mcp");
   vi.stubEnv("SITE_URL", "https://nakafa.com");
-
-  ({ getToken, handler } = await import("./server"));
 });
 
 afterEach(() => {
@@ -93,6 +95,7 @@ afterAll(() => {
 describe("Better Auth server boundary", () => {
   it.effect("forwards auth routes through the installed adapter", () =>
     Effect.gen(function* () {
+      const { handler } = yield* loadAuthServer();
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(null, { status: 200 }));
@@ -121,6 +124,7 @@ describe("Better Auth server boundary", () => {
 
   it.effect("gets the SSR token through the installed adapter", () =>
     Effect.gen(function* () {
+      const { getToken } = yield* loadAuthServer();
       const cookie = "better-auth.session_token=session-cookie";
       const requestHeaders = new Headers({
         cookie,
@@ -132,7 +136,7 @@ describe("Better Auth server boundary", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(Response.json({ token: "test-token" }));
 
-      const token = yield* runWithRequestHeaders(requestHeaders);
+      const token = yield* runWithRequestHeaders(requestHeaders, getToken);
       expect(token).toBe("test-token");
       const [, init] = fetchSpy.mock.calls[0] ?? [];
       const headers = new Headers(init?.headers);

--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -2,10 +2,6 @@
 
 import "next/dist/server/node-environment-baseline";
 
-import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
-import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
-import { createRequestStore } from "next/dist/server/async-storage/request-store";
-import { createWorkStore } from "next/dist/server/async-storage/work-store";
 import {
   afterAll,
   afterEach,
@@ -13,8 +9,13 @@ import {
   describe,
   expect,
   it,
-  vi,
-} from "vitest";
+} from "@effect/vitest";
+import { Effect } from "effect";
+import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
+import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
+import { createRequestStore } from "next/dist/server/async-storage/request-store";
+import { createWorkStore } from "next/dist/server/async-storage/work-store";
+import { vi } from "vitest";
 
 const CONVEX_SITE_URL = "https://test.convex.site";
 
@@ -64,8 +65,10 @@ const runWithRequestHeaders = (headers: Headers) => {
     },
   });
 
-  return workAsyncStorage.run(workStore, () =>
-    workUnitAsyncStorage.run(requestStore, getToken)
+  return Effect.tryPromise(() =>
+    workAsyncStorage.run(workStore, () =>
+      workUnitAsyncStorage.run(requestStore, getToken)
+    )
   );
 };
 
@@ -88,51 +91,57 @@ afterAll(() => {
 });
 
 describe("Better Auth server boundary", () => {
-  it("forwards auth routes through the installed adapter", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(null, { status: 200 }));
-    const request = new Request("https://nakafa.com/api/auth/sign-in/social", {
-      body: "{}",
-      headers: { "x-forwarded-host": "proxy.internal.example.com" },
-      method: "POST",
-    });
+  it.effect("forwards auth routes through the installed adapter", () =>
+    Effect.gen(function* () {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(null, { status: 200 }));
+      const request = new Request(
+        "https://nakafa.com/api/auth/sign-in/social",
+        {
+          body: "{}",
+          headers: { "x-forwarded-host": "proxy.internal.example.com" },
+          method: "POST",
+        }
+      );
 
-    const response = await handler.POST(request);
-    const [, init] = fetchSpy.mock.calls[0] ?? [];
-    const headers = new Headers(init?.headers);
+      const response = yield* Effect.tryPromise(() => handler.POST(request));
+      const [, init] = fetchSpy.mock.calls[0] ?? [];
+      const headers = new Headers(init?.headers);
 
-    expect(response.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
-      `${CONVEX_SITE_URL}/api/auth/sign-in/social`
-    );
-    expect(headers.get("host")).toBe("test.convex.site");
-    expect(headers.get("x-forwarded-proto")).toBe("https");
-  });
+      expect(response.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${CONVEX_SITE_URL}/api/auth/sign-in/social`
+      );
+      expect(headers.get("host")).toBe("test.convex.site");
+      expect(headers.get("x-forwarded-proto")).toBe("https");
+    })
+  );
 
-  it("gets the SSR token through the installed adapter", async () => {
-    const cookie = "better-auth.session_token=session-cookie";
-    const requestHeaders = new Headers({
-      cookie,
-      host: "render.internal.example.com",
-      "x-forwarded-host": "nakafa.com",
-      "x-forwarded-proto": "https",
-    });
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(Response.json({ token: "test-token" }));
+  it.effect("gets the SSR token through the installed adapter", () =>
+    Effect.gen(function* () {
+      const cookie = "better-auth.session_token=session-cookie";
+      const requestHeaders = new Headers({
+        cookie,
+        host: "render.internal.example.com",
+        "x-forwarded-host": "nakafa.com",
+        "x-forwarded-proto": "https",
+      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ token: "test-token" }));
 
-    await expect(runWithRequestHeaders(requestHeaders)).resolves.toBe(
-      "test-token"
-    );
-    const [, init] = fetchSpy.mock.calls[0] ?? [];
-    const headers = new Headers(init?.headers);
+      const token = yield* runWithRequestHeaders(requestHeaders);
+      expect(token).toBe("test-token");
+      const [, init] = fetchSpy.mock.calls[0] ?? [];
+      const headers = new Headers(init?.headers);
 
-    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
-      `${CONVEX_SITE_URL}/api/auth/convex/token`
-    );
-    expect(headers.get("host")).toBe("test.convex.site");
-    expect(headers.get("cookie")).toBe(cookie);
-  });
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        `${CONVEX_SITE_URL}/api/auth/convex/token`
+      );
+      expect(headers.get("host")).toBe("test.convex.site");
+      expect(headers.get("cookie")).toBe(cookie);
+    })
+  );
 });


### PR DESCRIPTION
## Summary

Migrates the two existing Better Auth server boundary tests directly to Effect v4 RC110 Vitest.

## Architecture

- Imports Vitest APIs directly from the RC110 `@effect/vitest` re-export.
- Runs both effectful cases with `it.effect`.
- Loads the environment-sensitive auth module lazily through named `Effect.fn` and `Effect.tryPromise`.
- Runs the Next.js request AsyncLocalStorage setup through a second named `Effect.fn` program.
- Lifts handler and token Promises with `Effect.tryPromise` because framework and network rejection is possible.
- Passes the loaded token reader explicitly and keeps `beforeAll` synchronous.

## Scope

Exactly one test file changes: `apps/www/lib/auth/server.test.ts`. Production auth code and behavior are unchanged.

## Identity

- Base: `b8e917905cfb732b00be2406538a0f1ed81c1ae8`
- Head: `c580a16a6ac0b0245298e5e8e36841e82211b2b8`
- Tree: `132d056aa91b62dd767b9488d72fe93991acb08a`
- Stable patch: `312de22c51aefcb50ecb5332e7895c9faad1952c`

## Validation

- Focused test: 2 passed with 100% coverage
- Full WWW suite: 209 files and 1,518 tests passed, 100% all coverage metrics
- Native TypeScript 7 WWW typecheck
- Format and lint
- Effect RC110 source parity and test policies
- Boundaries
- Script typecheck and 19 script tests
- React Doctor: 100/100

## Release

Test-only checkpoint. Production and dependency files are unchanged. No Vercel Preview or deployment is required.