### PR TITLE
test(backend): run Polar route with Effect Vitest

### DIFF
--- a/packages/backend/convex/routes/polar.test.ts
+++ b/packages/backend/convex/routes/polar.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment edge-runtime
 
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { SDKValidationError } from "@polar-sh/sdk/models/errors/sdkvalidationerror";
 import { WebhookVerificationError } from "@polar-sh/sdk/webhooks";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
@@ -7,7 +8,7 @@ import { registerPolarRoutes } from "@repo/backend/convex/routes/polar";
 import type { HonoWithConvex } from "convex-helpers/server/hono";
 import { Effect, Schema } from "effect";
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   processEvent: vi.fn(),
@@ -34,13 +35,21 @@ function createApp() {
   return app;
 }
 
-function postWebhook(body = "{}") {
-  return createApp().request("/polar/events", {
-    body,
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
-}
+const postWebhook = Effect.fn("routes.polar.test.postWebhook")((body = "{}") =>
+  Effect.promise(() =>
+    Promise.resolve(
+      createApp().request("/polar/events", {
+        body,
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      })
+    )
+  )
+);
+
+const readResponseText = Effect.fn("routes.polar.test.readResponseText")(
+  (response: Response) => Effect.promise(() => response.text())
+);
 
 beforeEach(() => {
   mocks.validateEvent.mockReset();
@@ -54,95 +63,113 @@ afterEach(() => {
 });
 
 describe("Polar webhook route", () => {
-  it("accepts one verified and handled event", async () => {
-    const response = await postWebhook('{"type":"test.event"}');
+  it.effect("accepts one verified and handled event", () =>
+    Effect.gen(function* () {
+      const response = yield* postWebhook('{"type":"test.event"}');
 
-    expect(response.status).toBe(202);
-    await expect(response.text()).resolves.toBe("Accepted");
-    expect(mocks.processEvent).toHaveBeenCalledOnce();
-  });
+      expect(response.status).toBe(202);
+      expect(yield* readResponseText(response)).toBe("Accepted");
+      expect(mocks.processEvent).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("returns a retryable bad request for a missing user", async () => {
-    mocks.processEvent.mockReturnValue(Effect.succeed(false));
+  it.effect("returns a retryable bad request for a missing user", () =>
+    Effect.gen(function* () {
+      mocks.processEvent.mockReturnValue(Effect.succeed(false));
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(400);
-    await expect(response.text()).resolves.toBe("Bad Request: Missing User");
-  });
+      expect(response.status).toBe(400);
+      expect(yield* readResponseText(response)).toBe(
+        "Bad Request: Missing User"
+      );
+    })
+  );
 
-  it("rejects an invalid signature before processing", async () => {
-    mocks.validateEvent.mockImplementation(() => {
-      throw new WebhookVerificationError("Invalid signature");
-    });
+  it.effect("rejects an invalid signature before processing", () =>
+    Effect.gen(function* () {
+      mocks.validateEvent.mockImplementation(() => {
+        throw new WebhookVerificationError("Invalid signature");
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(403);
-    await expect(response.text()).resolves.toBe("Forbidden");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(403);
+      expect(yield* readResponseText(response)).toBe("Forbidden");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("rejects a signed malformed payload before processing", async () => {
-    mocks.validateEvent.mockImplementation(() => {
-      throw new SDKValidationError("Invalid payload", undefined, {});
-    });
+  it.effect("rejects a signed malformed payload before processing", () =>
+    Effect.gen(function* () {
+      mocks.validateEvent.mockImplementation(() => {
+        throw new SDKValidationError("Invalid payload", undefined, {});
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(400);
-    await expect(response.text()).resolves.toBe("Bad Request");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(yield* readResponseText(response)).toBe("Bad Request");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps an unexpected SDK failure to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.validateEvent.mockImplementation(() => {
-      throw new Error("Unexpected SDK failure");
-    });
+  it.effect("maps an unexpected SDK failure to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.validateEvent.mockImplementation(() => {
+        throw new Error("Unexpected SDK failure");
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps a body read failure to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(Request.prototype, "text").mockRejectedValue(
-      new Error("Unreadable body")
-    );
+  it.effect("maps a body read failure to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.spyOn(Request.prototype, "text").mockRejectedValue(
+        new Error("Unreadable body")
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-    expect(mocks.validateEvent).not.toHaveBeenCalled();
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+      expect(mocks.validateEvent).not.toHaveBeenCalled();
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps typed processing failures to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.processEvent.mockReturnValue(
-      Effect.fail(new TestProcessingError({ message: "Database down" }))
-    );
+  it.effect("maps typed processing failures to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.processEvent.mockReturnValue(
+        Effect.fail(new TestProcessingError({ message: "Database down" }))
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+    })
+  );
 
-  it("contains unexpected processing defects at the HTTP boundary", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.processEvent.mockReturnValue(
-      Effect.die(new Error("Unexpected processing defect"))
-    );
+  it.effect("contains unexpected processing defects at the HTTP boundary", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.processEvent.mockReturnValue(
+        Effect.die(new Error("Unexpected processing defect"))
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+    })
+  );
 });


### PR DESCRIPTION
## Outcome

Migrates the eight existing Polar webhook route cases to the direct Effect v4 RC110 Vitest surface without changing production behavior.

## Architecture

- Imports test execution APIs from `@effect/vitest`.
- Runs every effectful case with `it.effect`.
- Names the request and response Promise seams with `Effect.fn` and lifts them with `Effect.promise`.
- Keeps `vi` imported directly from `vitest` because `vi.hoisted` and `vi.mock` are transform APIs that Vitest rejects when re-exported through another module.
- Retains `Effect.runPromise` only in the existing Hono framework route boundary.

## Scope

Exactly one authored test file changes: `packages/backend/convex/routes/polar.test.ts`. No production source, dependency, configuration, wrapper, or deployment file changes.

## Verification

- Focused route test: 8 of 8 passed
- Focused statements, branches, functions, and lines: 100%
- Full Backend: 380 files and 1,627 tests passed with coverage
- Native TypeScript 7 typecheck
- Format and lint
- Effect RC110 source parity and test ownership policies
- Dependency boundaries
- Script typecheck and 19 script tests
- Complete diff and invariant scan

## Identity

- Base: `b8e917905cfb732b00be2406538a0f1ed81c1ae8`
- Head: `103e08ee9f4b45f52ba37f349401d0b9429889da`
- Tree: `cfb1d1591739b745572c25bf74dfbf5b22b6bc6c`
- Stable patch: `eca3b41b609c78594af3b008fce46b901d7f1f3f`
- Commit archive SHA-256: `47f1b943ce876ddfeda7ffd86e95bb4a45d15268b2c830b2a1c93023f4d95795`

## Release

Test-only checkpoint. No Vercel Preview or production deployment is required. Enqueue only after exact-head required checks, review threads, mergeability, and patch identity are clean.