### PR TITLE
test(www): run Quran publication with Effect Vitest

### DIFF
--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import {
   encodeTestQuranRow,
@@ -8,7 +9,7 @@ import {
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedQuranCatalog,
   getPublishedQuranView,
@@ -41,131 +42,167 @@ beforeEach(() => {
   runtimeQueryMock.mockReset();
 });
 describe("published Quran content", () => {
-  it("reads the active identity through the one-row attribution query", async () => {
-    runtimeQueryMock.mockResolvedValue({
-      ...source,
-      rowJson: "attribution-row",
-    });
-    await expect(
-      Effect.runPromise(readPublishedQuranIdentity())
-    ).resolves.toMatchObject({ snapshotId: source.snapshotId });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
-  });
-  it("reads and caches the signed catalog through the Effect boundary", async () => {
-    runtimeQueryMock.mockResolvedValue(catalogResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranCatalog())
-    ).resolves.toMatchObject({ surahs: expect.any(Array) });
-    await expect(getPublishedQuranCatalog()).resolves.toMatchObject({
-      surahs: expect.any(Array),
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
-    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
-  });
-  it("reads the locale-specific signed markdown through the Effect boundary", async () => {
-    runtimeQueryMock.mockResolvedValue(markdownResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranMarkdown("id", 1, 80))
-    ).resolves.toMatchObject({
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(1),
-        },
-        number: 1,
-      },
-      verses: [{ number: {} }],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-      verseLimit: 80,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
-  });
-  it("reads the complete signed markdown when no verse limit is requested", async () => {
-    runtimeQueryMock.mockResolvedValue(markdownResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranMarkdown("id", 1))
-    ).resolves.toMatchObject({
-      surah: { number: 1 },
-      verses: [{ number: {} }],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-    });
-  });
-  it("keeps a failed Quran query in the Effect error channel", async () => {
-    runtimeQueryMock.mockRejectedValueOnce(new Error("Quran unavailable"));
-    await expect(
-      Effect.runPromise(Effect.result(readPublishedQuranCatalog()))
-    ).resolves.toMatchObject({
-      _tag: "Failure",
-      failure: {
-        _tag: "TestRuntimeQueryError",
-        message: "Error: Quran unavailable",
-      },
-    });
-  });
-  it("caches the locale-specific Quran web projection", async () => {
-    runtimeQueryMock.mockResolvedValue(viewResult());
-    await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
-      appLocale: "id",
-      nextSurah: {
-        name: {
-          meaning: makeQuranMeaning(2),
-        },
-        number: 2,
-      },
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(1),
-        },
-        number: 1,
-      },
-      verses: [
-        {
-          translation: {
-            notes: [
-              {
-                number: 4,
-                referenceOffset: 20,
-                text: "Catatan terjemahan Indonesia.",
-              },
-            ],
-            segments: [
-              { kind: "text", offset: 0, value: "Terjemahan teknis 1." },
-              { kind: "note", number: 4, offset: 20 },
-            ],
+  it.effect("reads the active identity through the attribution query", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue({
+        ...source,
+        rowJson: "attribution-row",
+      });
+
+      const identity = yield* readPublishedQuranIdentity();
+
+      expect(identity).toMatchObject({ snapshotId: source.snapshotId });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
+    })
+  );
+
+  it.effect("reads and caches the signed catalog", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(catalogResult());
+
+      const catalog = yield* readPublishedQuranCatalog();
+      const cachedCatalog = yield* Effect.tryPromise(() =>
+        getPublishedQuranCatalog()
+      );
+
+      expect(catalog).toMatchObject({ surahs: expect.any(Array) });
+      expect(cachedCatalog).toMatchObject({ surahs: expect.any(Array) });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
+      expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
+    })
+  );
+
+  it.effect("reads the locale-specific signed markdown", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(markdownResult());
+
+      const markdown = yield* readPublishedQuranMarkdown("id", 1, 80);
+
+      expect(markdown).toMatchObject({
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(1),
           },
+          number: 1,
         },
-      ],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-    });
-    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
-  });
-  it("preserves the final surah and its previous neighbor", async () => {
-    runtimeQueryMock.mockResolvedValue(finalViewResult());
-    await expect(getPublishedQuranView("id", 114)).resolves.toMatchObject({
-      nextSurah: null,
-      previousSurah: {
-        name: {
-          meaning: makeQuranMeaning(113),
+        verses: [{ number: {} }],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+        verseLimit: 80,
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it.effect("reads complete signed markdown without a verse limit", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(markdownResult());
+
+      const markdown = yield* readPublishedQuranMarkdown("id", 1);
+
+      expect(markdown).toMatchObject({
+        surah: { number: 1 },
+        verses: [{ number: {} }],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+      });
+    })
+  );
+
+  it.effect("keeps a failed Quran query in the Effect error channel", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockRejectedValueOnce(new Error("Quran unavailable"));
+
+      const result = yield* readPublishedQuranCatalog().pipe(Effect.result);
+
+      expect(result).toMatchObject({
+        _tag: "Failure",
+        failure: {
+          _tag: "TestRuntimeQueryError",
+          message: "Error: Quran unavailable",
         },
-        number: 113,
-      },
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(114),
+      });
+    })
+  );
+
+  it.effect("caches the locale-specific Quran web projection", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(viewResult());
+
+      const view = yield* Effect.tryPromise(() =>
+        getPublishedQuranView("id", 1)
+      );
+
+      expect(view).toMatchObject({
+        appLocale: "id",
+        nextSurah: {
+          name: {
+            meaning: makeQuranMeaning(2),
+          },
+          number: 2,
         },
-        number: 114,
-      },
-    });
-  });
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(1),
+          },
+          number: 1,
+        },
+        verses: [
+          {
+            translation: {
+              notes: [
+                {
+                  number: 4,
+                  referenceOffset: 20,
+                  text: "Catatan terjemahan Indonesia.",
+                },
+              ],
+              segments: [
+                { kind: "text", offset: 0, value: "Terjemahan teknis 1." },
+                { kind: "note", number: 4, offset: 20 },
+              ],
+            },
+          },
+        ],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+      });
+      expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
+      expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it.effect("preserves the final surah and its previous neighbor", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(finalViewResult());
+
+      const view = yield* Effect.tryPromise(() =>
+        getPublishedQuranView("id", 114)
+      );
+
+      expect(view).toMatchObject({
+        nextSurah: null,
+        previousSurah: {
+          name: {
+            meaning: makeQuranMeaning(113),
+          },
+          number: 113,
+        },
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(114),
+          },
+          number: 114,
+        },
+      });
+    })
+  );
 });
 /** Builds the complete signed metadata catalog response. */
 function catalogResult(snapshotId = source.snapshotId) {

--- a/apps/www/lib/content/quran/recovery.test.ts
+++ b/apps/www/lib/content/quran/recovery.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Result } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   QuranSnapshotRecoveryError,
   recoverStalePublishedQuranSnapshot,
@@ -29,80 +30,110 @@ beforeEach(() => {
   updateTagMock.mockReset();
 });
 describe("stale published Quran snapshot recovery", () => {
-  it("rejects an invalid captured snapshot before reading active state", async () => {
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot("not-a-snapshot").pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "invalid-input",
+  it.effect("rejects invalid input before reading active state", () =>
+    Effect.gen(function* () {
+      const result = yield* recoverStalePublishedQuranSnapshot(
+        "not-a-snapshot"
+      ).pipe(Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "QuranSnapshotRecoveryError",
+          reason: "invalid-input",
+        });
+      }
+      expect(readIdentityMock).not.toHaveBeenCalled();
+      expect(refreshMock).not.toHaveBeenCalled();
+      expect(updateTagMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("refreshes without expiring the active snapshot", () =>
+    Effect.gen(function* () {
+      const recovered =
+        yield* recoverStalePublishedQuranSnapshot(activeSnapshotId);
+
+      expect(recovered).toBe(false);
+      expect(refreshMock).toHaveBeenCalledOnce();
+      expect(updateTagMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("immediately expires only the captured stale snapshot tag", () =>
+    Effect.gen(function* () {
+      const recovered =
+        yield* recoverStalePublishedQuranSnapshot(staleSnapshotId);
+
+      expect(recovered).toBe(true);
+      expect(refreshMock).not.toHaveBeenCalled();
+      expect(updateTagMock).toHaveBeenCalledWith(
+        `content-artifact:${staleSnapshotId}`
+      );
+    })
+  );
+
+  it.effect(
+    "maps active identity failures into the recovery error channel",
+    () =>
+      Effect.gen(function* () {
+        const sourceFailure = new Error("identity unavailable");
+        readIdentityMock.mockReturnValueOnce(Effect.fail(sourceFailure));
+
+        const result = yield* recoverStalePublishedQuranSnapshot(
+          staleSnapshotId
+        ).pipe(Effect.result);
+
+        expect(result).toEqual(
+          Result.fail(
+            new QuranSnapshotRecoveryError({
+              cause: sourceFailure,
+              reason: "active-identity",
+            })
+          )
+        );
+      })
+  );
+
+  it.effect("keeps route refresh failures in the typed error channel", () =>
+    Effect.gen(function* () {
+      refreshMock.mockImplementationOnce(() => {
+        throw new Error("refresh unavailable");
       });
-    }
-    expect(readIdentityMock).not.toHaveBeenCalled();
-    expect(refreshMock).not.toHaveBeenCalled();
-    expect(updateTagMock).not.toHaveBeenCalled();
-  });
-  it("refreshes without expiring the currently active snapshot", async () => {
-    await expect(
-      Effect.runPromise(recoverStalePublishedQuranSnapshot(activeSnapshotId))
-    ).resolves.toBe(false);
-    expect(refreshMock).toHaveBeenCalledOnce();
-    expect(updateTagMock).not.toHaveBeenCalled();
-  });
-  it("immediately expires only the captured stale snapshot tag", async () => {
-    await expect(
-      Effect.runPromise(recoverStalePublishedQuranSnapshot(staleSnapshotId))
-    ).resolves.toBe(true);
-    expect(refreshMock).not.toHaveBeenCalled();
-    expect(updateTagMock).toHaveBeenCalledWith(
-      `content-artifact:${staleSnapshotId}`
-    );
-  });
-  it("maps active identity failures into the recovery error channel", async () => {
-    const sourceFailure = new Error("identity unavailable");
-    readIdentityMock.mockReturnValueOnce(Effect.fail(sourceFailure));
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.result)
-    );
-    expect(result).toEqual(
-      Result.fail(
-        new QuranSnapshotRecoveryError({
-          cause: sourceFailure,
-          reason: "active-identity",
-        })
-      )
-    );
-  });
-  it("keeps route refresh failures in the typed error channel", async () => {
-    refreshMock.mockImplementationOnce(() => {
-      throw new Error("refresh unavailable");
-    });
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(activeSnapshotId).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "route-refresh",
-      });
-    }
-  });
-  it("keeps cache invalidation failures in the typed error channel", async () => {
-    updateTagMock.mockImplementationOnce(() => {
-      throw new Error("cache unavailable");
-    });
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "cache-invalidation",
-      });
-    }
-  });
+
+      const result = yield* recoverStalePublishedQuranSnapshot(
+        activeSnapshotId
+      ).pipe(Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "QuranSnapshotRecoveryError",
+          reason: "route-refresh",
+        });
+      }
+    })
+  );
+
+  it.effect(
+    "keeps cache invalidation failures in the typed error channel",
+    () =>
+      Effect.gen(function* () {
+        updateTagMock.mockImplementationOnce(() => {
+          throw new Error("cache unavailable");
+        });
+
+        const result = yield* recoverStalePublishedQuranSnapshot(
+          staleSnapshotId
+        ).pipe(Effect.result);
+
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure).toMatchObject({
+            _tag: "QuranSnapshotRecoveryError",
+            reason: "cache-invalidation",
+          });
+        }
+      })
+  );
 });


### PR DESCRIPTION
## Summary

- migrate the Quran publication and recovery tests from raw async Effect runners to direct RC110 `@effect/vitest` `it.effect`
- compose production Effects directly and use `Effect.tryPromise` only at the existing cached Next.js Promise boundary
- preserve raw `vi` imports for hoisted framework mocks, matching the pinned Effect repository test convention

## Effect v4 evidence

- `repos/effect/packages/vitest/src/index.ts` defines the direct `it.effect` surface
- pinned Effect tests keep `vi` from Vitest for hoisted mocks
- no `@repo/testing/effect`, direct Effect runtime runner, or raw async test callback remains in either file

## Scope

Two WWW test files only. No production code, dependency, lockfile, content, Convex, or deployment contract changes.

## Verification

- focused: 2 files, 13 tests, 100% coverage
- WWW: 209 files, 1,518 tests, 100% coverage
- repository: 15 test tasks green, including backend 380 files and 1,627 tests
- WWW TypeScript 7 typecheck green with schema-valid non-secret local environment placeholders
- lint, Effect source parity, script tests 19/19, boundaries, and Doctor 100 green

## Release

Ready for protected merge queue after exact-head checks and review. Production acceptance should classify this as test-only. No Vercel Preview was created.