### PR TITLE
fix(migration): prove retained repair placements

### DIFF
--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -1,66 +1,84 @@
-import {
-  tryoutCatalogIdentity,
-  tryoutPlacementIdentity,
-} from "@nakafa/aksara-contracts/tryout/identity";
+import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import { tryoutCatalogNodeIdentity } from "@nakafa/aksara-contracts/tryout/identity";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
-import { readTryoutSectionRows } from "@repo/backend/convex/contentRelease/tryout/section";
+import { loadStoredTryoutPlacement } from "@repo/backend/convex/tryouts/history/rows";
 import { Effect } from "effect";
 
-interface RepairRun {
-  readonly questionCount: number;
-  readonly sectionIdentity: string;
-}
+type RepairItem = Pick<
+  Doc<"irtScaleItems">,
+  "placementIdentity" | "placementRowHash"
+>;
 
 interface SignedPlacement {
   readonly rowHash: string;
   readonly sectionIdentity: string;
 }
 
-/** Authenticates every signed source placement selected by the repair runs. */
+/** Authenticates every scale item against its immutable retained placement. */
 export const loadRepairPlacements = Effect.fn(
   "tryouts.migration.loadRepairPlacements"
-)(function* (ctx: MutationCtx, snapshotId: string, runs: readonly RepairRun[]) {
+)(function* (
+  ctx: MutationCtx,
+  migrationId: string,
+  snapshotId: string,
+  items: readonly RepairItem[]
+) {
   const placements = new Map<string, SignedPlacement>();
-  for (const run of runs) {
-    const storedSection = yield* Effect.promise(() =>
+  for (const item of items) {
+    const placement = yield* loadStoredTryoutPlacement(
+      ctx,
+      snapshotId,
+      item.placementRowHash
+    ).pipe(
+      Effect.catchTag("TryoutRuntimeError", () =>
+        releaseFail(
+          "CONTENT_RELEASE_INTEGRITY",
+          "Try-out history scale repair could not authenticate a retained placement."
+        )
+      )
+    );
+    if (!placement) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "Try-out history scale repair lost a retained placement."
+      );
+    }
+    const mapping = yield* Effect.promise(() =>
       ctx.db
-        .query("tryoutCatalog")
-        .withIndex("by_snapshotId_and_identity", (query) =>
-          query.eq("snapshotId", snapshotId).eq("identity", run.sectionIdentity)
+        .query("tryoutHistoryMigrationMaps")
+        .withIndex("by_migrationId_and_kind_and_oldHash", (query) =>
+          query
+            .eq("migrationId", migrationId)
+            .eq("kind", "placement")
+            .eq("oldHash", item.placementRowHash)
         )
         .unique()
     );
-    if (!storedSection) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Try-out history scale repair lost a signed source section."
-      );
-    }
-    const source = yield* readTryoutSectionRows(ctx, snapshotId, storedSection);
     if (
-      tryoutCatalogIdentity(source.section.row) !== run.sectionIdentity ||
-      source.placements.length !== run.questionCount
+      !mapping ||
+      mapping.identity !== item.placementIdentity ||
+      placements.has(mapping.identity)
     ) {
       return yield* releaseFail(
         "CONTENT_RELEASE_INTEGRITY",
-        "Try-out history scale repair changed signed section ownership."
+        "Try-out history scale repair changed retained placement ownership."
       );
     }
-    for (const placement of source.placements) {
-      const identity = tryoutPlacementIdentity(placement.row);
-      if (placements.has(identity)) {
-        return yield* releaseFail(
-          "CONTENT_RELEASE_INTEGRITY",
-          "Try-out history scale repair found duplicate signed placements."
-        );
-      }
-      placements.set(identity, {
-        rowHash: placement.rowHash,
-        sectionIdentity: run.sectionIdentity,
-      });
-    }
+    const sectionIdentity = tryoutCatalogNodeIdentity({
+      appLocale: AppLocaleSchema.make(placement.locale),
+      countryKey: placement.countryKey,
+      examKey: placement.examKey,
+      kind: "section",
+      sectionKey: placement.sectionKey,
+      setKey: placement.setKey,
+      trackKey: placement.trackKey,
+    });
+    placements.set(mapping.identity, {
+      rowHash: item.placementRowHash,
+      sectionIdentity,
+    });
   }
   return placements;
 });

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -96,6 +96,49 @@ describe("tryouts/migration/cleanup/repair", () => {
     })
   );
 
+  it.effect("repairs from retained history after current rows are gone", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const { repair } = yield* Effect.promise(() => seedRepair(t));
+      yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const [catalog, placements] = await Promise.all([
+            ctx.db
+              .query("tryoutCatalog")
+              .withIndex("by_snapshotId_and_index", (query) =>
+                query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+              )
+              .collect(),
+            ctx.db
+              .query("tryoutPlacements")
+              .withIndex("by_snapshotId_and_index", (query) =>
+                query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+              )
+              .collect(),
+          ]);
+          await Promise.all(
+            [...catalog, ...placements].map(({ _id }) => ctx.db.delete(_id))
+          );
+        })
+      );
+
+      const result = yield* Effect.promise(() =>
+        runCleanup(t, repair.evidence)
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+
+      assert.deepStrictEqual(result, {
+        deleted: 0,
+        done: false,
+        repaired: countScaleRepairRows(repair.evidence),
+      });
+      assert.strictEqual(state.scale, null);
+      assert.ok(state.items.every((item) => item === null));
+      assert.ok(state.runs.every((run) => run === null));
+      assert.ok(state.receipt?.repair);
+    })
+  );
+
   it.effect("rejects a cleaned retry without its exact repair audit", () =>
     Effect.gen(function* () {
       for (const damage of ["missing", "tampered"] as const) {

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -164,8 +164,9 @@ export const prepareUnusedScale = Effect.fn(
   );
   const signedPlacements = yield* loadRepairPlacements(
     ctx,
+    migration.migrationId,
     migration.sourceSnapshotId,
-    evidence.runs
+    items
   );
   const runIds = new Set(runs.map(({ _id }) => _id));
   const itemIds = new Set(items.map(({ _id }) => _id));

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -1,9 +1,11 @@
 import { strict as assert } from "node:assert/strict";
+import { createHash } from "node:crypto";
+import type { StoredTryoutPlacementRow } from "@nakafa/aksara-contracts/history/decode";
 import {
   ContentKeySchema,
   CorpusSourcePathSchema,
+  Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
-import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot/data";
 import { makeTryoutCatalogRecord } from "@nakafa/aksara-contracts/tryout/catalog-hash";
 import {
   tryoutCatalogIdentity,
@@ -13,20 +15,20 @@ import {
 import { makeTryoutPlacementRecord } from "@nakafa/aksara-contracts/tryout/placement-hash";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
-import {
-  tryoutCatalogFacts,
-  tryoutPlacementFacts,
-} from "@repo/backend/convex/contentRelease/tryout/facts";
 import type schema from "@repo/backend/convex/schema";
 import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
-import { CLEANUP_SOURCE_SNAPSHOT } from "@repo/backend/test/migration/state";
+import {
+  CLEANUP_MIGRATION_ID,
+  CLEANUP_SOURCE_SNAPSHOT,
+} from "@repo/backend/test/migration/state";
 import { makeTryoutPlacementRow } from "@repo/backend/test/tryout/snapshot";
 import { makeTryoutStartCatalog } from "@repo/backend/test/tryout/source";
 import type { TestConvex } from "convex-test";
 
 const REPAIR_PUBLISHED_AT = 20;
 type CleanupTest = TestConvex<typeof schema>;
+type CleanupSeed = Awaited<ReturnType<typeof seedCleanupSuccess>>;
 
 /** Builds one signed section and placement selected by the repair graph. */
 function makeRepairSource(sectionKey: string, order: number) {
@@ -66,49 +68,117 @@ function makeRepairSource(sectionKey: string, order: number) {
     }),
     rowKind: "placement",
   } as const;
-  return { placement, section };
+  const current = placement.record.row;
+  assert.strictEqual(current.appLocale, "en");
+  assert.strictEqual(current.rendererDomain, "snbt-quant");
+  const historical = {
+    answerArtifactHash: current.answerArtifactHash,
+    answerContentKey: current.answerContentKey,
+    choices: current.choices,
+    contentHash: current.contentHash,
+    countryKey: current.countryKey,
+    examKey: current.examKey,
+    locale: current.appLocale,
+    questionArtifactHash: current.questionArtifactHash,
+    questionContentKey: current.questionContentKey,
+    questionOrder: current.questionOrder,
+    questionSourcePath: current.questionSourcePath,
+    rendererDomain: current.rendererDomain,
+    scope: current.scope,
+    sectionKey: current.sectionKey,
+    setKey: current.setKey,
+    sourceRevision: current.sourceRevision,
+    title: "Question 1",
+    trackKey: current.trackKey,
+  };
+  const historicalHash = Sha256HashSchema.make(
+    `sha256:${createHash("sha256")
+      .update(
+        `nakafa.aksara.tryout-placements.v1\n${JSON.stringify(historical)}`
+      )
+      .digest("hex")}`
+  );
+  const retained = {
+    family: "tryout",
+    record: { row: historical, rowHash: historicalHash },
+    rowKind: "placement",
+  } satisfies StoredTryoutPlacementRow;
+  return { placement, retained, section };
 }
 
-/** Replaces legacy test placeholders with authenticated source rows. */
+/** Replaces retained-history placeholders with authenticated placements. */
 async function seedRepairSource(
   ctx: MutationCtx,
+  cleanup: CleanupSeed,
   source: readonly ReturnType<typeof makeRepairSource>[]
 ) {
-  const catalogs = await ctx.db
-    .query("tryoutCatalog")
-    .withIndex("by_snapshotId_and_index", (query) =>
-      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
-    )
-    .take(source.length);
   const placements = await ctx.db
-    .query("tryoutPlacements")
-    .withIndex("by_snapshotId_and_index", (query) =>
-      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+    .query("tryoutHistoryRows")
+    .withIndex("by_snapshotId_and_rowKind_and_index", (query) =>
+      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT).eq("rowKind", "placement")
     )
     .take(source.length);
-  assert.ok(catalogs.length === source.length && placements[0]);
+  const mappings = await ctx.db
+    .query("tryoutHistoryMigrationMaps")
+    .withIndex("by_migrationId_and_kind_and_index", (query) =>
+      query.eq("migrationId", CLEANUP_MIGRATION_ID).eq("kind", "placement")
+    )
+    .take(source.length);
   for (const [index, row] of source.entries()) {
-    const catalog = catalogs[index];
-    assert.ok(catalog);
-    await ctx.db.replace("tryoutCatalog", catalog._id, {
-      ...tryoutCatalogFacts(row.section.record),
-      index: catalog.index,
-      rowHash: row.section.record.rowHash,
-      rowJson: canonicalizeContentSnapshotRow(row.section),
-      snapshotId: CLEANUP_SOURCE_SNAPSHOT,
-    });
     const stored = placements[index];
     const next = {
-      ...tryoutPlacementFacts(row.placement.record),
-      index: stored?.index ?? index + 1,
-      rowHash: row.placement.record.rowHash,
-      rowJson: canonicalizeContentSnapshotRow(row.placement),
+      answerArtifactHash: row.retained.record.row.answerArtifactHash,
+      index: stored?.index ?? index + 33,
+      questionArtifactHash: row.retained.record.row.questionArtifactHash,
+      rowHash: row.retained.record.rowHash,
+      rowJson: JSON.stringify(row.retained),
+      rowKind: "placement" as const,
       snapshotId: CLEANUP_SOURCE_SNAPSHOT,
     };
     if (stored) {
-      await ctx.db.replace("tryoutPlacements", stored._id, next);
+      await ctx.db.replace("tryoutHistoryRows", stored._id, next);
     } else {
-      await ctx.db.insert("tryoutPlacements", next);
+      await ctx.db.insert("tryoutHistoryRows", next);
+    }
+    const mapping = mappings[index];
+    const mapped = {
+      identity: tryoutPlacementIdentity(row.placement.record.row),
+      index: mapping?.index ?? index,
+      kind: "placement" as const,
+      migrationId: CLEANUP_MIGRATION_ID,
+      newHash: row.placement.record.rowHash,
+      oldHash: row.retained.record.rowHash,
+      targetCreated: false,
+    };
+    if (mapping) {
+      await ctx.db.replace("tryoutHistoryMigrationMaps", mapping._id, mapped);
+    } else {
+      await ctx.db.insert("tryoutHistoryMigrationMaps", mapped);
+    }
+    if (index === 0) {
+      const [sourceItem, targetItem] = await Promise.all([
+        ctx.db
+          .query("irtScaleItems")
+          .withIndex("by_scaleVersionId_and_placementIdentity", (query) =>
+            query.eq("scaleVersionId", cleanup.sourceScale.scaleVersionId)
+          )
+          .unique(),
+        ctx.db
+          .query("irtScaleItems")
+          .withIndex("by_scaleVersionId_and_placementIdentity", (query) =>
+            query.eq("scaleVersionId", cleanup.targetScaleId)
+          )
+          .unique(),
+      ]);
+      assert.ok(sourceItem && targetItem);
+      await ctx.db.patch(sourceItem._id, {
+        placementIdentity: mapped.identity,
+        placementRowHash: mapped.oldHash,
+      });
+      await ctx.db.patch(targetItem._id, {
+        placementIdentity: mapped.identity,
+        placementRowHash: mapped.newHash,
+      });
     }
   }
 }
@@ -165,7 +235,7 @@ export async function seedUnusedScale(
         difficulty: 0,
         discrimination: 1,
         placementIdentity: tryoutPlacementIdentity(row.placement.record.row),
-        placementRowHash: row.placement.record.rowHash,
+        placementRowHash: row.retained.record.rowHash,
         responseCount: 0,
         scaleVersionId,
       })
@@ -201,7 +271,7 @@ export async function seedRepair(
   const repair = await test.mutation(async (ctx) => {
     const migration = await ctx.db.query("tryoutHistoryMigrations").unique();
     assert.ok(migration?.phase === "completed");
-    await seedRepairSource(ctx, source);
+    await seedRepairSource(ctx, cleanup, source);
     const graph = await seedUnusedScale(ctx, source, responseCount);
     return {
       ...graph,


### PR DESCRIPTION
## Problem

The authenticated retained-history cleanup failed closed before any production write because the repair queried the retired current tryoutCatalog table. Production correctly retains the source bytes in tryoutHistoryRows.

## Change

- authenticate every provisional scale item through its immutable retained placement envelope
- bind each old row hash to the exact migration-map identity
- derive the historical section identity and preserve the existing exact run, item, row-hash, cardinality, retention, and terminal clone checks
- cover the production shape where current catalog and placement rows are already absent

## Evidence

Read-only production verification on dapper-antelope-269 found:
- 150 scale items
- 150 unique item identities
- 150 unique old row hashes
- 150 matching retained placement rows
- 150 matching migration-map identities
- 0 mapping or retained-row mismatches
- seven run sections with exact signed counts: six times 20 and one times 30

Exact current-base local proof at 61fc0f9a78df0ef06069b4103e0e2d8b842a2911 on 20dcafb7412be240307bf3c280d7c76921d6f9b8:
- focused cleanup repair: 1 file, 10 tests green
- broader retained-history suite: 6 files, 25 tests green
- full backend: 380 files, 1,628 tests green
- backend native TypeScript 7 check green
- full lint and Effect 4.0.0-rc.110 source parity green
- security audit has no known vulnerabilities
- boundaries green across 3,050 files
- changed files formatted and diff clean
- rebase range-diff patch-identical

Exact-head CI is running. No production mutation or Vercel Preview occurred.

## Deletion gate

This remains a one-time repair-only capability. Delete the repair module, evidence, tests, and cleanup exception immediately after the authenticated cleanup proves the migration root absent, the cleaned receipt and repair audit are verified, and the provisional scale graph is absent.