### PR TITLE
test(backend): run ingress lifecycle with Effect Vitest

### DIFF
--- a/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
@@ -12,9 +12,18 @@ import {
 } from "@nakafa/aksara-contracts/release";
 import { PublicationScopeSchema } from "@nakafa/aksara-contracts/release/snapshot/scope";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
-import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type {
+  ActionCtx,
+  MutationCtx,
+} from "@repo/backend/convex/_generated/server";
 import { advancePublication } from "@repo/backend/convex/contentRelease/ingress/lifecycle";
 import { encodeRendererJson } from "@repo/backend/convex/contentRelease/wire";
+import {
+  type ConvexTaggedError,
+  getUnknownErrorMessage,
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -30,8 +39,8 @@ import {
   insertZeroRelease,
 } from "@repo/backend/test/content/state";
 import { completeContentProof } from "@repo/backend/test/content/verify";
-import { convexTest } from "convex-test";
-import { Effect } from "effect";
+import { convexTest, type TestConvex } from "convex-test";
+import { Data, Effect, Schema } from "effect";
 import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
@@ -47,46 +56,65 @@ const recoveryReleaseId = ReleaseIdSchema.make(
   "release-lifecycle-ingress-recovery"
 );
 
+class ObservedLifecycleActionFailure extends Schema.TaggedError<ObservedLifecycleActionFailure>()(
+  "ObservedLifecycleActionFailure",
+  { cause: Schema.Unknown }
+) {}
+
+class UnexpectedLifecycleTestState extends Data.TaggedError(
+  "UnexpectedLifecycleTestState"
+)<{
+  readonly operation: "mark-proof-failed";
+}> {}
+
 /** Inserts one verified release with explicit frozen renderer bytes. */
-async function insertRelease(ctx: MutationCtx, rendererJson: string) {
-  const now = Date.UTC(2026, 6, 22, 12, 0, 0);
-  await ctx.db.insert("contentReleases", {
-    baseFamilies: [],
-    checkedIndex: -1,
-    checkedItems: 0,
-    createdAt: now,
-    proofAt: now,
-    proofJson: "{}",
-    releaseId,
-    releaseJson: JSON.stringify(release),
-    rendererJson,
-    resultFamilies: [...release.manifest.scope.families],
-    role: "candidate",
-    sequence: 1,
-    stagedArtifacts: 0,
-    stagedDeletes: 0,
-    stagedItems: 0,
-    stagedProjections: 0,
-    stagedRoutes: 0,
-    stagedSnapshotBatches: 0,
-    stagedSnapshotRows: 0,
-    stagedUpserts: 0,
-    status: "verified",
-    updatedAt: now,
-    verifiedAt: now,
-  });
-  await ctx.db.insert("contentState", {
-    candidateManifestHash: release.manifestHash,
-    candidateReleaseId: releaseId,
-    candidateSequence: 1,
-    key: "primary",
-    nextSequence: 2,
-    updatedAt: now,
-  });
-}
+const insertRelease = Effect.fn("test.contentRelease.insertLifecycleRelease")(
+  function* (ctx: MutationCtx, rendererJson: string) {
+    const now = Date.UTC(2026, 6, 22, 12, 0, 0);
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentReleases", {
+        baseFamilies: [],
+        checkedIndex: -1,
+        checkedItems: 0,
+        createdAt: now,
+        proofAt: now,
+        proofJson: "{}",
+        releaseId,
+        releaseJson: JSON.stringify(release),
+        rendererJson,
+        resultFamilies: [...release.manifest.scope.families],
+        role: "candidate",
+        sequence: 1,
+        stagedArtifacts: 0,
+        stagedDeletes: 0,
+        stagedItems: 0,
+        stagedProjections: 0,
+        stagedRoutes: 0,
+        stagedSnapshotBatches: 0,
+        stagedSnapshotRows: 0,
+        stagedUpserts: 0,
+        status: "verified",
+        updatedAt: now,
+        verifiedAt: now,
+      })
+    );
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentState", {
+        candidateManifestHash: release.manifestHash,
+        candidateReleaseId: releaseId,
+        candidateSequence: 1,
+        key: "primary",
+        nextSequence: 2,
+        updatedAt: now,
+      })
+    );
+  }
+);
 
 /** Inserts one authenticated zero-impact candidate and its exact inverse. */
-async function insertActivationPair(
+const insertActivationPair = Effect.fn(
+  "test.contentRelease.insertActivationPair"
+)(function* (
   ctx: MutationCtx,
   candidate: SignedContentRelease,
   recovery: SignedContentRelease
@@ -101,40 +129,50 @@ async function insertActivationPair(
     releaseId: recovery.manifest.releaseId,
     sequence: 2,
   };
-  await insertZeroRelease(ctx, {
-    ...candidateIdentity,
-    ownership: { base: [], result: [] },
-    role: "candidate",
-    scope: candidate.manifest.scope,
-    snapshots: candidate.manifest.snapshots,
-    status: "verified",
-  });
-  await insertZeroRelease(ctx, {
-    ...recoveryIdentity,
-    base: candidateIdentity,
-    originReleaseId: candidate.manifest.releaseId,
-    ownership: { base: [], result: [] },
-    role: "recovery",
-    scope: recovery.manifest.scope,
-    snapshots: recovery.manifest.snapshots,
-    status: "verified",
-  });
+  yield* Effect.promise(() =>
+    insertZeroRelease(ctx, {
+      ...candidateIdentity,
+      ownership: { base: [], result: [] },
+      role: "candidate",
+      scope: candidate.manifest.scope,
+      snapshots: candidate.manifest.snapshots,
+      status: "verified",
+    })
+  );
+  yield* Effect.promise(() =>
+    insertZeroRelease(ctx, {
+      ...recoveryIdentity,
+      base: candidateIdentity,
+      originReleaseId: candidate.manifest.releaseId,
+      ownership: { base: [], result: [] },
+      role: "recovery",
+      scope: recovery.manifest.scope,
+      snapshots: recovery.manifest.snapshots,
+      status: "verified",
+    })
+  );
   const rendererJson = encodeRendererJson(TEST_PROOF_RENDERER);
-  const releases = await ctx.db.query("contentReleases").collect();
+  const releases = yield* Effect.promise(() =>
+    ctx.db.query("contentReleases").collect()
+  );
   for (const stored of releases) {
     const signed =
       stored.releaseId === candidate.manifest.releaseId ? candidate : recovery;
-    await ctx.db.patch("contentReleases", stored._id, {
-      releaseJson: JSON.stringify(signed),
-      rendererJson,
-    });
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", stored._id, {
+        releaseJson: JSON.stringify(signed),
+        rendererJson,
+      })
+    );
   }
-  await insertTestState(ctx, {
-    candidate: candidateIdentity,
-    nextSequence: 3,
-    recovery: recoveryIdentity,
-  });
-}
+  yield* Effect.promise(() =>
+    insertTestState(ctx, {
+      candidate: candidateIdentity,
+      nextSequence: 3,
+      recovery: recoveryIdentity,
+    })
+  );
+});
 
 /** Creates signed zero-impact manifests that complete read models immediately. */
 function makeActivationPair() {
@@ -163,197 +201,256 @@ function makeActivationPair() {
   };
 }
 
-/** Runs one lifecycle program through the explicit technical verification key. */
-function runLifecycle<A, E>(
-  program: Effect.Effect<A, E, ContentVerificationKeyResolver>
-) {
-  return Effect.runPromise(
-    program.pipe(
-      Effect.provideService(ContentVerificationKeyResolver, TEST_KEY_RESOLVER)
-    )
-  );
-}
-
-describe("content release lifecycle ingress", () => {
-  it("returns authenticated evidence after durable proof completion", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        releaseId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
+/** Marks one stored proof as terminally failed for ingress observation. */
+const markProofFailed = Effect.fn("test.contentRelease.markProofFailed")(
+  function* (ctx: MutationCtx) {
+    const stored = yield* Effect.promise(() =>
+      ctx.db.query("contentReleases").unique()
     );
-
-    await completeContentProof(t, release.manifestHash, releaseId);
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "verify", release }))
-      )
-    ).resolves.toMatchObject({
-      ok: true,
-      operation: "verify",
-      value: {
-        evidence: {
-          manifestHash: release.manifestHash,
-          releaseId,
-        },
-        phase: "verified",
-      },
-    });
-  });
-
-  it("surfaces only the stable terminal proof category", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        releaseId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-    await t.mutation(async (ctx) => {
-      const stored = await ctx.db.query("contentReleases").unique();
-      if (!stored) {
-        throw new Error("Expected proof release.");
-      }
-      await ctx.db.patch("contentReleases", stored._id, {
+    if (!stored) {
+      return yield* Effect.die(
+        new UnexpectedLifecycleTestState({
+          operation: "mark-proof-failed",
+        })
+      );
+    }
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", stored._id, {
         proofFailure: "failed",
         status: "verifying",
-      });
-    });
-
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "verify", release }))
-      )
-    ).rejects.toThrow(`Content release ${releaseId} proof workflow failed.`);
-  });
-
-  it("aborts through the server-owned cursor and returns exact evidence", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertRelease(ctx, JSON.stringify(TEST_PROOF_RENDERER))
+      })
     );
+  }
+);
 
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "abort", releaseId }))
-      )
-    ).resolves.toEqual({
-      ok: true,
-      operation: "abort",
-      value: {
-        complete: true,
-        processedItems: 0,
-        releaseId,
-        totalItems: 0,
-      },
-    });
-  });
-
-  it("rejects activation when the frozen renderer identity drifted", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertRelease(ctx, JSON.stringify(testProofRenderer("h1")))
-    );
-
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(
-          advancePublication(ctx, { operation: "activate", release })
+/** Runs one lifecycle program through the explicit technical verification key. */
+const runLifecycle = Effect.fn("test.contentRelease.runLifecycle")(function* <
+  A,
+  E extends ConvexTaggedError,
+>(
+  target: TestConvex<typeof schema>,
+  makeProgram: (
+    ctx: ActionCtx
+  ) => Effect.Effect<A, E, ContentVerificationKeyResolver>
+) {
+  return yield* Effect.tryPromise({
+    catch: (cause) => new ObservedLifecycleActionFailure({ cause }),
+    try: () =>
+      target.action((ctx) =>
+        runConvexActionProgram(
+          makeProgram(ctx).pipe(
+            Effect.provideService(
+              ContentVerificationKeyResolver,
+              TEST_KEY_RESOLVER
+            )
+          )
         )
-      )
-    ).rejects.toThrow("Lifecycle renderer does not match the signed release");
-  });
-
-  it("rejects a tampered release before any lifecycle read", async () => {
-    const t = convexTest(schema, convexModules);
-    const prefix = release.signature.startsWith("A") ? "B" : "A";
-    const tampered = {
-      ...release,
-      signature: Ed25519SignatureSchema.make(
-        `${prefix}${release.signature.slice(1)}`
       ),
-    };
+  });
+});
 
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(
-          advancePublication(ctx, { operation: "verify", release: tampered })
+describe("content release lifecycle ingress", () => {
+  it.effect(
+    "returns authenticated evidence after durable proof completion",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            insertSignedCandidate(
+              ctx,
+              releaseId,
+              release,
+              JSON.stringify(TEST_PROOF_RENDERER)
+            )
+          )
+        );
+
+        yield* Effect.promise(() =>
+          completeContentProof(t, release.manifestHash, releaseId)
+        );
+        const response = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "verify", release })
+        );
+        expect(response).toMatchObject({
+          ok: true,
+          operation: "verify",
+          value: {
+            evidence: {
+              manifestHash: release.manifestHash,
+              releaseId,
+            },
+            phase: "verified",
+          },
+        });
+      })
+  );
+
+  it.effect("surfaces only the stable terminal proof category", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          insertSignedCandidate(
+            ctx,
+            releaseId,
+            release,
+            JSON.stringify(TEST_PROOF_RENDERER)
+          )
         )
-      )
-    ).rejects.toThrow("Content release verification failed");
-  });
+      );
+      yield* Effect.promise(() =>
+        t.mutation((ctx) => runConvexProgram(markProofFailed(ctx)))
+      );
 
-  it("keeps the external activation receipt unchanged", async () => {
-    const t = convexTest(schema, convexModules);
-    const pair = makeActivationPair();
-    await t.mutation((ctx) =>
-      insertActivationPair(ctx, pair.candidate, pair.recovery)
-    );
+      const failure = yield* runLifecycle(t, (ctx) =>
+        advancePublication(ctx, { operation: "verify", release })
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        `Content release ${releaseId} proof workflow failed.`
+      );
+    })
+  );
 
-    const activated = await t.action((ctx) =>
-      runLifecycle(
+  it.effect(
+    "aborts through the server-owned cursor and returns exact evidence",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              insertRelease(ctx, JSON.stringify(TEST_PROOF_RENDERER))
+            )
+          )
+        );
+
+        const response = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "abort", releaseId })
+        );
+        expect(response).toEqual({
+          ok: true,
+          operation: "abort",
+          value: {
+            complete: true,
+            processedItems: 0,
+            releaseId,
+            totalItems: 0,
+          },
+        });
+      })
+  );
+
+  it.effect(
+    "rejects activation when the frozen renderer identity drifted",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              insertRelease(ctx, JSON.stringify(testProofRenderer("h1")))
+            )
+          )
+        );
+
+        const failure = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "activate", release })
+        ).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "Lifecycle renderer does not match the signed release"
+        );
+      })
+  );
+
+  it.effect("rejects a tampered release before any lifecycle read", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const prefix = release.signature.startsWith("A") ? "B" : "A";
+      const tampered = {
+        ...release,
+        signature: Ed25519SignatureSchema.make(
+          `${prefix}${release.signature.slice(1)}`
+        ),
+      };
+
+      const failure = yield* runLifecycle(t, (ctx) =>
+        advancePublication(ctx, { operation: "verify", release: tampered })
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        "Content release verification failed"
+      );
+    })
+  );
+
+  it.effect("keeps the external activation receipt unchanged", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const pair = makeActivationPair();
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            insertActivationPair(ctx, pair.candidate, pair.recovery)
+          )
+        )
+      );
+
+      const activated = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activate",
           release: pair.candidate,
         })
-      )
-    );
-    const repeated = await t.action((ctx) =>
-      runLifecycle(
+      );
+      const repeated = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activate",
           release: pair.candidate,
         })
-      )
-    );
+      );
 
-    expect(activated).toEqual(repeated);
-    expect(activated).toMatchObject({
-      ok: true,
-      operation: "activate",
-      value: {
-        manifestHash: pair.candidate.manifestHash,
-        releaseId,
-      },
-    });
-    expect(activated.value).not.toHaveProperty("kind");
-    await expect(
-      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toEqual([]);
+      expect(activated).toEqual(repeated);
+      expect(activated).toMatchObject({
+        ok: true,
+        operation: "activate",
+        value: {
+          manifestHash: pair.candidate.manifestHash,
+          releaseId,
+        },
+      });
+      expect(activated.value).not.toHaveProperty("kind");
+      expect(
+        yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+        )
+      ).toEqual([]);
 
-    const recovered = await t.action((ctx) =>
-      runLifecycle(
+      const recovered = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activateRecovery",
           release: pair.recovery,
         })
-      )
-    );
-    expect(recovered).toMatchObject({
-      ok: true,
-      operation: "activateRecovery",
-      value: {
-        manifestHash: pair.recovery.manifestHash,
-        releaseId: recoveryReleaseId,
-      },
-    });
-    expect(recovered.value).not.toHaveProperty("kind");
-    const repeatedRecovery = await t.action((ctx) =>
-      runLifecycle(
+      );
+      expect(recovered).toMatchObject({
+        ok: true,
+        operation: "activateRecovery",
+        value: {
+          manifestHash: pair.recovery.manifestHash,
+          releaseId: recoveryReleaseId,
+        },
+      });
+      expect(recovered.value).not.toHaveProperty("kind");
+      const repeatedRecovery = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activateRecovery",
           release: pair.recovery,
         })
-      )
-    );
-    expect(repeatedRecovery).toEqual(recovered);
-    await expect(
-      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toEqual([]);
-  });
+      );
+      expect(repeatedRecovery).toEqual(recovered);
+      expect(
+        yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+        )
+      ).toEqual([]);
+    })
+  );
 });

--- a/packages/backend/convex/contentRelease/ingress/rollback.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/rollback.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from "@effect/vitest";
 import { SignedContentReleaseSchema } from "@nakafa/aksara-contracts/release";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
 import { PublicationRequestSchema } from "@nakafa/aksara-contracts/transport/request";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { readRollback } from "@repo/backend/convex/contentRelease/ingress/rollback";
 import { makePublicationReceipt } from "@repo/backend/convex/contentRelease/receipt";
 import {
   RELEASE_PAGE_LIMIT,
   ROUTE_CATALOG_PAGE_LIMIT,
 } from "@repo/backend/convex/contentRelease/spec";
+import {
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -25,133 +30,216 @@ import {
   insertRoute,
 } from "@repo/backend/test/content/rollback";
 import { convexTest, type TestConvex } from "convex-test";
-import { Effect, Schema } from "effect";
+import { Data, Effect, Schema } from "effect";
 
-/** Activates one authenticated release that the ingress may replay. */
-async function activateAuthenticatedRelease(
-  t: TestConvex<typeof schema>,
+class UnexpectedRollbackTestState extends Data.TaggedError(
+  "UnexpectedRollbackTestState"
+)<{
+  readonly operation:
+    | "activate-release"
+    | "select-body-request"
+    | "select-route-request";
+}> {}
+
+/** Stores the exact authenticated release and active identity under test. */
+const storeAuthenticatedRelease = Effect.fn(
+  "test.contentRelease.storeAuthenticatedRelease"
+)(function* (
+  ctx: MutationCtx,
   itemCount: number,
-  routeCount = itemCount
+  routeCount: number,
+  release: ReturnType<typeof testSignedRelease>
 ) {
-  const unsigned = Schema.decodeUnknownSync(SignedContentReleaseSchema)(
-    JSON.parse(
-      testReleaseJson({
-        itemCount,
-        rendererHash: TEST_PROOF_RENDERER.hash,
-        routeCount,
-      })
-    )
+  yield* Effect.promise(() =>
+    activateRollbackFixture(ctx, itemCount, routeCount)
   );
-  const release = testSignedRelease(unsigned.manifest);
-  await t.mutation(async (ctx) => {
-    await activateRollbackFixture(ctx, itemCount, routeCount);
-    const stored = await ctx.db.query("contentReleases").unique();
-    const state = await ctx.db.query("contentState").unique();
-    if (!(stored && state)) {
-      throw new Error("Expected one rollback release fixture.");
-    }
-    await ctx.db.patch("contentReleases", stored._id, {
+  const stored = yield* Effect.promise(() =>
+    ctx.db.query("contentReleases").unique()
+  );
+  const state = yield* Effect.promise(() =>
+    ctx.db.query("contentState").unique()
+  );
+  if (!(stored && state)) {
+    return yield* Effect.die(
+      new UnexpectedRollbackTestState({ operation: "activate-release" })
+    );
+  }
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentReleases", stored._id, {
       receiptJson: JSON.stringify(makePublicationReceipt(stored, release)),
       releaseJson: JSON.stringify(release),
       rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
-    });
-    await ctx.db.patch("contentState", state._id, {
+    })
+  );
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentState", state._id, {
       activeManifestHash: release.manifestHash,
-    });
-  });
+    })
+  );
+});
+
+/** Activates one authenticated release that the ingress may replay. */
+const activateAuthenticatedRelease = Effect.fn(
+  "test.contentRelease.activateAuthenticatedRelease"
+)(function* (
+  target: TestConvex<typeof schema>,
+  itemCount: number,
+  routeCount = itemCount
+) {
+  const unsigned = yield* Schema.decodeEffect(
+    Schema.fromJsonString(SignedContentReleaseSchema)
+  )(
+    testReleaseJson({
+      itemCount,
+      rendererHash: TEST_PROOF_RENDERER.hash,
+      routeCount,
+    })
+  );
+  const release = testSignedRelease(unsigned.manifest);
+  yield* Effect.promise(() =>
+    target.mutation((ctx) =>
+      runConvexProgram(
+        storeAuthenticatedRelease(ctx, itemCount, routeCount, release)
+      )
+    )
+  );
   return release;
-}
+});
+
+/** Inserts rollback body rows in the original deterministic order. */
+const insertRollbackItems = Effect.fn(
+  "test.contentRelease.insertRollbackItems"
+)(function* (ctx: MutationCtx, itemCount: number) {
+  for (let index = 0; index < itemCount; index += 1) {
+    yield* Effect.promise(() =>
+      insertRollbackItem(ctx, index, false, "return {};", {
+        authenticatedArtifact: true,
+      })
+    );
+  }
+});
+
+/** Inserts every prior and current route pair in deterministic order. */
+const insertRollbackRoutes = Effect.fn(
+  "test.contentRelease.insertRollbackRoutes"
+)(function* (ctx: MutationCtx, routeCount: number) {
+  for (let index = 0; index < routeCount; index += 1) {
+    const publicPath = `test/route-${index}`;
+    yield* Effect.promise(() =>
+      insertRoute(ctx, {
+        contentKey: `test:prior-${index}`,
+        index,
+        publicPath,
+        releaseId: "release-base",
+        sequence: 0,
+      })
+    );
+    yield* Effect.promise(() =>
+      insertRoute(ctx, {
+        contentKey: `test:current-${index}`,
+        index,
+        publicPath,
+      })
+    );
+  }
+});
 
 describe("content publication rollback reads", () => {
-  it("aggregates safe body query transactions into one external page", async () => {
-    const t = convexTest(schema, convexModules);
-    const itemCount = RELEASE_PAGE_LIMIT + 1;
-    const release = await activateAuthenticatedRelease(t, itemCount);
-    await t.mutation(async (ctx) => {
-      for (let index = 0; index < itemCount; index += 1) {
-        await insertRollbackItem(ctx, index, false, "return {};", {
-          authenticatedArtifact: true,
-        });
-      }
-    });
-
-    const request = Schema.decodeSync(PublicationRequestSchema)({
-      afterIndex: -1,
-      limit: itemCount,
-      operation: "rollbackPage",
-      rollbackOf: TEST_RELEASE_ID,
-      rollbackOfManifestHash: release.manifestHash,
-    });
-    if (request.operation !== "rollbackPage") {
-      throw new Error("Expected one rollback page request.");
-    }
-    const response = await t.action((ctx) =>
-      Effect.runPromise(
-        readRollback(ctx, request).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+  it.effect(
+    "aggregates safe body query transactions into one external page",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const itemCount = RELEASE_PAGE_LIMIT + 1;
+        const release = yield* activateAuthenticatedRelease(t, itemCount);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertRollbackItems(ctx, itemCount))
           )
-        )
-      )
-    );
+        );
 
-    expect(response).toMatchObject({
-      done: true,
-      nextIndex: itemCount - 1,
-      total: itemCount,
-    });
-    expect(response.records).toHaveLength(itemCount);
-  });
-
-  it("aggregates safe route query transactions into one external page", async () => {
-    const t = convexTest(schema, convexModules);
-    const routeCount = ROUTE_CATALOG_PAGE_LIMIT + 1;
-    const release = await activateAuthenticatedRelease(t, 0, routeCount);
-    await t.mutation(async (ctx) => {
-      for (let index = 0; index < routeCount; index += 1) {
-        const publicPath = `test/route-${index}`;
-        await insertRoute(ctx, {
-          contentKey: `test:prior-${index}`,
-          index,
-          publicPath,
-          releaseId: "release-base",
-          sequence: 0,
+        const request = yield* Schema.decodeEffect(PublicationRequestSchema)({
+          afterIndex: -1,
+          limit: itemCount,
+          operation: "rollbackPage",
+          rollbackOf: TEST_RELEASE_ID,
+          rollbackOfManifestHash: release.manifestHash,
         });
-        await insertRoute(ctx, {
-          contentKey: `test:current-${index}`,
-          index,
-          publicPath,
-        });
-      }
-    });
-
-    const request = Schema.decodeSync(PublicationRequestSchema)({
-      afterIndex: -1,
-      limit: routeCount,
-      operation: "routePage",
-      rollbackOf: TEST_RELEASE_ID,
-      rollbackOfManifestHash: release.manifestHash,
-    });
-    if (request.operation !== "routePage") {
-      throw new Error("Expected one route rollback page request.");
-    }
-    const response = await t.action((ctx) =>
-      Effect.runPromise(
-        readRollback(ctx, request).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+        if (request.operation !== "rollbackPage") {
+          return yield* Effect.die(
+            new UnexpectedRollbackTestState({
+              operation: "select-body-request",
+            })
+          );
+        }
+        const response = yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexActionProgram(
+              readRollback(ctx, request).pipe(
+                Effect.provideService(
+                  ContentVerificationKeyResolver,
+                  TEST_KEY_RESOLVER
+                )
+              )
+            )
           )
-        )
-      )
-    );
+        );
 
-    expect(response).toMatchObject({
-      done: true,
-      nextIndex: routeCount - 1,
-      total: routeCount,
-    });
-    expect(response.records).toHaveLength(routeCount);
-  });
+        expect(response).toMatchObject({
+          done: true,
+          nextIndex: itemCount - 1,
+          total: itemCount,
+        });
+        expect(response.records).toHaveLength(itemCount);
+      })
+  );
+
+  it.effect(
+    "aggregates safe route query transactions into one external page",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const routeCount = ROUTE_CATALOG_PAGE_LIMIT + 1;
+        const release = yield* activateAuthenticatedRelease(t, 0, routeCount);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertRollbackRoutes(ctx, routeCount))
+          )
+        );
+
+        const request = yield* Schema.decodeEffect(PublicationRequestSchema)({
+          afterIndex: -1,
+          limit: routeCount,
+          operation: "routePage",
+          rollbackOf: TEST_RELEASE_ID,
+          rollbackOfManifestHash: release.manifestHash,
+        });
+        if (request.operation !== "routePage") {
+          return yield* Effect.die(
+            new UnexpectedRollbackTestState({
+              operation: "select-route-request",
+            })
+          );
+        }
+        const response = yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexActionProgram(
+              readRollback(ctx, request).pipe(
+                Effect.provideService(
+                  ContentVerificationKeyResolver,
+                  TEST_KEY_RESOLVER
+                )
+              )
+            )
+          )
+        );
+
+        expect(response).toMatchObject({
+          done: true,
+          nextIndex: routeCount - 1,
+          total: routeCount,
+        });
+        expect(response.records).toHaveLength(routeCount);
+      })
+  );
 });


### PR DESCRIPTION
## Summary

Migrate the two tightly coupled ingress lifecycle and rollback test modules to the native Effect v4 Vitest API.

## Architecture

- Use direct `@effect/vitest` ownership and `it.effect` for all effectful cases.
- Model durable fixture setup as named `Effect.fn` programs with typed impossible-state defects.
- Decode transport contracts through Effect Schema and compose Convex fixture operations through `Effect.promise`.
- Keep `runConvexProgram` and `runConvexActionProgram` only inside their required Convex callback boundaries.
- Retain direct Vitest only for the lifecycle module's transform mock API.
- Add no shared test wrapper, compatibility facade, or global mock.

## Scope

- `packages/backend/convex/contentRelease/ingress/lifecycle.test.ts`
- `packages/backend/convex/contentRelease/ingress/rollback.test.ts`

## Verification

- focused tests: 2 files and 8 tests passed
- full `@repo/backend` suite: 380 files and 1627 tests passed
- `@repo/backend` TypeScript 7 typecheck passed
- root lint and Effect policy checks passed
- boundaries passed
- script tests: 19 passed
- Doctor correctly skipped because no WWW React source changed
- final diff check passed

## Release

Test-only. No Vercel Preview and no production schema or runtime change.
