### PR TITLE
fix(tryout): authenticate retained-history cleanup

### DIFF
--- a/packages/backend/convex/tryouts/history/rows.ts
+++ b/packages/backend/convex/tryouts/history/rows.ts
@@ -7,10 +7,10 @@ import type {
   MutationCtx,
   QueryCtx,
 } from "@repo/backend/convex/_generated/server";
+import { retainedTryoutHistoryPlan } from "@repo/backend/convex/tryouts/history/spec";
 import { TryoutRuntimeError } from "@repo/backend/convex/tryouts/runtime/error";
 import { Effect } from "effect";
 
-export const RETAINED_TRYOUT_CATALOG_ROW_COUNT = 54;
 type ReadCtx = MutationCtx | QueryCtx;
 
 /** Loads and authenticates the complete retained catalog for one snapshot. */
@@ -19,12 +19,12 @@ export const loadStoredTryoutCatalogRows = Effect.fn(
 )(function* (
   ctx: ReadCtx,
   snapshotId: string,
-  expectedCount = RETAINED_TRYOUT_CATALOG_ROW_COUNT
+  expectedCount = retainedTryoutHistoryPlan.catalogRowCount
 ) {
   if (
     !Number.isSafeInteger(expectedCount) ||
     expectedCount <= 0 ||
-    expectedCount > RETAINED_TRYOUT_CATALOG_ROW_COUNT
+    expectedCount > retainedTryoutHistoryPlan.catalogRowCount
   ) {
     return yield* historyIntegrity(
       "Retained try-out catalog count exceeds its audited bound."
@@ -52,6 +52,51 @@ export const loadStoredTryoutCatalogRows = Effect.fn(
     );
   }
   return yield* Effect.forEach(stored, (row) => decodeCatalogHistoryRow(row));
+});
+
+/** Loads the complete bounded placement inventory for exact section proof. */
+export const loadStoredTryoutPlacementRows = Effect.fn(
+  "tryouts.history.loadStoredPlacementRows"
+)(function* (
+  ctx: ReadCtx,
+  snapshotId: string,
+  expectedCount = retainedTryoutHistoryPlan.placementRowCount
+) {
+  if (
+    !Number.isSafeInteger(expectedCount) ||
+    expectedCount <= 0 ||
+    expectedCount > retainedTryoutHistoryPlan.placementRowCount
+  ) {
+    return yield* historyIntegrity(
+      "Retained try-out placement count exceeds its audited bound."
+    );
+  }
+  const stored = yield* historyPromise(
+    "Unable to read retained try-out placement rows.",
+    () =>
+      ctx.db
+        .query("tryoutHistoryRows")
+        .withIndex("by_snapshotId_and_rowKind_and_index", (index) =>
+          index.eq("snapshotId", snapshotId).eq("rowKind", "placement")
+        )
+        .take(expectedCount + 1)
+  );
+  if (stored.length !== expectedCount) {
+    return yield* historyIntegrity(
+      "Retained try-out placements do not match their audited count."
+    );
+  }
+  const uniqueIndices = new Set(stored.map(({ index }) => index));
+  const uniqueHashes = new Set(stored.map(({ rowHash }) => rowHash));
+  if (
+    uniqueIndices.size !== stored.length ||
+    uniqueHashes.size !== stored.length
+  ) {
+    return yield* historyIntegrity(
+      "Retained try-out placements repeat a source identity."
+    );
+  }
+  return yield* Effect.forEach(stored, (row) => decodePlacementHistoryRow(row));
 });
 
 /** Narrows an authenticated retained row to the catalog family. */
@@ -87,13 +132,21 @@ export const loadStoredTryoutPlacement = Effect.fn(
   if (!stored) {
     return null;
   }
+  const decoded = yield* decodePlacementHistoryRow(stored);
+  return decoded.record.row;
+});
+
+/** Narrows one authenticated retained row to the placement family. */
+const decodePlacementHistoryRow = Effect.fn(
+  "tryouts.history.decodeStoredPlacementRow"
+)(function* (stored: Doc<"tryoutHistoryRows">) {
   const decoded = yield* decodeHistoryRow(stored);
   if (decoded.rowKind !== "placement") {
     return yield* historyIntegrity(
       "Retained try-out placement changed its row kind."
     );
   }
-  return decoded.record.row;
+  return decoded;
 });
 
 /** Decodes one exact envelope and checks its indexed storage facts. */

--- a/packages/backend/convex/tryouts/history/rows.ts
+++ b/packages/backend/convex/tryouts/history/rows.ts
@@ -16,7 +16,20 @@ type ReadCtx = MutationCtx | QueryCtx;
 /** Loads and authenticates the complete retained catalog for one snapshot. */
 export const loadStoredTryoutCatalogRows = Effect.fn(
   "tryouts.history.loadStoredCatalogRows"
-)(function* (ctx: ReadCtx, snapshotId: string) {
+)(function* (
+  ctx: ReadCtx,
+  snapshotId: string,
+  expectedCount = RETAINED_TRYOUT_CATALOG_ROW_COUNT
+) {
+  if (
+    !Number.isSafeInteger(expectedCount) ||
+    expectedCount <= 0 ||
+    expectedCount > RETAINED_TRYOUT_CATALOG_ROW_COUNT
+  ) {
+    return yield* historyIntegrity(
+      "Retained try-out catalog count exceeds its audited bound."
+    );
+  }
   const stored = yield* historyPromise(
     "Unable to read retained try-out catalog rows.",
     () =>
@@ -25,9 +38,9 @@ export const loadStoredTryoutCatalogRows = Effect.fn(
         .withIndex("by_snapshotId_and_rowKind_and_index", (index) =>
           index.eq("snapshotId", snapshotId).eq("rowKind", "catalog")
         )
-        .take(RETAINED_TRYOUT_CATALOG_ROW_COUNT + 1)
+        .take(expectedCount + 1)
   );
-  if (stored.length !== RETAINED_TRYOUT_CATALOG_ROW_COUNT) {
+  if (stored.length !== expectedCount) {
     return yield* historyIntegrity(
       "Retained try-out catalog does not match its audited count."
     );

--- a/packages/backend/convex/tryouts/migration/cleanup/count.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/count.ts
@@ -40,14 +40,16 @@ function cleanupBounds(
       return { maximum: count, minimum: count };
     }
     case "catalog":
+      // History storage is authoritative; an old physical duplicate is optional.
       return {
         maximum: plan.source.catalogRowCount,
-        minimum: plan.source.catalogRowCount,
+        minimum: 0,
       };
     case "placement":
+      // History storage is authoritative; an old physical duplicate is optional.
       return {
         maximum: plan.source.placementRowCount,
-        minimum: plan.source.placementRowCount,
+        minimum: 0,
       };
     case "legacy":
       return {

--- a/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/evidence.ts
@@ -1,3 +1,5 @@
+import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import { tryoutCatalogNodeIdentity } from "@nakafa/aksara-contracts/tryout/identity";
 import type { CleanupRepair } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 
 interface RepairRun {
@@ -17,7 +19,22 @@ export interface ScaleRepairEvidence {
   readonly sourceSnapshotId: string;
 }
 
-const identity = (...parts: readonly string[]) => parts.join("\0");
+const retainedCatalogParent = {
+  appLocale: AppLocaleSchema.make("en"),
+  countryKey: "indonesia",
+  examKey: "snbt",
+  setKey: "set-2",
+  trackKey: "2027",
+} as const;
+
+/** Projects a retained section through Aksara's identity contract. */
+function retainedSectionIdentity(sectionKey: string) {
+  return tryoutCatalogNodeIdentity({
+    ...retainedCatalogParent,
+    kind: "section",
+    sectionKey,
+  });
+}
 
 /** Exact production graph omitted by the signed attempt-derived inventory. */
 export const retainedScaleRepair = {
@@ -30,91 +47,38 @@ export const retainedScaleRepair = {
   runs: [
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "reading-and-writing-skills"
-      ),
+      sectionIdentity: retainedSectionIdentity("reading-and-writing-skills"),
     },
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "general-knowledge"
-      ),
+      sectionIdentity: retainedSectionIdentity("general-knowledge"),
     },
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "english-language"
-      ),
+      sectionIdentity: retainedSectionIdentity("english-language"),
     },
     {
       questionCount: 30,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "indonesian-language"
-      ),
+      sectionIdentity: retainedSectionIdentity("indonesian-language"),
     },
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "general-reasoning"
-      ),
+      sectionIdentity: retainedSectionIdentity("general-reasoning"),
     },
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "mathematical-reasoning"
-      ),
+      sectionIdentity: retainedSectionIdentity("mathematical-reasoning"),
     },
     {
       questionCount: 20,
-      sectionIdentity: identity(
-        "en",
-        "section",
-        "indonesia",
-        "snbt",
-        "2027",
-        "set-2",
-        "quantitative-knowledge"
-      ),
+      sectionIdentity: retainedSectionIdentity("quantitative-knowledge"),
     },
   ],
   scaleVersionId: "wh77kyh90xdyy9bxkve0h7w4d98a5ghm",
-  setIdentity: identity("en", "set", "indonesia", "snbt", "2027", "set-2", ""),
+  setIdentity: tryoutCatalogNodeIdentity({
+    ...retainedCatalogParent,
+    kind: "set",
+  }),
   sourceSnapshotId:
     "sha256:0a43a4125fc4886f90b5a509405178bfb8762ad3c7f72be80614fce2671b5162",
 } satisfies ScaleRepairEvidence;

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -84,8 +84,15 @@ export const verifyRepairPlacements = Effect.fn(
       });
     }
   }
+  const itemPlacementIdentities = new Set(
+    items.map(({ placementIdentity }) => placementIdentity)
+  );
   if (
-    signedPlacements.size !== items.length ||
+    itemPlacementIdentities.size !== items.length ||
+    itemPlacementIdentities.size !== signedPlacements.size ||
+    [...signedPlacements.keys()].some(
+      (identity) => !itemPlacementIdentities.has(identity)
+    ) ||
     items.some((item) => {
       const placement = signedPlacements.get(item.placementIdentity);
       const run = runById.get(item.calibrationRunId);

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -1,4 +1,16 @@
 import type { StoredTryoutRow } from "@nakafa/aksara-contracts/history/decode";
+import {
+  AppLocaleSchema,
+  ArtifactLocaleSchema,
+} from "@nakafa/aksara-contracts/locale";
+import {
+  tryoutCatalogNodeIdentity,
+  tryoutPlacementIdentity,
+} from "@nakafa/aksara-contracts/tryout/identity";
+import {
+  deliveryLanguageForSection,
+  questionArtifactLocaleForSection,
+} from "@nakafa/aksara-contracts/tryout/language";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
@@ -34,7 +46,7 @@ export const verifyRepairPlacements = Effect.fn(
     record.row.kind === "section" ? [record.row] : []
   );
   const sections = new Map(
-    sectionRows.map((row) => [historicalCatalogIdentity(row), row] as const)
+    sectionRows.map((row) => [historicalSectionIdentity(row), row] as const)
   );
   const runById = new Map(runs.map((run) => [run._id, run]));
   if (sections.size !== sectionRows.length || runById.size !== runs.length) {
@@ -88,53 +100,47 @@ export const verifyRepairPlacements = Effect.fn(
   }
 });
 
-type HistoricalCatalogRow = Extract<
-  StoredTryoutRow,
-  { readonly rowKind: "catalog" }
->["record"]["row"];
+type HistoricalSection = Extract<
+  Extract<StoredTryoutRow, { readonly rowKind: "catalog" }>["record"]["row"],
+  { readonly kind: "section" }
+>;
 type HistoricalPlacement = Extract<
   StoredTryoutRow,
   { readonly rowKind: "placement" }
 >["record"]["row"];
 
-/** Reconstructs the ordering identity frozen into the retained catalog. */
-function historicalCatalogIdentity(row: HistoricalCatalogRow) {
-  return [
-    row.locale,
-    row.kind,
-    row.countryKey,
-    "examKey" in row ? row.examKey : "",
-    "trackKey" in row ? row.trackKey : "",
-    "setKey" in row ? row.setKey : "",
-    "sectionKey" in row ? row.sectionKey : "",
-  ].join("\0");
+/** Projects one retained row through Aksara's current section identity. */
+function historicalSectionIdentity(
+  row: HistoricalPlacement | HistoricalSection
+) {
+  return tryoutCatalogNodeIdentity({
+    appLocale: AppLocaleSchema.make(row.locale),
+    countryKey: row.countryKey,
+    examKey: row.examKey,
+    kind: "section",
+    sectionKey: row.sectionKey,
+    setKey: row.setKey,
+    trackKey: row.trackKey,
+  });
 }
 
-/** Derives the exact retained section identity for one old placement. */
-function historicalSectionIdentity(row: HistoricalPlacement) {
-  return [
-    row.locale,
-    "section",
-    row.countryKey,
-    row.examKey,
-    row.trackKey,
-    row.setKey,
-    row.sectionKey,
-  ].join("\0");
-}
-
-/** Reconstructs the placement identity frozen into the old scale graph. */
+/** Projects one retained row through Aksara's current placement identity. */
 function historicalPlacementIdentity(row: HistoricalPlacement) {
-  return [
-    row.countryKey,
-    row.examKey,
-    row.trackKey,
-    row.setKey,
-    row.sectionKey,
-    row.questionOrder,
-    row.questionContentKey,
-    row.locale,
-  ].join("\0");
+  const { locale, ...placement } = row;
+  const appLocale = AppLocaleSchema.make(locale);
+  return tryoutPlacementIdentity({
+    ...placement,
+    answerArtifactLocale: ArtifactLocaleSchema.make(locale),
+    appLocale,
+    deliveryLanguage: deliveryLanguageForSection(
+      placement.sectionKey,
+      appLocale
+    ),
+    questionArtifactLocale: questionArtifactLocaleForSection(
+      placement.sectionKey,
+      appLocale
+    ),
+  });
 }
 
 /** Maps retained-history failures into the signed cleanup boundary. */

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -1,89 +1,138 @@
-import {
-  tryoutCatalogIdentity,
-  tryoutPlacementIdentity,
-} from "@nakafa/aksara-contracts/tryout/identity";
+import type { StoredTryoutRow } from "@nakafa/aksara-contracts/history/decode";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
-import { releaseFail } from "@repo/backend/convex/contentRelease/error";
-import { readTryoutSectionRows } from "@repo/backend/convex/contentRelease/tryout/section";
+import {
+  ReleaseError,
+  releaseFail,
+} from "@repo/backend/convex/contentRelease/error";
+import {
+  loadStoredTryoutCatalogRows,
+  loadStoredTryoutPlacement,
+} from "@repo/backend/convex/tryouts/history/rows";
 import { Effect } from "effect";
 
-interface RepairRun {
-  readonly questionCount: number;
-  readonly sectionIdentity: string;
-}
-
-interface SignedPlacement {
-  readonly rowHash: string;
-  readonly sectionIdentity: string;
-}
-
 /** Authenticates every signed source placement selected by the repair runs. */
-export const loadRepairPlacements = Effect.fn(
-  "tryouts.migration.loadRepairPlacements"
-)(function* (ctx: MutationCtx, snapshotId: string, runs: readonly RepairRun[]) {
-  const placements = new Map<string, SignedPlacement>();
-  for (const run of runs) {
-    const storedSection = yield* Effect.promise(() =>
-      ctx.db
-        .query("tryoutCatalog")
-        .withIndex("by_snapshotId_and_identity", (query) =>
-          query.eq("snapshotId", snapshotId).eq("identity", run.sectionIdentity)
-        )
-        .unique()
-    );
-    if (!storedSection) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Try-out history scale repair lost a signed source section."
-      );
-    }
-    const source = yield* readTryoutSectionRows(ctx, snapshotId, storedSection);
-    if (
-      tryoutCatalogIdentity(source.section.row) !== run.sectionIdentity ||
-      source.placements.length !== run.questionCount
-    ) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_INTEGRITY",
-        "Try-out history scale repair changed signed section ownership."
-      );
-    }
-    for (const placement of source.placements) {
-      const identity = tryoutPlacementIdentity(placement.row);
-      if (placements.has(identity)) {
-        return yield* releaseFail(
-          "CONTENT_RELEASE_INTEGRITY",
-          "Try-out history scale repair found duplicate signed placements."
-        );
-      }
-      placements.set(identity, {
-        rowHash: placement.rowHash,
-        sectionIdentity: run.sectionIdentity,
-      });
-    }
-  }
-  return placements;
-});
-
-/** Binds each provisional item to its exact signed row and section run. */
-export function matchesRepairPlacements(
-  placements: ReadonlyMap<string, SignedPlacement>,
+export const verifyRepairPlacements = Effect.fn(
+  "tryouts.migration.verifyRepairPlacements"
+)(function* (
+  ctx: MutationCtx,
+  snapshotId: string,
+  catalogRowCount: number,
   items: readonly Doc<"irtScaleItems">[],
   runs: readonly Doc<"irtCalibrationRuns">[]
 ) {
-  const sectionByRun = new Map(
-    runs.map((run) => [run._id, run.sectionIdentity])
+  const catalog = yield* loadStoredTryoutCatalogRows(
+    ctx,
+    snapshotId,
+    catalogRowCount
+  ).pipe(Effect.mapError(repairSourceError));
+  const sectionRows = catalog.flatMap(({ record }) =>
+    record.row.kind === "section" ? [record.row] : []
   );
-  return (
-    placements.size === items.length &&
-    new Set(items.map(({ placementIdentity }) => placementIdentity)).size ===
-      items.length &&
-    items.every((item) => {
-      const placement = placements.get(item.placementIdentity);
-      return (
-        placement?.rowHash === item.placementRowHash &&
-        placement.sectionIdentity === sectionByRun.get(item.calibrationRunId)
-      );
+  const sections = new Map(
+    sectionRows.map((row) => [historicalCatalogIdentity(row), row] as const)
+  );
+  const runById = new Map(runs.map((run) => [run._id, run]));
+  if (sections.size !== sectionRows.length || runById.size !== runs.length) {
+    return yield* repairPlacementFailure();
+  }
+  for (const run of runs) {
+    const section = sections.get(run.sectionIdentity);
+    if (!section || section.questionCount !== run.questionCount) {
+      return yield* repairPlacementFailure();
+    }
+  }
+  const placementIdentities = new Set<string>();
+  yield* Effect.forEach(items, (item) =>
+    Effect.gen(function* () {
+      const placement = yield* loadStoredTryoutPlacement(
+        ctx,
+        snapshotId,
+        item.placementRowHash
+      ).pipe(Effect.mapError(repairSourceError));
+      if (!placement) {
+        return yield* repairPlacementFailure();
+      }
+      const placementIdentity = historicalPlacementIdentity(placement);
+      const run = runById.get(item.calibrationRunId);
+      const sectionIdentity = historicalSectionIdentity(placement);
+      if (
+        !run ||
+        placementIdentity !== item.placementIdentity ||
+        run.sectionIdentity !== sectionIdentity ||
+        placementIdentities.has(placementIdentity)
+      ) {
+        return yield* repairPlacementFailure();
+      }
+      placementIdentities.add(placementIdentity);
     })
+  );
+  if (placementIdentities.size !== items.length) {
+    return yield* repairPlacementFailure();
+  }
+});
+
+type HistoricalCatalogRow = Extract<
+  StoredTryoutRow,
+  { readonly rowKind: "catalog" }
+>["record"]["row"];
+type HistoricalPlacement = Extract<
+  StoredTryoutRow,
+  { readonly rowKind: "placement" }
+>["record"]["row"];
+
+/** Reconstructs the ordering identity frozen into the retained catalog. */
+function historicalCatalogIdentity(row: HistoricalCatalogRow) {
+  return [
+    row.locale,
+    row.kind,
+    row.countryKey,
+    "examKey" in row ? row.examKey : "",
+    "trackKey" in row ? row.trackKey : "",
+    "setKey" in row ? row.setKey : "",
+    "sectionKey" in row ? row.sectionKey : "",
+  ].join("\0");
+}
+
+/** Derives the exact retained section identity for one old placement. */
+function historicalSectionIdentity(row: HistoricalPlacement) {
+  return [
+    row.locale,
+    "section",
+    row.countryKey,
+    row.examKey,
+    row.trackKey,
+    row.setKey,
+    row.sectionKey,
+  ].join("\0");
+}
+
+/** Reconstructs the placement identity frozen into the old scale graph. */
+function historicalPlacementIdentity(row: HistoricalPlacement) {
+  return [
+    row.countryKey,
+    row.examKey,
+    row.trackKey,
+    row.setKey,
+    row.sectionKey,
+    row.questionOrder,
+    row.questionContentKey,
+    row.locale,
+  ].join("\0");
+}
+
+/** Maps retained-history failures into the signed cleanup boundary. */
+function repairSourceError() {
+  return new ReleaseError({
+    code: "CONTENT_RELEASE_INTEGRITY",
+    message: "Try-out history scale repair lost its signed source rows.",
+  });
+}
+
+/** Fails one mismatch without exposing immutable historical row bytes. */
+function repairPlacementFailure() {
+  return releaseFail(
+    "CONTENT_RELEASE_INTEGRITY",
+    "Try-out history scale repair changed signed placement ownership."
   );
 }

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -7,9 +7,9 @@ import {
 } from "@repo/backend/convex/contentRelease/error";
 import {
   loadStoredTryoutCatalogRows,
-  loadStoredTryoutPlacement,
+  loadStoredTryoutPlacementRows,
 } from "@repo/backend/convex/tryouts/history/rows";
-import { Effect } from "effect";
+import { Effect, Array as EffectArray } from "effect";
 
 /** Authenticates every signed source placement selected by the repair runs. */
 export const verifyRepairPlacements = Effect.fn(
@@ -18,14 +18,18 @@ export const verifyRepairPlacements = Effect.fn(
   ctx: MutationCtx,
   snapshotId: string,
   catalogRowCount: number,
+  placementRowCount: number,
   items: readonly Doc<"irtScaleItems">[],
   runs: readonly Doc<"irtCalibrationRuns">[]
 ) {
-  const catalog = yield* loadStoredTryoutCatalogRows(
-    ctx,
-    snapshotId,
-    catalogRowCount
-  ).pipe(Effect.mapError(repairSourceError));
+  const { catalog, placements } = yield* Effect.all({
+    catalog: loadStoredTryoutCatalogRows(ctx, snapshotId, catalogRowCount),
+    placements: loadStoredTryoutPlacementRows(
+      ctx,
+      snapshotId,
+      placementRowCount
+    ),
+  }).pipe(Effect.mapError(repairSourceError));
   const sectionRows = catalog.flatMap(({ record }) =>
     record.row.kind === "section" ? [record.row] : []
   );
@@ -42,32 +46,44 @@ export const verifyRepairPlacements = Effect.fn(
       return yield* repairPlacementFailure();
     }
   }
-  const placementIdentities = new Set<string>();
-  yield* Effect.forEach(items, (item) =>
-    Effect.gen(function* () {
-      const placement = yield* loadStoredTryoutPlacement(
-        ctx,
-        snapshotId,
-        item.placementRowHash
-      ).pipe(Effect.mapError(repairSourceError));
-      if (!placement) {
-        return yield* repairPlacementFailure();
-      }
-      const placementIdentity = historicalPlacementIdentity(placement);
-      const run = runById.get(item.calibrationRunId);
-      const sectionIdentity = historicalSectionIdentity(placement);
-      if (
-        !run ||
-        placementIdentity !== item.placementIdentity ||
-        run.sectionIdentity !== sectionIdentity ||
-        placementIdentities.has(placementIdentity)
-      ) {
-        return yield* repairPlacementFailure();
-      }
-      placementIdentities.add(placementIdentity);
-    })
+  const placementsBySection = EffectArray.groupBy(placements, ({ record }) =>
+    historicalSectionIdentity(record.row)
   );
-  if (placementIdentities.size !== items.length) {
+  const signedPlacements = new Map<
+    string,
+    { readonly rowHash: string; readonly sectionIdentity: string }
+  >();
+  for (const run of runs) {
+    const source = placementsBySection[run.sectionIdentity] ?? [];
+    if (
+      source.length !== run.questionCount ||
+      source.some(({ record }, index) => record.row.questionOrder !== index + 1)
+    ) {
+      return yield* repairPlacementFailure();
+    }
+    for (const { record } of source) {
+      const placementIdentity = historicalPlacementIdentity(record.row);
+      if (signedPlacements.has(placementIdentity)) {
+        return yield* repairPlacementFailure();
+      }
+      signedPlacements.set(placementIdentity, {
+        rowHash: record.rowHash,
+        sectionIdentity: run.sectionIdentity,
+      });
+    }
+  }
+  if (
+    signedPlacements.size !== items.length ||
+    items.some((item) => {
+      const placement = signedPlacements.get(item.placementIdentity);
+      const run = runById.get(item.calibrationRunId);
+      return (
+        !(placement && run) ||
+        placement.rowHash !== item.placementRowHash ||
+        placement.sectionIdentity !== run.sectionIdentity
+      );
+    })
+  ) {
     return yield* repairPlacementFailure();
   }
 });

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -87,12 +87,10 @@ export const verifyRepairPlacements = Effect.fn(
   const itemPlacementIdentities = new Set(
     items.map(({ placementIdentity }) => placementIdentity)
   );
+  // Unique item identities, equal cardinality, and membership prove exact equality.
   if (
     itemPlacementIdentities.size !== items.length ||
-    itemPlacementIdentities.size !== signedPlacements.size ||
-    [...signedPlacements.keys()].some(
-      (identity) => !itemPlacementIdentities.has(identity)
-    ) ||
+    signedPlacements.size !== items.length ||
     items.some((item) => {
       const placement = signedPlacements.get(item.placementIdentity);
       const run = runById.get(item.calibrationRunId);

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
 import {
+  seedDuplicateScaleItemIdentity,
   seedRepair,
   seedUnusedScale,
 } from "@repo/backend/test/migration/repair";
@@ -291,6 +292,25 @@ describe("tryouts/migration/cleanup/repair", () => {
       );
       const state = yield* Effect.promise(() => readRepair(t, repair));
       assert.ok(state.scale);
+      assert.strictEqual(state.receipt?.repair, undefined);
+    })
+  );
+
+  it.effect("rejects duplicate item placement identities before writes", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const seeded = yield* Effect.promise(() =>
+        seedDuplicateScaleItemIdentity(t)
+      );
+
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, seeded.evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, seeded.repair));
+      assert.ok(state.scale);
+      assert.ok(state.items.every((item) => item !== null));
       assert.strictEqual(state.receipt?.repair, undefined);
     })
   );

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -51,6 +51,24 @@ function readRepair(
     receipt: await ctx.db.query("tryoutHistoryMigrationReceipts").unique(),
     runs: await Promise.all(graph.runIds.map((id) => ctx.db.get(id))),
     scale: await ctx.db.get(graph.scaleVersionId),
+    sourceCatalog: await ctx.db
+      .query("tryoutCatalog")
+      .withIndex("by_snapshotId_and_index", (query) =>
+        query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+      )
+      .collect(),
+    sourceHistory: await ctx.db
+      .query("tryoutHistoryRows")
+      .withIndex("by_snapshotId_and_rowKind_and_index", (query) =>
+        query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+      )
+      .collect(),
+    sourcePlacements: await ctx.db
+      .query("tryoutPlacements")
+      .withIndex("by_snapshotId_and_index", (query) =>
+        query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+      )
+      .collect(),
   }));
 }
 
@@ -83,6 +101,9 @@ describe("tryouts/migration/cleanup/repair", () => {
       assert.strictEqual(repaired.receipt?.deletedRows, 0);
       assert.deepStrictEqual(repaired.receipt?.proof, CLEANUP_PROOF);
       assert.strictEqual(repaired.receipt?.repair?.deletedRows, repairedRows);
+      assert.deepStrictEqual(repaired.sourceCatalog, []);
+      assert.strictEqual(repaired.sourceHistory.length, 2);
+      assert.deepStrictEqual(repaired.sourcePlacements, []);
       assert.strictEqual(
         repaired.receipt?.repair?.scaleVersionId,
         repair.scaleVersionId
@@ -91,7 +112,7 @@ describe("tryouts/migration/cleanup/repair", () => {
       yield* Effect.promise(() => finishCleanup(t, repair.evidence));
       const finished = yield* Effect.promise(() => readRepair(t, repair));
       assert.strictEqual(finished.receipt?.phase, "cleaned");
-      assert.strictEqual(finished.receipt?.deletedRows, 82);
+      assert.strictEqual(finished.receipt?.deletedRows, 16);
       assert.strictEqual(finished.receipt?.repair?.deletedRows, repairedRows);
     })
   );
@@ -154,7 +175,7 @@ describe("tryouts/migration/cleanup/repair", () => {
       for (const drift of ["identity", "rowHash", "section"] as const) {
         const t = createConvexTestWithBetterAuth();
         const { repair } = yield* Effect.promise(() =>
-          seedRepair(t, 0, ["quantitative-knowledge", "english-language"])
+          seedRepair(t, 0, ["general-reasoning", "english-language"])
         );
         const [firstItemId, secondItemId] = repair.itemIds;
         const [firstRunId, secondRunId] = repair.runIds;
@@ -200,7 +221,7 @@ describe("tryouts/migration/cleanup/repair", () => {
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();
       const { repair } = yield* Effect.promise(() =>
-        seedRepair(t, 0, ["quantitative-knowledge", "english-language"])
+        seedRepair(t, 0, ["general-reasoning", "english-language"])
       );
       const [firstRun, secondRun] = repair.runIds;
       const [firstEvidence, secondEvidence] = repair.evidence.runs;

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.test.ts
@@ -217,6 +217,84 @@ describe("tryouts/migration/cleanup/repair", () => {
     })
   );
 
+  it.effect("rejects an incomplete retained section before writes", () =>
+    Effect.gen(function* () {
+      const t = createConvexTestWithBetterAuth();
+      const { repair, source } = yield* Effect.promise(() =>
+        seedRepair(t, 0, ["general-reasoning", "english-language"])
+      );
+      const [, removedItemId] = repair.itemIds;
+      const [, removedRunId] = repair.runIds;
+      const [retainedRun] = repair.evidence.runs;
+      const [retainedSource, replacedSource] = source;
+      assert.ok(
+        removedItemId &&
+          removedRunId &&
+          retainedRun &&
+          retainedSource &&
+          replacedSource
+      );
+      const evidence = {
+        ...repair.evidence,
+        itemCount: 1,
+        questionCount: 1,
+        runs: [retainedRun],
+      };
+      yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          await ctx.db.delete("irtScaleItems", removedItemId);
+          await ctx.db.delete("irtCalibrationRuns", removedRunId);
+          await ctx.db.patch("irtScaleVersions", repair.scaleVersionId, {
+            questionCount: 1,
+          });
+          const replaced = await ctx.db
+            .query("tryoutHistoryRows")
+            .withIndex("by_snapshotId_and_rowKind_and_rowHash", (query) =>
+              query
+                .eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+                .eq("rowKind", "placement")
+                .eq("rowHash", replacedSource.placement.record.rowHash)
+            )
+            .unique();
+          assert.ok(replaced?.rowKind === "placement");
+          const questionRoot =
+            "question-bank/tryout/indonesia/snbt/general-reasoning/set-2/question-2";
+          const rowHash =
+            "sha256:c7e013e48e7bb05b0e1feaf1f59e238da2470163d345bfe5dc22b351aeb9ae6a";
+          const row = {
+            ...retainedSource.placement.record.row,
+            answerContentKey: `${questionRoot}/answer`,
+            questionContentKey: `${questionRoot}/question`,
+            questionOrder: 2,
+            questionSourcePath: `packages/corpus/${questionRoot}`,
+            title: "Question 2",
+          };
+          await ctx.db.replace("tryoutHistoryRows", replaced._id, {
+            answerArtifactHash: row.answerArtifactHash,
+            index: replaced.index,
+            questionArtifactHash: row.questionArtifactHash,
+            rowHash,
+            rowJson: JSON.stringify({
+              ...retainedSource.placement,
+              record: { row, rowHash },
+            }),
+            rowKind: "placement",
+            snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+          });
+        })
+      );
+
+      yield* Effect.promise(() =>
+        expect(runCleanup(t, evidence)).rejects.toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        })
+      );
+      const state = yield* Effect.promise(() => readRepair(t, repair));
+      assert.ok(state.scale);
+      assert.strictEqual(state.receipt?.repair, undefined);
+    })
+  );
+
   it.effect("rejects duplicate run identities before any repair write", () =>
     Effect.gen(function* () {
       const t = createConvexTestWithBetterAuth();

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -9,10 +9,7 @@ import {
   retainedScaleRepair,
   type ScaleRepairEvidence,
 } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
-import {
-  loadRepairPlacements,
-  matchesRepairPlacements,
-} from "@repo/backend/convex/tryouts/migration/cleanup/placement";
+import { verifyRepairPlacements } from "@repo/backend/convex/tryouts/migration/cleanup/placement";
 import type { CleanupRepair } from "@repo/backend/convex/tryouts/migration/cleanup/schema";
 import { Effect } from "effect";
 
@@ -44,6 +41,7 @@ export const prepareUnusedScale = Effect.fn(
   ctx: MutationCtx,
   migration: CleanupMigration,
   receipt: CleanupReceipt,
+  sourceCatalogRowCount: number,
   evidence: ScaleRepairEvidence = retainedScaleRepair
 ) {
   const applies =
@@ -162,10 +160,12 @@ export const prepareUnusedScale = Effect.fn(
   const observedRunIdentities = new Set(
     runs.map(({ sectionIdentity }) => sectionIdentity)
   );
-  const signedPlacements = yield* loadRepairPlacements(
+  yield* verifyRepairPlacements(
     ctx,
     migration.sourceSnapshotId,
-    evidence.runs
+    sourceCatalogRowCount,
+    items,
+    runs
   );
   const runIds = new Set(runs.map(({ _id }) => _id));
   const itemIds = new Set(items.map(({ _id }) => _id));
@@ -193,7 +193,6 @@ export const prepareUnusedScale = Effect.fn(
     attempt !== null ||
     score !== null ||
     items.length !== evidence.itemCount ||
-    !matchesRepairPlacements(signedPlacements, items, runs) ||
     runs.length !== evidence.runs.length ||
     expectedRuns.size !== runs.length ||
     observedRunIdentities.size !== runs.length ||

--- a/packages/backend/convex/tryouts/migration/cleanup/repair.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/repair.ts
@@ -42,6 +42,7 @@ export const prepareUnusedScale = Effect.fn(
   migration: CleanupMigration,
   receipt: CleanupReceipt,
   sourceCatalogRowCount: number,
+  sourcePlacementRowCount: number,
   evidence: ScaleRepairEvidence = retainedScaleRepair
 ) {
   const applies =
@@ -164,6 +165,7 @@ export const prepareUnusedScale = Effect.fn(
     ctx,
     migration.sourceSnapshotId,
     sourceCatalogRowCount,
+    sourcePlacementRowCount,
     items,
     runs
   );

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -131,6 +131,7 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
     ctx,
     migration,
     receipt,
+    plan.payload.source.catalogRowCount,
     repairEvidence
   );
   if (preparedRepair !== null) {

--- a/packages/backend/convex/tryouts/migration/cleanup/run.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/run.ts
@@ -132,6 +132,7 @@ export const cleanupProgram = Effect.fn("tryouts.migration.cleanup")(function* (
     migration,
     receipt,
     plan.payload.source.catalogRowCount,
+    plan.payload.source.placementRowCount,
     repairEvidence
   );
   if (preparedRepair !== null) {

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -1,4 +1,17 @@
 import { strict as assert } from "node:assert/strict";
+import {
+  AppLocaleSchema,
+  ArtifactLocaleSchema,
+} from "@nakafa/aksara-contracts/locale";
+import {
+  tryoutCatalogNodeIdentity,
+  tryoutPlacementIdentity,
+} from "@nakafa/aksara-contracts/tryout/identity";
+import {
+  deliveryLanguageForSection,
+  questionArtifactLocaleForSection,
+} from "@nakafa/aksara-contracts/tryout/language";
+import { TryoutPlacementSourceSchema } from "@nakafa/aksara-contracts/tryout/placement";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import type schema from "@repo/backend/convex/schema";
@@ -9,6 +22,7 @@ import {
   type CleanupSourceInventory,
 } from "@repo/backend/test/migration/state";
 import type { TestConvex } from "convex-test";
+import { Schema } from "effect";
 
 const REPAIR_PUBLISHED_AT = 20;
 type CleanupTest = TestConvex<typeof schema>;
@@ -268,43 +282,55 @@ function historicalCatalogIdentity(
   row: {
     readonly countryKey: string;
     readonly examKey: string;
-    readonly locale: string;
+    readonly locale: "en" | "id";
     readonly sectionKey?: string;
     readonly setKey: string;
     readonly trackKey: string;
   },
   kind: "section" | "set"
 ) {
-  return [
-    row.locale,
+  const appLocale = AppLocaleSchema.make(row.locale);
+  if (kind === "set") {
+    return tryoutCatalogNodeIdentity({
+      appLocale,
+      countryKey: row.countryKey,
+      examKey: row.examKey,
+      kind,
+      setKey: row.setKey,
+      trackKey: row.trackKey,
+    });
+  }
+  assert.ok(row.sectionKey);
+  return tryoutCatalogNodeIdentity({
+    appLocale,
+    countryKey: row.countryKey,
+    examKey: row.examKey,
     kind,
-    row.countryKey,
-    row.examKey,
-    row.trackKey,
-    row.setKey,
-    kind === "section" ? row.sectionKey : "",
-  ].join("\0");
+    sectionKey: row.sectionKey,
+    setKey: row.setKey,
+    trackKey: row.trackKey,
+  });
 }
 
-/** Reconstructs one exact historical placement identity for test rows. */
-function historicalPlacementIdentity(row: {
-  readonly countryKey: string;
-  readonly examKey: string;
-  readonly locale: string;
-  readonly questionContentKey: string;
-  readonly questionOrder: number;
-  readonly sectionKey: string;
-  readonly setKey: string;
-  readonly trackKey: string;
-}) {
-  return [
-    row.countryKey,
-    row.examKey,
-    row.trackKey,
-    row.setKey,
-    row.sectionKey,
-    row.questionOrder,
-    row.questionContentKey,
-    row.locale,
-  ].join("\0");
+/** Projects one retained fixture through Aksara's placement contract. */
+function historicalPlacementIdentity(
+  row: ReturnType<typeof makeRepairSource>["placement"]["record"]["row"]
+) {
+  const { locale, ...placement } = row;
+  const appLocale = AppLocaleSchema.make(locale);
+  return tryoutPlacementIdentity(
+    Schema.decodeSync(TryoutPlacementSourceSchema)({
+      ...placement,
+      answerArtifactLocale: ArtifactLocaleSchema.make(locale),
+      appLocale,
+      deliveryLanguage: deliveryLanguageForSection(
+        placement.sectionKey,
+        appLocale
+      ),
+      questionArtifactLocale: questionArtifactLocaleForSection(
+        placement.sectionKey,
+        appLocale
+      ),
+    })
+  );
 }

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -277,6 +277,106 @@ export async function seedRepair(
   return { cleanup, repair, source };
 }
 
+/** Seeds two exact placements whose stored items duplicate one identity. */
+export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
+  const seeded = await seedRepair(test, 0, [
+    "general-reasoning",
+    "english-language",
+  ]);
+  const [firstItemId, secondItemId] = seeded.repair.itemIds;
+  const [firstRunId, secondRunId] = seeded.repair.runIds;
+  const [firstRun] = seeded.repair.evidence.runs;
+  const [firstSource, secondSource] = seeded.source;
+  assert.ok(
+    firstItemId &&
+      secondItemId &&
+      firstRunId &&
+      secondRunId &&
+      firstRun &&
+      firstSource &&
+      secondSource
+  );
+  await test.mutation(async (ctx) => {
+    const firstItem = await ctx.db.get(firstItemId);
+    const firstCatalog = await ctx.db
+      .query("tryoutHistoryRows")
+      .withIndex("by_snapshotId_and_rowKind_and_rowHash", (query) =>
+        query
+          .eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+          .eq("rowKind", "catalog")
+          .eq("rowHash", firstSource.section.record.rowHash)
+      )
+      .unique();
+    const secondPlacement = await ctx.db
+      .query("tryoutHistoryRows")
+      .withIndex("by_snapshotId_and_rowKind_and_rowHash", (query) =>
+        query
+          .eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+          .eq("rowKind", "placement")
+          .eq("rowHash", secondSource.placement.record.rowHash)
+      )
+      .unique();
+    assert.ok(firstItem && firstCatalog && secondPlacement);
+    const catalogRowHash =
+      "sha256:a82e49366921f6bdc2e61b36ccb09bcf50eb56a352f0fe9d85f3ab40701940b8";
+    const section = {
+      ...firstSource.section,
+      record: {
+        row: { ...firstSource.section.record.row, questionCount: 2 },
+        rowHash: catalogRowHash,
+      },
+    };
+    await ctx.db.replace("tryoutHistoryRows", firstCatalog._id, {
+      index: firstCatalog.index,
+      rowHash: catalogRowHash,
+      rowJson: JSON.stringify(section),
+      rowKind: "catalog",
+      snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+    });
+    const questionRoot =
+      "question-bank/tryout/indonesia/snbt/general-reasoning/set-2/question-2";
+    const placementRowHash =
+      "sha256:c7e013e48e7bb05b0e1feaf1f59e238da2470163d345bfe5dc22b351aeb9ae6a";
+    const placement = {
+      ...firstSource.placement,
+      record: {
+        row: {
+          ...firstSource.placement.record.row,
+          answerContentKey: `${questionRoot}/answer`,
+          questionContentKey: `${questionRoot}/question`,
+          questionOrder: 2,
+          questionSourcePath: `packages/corpus/${questionRoot}`,
+          title: "Question 2",
+        },
+        rowHash: placementRowHash,
+      },
+    };
+    await ctx.db.replace("tryoutHistoryRows", secondPlacement._id, {
+      answerArtifactHash: placement.record.row.answerArtifactHash,
+      index: secondPlacement.index,
+      questionArtifactHash: placement.record.row.questionArtifactHash,
+      rowHash: placementRowHash,
+      rowJson: JSON.stringify(placement),
+      rowKind: "placement",
+      snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+    });
+    await ctx.db.patch(firstRunId, { questionCount: 2 });
+    await ctx.db.delete(secondRunId);
+    await ctx.db.patch(secondItemId, {
+      calibrationRunId: firstRunId,
+      placementIdentity: firstItem.placementIdentity,
+      placementRowHash: firstItem.placementRowHash,
+    });
+  });
+  return {
+    ...seeded,
+    evidence: {
+      ...seeded.repair.evidence,
+      runs: [{ ...firstRun, questionCount: 2 }],
+    },
+  };
+}
+
 /** Reconstructs the frozen catalog identity used by retained scale rows. */
 function historicalCatalogIdentity(
   row: {

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -1,114 +1,157 @@
 import { strict as assert } from "node:assert/strict";
-import {
-  ContentKeySchema,
-  CorpusSourcePathSchema,
-} from "@nakafa/aksara-contracts/ids";
-import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot/data";
-import { makeTryoutCatalogRecord } from "@nakafa/aksara-contracts/tryout/catalog-hash";
-import {
-  tryoutCatalogIdentity,
-  tryoutCatalogNodeIdentity,
-  tryoutPlacementIdentity,
-} from "@nakafa/aksara-contracts/tryout/identity";
-import { makeTryoutPlacementRecord } from "@nakafa/aksara-contracts/tryout/placement-hash";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
-import {
-  tryoutCatalogFacts,
-  tryoutPlacementFacts,
-} from "@repo/backend/convex/contentRelease/tryout/facts";
 import type schema from "@repo/backend/convex/schema";
 import type { ScaleRepairEvidence } from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
 import { seedCleanupSuccess } from "@repo/backend/test/migration/seed";
-import { CLEANUP_SOURCE_SNAPSHOT } from "@repo/backend/test/migration/state";
-import { makeTryoutPlacementRow } from "@repo/backend/test/tryout/snapshot";
-import { makeTryoutStartCatalog } from "@repo/backend/test/tryout/source";
+import {
+  CLEANUP_SOURCE_SNAPSHOT,
+  type CleanupSourceInventory,
+} from "@repo/backend/test/migration/state";
 import type { TestConvex } from "convex-test";
 
 const REPAIR_PUBLISHED_AT = 20;
 type CleanupTest = TestConvex<typeof schema>;
+const repairHashes = {
+  "english-language": {
+    placement:
+      "sha256:4e5e666678434bd288e326190030a91111f2756a683d3580d3aa1788e3c1dcf8",
+    section:
+      "sha256:b819e3469bd3413932059526a523d47ec0a895b1f620b3735270fd31c8f8e22d",
+  },
+  "general-reasoning": {
+    placement:
+      "sha256:2bf92b47875b9ead349b5416397dffc6b76db9543749c2a6c33f48c77c9b48d7",
+    section:
+      "sha256:3b7e00e4f173ea16c29749bfc46385da19f224ddc9a337484fd51fc56702ea63",
+  },
+} as const;
+type RepairSectionKey = keyof typeof repairHashes;
 
-/** Builds one signed section and placement selected by the repair graph. */
-function makeRepairSource(sectionKey: string, order: number) {
-  const baseSection = makeTryoutStartCatalog("en", "visible", "irt").find(
-    (row) => row.kind === "section"
-  );
-  assert.ok(baseSection?.kind === "section");
+/** Builds one frozen history fixture without exposing an old writer. */
+function makeRepairSource(sectionKey: RepairSectionKey) {
+  const hashes = repairHashes[sectionKey];
+  const questionRoot = `question-bank/tryout/indonesia/snbt/${sectionKey}/set-2/question-1`;
   const section = {
     family: "tryout",
-    record: makeTryoutCatalogRecord({
-      ...baseSection,
-      examKey: "snbt",
-      order,
-      questionCount: 1,
-      sectionKey,
-      setKey: "set-2",
-      trackKey: "2027",
-    }),
+    record: {
+      row: {
+        countryKey: "indonesia",
+        examKey: "snbt",
+        graph: {
+          alignmentId: `alignment:tryout:${sectionKey}`,
+          assetId: `asset:tryout:${sectionKey}`,
+          conceptId: `concept:tryout:${sectionKey}`,
+          learningObjectId: `lo:tryout-${sectionKey}`,
+          lensId: "lens:tryout:test",
+        },
+        kind: "section",
+        locale: "en",
+        order: 1,
+        publicPath: `try-out/indonesia/snbt/2027/set-2/${sectionKey}`,
+        questionCount: 1,
+        questionSourcePath: `packages/corpus/question-bank/tryout/indonesia/snbt/${sectionKey}/set-2`,
+        sectionKey,
+        setKey: "set-2",
+        sourceRevision: "retained-source",
+        timeLimitSeconds: 1800,
+        title: sectionKey,
+        trackKey: "2027",
+        visibility: "visible",
+      },
+      rowHash: hashes.section,
+    },
     rowKind: "catalog",
   } as const;
-  const basePlacement = makeTryoutPlacementRow("en");
-  const questionRoot = `question-bank/tryout/indonesia/snbt/${sectionKey}/set-2/question-1`;
   const placement = {
     family: "tryout",
-    record: makeTryoutPlacementRecord({
-      ...basePlacement.record.row,
-      answerContentKey: ContentKeySchema.make(`${questionRoot}/answer`),
-      examKey: "snbt",
-      questionContentKey: ContentKeySchema.make(`${questionRoot}/question`),
-      questionOrder: 1,
-      questionSourcePath: CorpusSourcePathSchema.make(
-        `packages/corpus/${questionRoot}`
-      ),
-      sectionKey,
-      setKey: "set-2",
-      trackKey: "2027",
-    }),
+    record: {
+      row: {
+        answerArtifactHash: `sha256:${"c".repeat(64)}`,
+        answerContentKey: `${questionRoot}/answer`,
+        choices: [
+          { isCorrect: true, label: "A", optionKey: "option-1", order: 1 },
+          { isCorrect: false, label: "B", optionKey: "option-2", order: 2 },
+        ],
+        countryKey: "indonesia",
+        examKey: "snbt",
+        locale: "en",
+        questionArtifactHash: `sha256:${"d".repeat(64)}`,
+        questionContentKey: `${questionRoot}/question`,
+        questionOrder: 1,
+        questionSourcePath: `packages/corpus/${questionRoot}`,
+        rendererDomain: "snbt-general",
+        scope: "server",
+        sectionKey,
+        setKey: "set-2",
+        sourceRevision: "retained-source",
+        title: "Question 1",
+        trackKey: "2027",
+      },
+      rowHash: hashes.placement,
+    },
     rowKind: "placement",
   } as const;
   return { placement, section };
 }
 
-/** Replaces legacy test placeholders with authenticated source rows. */
+/** Replaces placeholders with the authenticated history-only source shape. */
 async function seedRepairSource(
   ctx: MutationCtx,
   source: readonly ReturnType<typeof makeRepairSource>[]
 ) {
   const catalogs = await ctx.db
-    .query("tryoutCatalog")
-    .withIndex("by_snapshotId_and_index", (query) =>
-      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+    .query("tryoutHistoryRows")
+    .withIndex("by_snapshotId_and_rowKind_and_index", (query) =>
+      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT).eq("rowKind", "catalog")
     )
     .take(source.length);
   const placements = await ctx.db
-    .query("tryoutPlacements")
-    .withIndex("by_snapshotId_and_index", (query) =>
-      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+    .query("tryoutHistoryRows")
+    .withIndex("by_snapshotId_and_rowKind_and_index", (query) =>
+      query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT).eq("rowKind", "placement")
     )
     .take(source.length);
-  assert.ok(catalogs.length === source.length && placements[0]);
+  assert.strictEqual(catalogs.length, source.length);
+  assert.strictEqual(placements.length, source.length);
   for (const [index, row] of source.entries()) {
     const catalog = catalogs[index];
-    assert.ok(catalog);
-    await ctx.db.replace("tryoutCatalog", catalog._id, {
-      ...tryoutCatalogFacts(row.section.record),
+    const placement = placements[index];
+    assert.ok(catalog && placement);
+    await ctx.db.replace("tryoutHistoryRows", catalog._id, {
       index: catalog.index,
       rowHash: row.section.record.rowHash,
-      rowJson: canonicalizeContentSnapshotRow(row.section),
+      rowJson: JSON.stringify(row.section),
+      rowKind: "catalog",
       snapshotId: CLEANUP_SOURCE_SNAPSHOT,
     });
-    const stored = placements[index];
-    const next = {
-      ...tryoutPlacementFacts(row.placement.record),
-      index: stored?.index ?? index + 1,
+    await ctx.db.replace("tryoutHistoryRows", placement._id, {
+      answerArtifactHash: row.placement.record.row.answerArtifactHash,
+      index: placement.index,
+      questionArtifactHash: row.placement.record.row.questionArtifactHash,
       rowHash: row.placement.record.rowHash,
-      rowJson: canonicalizeContentSnapshotRow(row.placement),
+      rowJson: JSON.stringify(row.placement),
+      rowKind: "placement",
       snapshotId: CLEANUP_SOURCE_SNAPSHOT,
-    };
-    if (stored) {
-      await ctx.db.replace("tryoutPlacements", stored._id, next);
-    } else {
-      await ctx.db.insert("tryoutPlacements", next);
+    });
+  }
+  const transitionRows = await Promise.all([
+    ctx.db
+      .query("tryoutCatalog")
+      .withIndex("by_snapshotId_and_index", (query) =>
+        query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+      )
+      .collect(),
+    ctx.db
+      .query("tryoutPlacements")
+      .withIndex("by_snapshotId_and_index", (query) =>
+        query.eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+      )
+      .collect(),
+  ]);
+  for (const rows of transitionRows) {
+    for (const row of rows) {
+      await ctx.db.delete(row._id);
     }
   }
 }
@@ -122,14 +165,7 @@ export async function seedUnusedScale(
   const first = source[0];
   assert.ok(first);
   const firstPlacement = first.placement.record.row;
-  const setIdentity = tryoutCatalogNodeIdentity({
-    appLocale: firstPlacement.appLocale,
-    countryKey: firstPlacement.countryKey,
-    examKey: firstPlacement.examKey,
-    kind: "set",
-    setKey: firstPlacement.setKey,
-    trackKey: firstPlacement.trackKey,
-  });
+  const setIdentity = historicalCatalogIdentity(firstPlacement, "set");
   const scaleVersionId = await ctx.db.insert("irtScaleVersions", {
     model: "2pl",
     publishedAt: REPAIR_PUBLISHED_AT,
@@ -141,7 +177,10 @@ export async function seedUnusedScale(
   const itemIds: Id<"irtScaleItems">[] = [];
   const runIds: Id<"irtCalibrationRuns">[] = [];
   for (const row of source) {
-    const sectionIdentity = tryoutCatalogIdentity(row.section.record.row);
+    const sectionIdentity = historicalCatalogIdentity(
+      row.section.record.row,
+      "section"
+    );
     const runId = await ctx.db.insert("irtCalibrationRuns", {
       attemptCount: 0,
       completedAt: REPAIR_PUBLISHED_AT,
@@ -164,7 +203,9 @@ export async function seedUnusedScale(
         correctRate: 0,
         difficulty: 0,
         discrimination: 1,
-        placementIdentity: tryoutPlacementIdentity(row.placement.record.row),
+        placementIdentity: historicalPlacementIdentity(
+          row.placement.record.row
+        ),
         placementRowHash: row.placement.record.rowHash,
         responseCount: 0,
         scaleVersionId,
@@ -178,7 +219,10 @@ export async function seedUnusedScale(
       questionCount: source.length,
       runs: source.map((row) => ({
         questionCount: 1,
-        sectionIdentity: tryoutCatalogIdentity(row.section.record.row),
+        sectionIdentity: historicalCatalogIdentity(
+          row.section.record.row,
+          "section"
+        ),
       })),
       setIdentity,
     },
@@ -192,12 +236,14 @@ export async function seedUnusedScale(
 export async function seedRepair(
   test: CleanupTest,
   responseCount = 0,
-  sectionKeys: readonly string[] = ["quantitative-knowledge"]
+  sectionKeys: readonly RepairSectionKey[] = ["general-reasoning"]
 ) {
-  const cleanup = await seedCleanupSuccess(test);
-  const source = sectionKeys.map((sectionKey, index) =>
-    makeRepairSource(sectionKey, index + 1)
-  );
+  const source = sectionKeys.map(makeRepairSource);
+  const sourceInventory: CleanupSourceInventory = {
+    catalogRowCount: source.length,
+    placementRowCount: source.length,
+  };
+  const cleanup = await seedCleanupSuccess(test, 1, sourceInventory);
   const repair = await test.mutation(async (ctx) => {
     const migration = await ctx.db.query("tryoutHistoryMigrations").unique();
     assert.ok(migration?.phase === "completed");
@@ -215,4 +261,50 @@ export async function seedRepair(
     };
   });
   return { cleanup, repair, source };
+}
+
+/** Reconstructs the frozen catalog identity used by retained scale rows. */
+function historicalCatalogIdentity(
+  row: {
+    readonly countryKey: string;
+    readonly examKey: string;
+    readonly locale: string;
+    readonly sectionKey?: string;
+    readonly setKey: string;
+    readonly trackKey: string;
+  },
+  kind: "section" | "set"
+) {
+  return [
+    row.locale,
+    kind,
+    row.countryKey,
+    row.examKey,
+    row.trackKey,
+    row.setKey,
+    kind === "section" ? row.sectionKey : "",
+  ].join("\0");
+}
+
+/** Reconstructs one exact historical placement identity for test rows. */
+function historicalPlacementIdentity(row: {
+  readonly countryKey: string;
+  readonly examKey: string;
+  readonly locale: string;
+  readonly questionContentKey: string;
+  readonly questionOrder: number;
+  readonly sectionKey: string;
+  readonly setKey: string;
+  readonly trackKey: string;
+}) {
+  return [
+    row.countryKey,
+    row.examKey,
+    row.trackKey,
+    row.setKey,
+    row.sectionKey,
+    row.questionOrder,
+    row.questionContentKey,
+    row.locale,
+  ].join("\0");
 }

--- a/packages/backend/test/migration/root.ts
+++ b/packages/backend/test/migration/root.ts
@@ -12,7 +12,9 @@ import {
   CLEANUP_LIMIT,
   CLEANUP_MIGRATION_ID,
   CLEANUP_RECEIPT_HASH,
+  CLEANUP_SOURCE_INVENTORY,
   CLEANUP_SOURCE_SNAPSHOT,
+  type CleanupSourceInventory,
 } from "@repo/backend/test/migration/state";
 import type { CleanupTarget } from "@repo/backend/test/migration/target";
 import { Effect, Schema } from "effect";
@@ -22,7 +24,8 @@ const digest = (digit: string) => `sha256:${digit.repeat(64)}`;
 /** Builds the exact signed-plan shape rehashed by native cleanup code. */
 async function makeCleanupPlan(
   target: CleanupTarget,
-  scaleVersionCount: number
+  scaleVersionCount: number,
+  sourceInventory: CleanupSourceInventory
 ) {
   const payload = Schema.decodeSync(TryoutHistoryMigrationPlanPayloadSchema)({
     format: "signed-tryout-history-migration-plan",
@@ -38,10 +41,10 @@ async function makeCleanupPlan(
         scoreCount: 1,
         sectionAttemptCount: 1,
       },
-      catalogRowCount: 33,
+      catalogRowCount: sourceInventory.catalogRowCount,
       creatingReleaseId: "source-release",
       legacyBundleCount: 1,
-      placementRowCount: 1,
+      placementRowCount: sourceInventory.placementRowCount,
       releases: [
         {
           attemptCount: 1,
@@ -62,7 +65,7 @@ async function makeCleanupPlan(
         counts: { country: 1, exam: 1, section: 1, set: 1, track: 1 },
         format: "tryout-v1",
         locales: ["en", "id"],
-        placementCount: 1,
+        placementCount: sourceInventory.placementRowCount,
         placementDigest: digest("7"),
         routeCount: 1,
         snapshotId: CLEANUP_SOURCE_SNAPSHOT,
@@ -97,7 +100,13 @@ async function makeCleanupPlan(
   const cleanupLimit = await Effect.runPromise(
     computeTryoutHistoryCleanupLimit(payload)
   );
-  if (scaleVersionCount === 1) {
+  if (
+    scaleVersionCount === 1 &&
+    sourceInventory.catalogRowCount ===
+      CLEANUP_SOURCE_INVENTORY.catalogRowCount &&
+    sourceInventory.placementRowCount ===
+      CLEANUP_SOURCE_INVENTORY.placementRowCount
+  ) {
     assert.equal(cleanupLimit, CLEANUP_LIMIT);
   }
   return {
@@ -111,9 +120,14 @@ async function makeCleanupPlan(
 export async function seedRoot(
   ctx: MutationCtx,
   target: CleanupTarget,
-  sourceScaleVersionIds: readonly Id<"irtScaleVersions">[]
+  sourceScaleVersionIds: readonly Id<"irtScaleVersions">[],
+  sourceInventory: CleanupSourceInventory = CLEANUP_SOURCE_INVENTORY
 ) {
-  const signed = await makeCleanupPlan(target, sourceScaleVersionIds.length);
+  const signed = await makeCleanupPlan(
+    target,
+    sourceScaleVersionIds.length,
+    sourceInventory
+  );
   const completion = {
     cleanupLimit: signed.cleanupLimit,
     completedAt: 10,

--- a/packages/backend/test/migration/seed.ts
+++ b/packages/backend/test/migration/seed.ts
@@ -9,7 +9,9 @@ import {
 } from "@repo/backend/test/migration/source";
 import {
   CLEANUP_MIGRATION_ID,
+  CLEANUP_SOURCE_INVENTORY,
   CLEANUP_SOURCE_SNAPSHOT,
+  type CleanupSourceInventory,
   type CleanupTest,
 } from "@repo/backend/test/migration/state";
 import { seedTarget } from "@repo/backend/test/migration/target";
@@ -116,7 +118,11 @@ export function seedCleanupGuard(
 }
 
 /** Seeds a multi-page source plus permanent target and shared references. */
-export function seedCleanupSuccess(t: CleanupTest, sourceScaleCount = 1) {
+export function seedCleanupSuccess(
+  t: CleanupTest,
+  sourceScaleCount = 1,
+  sourceInventory: CleanupSourceInventory = CLEANUP_SOURCE_INVENTORY
+) {
   return t.mutation(async (ctx) => {
     const target = await seedTarget(ctx);
     const sourceScale = await seedSourceScale(ctx);
@@ -143,7 +149,7 @@ export function seedCleanupSuccess(t: CleanupTest, sourceScaleCount = 1) {
     await ctx.db.patch(target.attemptId, {
       scaleVersionId: targetScale.scaleVersionId,
     });
-    await seedSourceRows(ctx, target);
+    await seedSourceRows(ctx, target, sourceInventory);
     const markerId = await ctx.db.insert("tryoutAttemptHistory", {
       snapshotReleaseId: "source-release",
       tryoutAttemptId: target.attemptId,
@@ -165,7 +171,8 @@ export function seedCleanupSuccess(t: CleanupTest, sourceScaleCount = 1) {
     await seedRoot(
       ctx,
       target,
-      sourceScales.map(({ scaleVersionId }) => scaleVersionId)
+      sourceScales.map(({ scaleVersionId }) => scaleVersionId),
+      sourceInventory
     );
     return {
       sourceScale,

--- a/packages/backend/test/migration/source.ts
+++ b/packages/backend/test/migration/source.ts
@@ -3,7 +3,9 @@ import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
   CLEANUP_ORPHAN_ARTIFACT,
   CLEANUP_SHARED_ARTIFACT,
+  CLEANUP_SOURCE_INVENTORY,
   CLEANUP_SOURCE_SNAPSHOT,
+  type CleanupSourceInventory,
 } from "@repo/backend/test/migration/state";
 import type { CleanupTarget } from "@repo/backend/test/migration/target";
 
@@ -46,7 +48,11 @@ export async function seedSourceScale(ctx: MutationCtx) {
 }
 
 /** Seeds every legacy source row removed only after signed completion. */
-export async function seedSourceRows(ctx: MutationCtx, target: CleanupTarget) {
+export async function seedSourceRows(
+  ctx: MutationCtx,
+  target: CleanupTarget,
+  sourceInventory: CleanupSourceInventory = CLEANUP_SOURCE_INVENTORY
+) {
   await ctx.db.insert("contentSnapshots", {
     createdAt: 1,
     family: "tryout",
@@ -55,7 +61,7 @@ export async function seedSourceRows(ctx: MutationCtx, target: CleanupTarget) {
     snapshotJson: "{}",
   });
   await Promise.all(
-    Array.from({ length: 33 }, (_, index) =>
+    Array.from({ length: sourceInventory.catalogRowCount }, (_, index) =>
       ctx.db.insert("tryoutHistoryRows", {
         index,
         rowHash: `source-history-${index}`,
@@ -65,17 +71,21 @@ export async function seedSourceRows(ctx: MutationCtx, target: CleanupTarget) {
       })
     )
   );
-  await ctx.db.insert("tryoutHistoryRows", {
-    answerArtifactHash: CLEANUP_ORPHAN_ARTIFACT,
-    index: 33,
-    questionArtifactHash: CLEANUP_SHARED_ARTIFACT,
-    rowHash: "source-history-33",
-    rowJson: "{}",
-    rowKind: "placement",
-    snapshotId: CLEANUP_SOURCE_SNAPSHOT,
-  });
   await Promise.all(
-    Array.from({ length: 33 }, (_, index) =>
+    Array.from({ length: sourceInventory.placementRowCount }, (_, index) =>
+      ctx.db.insert("tryoutHistoryRows", {
+        answerArtifactHash: CLEANUP_ORPHAN_ARTIFACT,
+        index: sourceInventory.catalogRowCount + index,
+        questionArtifactHash: CLEANUP_SHARED_ARTIFACT,
+        rowHash: `source-placement-${index}`,
+        rowJson: "{}",
+        rowKind: "placement",
+        snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+      })
+    )
+  );
+  await Promise.all(
+    Array.from({ length: sourceInventory.catalogRowCount }, (_, index) =>
       ctx.db.insert("tryoutCatalog", {
         appLocale: "id",
         assetId: `source-catalog-${index}`,
@@ -89,26 +99,30 @@ export async function seedSourceRows(ctx: MutationCtx, target: CleanupTarget) {
       })
     )
   );
-  await ctx.db.insert("tryoutPlacements", {
-    answerArtifactHash: CLEANUP_ORPHAN_ARTIFACT,
-    answerArtifactLocale: "id",
-    appLocale: "id",
-    contentHash: "source-content",
-    countryKey: "indonesia",
-    deliveryLanguage: "id",
-    examKey: "snbt",
-    identity: "source-placement",
-    index: 1,
-    questionArtifactHash: CLEANUP_SHARED_ARTIFACT,
-    questionArtifactLocale: "id",
-    questionOrder: 1,
-    rowHash: "source-placement",
-    rowJson: "{}",
-    sectionKey: "section-1",
-    setKey: "set-1",
-    snapshotId: CLEANUP_SOURCE_SNAPSHOT,
-    trackKey: "2027",
-  });
+  await Promise.all(
+    Array.from({ length: sourceInventory.placementRowCount }, (_, index) =>
+      ctx.db.insert("tryoutPlacements", {
+        answerArtifactHash: CLEANUP_ORPHAN_ARTIFACT,
+        answerArtifactLocale: "id",
+        appLocale: "id",
+        contentHash: `source-content-${index}`,
+        countryKey: "indonesia",
+        deliveryLanguage: "id",
+        examKey: "snbt",
+        identity: `source-placement-${index}`,
+        index: index + 1,
+        questionArtifactHash: CLEANUP_SHARED_ARTIFACT,
+        questionArtifactLocale: "id",
+        questionOrder: index + 1,
+        rowHash: `source-placement-${index}`,
+        rowJson: "{}",
+        sectionKey: "section-1",
+        setKey: "set-1",
+        snapshotId: CLEANUP_SOURCE_SNAPSHOT,
+        trackKey: "2027",
+      })
+    )
+  );
   await ctx.db.insert("tryoutBundles", {
     createdAt: 1,
     index: 0,

--- a/packages/backend/test/migration/state.ts
+++ b/packages/backend/test/migration/state.ts
@@ -8,12 +8,20 @@ export const CLEANUP_SOURCE_SNAPSHOT = `sha256:${"1".repeat(64)}`;
 export const CLEANUP_SHARED_ARTIFACT = "artifact-cleanup-shared";
 export const CLEANUP_ORPHAN_ARTIFACT = "artifact-cleanup-orphan";
 export const CLEANUP_LIMIT = 87;
+export const CLEANUP_SOURCE_INVENTORY = {
+  catalogRowCount: 33,
+  placementRowCount: 1,
+} as const;
 export const CLEANUP_PROOF = {
   assetHash: `sha256:${"a".repeat(64)}`,
   sourceSha: "b".repeat(40),
 } as const;
 
 export type CleanupTest = TestConvex<typeof schema>;
+export interface CleanupSourceInventory {
+  readonly catalogRowCount: number;
+  readonly placementRowCount: number;
+}
 
 /** Captures every cleanup-owned table for before-and-after guard proof. */
 export function readCleanupState(t: CleanupTest) {


### PR DESCRIPTION
## Summary

Repair the retained try-out history cleanup against the authenticated historical source that production actually stores.

## Why

Production cleanup for `retained-tryout-history` failed with `CONTENT_RELEASE_INTEGRITY`. Read-only production inventory proves the source snapshot has zero current `tryoutCatalog` and `tryoutPlacements` rows, while authoritative `tryoutHistoryRows` stores exactly 54 catalog and 840 placement records. The previous cleanup incorrectly required deleted transition duplicates and did not prove complete section and item ownership.

## Scope

- authenticate the exact catalog and placement counts from the signed migration plan
- authenticate all 894 retained rows before a repair write
- prove exact section membership, contiguous question order, unique item identity, row hash, placement identity, run ownership, and item ownership
- derive retained identities through the installed Aksara contract instead of duplicate local reconstruction
- accept zero through the signed maximum of old physical duplicates while preserving exact historical counts
- add history-only cleanup coverage plus extra-placement and duplicate-item regressions

## Exact-head verification

Head: `b8d20840bc`

- both new regressions cover fail-closed behavior before writes
- repair owner suite: 11/11
- related focused suites: 27/27 before the final duplicate-item addition
- full backend with one worker: 380 files and 1,628 tests before the final duplicate-item addition; exact-head CI owns the final complete count
- backend TypeScript, lint, Effect v4 source identity, package boundaries, diff check, and security audit pass
- all 894 production rows authenticate in 66 ms locally; serialized inventory is 1,840,087 bytes, below the 16 MiB Convex transaction limit
- installed Aksara identity functions were verified against the removed local formulas
- all touched handwritten files remain below 500 LOC
- exact-head GitHub CI and one fresh review are running or pending

## Rollout

This PR performs no production write and creates no Vercel Preview. After protected merge and exact-main production readiness, the existing signed Aksara cleanup workflow retries the same sealed receipt. The resulting cleanup is verified before the temporary migration implementation and evidence are removed in a separate final contraction.

## Risks

The authenticated full inventory increases one cleanup transaction read, but the immutable production source is measured below the platform limit. Any count, order, identity, hash, or ownership mismatch fails before repair writes.