### PR TITLE
test(backend): run program route with Effect Vitest

### DIFF
--- a/packages/backend/convex/contentRelease/program/route.test.ts
+++ b/packages/backend/convex/contentRelease/program/route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { CurriculumRouteSchema } from "@nakafa/aksara-contracts/program/curriculum";
 import { makeCurriculumSnapshotRow } from "@nakafa/aksara-contracts/program/snapshot/row-hash";
 import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot/data";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
 import { readProgramRoute } from "@repo/backend/convex/contentRelease/program/route";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -25,6 +26,16 @@ import { convexTest, type TestConvex } from "convex-test";
 import { Effect, Schema } from "effect";
 
 const PROGRAM_ROOT = "curriculum/technical-program-1";
+
+class ProgramRouteQueryRejected extends Schema.TaggedError<ProgramRouteQueryRejected>()(
+  "ProgramRouteQueryRejected",
+  { cause: Schema.Unknown }
+) {}
+
+class UnexpectedProgramRouteTestState extends Schema.TaggedError<UnexpectedProgramRouteTestState>()(
+  "UnexpectedProgramRouteTestState",
+  { operation: Schema.Literal("load-active-curriculum-route") }
+) {}
 
 /** Creates one authored material group under the technical root. */
 function materialGroup(groupIndex: number, order: number) {
@@ -74,42 +85,54 @@ function materialContext(
 }
 
 /** Adds exact authored curriculum routes to one active test snapshot. */
-async function insertCurriculumRoutes(
+const insertCurriculumRoutes = Effect.fn(
+  "contentRelease.program.route.test.insertCurriculumRoutes"
+)(function* (
   target: TestConvex<typeof schema>,
   snapshotId: string,
   routes: readonly ReturnType<typeof materialContext>[]
 ) {
-  const records = await Effect.runPromise(
-    Effect.forEach(routes, makeCurriculumSnapshotRow)
+  const records = yield* Effect.forEach(routes, makeCurriculumSnapshotRow);
+  yield* Effect.promise(() =>
+    target.mutation((ctx) =>
+      runConvexProgram(
+        Effect.forEach(
+          records,
+          (record, offset) => {
+            const row = record.row;
+            return Effect.promise(() =>
+              ctx.db.insert("curriculumRoutes", {
+                appLocale: row.appLocale,
+                index: 10 + offset,
+                level: row.level,
+                contextPath: row.materialContextParentPath,
+                materialKey: row.materialKey,
+                nodeKey: row.nodeKey,
+                order: row.order,
+                parentPath: row.parentPath,
+                programKey: row.programKey,
+                path: row.publicPath,
+                rowHash: record.rowHash,
+                rowJson: canonicalizeContentSnapshotRow({
+                  family: "program",
+                  record,
+                }),
+                snapshotId,
+                sourcePath: row.sourcePath,
+              })
+            );
+          },
+          { discard: true }
+        )
+      )
+    )
   );
-  await target.mutation(async (ctx) => {
-    for (const [offset, record] of records.entries()) {
-      const row = record.row;
-      await ctx.db.insert("curriculumRoutes", {
-        appLocale: row.appLocale,
-        index: 10 + offset,
-        level: row.level,
-        contextPath: row.materialContextParentPath,
-        materialKey: row.materialKey,
-        nodeKey: row.nodeKey,
-        order: row.order,
-        parentPath: row.parentPath,
-        programKey: row.programKey,
-        path: row.publicPath,
-        rowHash: record.rowHash,
-        rowJson: canonicalizeContentSnapshotRow({
-          family: "program",
-          record,
-        }),
-        snapshotId,
-        sourcePath: row.sourcePath,
-      });
-    }
-  });
-}
+});
 
 /** Inserts material projections in bounded test transactions. */
-async function insertMaterialGroups(
+const insertMaterialGroups = Effect.fn(
+  "contentRelease.program.route.test.insertMaterialGroups"
+)(function* (
   target: TestConvex<typeof schema>,
   groups: readonly {
     readonly materialIndex: number;
@@ -122,238 +145,274 @@ async function insertMaterialGroups(
     )
   );
   for (let first = 0; first < projections.length; first += 32) {
-    await target.mutation(async (ctx) => {
-      for (const projection of projections.slice(first, first + 32)) {
-        await insertMaterialProjection(ctx, projection);
-      }
-    });
-  }
-}
-
-describe("contentRelease/program/route", () => {
-  it.live("returns one exact verified route and its program provenance", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const t = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      const result = yield* Effect.promise(() =>
-        t.query((ctx) =>
-          runConvexProgram(
-            readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+    yield* Effect.promise(() =>
+      target.mutation((ctx) =>
+        runConvexProgram(
+          Effect.forEach(
+            projections.slice(first, first + 32),
+            (projection) =>
+              Effect.promise(() => insertMaterialProjection(ctx, projection)),
+            { discard: true }
           )
         )
-      );
-      const [program, route] = yield* Effect.all([
-        decodeSnapshotRowJson(result.programJson ?? ""),
-        decodeSnapshotRowJson(result.routeJson ?? ""),
-      ]);
+      )
+    );
+  }
+});
 
-      expect(result).toMatchObject({
-        activeManifestHash: TEST_MANIFEST_HASH,
-        activeReleaseId: TEST_RELEASE_ID,
-        ancestorJson: [],
-        childJson: [],
-        contextJson: [],
-        groupJson: [],
-        managed: true,
-        materialJson: [],
-        snapshotId: data.snapshotId,
-        sourceRevision: "a".repeat(40),
-      });
-      expect(program).toMatchObject({
-        family: "program",
-        record: {
-          kind: "program",
-          row: { key: "technical-program-1" },
-        },
-      });
-      expect(route).toMatchObject({
-        family: "program",
-        record: {
-          kind: "curriculum",
-          row: { appLocale: "en", programKey: "technical-program-1" },
-        },
-      });
+/** Corrupts one indexed identity to exercise the read integrity boundary. */
+const tamperCurriculumRoute = Effect.fn(
+  "contentRelease.program.route.test.tamperCurriculumRoute"
+)(function* (ctx: MutationCtx, snapshotId: string) {
+  const row = yield* Effect.promise(() =>
+    ctx.db
+      .query("curriculumRoutes")
+      .withIndex("by_snapshotId_and_index", (index) =>
+        index.eq("snapshotId", snapshotId).eq("index", 2)
+      )
+      .unique()
+  );
+  if (!row) {
+    return yield* Effect.die(
+      new UnexpectedProgramRouteTestState({
+        operation: "load-active-curriculum-route",
+      })
+    );
+  }
+  yield* Effect.promise(() =>
+    ctx.db.patch("curriculumRoutes", row._id, {
+      programKey: "tampered-program",
     })
   );
+});
 
-  it.live(
-    "distinguishes a managed missing route from an unmanaged source",
-    () =>
-      Effect.gen(function* () {
+describe("contentRelease/program/route", () => {
+  it.effect(
+    "returns one exact verified route and its program provenance",
+    Effect.fn("contentRelease.program.route.test.returnsExactRoute")(
+      function* () {
         const data = yield* makeProgramSnapshotData();
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
-
-        yield* Effect.promise(() =>
-          expect(
-            t.query((ctx) =>
-              runConvexProgram(readProgramRoute(ctx, "id", "kurikulum/missing"))
-            )
-          ).resolves.toMatchObject({
-            managed: true,
-            programJson: null,
-            routeJson: null,
-          })
-        );
-      })
-  );
-
-  it("preserves the active release while programs remain source-owned", async () => {
-    const target = convexTest(schema, convexModules);
-    await activateMaterialCatalog(target);
-
-    await expect(
-      target.query((ctx) =>
-        runConvexProgram(
-          readProgramRoute(ctx, "en", "curriculum/technical-program-1")
-        )
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId: MATERIAL_IDENTITY.releaseId,
-      managed: false,
-      routeJson: null,
-    });
-  });
-
-  it.live("rejects a curriculum row whose indexed identity drifted", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const t = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      yield* Effect.promise(() =>
-        t.mutation(async (ctx) => {
-          const row = await ctx.db
-            .query("curriculumRoutes")
-            .withIndex("by_snapshotId_and_index", (index) =>
-              index.eq("snapshotId", data.snapshotId).eq("index", 2)
-            )
-            .unique();
-          if (!row) {
-            throw new Error("Expected one active curriculum route.");
-          }
-          await ctx.db.patch("curriculumRoutes", row._id, {
-            programKey: "tampered-program",
-          });
-        })
-      );
-
-      yield* Effect.promise(() =>
-        expect(
+        const result = yield* Effect.promise(() =>
           t.query((ctx) =>
             runConvexProgram(
               readProgramRoute(ctx, "en", "curriculum/technical-program-1")
             )
           )
-        ).rejects.toMatchObject({
-          data: { code: "CONTENT_RELEASE_INTEGRITY" },
-        })
-      );
-    })
+        );
+        const [program, route] = yield* Effect.all([
+          decodeSnapshotRowJson(result.programJson ?? ""),
+          decodeSnapshotRowJson(result.routeJson ?? ""),
+        ]);
+
+        expect(result).toMatchObject({
+          activeManifestHash: TEST_MANIFEST_HASH,
+          activeReleaseId: TEST_RELEASE_ID,
+          ancestorJson: [],
+          childJson: [],
+          contextJson: [],
+          groupJson: [],
+          managed: true,
+          materialJson: [],
+          snapshotId: data.snapshotId,
+          sourceRevision: "a".repeat(40),
+        });
+        expect(program).toMatchObject({
+          family: "program",
+          record: {
+            kind: "program",
+            row: { key: "technical-program-1" },
+          },
+        });
+        expect(route).toMatchObject({
+          family: "program",
+          record: {
+            kind: "curriculum",
+            row: { appLocale: "en", programKey: "technical-program-1" },
+          },
+        });
+      }
+    )
   );
 
-  it.live("omits material projections removed after the program snapshot", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [materialContext(1)])
-      );
+  it.effect(
+    "distinguishes a managed missing route from an unmanaged source",
+    Effect.fn("contentRelease.program.route.test.distinguishesMissingRoute")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(t, data));
 
-      yield* Effect.promise(() =>
-        expect(
+        const result = yield* Effect.promise(() =>
+          t.query((ctx) =>
+            runConvexProgram(readProgramRoute(ctx, "id", "kurikulum/missing"))
+          )
+        );
+        expect(result).toMatchObject({
+          managed: true,
+          programJson: null,
+          routeJson: null,
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "preserves the active release while programs remain source-owned",
+    Effect.fn("contentRelease.program.route.test.preservesActiveRelease")(
+      function* () {
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateMaterialCatalog(target));
+
+        const result = yield* Effect.promise(() =>
+          target.query((ctx) =>
+            runConvexProgram(
+              readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+            )
+          )
+        );
+        expect(result).toMatchObject({
+          activeReleaseId: MATERIAL_IDENTITY.releaseId,
+          managed: false,
+          routeJson: null,
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "rejects a curriculum row whose indexed identity drifted",
+    Effect.fn("contentRelease.program.route.test.rejectsDriftedIdentity")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(t, data));
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(tamperCurriculumRoute(ctx, data.snapshotId))
+          )
+        );
+
+        const failure = yield* Effect.tryPromise({
+          try: () =>
+            t.query((ctx) =>
+              runConvexProgram(
+                readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+              )
+            ),
+          catch: (cause) => new ProgramRouteQueryRejected({ cause }),
+        }).pipe(Effect.flip);
+        expect(failure.cause).toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "omits material projections removed after the program snapshot",
+    Effect.fn("contentRelease.program.route.test.omitsRemovedMaterials")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
+          materialContext(1),
+        ]);
+
+        const result = yield* Effect.promise(() =>
           target.query((ctx) =>
             runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
           )
-        ).resolves.toMatchObject({
+        );
+        expect(result).toMatchObject({
           managed: true,
           materialJson: [],
-        })
-      );
-    })
+        });
+      }
+    )
   );
 
-  it.live("rejects aggregate material fan-out beyond one route budget", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [
+  it.effect(
+    "rejects aggregate material fan-out beyond one route budget",
+    Effect.fn("contentRelease.program.route.test.rejectsMaterialFanOut")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
           materialContext(1),
           materialContext(2),
           materialContext(3),
-        ])
-      );
-      yield* Effect.promise(() =>
-        insertMaterialGroups(target, [
+        ]);
+        yield* insertMaterialGroups(target, [
           { materialIndex: 1, rowCount: 79 },
           { materialIndex: 2, rowCount: 78 },
           { materialIndex: 3, rowCount: 100 },
-        ])
-      );
+        ]);
 
-      yield* Effect.promise(() =>
-        expect(
-          target.query((ctx) =>
-            runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
-          )
-        ).rejects.toMatchObject({
+        const failure = yield* Effect.tryPromise({
+          try: () =>
+            target.query((ctx) =>
+              runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
+            ),
+          catch: (cause) => new ProgramRouteQueryRejected({ cause }),
+        }).pipe(Effect.flip);
+        expect(failure.cause).toMatchObject({
           data: { code: "CONTENT_RELEASE_LIMIT" },
-        })
-      );
-    })
+        });
+      }
+    )
   );
 
-  it.live("orders material groups by their authored route order", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      const earlierGroup = materialGroup(1, 10);
-      const laterGroup = materialGroup(2, 20);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [
+  it.effect(
+    "orders material groups by their authored route order",
+    Effect.fn("contentRelease.program.route.test.ordersAuthoredGroups")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        const earlierGroup = materialGroup(1, 10);
+        const laterGroup = materialGroup(2, 20);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
           earlierGroup,
           laterGroup,
           materialContext(1, laterGroup),
           materialContext(2, earlierGroup),
-        ])
-      );
-      yield* Effect.promise(() =>
-        insertMaterialGroups(target, [
+        ]);
+        yield* insertMaterialGroups(target, [
           { materialIndex: 1, rowCount: 1 },
           { materialIndex: 2, rowCount: 1 },
-        ])
-      );
+        ]);
 
-      const result = yield* Effect.promise(() =>
-        target.query((ctx) =>
-          runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
-        )
-      );
-      const groups = yield* Effect.forEach(
-        result.groupJson,
-        decodeSnapshotRowJson
-      );
+        const result = yield* Effect.promise(() =>
+          target.query((ctx) =>
+            runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
+          )
+        );
+        const groups = yield* Effect.forEach(
+          result.groupJson,
+          decodeSnapshotRowJson
+        );
 
-      expect(groups).toMatchObject([
-        {
-          family: "program",
-          record: {
-            kind: "curriculum",
-            row: { publicPath: earlierGroup.publicPath },
+        expect(groups).toMatchObject([
+          {
+            family: "program",
+            record: {
+              kind: "curriculum",
+              row: { publicPath: earlierGroup.publicPath },
+            },
           },
-        },
-        {
-          family: "program",
-          record: {
-            kind: "curriculum",
-            row: { publicPath: laterGroup.publicPath },
+          {
+            family: "program",
+            record: {
+              kind: "curriculum",
+              row: { publicPath: laterGroup.publicPath },
+            },
           },
-        },
-      ]);
-    })
+        ]);
+      }
+    )
   );
 });


### PR DESCRIPTION
## Summary

- runs all seven effectful program-route cases through direct `@effect/vitest` `it.effect`
- replaces raw async helpers and the direct Effect runner with named `Effect.fn` programs
- models expected test-boundary failures with `Schema.TaggedError`
- keeps `runConvexProgram` only at Convex query and mutation callback boundaries
- preserves the existing route behavior coverage

## Exact head

- base: `20dcafb7412be240307bf3c280d7c76921d6f9b8`
- head: `69b596e5c589cdc7ac9698374d1fa7832c8c3bca`
- tree: `593b46b94241db718238685e7a4f711a599304f7`
- raw target Git diff SHA-256: `1f6a598cfab0c268033deb3f7881f0be13e59ed35f86ede98dd965cbccc3dfa7`
- canonical local/PR patch SHA-256, with the renderer-specific `index` line omitted: `49310d0c5be0f1f885ba13a4fee1c80df86f542b471fe769ac455644d9c519a7`

## Verification

Exact head:

- `pnpm --filter @repo/backend exec vitest run convex/contentRelease/program/route.test.ts --no-file-parallelism` (7 tests, coverage enabled)
- `pnpm --filter @repo/backend typecheck`
- `pnpm exec tsc --version` (`7.0.2+effect-tsgo.0.36.5`)
- `pnpm lint`
- prohibited-pattern and complete-diff scans
- exact-head CI: Quality, Required, Production Scope, and Doctor passed
- exact-head Codex review found no major issues

Behavioral patch before the final schema-only error-contract correction:

- full `@repo/backend` suite (380 files, 1627 tests)
- `pnpm test:scripts` (19 tests)
- `pnpm boundaries` (3050 files)
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (no changed WWW source files)

## Release

Test-only. No Vercel Preview, production deployment, schema change, or runtime change.