### PR TITLE
refactor(www): keep school data Effect native

### DIFF
--- a/apps/www/app/[locale]/(app)/school/(authenticated)/[slug]/(main)/classes/[id]/layout.tsx
+++ b/apps/www/app/[locale]/(app)/school/(authenticated)/[slug]/(main)/classes/[id]/layout.tsx
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
@@ -6,6 +7,7 @@ import { SchoolClassesHeaderInfo } from "@/components/school/classes/info";
 import { SchoolClassesJoinForm } from "@/components/school/classes/join-form";
 import { SchoolClassesTabs } from "@/components/school/classes/tabs";
 import { SchoolClassesWorkspaceShell } from "@/components/school/classes/workspace-shell";
+import { getToken } from "@/lib/auth/server";
 import { ClassContextProvider } from "@/lib/context/use-class";
 import { preloadClassRoute } from "@/lib/school/server";
 
@@ -59,7 +61,8 @@ async function ClassRouteBoundary({
   classId: string;
   panel: ReactNode;
 }) {
-  const route = await preloadClassRoute({ classId });
+  const token = await getToken();
+  const route = await Effect.runPromise(preloadClassRoute({ classId, token }));
 
   if (!route) {
     notFound();

--- a/apps/www/components/school/sidebar/index.tsx
+++ b/apps/www/components/school/sidebar/index.tsx
@@ -6,11 +6,13 @@ import {
 import { SidebarMenu } from "@repo/design-system/components/ui/sidebar-menu";
 import { Sidebar } from "@repo/design-system/components/ui/sidebar-shell";
 import { cn } from "@repo/design-system/lib/utils";
+import { Effect } from "effect";
 import { type ComponentProps, Suspense } from "react";
 import { SchoolSidebarNavLearning } from "@/components/school/sidebar/nav-learning";
 import { SchoolSidebarNavUser } from "@/components/school/sidebar/nav-user";
 import { SchoolSidebarNavYours } from "@/components/school/sidebar/nav-yours";
 import { SchoolSwitcher } from "@/components/school/sidebar/school-switcher";
+import { getToken } from "@/lib/auth/server";
 import { getSchoolSwitcherPage } from "@/lib/school/server";
 
 /** Render the School sidebar shell while the switcher data streams independently. */
@@ -37,7 +39,10 @@ export function SchoolSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 
 /** Load the first school switcher page without blocking the surrounding sidebar. */
 async function SchoolSwitcherSlot() {
-  const initialSchoolPage = await getSchoolSwitcherPage();
+  const token = await getToken();
+  const initialSchoolPage = await Effect.runPromise(
+    getSchoolSwitcherPage(token)
+  );
 
   return <SchoolSwitcher initialSchoolPage={initialSchoolPage} />;
 }

--- a/apps/www/lib/school/server.ts
+++ b/apps/www/lib/school/server.ts
@@ -7,6 +7,7 @@ import { cache } from "react";
 import { fetchAuthQuery, getToken, preloadAuthQuery } from "@/lib/auth/server";
 
 const SCHOOL_SWITCHER_PAGE_SIZE = 20;
+type SchoolAuthToken = Awaited<ReturnType<typeof getToken>>;
 
 const emptySchoolSwitcherPage = {
   continueCursor: "",
@@ -82,15 +83,19 @@ export const getSchoolRouteSnapshot = cache(
  * Returns `null` when the class cannot be resolved for the current viewer so
  * the route can delegate to Next's native not-found handling.
  */
-export async function preloadClassRoute({ classId }: { classId: string }) {
-  const token = await getToken();
+export const preloadClassRoute = Effect.fn("www.school.preloadClassRoute")(
+  function* ({
+    classId,
+    token,
+  }: {
+    readonly classId: string;
+    readonly token: SchoolAuthToken;
+  }) {
+    if (!token) {
+      return null;
+    }
 
-  if (!token) {
-    return null;
-  }
-
-  return Effect.runPromise(
-    Effect.tryPromise(() =>
+    return yield* Effect.tryPromise(() =>
       preloadAuthQuery(api.classes.queries.getClassRoute, { classId })
     ).pipe(
       Effect.map((preloaded) => ({
@@ -109,30 +114,28 @@ export async function preloadClassRoute({ classId }: { classId: string }) {
       Effect.catch((error) =>
         captureSchoolRouteError(error, "school-class-route-boundary")
       )
-    )
-  );
-}
+    );
+  }
+);
 
 /** Load the first school-switcher page for the authenticated school shell. */
-export async function getSchoolSwitcherPage() {
-  const token = await getToken();
-
+export const getSchoolSwitcherPage = Effect.fn(
+  "www.school.getSchoolSwitcherPage"
+)(function* (token: SchoolAuthToken) {
   if (!token) {
     return emptySchoolSwitcherPage;
   }
 
-  return Effect.runPromise(
-    Effect.tryPromise(() =>
-      fetchAuthQuery(api.schools.queries.getMySchoolsPage, {
-        paginationOpts: {
-          cursor: null,
-          numItems: SCHOOL_SWITCHER_PAGE_SIZE,
-        },
-      })
-    ).pipe(
-      Effect.catch((error) =>
-        captureSchoolRouteError(error, "school-switcher-page")
-      )
+  return yield* Effect.tryPromise(() =>
+    fetchAuthQuery(api.schools.queries.getMySchoolsPage, {
+      paginationOpts: {
+        cursor: null,
+        numItems: SCHOOL_SWITCHER_PAGE_SIZE,
+      },
+    })
+  ).pipe(
+    Effect.catch((error) =>
+      captureSchoolRouteError(error, "school-switcher-page")
     )
   );
-}
+});


### PR DESCRIPTION
## Why

Two reusable school data helpers executed Effects internally, hiding the runtime boundary from their only Server Component callers.

## Architecture

- `preloadClassRoute` and `getSchoolSwitcherPage` are named `Effect.fn` programs.
- Each Server Component first awaits the cached Better Auth token, establishing Next.js request time before any non-fast-path Effect runtime starts.
- The resolved schema-derived token is passed into the Effect program, and Convex Promise work is composed with `Effect.tryPromise`.
- The class layout and streamed sidebar slot own `Effect.runPromise` at the actual Next.js render boundaries.
- Existing typed Convex failure handling and analytics capture remain unchanged.

## Effect v4 evidence

The change follows pinned RC110 `Effect.fn` and `tryPromise` semantics plus the repository prerender rule backed by installed Next 16.3.2 documentation. No adapter, compatibility facade, raw helper runner, or dependency change is introduced.

## Scope

Exactly three package-owned files change. Fresh GitHub and local ref scans found no overlapping open PR, committed branch patch, or dirty worktree.

## Verification

- WWW TypeScript 7 typecheck
- root test suite: 15 tasks green
- WWW: 209 files, 1518 tests, 100% statements, branches, functions, and lines
- lint and format
- Effect source parity at `effect@4.0.0-rc.110` and source `66114151`
- workspace boundaries
- React Doctor full scope: 100/100
- independent prerender-boundary review, with the initial clock-order finding corrected before release
- diff and direct-runner scans

## Release

Ready for exact-head CI and protected merge-queue validation. Production deployment remains main-only. No Vercel Preview was created.