### PR TITLE
refactor(backend): keep MCP rate-limit runner at route boundary

### DIFF
--- a/packages/backend/convex/routes/agent/mcp/route.ts
+++ b/packages/backend/convex/routes/agent/mcp/route.ts
@@ -29,7 +29,20 @@ export function registerAgentMcpRoutes(app: AgentApp) {
     if (request.method === "OPTIONS") {
       return mcpOptionsResponse(request);
     }
-    const limited = await readRateLimit(context.env, request);
+    const limited = await Effect.runPromise(
+      enforceAgentReadLimit(context.env, request).pipe(
+        Effect.match({
+          onFailure: (error) =>
+            error._tag === "AgentRateLimitError"
+              ? {
+                  kind: "limited" as const,
+                  retryAfterMs: error.retryAfterMs,
+                }
+              : { kind: "unavailable" as const },
+          onSuccess: () => ({ kind: "allowed" as const }),
+        })
+      )
+    );
     if (limited.kind === "unavailable") {
       return withMcpResponseHeaders(mcpTransportErrorResponse(503), request);
     }
@@ -116,20 +129,3 @@ const loadMcpRuntime = Effect.fn("agent.mcp.loadRuntime")(() =>
       ]).then(([sdk, server]) => ({ sdk, server })),
   })
 );
-
-function readRateLimit(ctx: ActionCtx, request: Request) {
-  return Effect.runPromise(
-    enforceAgentReadLimit(ctx, request).pipe(
-      Effect.match({
-        onFailure: (error) =>
-          error._tag === "AgentRateLimitError"
-            ? {
-                kind: "limited" as const,
-                retryAfterMs: error.retryAfterMs,
-              }
-            : { kind: "unavailable" as const },
-        onSuccess: () => ({ kind: "allowed" as const }),
-      })
-    )
-  );
-}


### PR DESCRIPTION
## Description

- Run the existing MCP rate-limit Effect directly in the registered Hono callback.
- Remove the private `readRateLimit` Promise runner helper while preserving the existing allowed, limited, and unavailable response mapping.
- This follows the repository Effect v4 boundary rule and the same direct route-runner shape established by #489.

## Type

- Refactoring

## Testing

- Focused route coverage: `pnpm --filter @repo/backend exec vitest run convex/routes/agent/mcp/route.test.ts --coverage` (10 tests)
- Backend TypeScript 7: `pnpm --filter @repo/backend typecheck`
- Full backend serialized coverage: `pnpm --filter @repo/backend exec vitest run --no-file-parallelism` (380 files, 1,627 tests)
- Formatting: `pnpm format`
- Lint, Effect RC110 source parity, patch policy, and test ownership: `pnpm lint`
- Script TypeScript and policy tests: `pnpm test:scripts` (19 tests)
- Package boundaries: `pnpm boundaries` (3,051 files)
- Doctor: `pnpm run doctor --verbose --scope changed --base origin/main --include-untracked` (no changed `apps/www` source)
- Dependency audit not applicable: no dependency or lockfile changes
- Convex deployment not applicable: no schema, registered function, validator, or external contract change
- No Vercel Preview was created

## Related Issues

None.

## Additional Context

Base: `45a9b68dd586f67fd62b355c60841475a27d957a`

Head: `f84b7de8e5ac9c71347012a062ff50649a159285`

Patch SHA-256: `42fdeee8a639aa7e9d64a73b2753d8a7d24783a9fa3b1787cf089d9f6fa09122`

The existing route test already covers allowed traffic, throttling with `Retry-After`, and limiter-unavailable 503 behavior, so the separately owned test file remains untouched.