### PR TITLE
test: consolidate Effect Vitest migration

### DIFF
--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -2,10 +2,6 @@
 
 import "next/dist/server/node-environment-baseline";
 
-import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
-import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
-import { createRequestStore } from "next/dist/server/async-storage/request-store";
-import { createWorkStore } from "next/dist/server/async-storage/work-store";
 import {
   afterAll,
   afterEach,
@@ -14,14 +10,22 @@ import {
   expect,
   it,
   vi,
-} from "vitest";
+} from "@effect/vitest";
+import { Effect } from "effect";
+import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";
+import { workUnitAsyncStorage } from "next/dist/server/app-render/work-unit-async-storage.external";
+import { createRequestStore } from "next/dist/server/async-storage/request-store";
+import { createWorkStore } from "next/dist/server/async-storage/work-store";
 
 const CONVEX_SITE_URL = "https://test.convex.site";
 
-let handler: typeof import("./server")["handler"];
-let getToken: typeof import("./server")["getToken"];
+const loadAuthServer = Effect.fn("auth.server.test.load")(() =>
+  Effect.tryPromise(() => import("./server"))
+);
 
-const runWithRequestHeaders = (headers: Headers) => {
+const runWithRequestHeaders = Effect.fn(
+  "auth.server.test.runWithRequestHeaders"
+)((headers: Headers, getToken: typeof import("./server")["getToken"]) => {
   const requestStore = createRequestStore({
     fallbackParams: null,
     headers,
@@ -64,19 +68,19 @@ const runWithRequestHeaders = (headers: Headers) => {
     },
   });
 
-  return workAsyncStorage.run(workStore, () =>
-    workUnitAsyncStorage.run(requestStore, getToken)
+  return Effect.tryPromise(() =>
+    workAsyncStorage.run(workStore, () =>
+      workUnitAsyncStorage.run(requestStore, getToken)
+    )
   );
-};
+});
 
-beforeAll(async () => {
+beforeAll(() => {
   vi.stubEnv("INTERNAL_CONTENT_API_KEY", "test-content-key");
   vi.stubEnv("NEXT_PUBLIC_CONVEX_URL", "https://test.convex.cloud");
   vi.stubEnv("NEXT_PUBLIC_CONVEX_SITE_URL", CONVEX_SITE_URL);
   vi.stubEnv("NEXT_PUBLIC_MCP_URL", "https://test.example.com/mcp");
   vi.stubEnv("SITE_URL", "https://nakafa.com");
-
-  ({ getToken, handler } = await import("./server"));
 });
 
 afterEach(() => {
@@ -88,51 +92,59 @@ afterAll(() => {
 });
 
 describe("Better Auth server boundary", () => {
-  it("forwards auth routes through the installed adapter", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(null, { status: 200 }));
-    const request = new Request("https://nakafa.com/api/auth/sign-in/social", {
-      body: "{}",
-      headers: { "x-forwarded-host": "proxy.internal.example.com" },
-      method: "POST",
-    });
+  it.effect("forwards auth routes through the installed adapter", () =>
+    Effect.gen(function* () {
+      const { handler } = yield* loadAuthServer();
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(null, { status: 200 }));
+      const request = new Request(
+        "https://nakafa.com/api/auth/sign-in/social",
+        {
+          body: "{}",
+          headers: { "x-forwarded-host": "proxy.internal.example.com" },
+          method: "POST",
+        }
+      );
 
-    const response = await handler.POST(request);
-    const [, init] = fetchSpy.mock.calls[0] ?? [];
-    const headers = new Headers(init?.headers);
+      const response = yield* Effect.tryPromise(() => handler.POST(request));
+      const [, init] = fetchSpy.mock.calls[0] ?? [];
+      const headers = new Headers(init?.headers);
 
-    expect(response.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
-      `${CONVEX_SITE_URL}/api/auth/sign-in/social`
-    );
-    expect(headers.get("host")).toBe("test.convex.site");
-    expect(headers.get("x-forwarded-proto")).toBe("https");
-  });
+      expect(response.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${CONVEX_SITE_URL}/api/auth/sign-in/social`
+      );
+      expect(headers.get("host")).toBe("test.convex.site");
+      expect(headers.get("x-forwarded-proto")).toBe("https");
+    })
+  );
 
-  it("gets the SSR token through the installed adapter", async () => {
-    const cookie = "better-auth.session_token=session-cookie";
-    const requestHeaders = new Headers({
-      cookie,
-      host: "render.internal.example.com",
-      "x-forwarded-host": "nakafa.com",
-      "x-forwarded-proto": "https",
-    });
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(Response.json({ token: "test-token" }));
+  it.effect("gets the SSR token through the installed adapter", () =>
+    Effect.gen(function* () {
+      const { getToken } = yield* loadAuthServer();
+      const cookie = "better-auth.session_token=session-cookie";
+      const requestHeaders = new Headers({
+        cookie,
+        host: "render.internal.example.com",
+        "x-forwarded-host": "nakafa.com",
+        "x-forwarded-proto": "https",
+      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ token: "test-token" }));
 
-    await expect(runWithRequestHeaders(requestHeaders)).resolves.toBe(
-      "test-token"
-    );
-    const [, init] = fetchSpy.mock.calls[0] ?? [];
-    const headers = new Headers(init?.headers);
+      const token = yield* runWithRequestHeaders(requestHeaders, getToken);
+      expect(token).toBe("test-token");
+      const [, init] = fetchSpy.mock.calls[0] ?? [];
+      const headers = new Headers(init?.headers);
 
-    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
-      `${CONVEX_SITE_URL}/api/auth/convex/token`
-    );
-    expect(headers.get("host")).toBe("test.convex.site");
-    expect(headers.get("cookie")).toBe(cookie);
-  });
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        `${CONVEX_SITE_URL}/api/auth/convex/token`
+      );
+      expect(headers.get("host")).toBe("test.convex.site");
+      expect(headers.get("cookie")).toBe(cookie);
+    })
+  );
 });

--- a/apps/www/lib/content/material/discovery.test.ts
+++ b/apps/www/lib/content/material/discovery.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
-import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Data, Effect } from "effect";
+import { vi } from "vitest";
 import {
   readPublishedLatestMaterials,
   readPublishedMaterialBucket,
@@ -14,6 +15,12 @@ const publicPath =
 const sourcePath =
   "packages/corpus/material/lesson/mathematics/function-composition-inverse-function/function-concept/en.mdx";
 const activeReleaseId = ReleaseIdSchema.make("release-material");
+
+class TestMaterialRuntimeUnavailable extends Data.TaggedError(
+  "TestMaterialRuntimeUnavailable"
+)<{
+  readonly operation: "query";
+}> {}
 
 vi.mock("@/lib/content/runtime/query", async () => {
   const { createTestRuntimeQuery } = await import("@/test/runtime-query");
@@ -38,136 +45,144 @@ describe("published material discovery", () => {
     runtimeQueryMock.mockReset();
   });
 
-  it("rejects unmanaged buckets and reads complete signed buckets", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: false,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId: null,
-        managed: true,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: null,
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [summary],
-      });
+  it.effect("rejects unmanaged buckets and reads complete signed buckets", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: false,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId: null,
+          managed: true,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: null,
+        })
+        .mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: [summary],
+        });
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "abc").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "def").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(readPublishedMaterialBucket("en", "ghi"))
-    ).resolves.toEqual({ activeReleaseId, materials: null });
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "jkl", activeReleaseId)
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      materials: [
-        {
-          publicPath,
-          sourcePath,
-        },
-      ],
-    });
-  });
-
-  it.each(["en", "id", "de"] as const)(
-    "decodes newest %s materials from the expected release",
-    async (appLocale) => {
-      const {
-        dateModified: _dateModified,
-        description: _description,
-        ...publishedOnly
-      } = summary;
-      runtimeQueryMock.mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [publishedOnly],
-      });
-
-      const result = await Effect.runPromise(
-        readPublishedLatestMaterials(appLocale, 10, activeReleaseId)
+      const unmanaged = yield* readPublishedMaterialBucket("en", "abc").pipe(
+        Effect.flip
       );
-      expect(result).toMatchObject({
+      const inactive = yield* readPublishedMaterialBucket("en", "def").pipe(
+        Effect.flip
+      );
+      const absent = yield* readPublishedMaterialBucket("en", "ghi");
+      const published = yield* readPublishedMaterialBucket(
+        "en",
+        "jkl",
+        activeReleaseId
+      );
+
+      expect(unmanaged).toMatchObject({ _tag: "PublishedProjectionError" });
+      expect(inactive).toMatchObject({ _tag: "PublishedProjectionError" });
+      expect(absent).toEqual({ activeReleaseId, materials: null });
+      expect(published).toMatchObject({
         activeReleaseId,
-        materials: [{ datePublished: summary.datePublished, sourcePath }],
+        materials: [
+          {
+            publicPath,
+            sourcePath,
+          },
+        ],
       });
-      expect(result.materials[0]).not.toHaveProperty("description");
-      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-        appLocale,
-        limit: 10,
-      });
-    }
+    })
   );
 
-  it("rejects malformed summaries, unmanaged results, and runtime failures", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: true,
-        materials: [{ ...summary, sourcePath: "" }],
-      })
-      .mockResolvedValueOnce({
-        activeReleaseId,
-        managed: false,
-        materials: [],
-      })
-      .mockRejectedValueOnce(new Error("runtime unavailable"));
+  it.effect.each(["en", "id", "de"] as const)(
+    "decodes newest %s materials from the expected release",
+    (appLocale) =>
+      Effect.gen(function* () {
+        const {
+          dateModified: _dateModified,
+          description: _description,
+          ...publishedOnly
+        } = summary;
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId,
+          managed: true,
+          materials: [publishedOnly],
+        });
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialBucket("en", "abc").pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedLatestMaterials("en", 10).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-    await expect(
-      Effect.runPromise(
-        readPublishedLatestMaterials("en", 10).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({ _tag: "TestRuntimeQueryError" });
-  });
+        const result = yield* readPublishedLatestMaterials(
+          appLocale,
+          10,
+          activeReleaseId
+        );
+        expect(result).toMatchObject({
+          activeReleaseId,
+          materials: [{ datePublished: summary.datePublished, sourcePath }],
+        });
+        expect(result.materials[0]).not.toHaveProperty("description");
+        expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+          appLocale,
+          limit: 10,
+        });
+      })
+  );
 
-  it.each(["en", "id", "de"] as const)(
+  it.effect(
+    "rejects malformed summaries, unmanaged results, and runtime failures",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock
+          .mockResolvedValueOnce({
+            activeReleaseId,
+            managed: true,
+            materials: [{ ...summary, sourcePath: "" }],
+          })
+          .mockResolvedValueOnce({
+            activeReleaseId,
+            managed: false,
+            materials: [],
+          })
+          .mockRejectedValueOnce(
+            new TestMaterialRuntimeUnavailable({ operation: "query" })
+          );
+
+        const malformed = yield* readPublishedMaterialBucket("en", "abc").pipe(
+          Effect.flip
+        );
+        const unmanaged = yield* readPublishedLatestMaterials("en", 10).pipe(
+          Effect.flip
+        );
+        const unavailable = yield* readPublishedLatestMaterials("en", 10).pipe(
+          Effect.flip
+        );
+
+        expect(malformed).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(unmanaged).toMatchObject({ _tag: "PublishedProjectionError" });
+        expect(unavailable).toMatchObject({ _tag: "TestRuntimeQueryError" });
+      })
+  );
+
+  it.effect.each(["en", "id", "de"] as const)(
     "rejects a %s material bucket from a different active release",
-    async (appLocale) => {
-      runtimeQueryMock.mockResolvedValueOnce({
-        activeReleaseId: ReleaseIdSchema.make("release-next"),
-        managed: true,
-        materials: [summary],
-      });
+    (appLocale) =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce({
+          activeReleaseId: ReleaseIdSchema.make("release-next"),
+          managed: true,
+          materials: [summary],
+        });
 
-      await expect(
-        Effect.runPromise(
-          readPublishedMaterialBucket(appLocale, "abc", activeReleaseId).pipe(
-            Effect.flip
-          )
-        )
-      ).resolves.toMatchObject({
-        _tag: "PublishedReleaseMismatchError",
-        expectedReleaseId: activeReleaseId,
-      });
-    }
+        const mismatch = yield* readPublishedMaterialBucket(
+          appLocale,
+          "abc",
+          activeReleaseId
+        ).pipe(Effect.flip);
+        expect(mismatch).toMatchObject({
+          _tag: "PublishedReleaseMismatchError",
+          expectedReleaseId: activeReleaseId,
+        });
+      })
   );
 });

--- a/apps/www/lib/content/material/route.test.ts
+++ b/apps/www/lib/content/material/route.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedMaterialRoute,
   readPublishedMaterialRoute,
@@ -91,82 +92,95 @@ beforeEach(() => {
 });
 
 describe("published material route", () => {
-  it("decodes one complete signed route, locale set, and sibling group", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
+  it.effect(
+    "decodes one complete signed route, locale set, and sibling group",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      getPublishedMaterialRoute("en", previewProjection.publicPath)
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      alternates: [previewProjection, previewIdProjection, previewDeProjection],
-      projection: previewProjection,
-      rendererDomain: "mathematics",
-      siblings: [previewProjection, previewNextProjection],
-      sourceRevision,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledOnce();
-    expect(cacheMock).toHaveBeenCalledOnce();
-  });
+        const route = yield* Effect.tryPromise(() =>
+          getPublishedMaterialRoute("en", previewProjection.publicPath)
+        );
+        expect(route).toMatchObject({
+          activeReleaseId,
+          alternates: [
+            previewProjection,
+            previewIdProjection,
+            previewDeProjection,
+          ],
+          projection: previewProjection,
+          rendererDomain: "mathematics",
+          siblings: [previewProjection, previewNextProjection],
+          sourceRevision,
+        });
+        expect(runtimeQueryMock).toHaveBeenCalledOnce();
+        expect(cacheMock).toHaveBeenCalledOnce();
+      })
+  );
 
-  it("pins a route read to the expected active release", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
+  it.effect("pins a route read to the expected active release", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
 
-    await expect(
-      getPublishedMaterialRoute(
-        "en",
-        previewProjection.publicPath,
-        activeReleaseId
-      )
-    ).resolves.toMatchObject({ activeReleaseId });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
-    );
-  });
-
-  it("preserves an active release mismatch for pinned callers", async () => {
-    const expectedReleaseId = ReleaseIdSchema.make("release-previous");
-    runtimeQueryMock.mockResolvedValueOnce(foundModel());
-
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute(
+      const route = yield* Effect.tryPromise(() =>
+        getPublishedMaterialRoute(
           "en",
           previewProjection.publicPath,
-          expectedReleaseId
-        ).pipe(Effect.flip)
-      )
-    ).resolves.toMatchObject({
-      _tag: "PublishedReleaseMismatchError",
-      actualReleaseId: activeReleaseId,
-      expectedReleaseId,
-    });
-  });
+          activeReleaseId
+        )
+      );
+      expect(route).toMatchObject({ activeReleaseId });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ expectedActiveReleaseId: activeReleaseId })
+      );
+    })
+  );
 
-  it("preserves a signed missing-route tombstone", async () => {
-    runtimeQueryMock.mockResolvedValueOnce(
-      foundModel({
-        alternateJson: [],
-        projectionJson: null,
-        rendererDomain: null,
-        siblingJson: [],
+  it.effect("preserves an active release mismatch for pinned callers", () =>
+    Effect.gen(function* () {
+      const expectedReleaseId = ReleaseIdSchema.make("release-previous");
+      runtimeQueryMock.mockResolvedValueOnce(foundModel());
+
+      const mismatch = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath,
+        expectedReleaseId
+      ).pipe(Effect.flip);
+      expect(mismatch).toMatchObject({
+        _tag: "PublishedReleaseMismatchError",
+        actualReleaseId: activeReleaseId,
+        expectedReleaseId,
+      });
+    })
+  );
+
+  it.effect("preserves a signed missing-route tombstone", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(
+        foundModel({
+          alternateJson: [],
+          projectionJson: null,
+          rendererDomain: null,
+          siblingJson: [],
+          sourcePath: null,
+        })
+      );
+
+      const route = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath
+      );
+      expect(route).toMatchObject({
+        activeReleaseId,
+        alternates: [],
+        projection: null,
         sourcePath: null,
-      })
-    );
+      });
+    })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute("en", previewProjection.publicPath)
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId,
-      alternates: [],
-      projection: null,
-      sourcePath: null,
-    });
-  });
-
-  it.each([
+  it.effect.each([
     ["active manifest", foundModel({ activeManifestHash: "invalid" })],
     ["missing manifest", foundModel({ activeManifestHash: null })],
     ["active locales", foundModel({ activeAppLocales: ["id", "en", "de"] })],
@@ -219,15 +233,15 @@ describe("published material route", () => {
     ["projection JSON", foundModel({ projectionJson: "{}" })],
     ["alternate JSON", foundModel({ alternateJson: ["{}"] })],
     ["sibling JSON", foundModel({ siblingJson: ["{}"] })],
-  ])("rejects an invalid %s", async (_label, result) => {
-    runtimeQueryMock.mockResolvedValueOnce(result);
+  ])("rejects an invalid %s", ([, result]) =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValueOnce(result);
 
-    await expect(
-      Effect.runPromise(
-        readPublishedMaterialRoute("en", previewProjection.publicPath).pipe(
-          Effect.flip
-        )
-      )
-    ).resolves.toMatchObject({ _tag: "PublishedProjectionError" });
-  });
+      const failure = yield* readPublishedMaterialRoute(
+        "en",
+        previewProjection.publicPath
+      ).pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PublishedProjectionError" });
+    })
+  );
 });

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import {
   encodeTestQuranRow,
@@ -8,7 +9,7 @@ import {
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   getPublishedQuranCatalog,
   getPublishedQuranView,
@@ -41,131 +42,167 @@ beforeEach(() => {
   runtimeQueryMock.mockReset();
 });
 describe("published Quran content", () => {
-  it("reads the active identity through the one-row attribution query", async () => {
-    runtimeQueryMock.mockResolvedValue({
-      ...source,
-      rowJson: "attribution-row",
-    });
-    await expect(
-      Effect.runPromise(readPublishedQuranIdentity())
-    ).resolves.toMatchObject({ snapshotId: source.snapshotId });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
-  });
-  it("reads and caches the signed catalog through the Effect boundary", async () => {
-    runtimeQueryMock.mockResolvedValue(catalogResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranCatalog())
-    ).resolves.toMatchObject({ surahs: expect.any(Array) });
-    await expect(getPublishedQuranCatalog()).resolves.toMatchObject({
-      surahs: expect.any(Array),
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
-    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
-  });
-  it("reads the locale-specific signed markdown through the Effect boundary", async () => {
-    runtimeQueryMock.mockResolvedValue(markdownResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranMarkdown("id", 1, 80))
-    ).resolves.toMatchObject({
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(1),
-        },
-        number: 1,
-      },
-      verses: [{ number: {} }],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-      verseLimit: 80,
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
-  });
-  it("reads the complete signed markdown when no verse limit is requested", async () => {
-    runtimeQueryMock.mockResolvedValue(markdownResult());
-    await expect(
-      Effect.runPromise(readPublishedQuranMarkdown("id", 1))
-    ).resolves.toMatchObject({
-      surah: { number: 1 },
-      verses: [{ number: {} }],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-    });
-  });
-  it("keeps a failed Quran query in the Effect error channel", async () => {
-    runtimeQueryMock.mockRejectedValueOnce(new Error("Quran unavailable"));
-    await expect(
-      Effect.runPromise(Effect.result(readPublishedQuranCatalog()))
-    ).resolves.toMatchObject({
-      _tag: "Failure",
-      failure: {
-        _tag: "TestRuntimeQueryError",
-        message: "Error: Quran unavailable",
-      },
-    });
-  });
-  it("caches the locale-specific Quran web projection", async () => {
-    runtimeQueryMock.mockResolvedValue(viewResult());
-    await expect(getPublishedQuranView("id", 1)).resolves.toMatchObject({
-      appLocale: "id",
-      nextSurah: {
-        name: {
-          meaning: makeQuranMeaning(2),
-        },
-        number: 2,
-      },
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(1),
-        },
-        number: 1,
-      },
-      verses: [
-        {
-          translation: {
-            notes: [
-              {
-                number: 4,
-                referenceOffset: 20,
-                text: "Catatan terjemahan Indonesia.",
-              },
-            ],
-            segments: [
-              { kind: "text", offset: 0, value: "Terjemahan teknis 1." },
-              { kind: "note", number: 4, offset: 20 },
-            ],
+  it.effect("reads the active identity through the attribution query", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue({
+        ...source,
+        rowJson: "attribution-row",
+      });
+
+      const identity = yield* readPublishedQuranIdentity();
+
+      expect(identity).toMatchObject({ snapshotId: source.snapshotId });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
+    })
+  );
+
+  it.effect("reads and caches the signed catalog", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(catalogResult());
+
+      const catalog = yield* readPublishedQuranCatalog();
+      const cachedCatalog = yield* Effect.tryPromise(() =>
+        getPublishedQuranCatalog()
+      );
+
+      expect(catalog).toMatchObject({ surahs: expect.any(Array) });
+      expect(cachedCatalog).toMatchObject({ surahs: expect.any(Array) });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {});
+      expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
+    })
+  );
+
+  it.effect("reads the locale-specific signed markdown", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(markdownResult());
+
+      const markdown = yield* readPublishedQuranMarkdown("id", 1, 80);
+
+      expect(markdown).toMatchObject({
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(1),
           },
+          number: 1,
         },
-      ],
-    });
-    expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
-      appLocale: "id",
-      surahNumber: 1,
-    });
-    expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
-    expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
-  });
-  it("preserves the final surah and its previous neighbor", async () => {
-    runtimeQueryMock.mockResolvedValue(finalViewResult());
-    await expect(getPublishedQuranView("id", 114)).resolves.toMatchObject({
-      nextSurah: null,
-      previousSurah: {
-        name: {
-          meaning: makeQuranMeaning(113),
+        verses: [{ number: {} }],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+        verseLimit: 80,
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it.effect("reads complete signed markdown without a verse limit", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(markdownResult());
+
+      const markdown = yield* readPublishedQuranMarkdown("id", 1);
+
+      expect(markdown).toMatchObject({
+        surah: { number: 1 },
+        verses: [{ number: {} }],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+      });
+    })
+  );
+
+  it.effect("keeps a failed Quran query in the Effect error channel", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockRejectedValueOnce(new Error("Quran unavailable"));
+
+      const result = yield* readPublishedQuranCatalog().pipe(Effect.result);
+
+      expect(result).toMatchObject({
+        _tag: "Failure",
+        failure: {
+          _tag: "TestRuntimeQueryError",
+          message: "Error: Quran unavailable",
         },
-        number: 113,
-      },
-      surah: {
-        name: {
-          meaning: makeQuranMeaning(114),
+      });
+    })
+  );
+
+  it.effect("caches the locale-specific Quran web projection", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(viewResult());
+
+      const view = yield* Effect.tryPromise(() =>
+        getPublishedQuranView("id", 1)
+      );
+
+      expect(view).toMatchObject({
+        appLocale: "id",
+        nextSurah: {
+          name: {
+            meaning: makeQuranMeaning(2),
+          },
+          number: 2,
         },
-        number: 114,
-      },
-    });
-  });
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(1),
+          },
+          number: 1,
+        },
+        verses: [
+          {
+            translation: {
+              notes: [
+                {
+                  number: 4,
+                  referenceOffset: 20,
+                  text: "Catatan terjemahan Indonesia.",
+                },
+              ],
+              segments: [
+                { kind: "text", offset: 0, value: "Terjemahan teknis 1." },
+                { kind: "note", number: 4, offset: 20 },
+              ],
+            },
+          },
+        ],
+      });
+      expect(runtimeQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        appLocale: "id",
+        surahNumber: 1,
+      });
+      expect(cacheMock).toHaveBeenCalledWith(source.snapshotId);
+      expect(runtimeQueryMock).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it.effect("preserves the final surah and its previous neighbor", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock.mockResolvedValue(finalViewResult());
+
+      const view = yield* Effect.tryPromise(() =>
+        getPublishedQuranView("id", 114)
+      );
+
+      expect(view).toMatchObject({
+        nextSurah: null,
+        previousSurah: {
+          name: {
+            meaning: makeQuranMeaning(113),
+          },
+          number: 113,
+        },
+        surah: {
+          name: {
+            meaning: makeQuranMeaning(114),
+          },
+          number: 114,
+        },
+      });
+    })
+  );
 });
 /** Builds the complete signed metadata catalog response. */
 function catalogResult(snapshotId = source.snapshotId) {

--- a/apps/www/lib/content/quran/recovery.test.ts
+++ b/apps/www/lib/content/quran/recovery.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Result } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import {
   QuranSnapshotRecoveryError,
   recoverStalePublishedQuranSnapshot,
@@ -29,80 +30,110 @@ beforeEach(() => {
   updateTagMock.mockReset();
 });
 describe("stale published Quran snapshot recovery", () => {
-  it("rejects an invalid captured snapshot before reading active state", async () => {
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot("not-a-snapshot").pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "invalid-input",
+  it.effect("rejects invalid input before reading active state", () =>
+    Effect.gen(function* () {
+      const result = yield* recoverStalePublishedQuranSnapshot(
+        "not-a-snapshot"
+      ).pipe(Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "QuranSnapshotRecoveryError",
+          reason: "invalid-input",
+        });
+      }
+      expect(readIdentityMock).not.toHaveBeenCalled();
+      expect(refreshMock).not.toHaveBeenCalled();
+      expect(updateTagMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("refreshes without expiring the active snapshot", () =>
+    Effect.gen(function* () {
+      const recovered =
+        yield* recoverStalePublishedQuranSnapshot(activeSnapshotId);
+
+      expect(recovered).toBe(false);
+      expect(refreshMock).toHaveBeenCalledOnce();
+      expect(updateTagMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("immediately expires only the captured stale snapshot tag", () =>
+    Effect.gen(function* () {
+      const recovered =
+        yield* recoverStalePublishedQuranSnapshot(staleSnapshotId);
+
+      expect(recovered).toBe(true);
+      expect(refreshMock).not.toHaveBeenCalled();
+      expect(updateTagMock).toHaveBeenCalledWith(
+        `content-artifact:${staleSnapshotId}`
+      );
+    })
+  );
+
+  it.effect(
+    "maps active identity failures into the recovery error channel",
+    () =>
+      Effect.gen(function* () {
+        const sourceFailure = new Error("identity unavailable");
+        readIdentityMock.mockReturnValueOnce(Effect.fail(sourceFailure));
+
+        const result = yield* recoverStalePublishedQuranSnapshot(
+          staleSnapshotId
+        ).pipe(Effect.result);
+
+        expect(result).toEqual(
+          Result.fail(
+            new QuranSnapshotRecoveryError({
+              cause: sourceFailure,
+              reason: "active-identity",
+            })
+          )
+        );
+      })
+  );
+
+  it.effect("keeps route refresh failures in the typed error channel", () =>
+    Effect.gen(function* () {
+      refreshMock.mockImplementationOnce(() => {
+        throw new Error("refresh unavailable");
       });
-    }
-    expect(readIdentityMock).not.toHaveBeenCalled();
-    expect(refreshMock).not.toHaveBeenCalled();
-    expect(updateTagMock).not.toHaveBeenCalled();
-  });
-  it("refreshes without expiring the currently active snapshot", async () => {
-    await expect(
-      Effect.runPromise(recoverStalePublishedQuranSnapshot(activeSnapshotId))
-    ).resolves.toBe(false);
-    expect(refreshMock).toHaveBeenCalledOnce();
-    expect(updateTagMock).not.toHaveBeenCalled();
-  });
-  it("immediately expires only the captured stale snapshot tag", async () => {
-    await expect(
-      Effect.runPromise(recoverStalePublishedQuranSnapshot(staleSnapshotId))
-    ).resolves.toBe(true);
-    expect(refreshMock).not.toHaveBeenCalled();
-    expect(updateTagMock).toHaveBeenCalledWith(
-      `content-artifact:${staleSnapshotId}`
-    );
-  });
-  it("maps active identity failures into the recovery error channel", async () => {
-    const sourceFailure = new Error("identity unavailable");
-    readIdentityMock.mockReturnValueOnce(Effect.fail(sourceFailure));
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.result)
-    );
-    expect(result).toEqual(
-      Result.fail(
-        new QuranSnapshotRecoveryError({
-          cause: sourceFailure,
-          reason: "active-identity",
-        })
-      )
-    );
-  });
-  it("keeps route refresh failures in the typed error channel", async () => {
-    refreshMock.mockImplementationOnce(() => {
-      throw new Error("refresh unavailable");
-    });
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(activeSnapshotId).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "route-refresh",
-      });
-    }
-  });
-  it("keeps cache invalidation failures in the typed error channel", async () => {
-    updateTagMock.mockImplementationOnce(() => {
-      throw new Error("cache unavailable");
-    });
-    const result = await Effect.runPromise(
-      recoverStalePublishedQuranSnapshot(staleSnapshotId).pipe(Effect.result)
-    );
-    expect(Result.isFailure(result)).toBe(true);
-    if (Result.isFailure(result)) {
-      expect(result.failure).toMatchObject({
-        _tag: "QuranSnapshotRecoveryError",
-        reason: "cache-invalidation",
-      });
-    }
-  });
+
+      const result = yield* recoverStalePublishedQuranSnapshot(
+        activeSnapshotId
+      ).pipe(Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: "QuranSnapshotRecoveryError",
+          reason: "route-refresh",
+        });
+      }
+    })
+  );
+
+  it.effect(
+    "keeps cache invalidation failures in the typed error channel",
+    () =>
+      Effect.gen(function* () {
+        updateTagMock.mockImplementationOnce(() => {
+          throw new Error("cache unavailable");
+        });
+
+        const result = yield* recoverStalePublishedQuranSnapshot(
+          staleSnapshotId
+        ).pipe(Effect.result);
+
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure).toMatchObject({
+            _tag: "QuranSnapshotRecoveryError",
+            reason: "cache-invalidation",
+          });
+        }
+      })
+  );
 });

--- a/apps/www/lib/routing/public/source.test.ts
+++ b/apps/www/lib/routing/public/source.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { readSourceBackedHtmlRouteRejection } from "@/lib/routing/public/source";
 
 const publishedMocks = vi.hoisted(() => ({
@@ -52,323 +53,342 @@ describe("public HTML route rejection", () => {
     previewMocks.matchesPreviewRoute.mockReturnValue(Effect.succeed(false));
   });
 
-  it("rejects stale public namespaces and invisible route groups", async () => {
-    const paths = [
-      ["/id/curricula/merdeka", "id"],
-      ["/id/subjects/matematika/integral", "id"],
-      ["/en/kurikulum/merdeka/kelas-10", "en"],
-      ["/en/materi/mathematics/integral", "en"],
-      ["/learn", "en"],
-    ] as const;
+  it.effect("rejects stale public namespaces and invisible route groups", () =>
+    Effect.gen(function* () {
+      const paths = [
+        ["/id/curricula/merdeka", "id"],
+        ["/id/subjects/matematika/integral", "id"],
+        ["/en/kurikulum/merdeka/kelas-10", "en"],
+        ["/en/materi/mathematics/integral", "en"],
+        ["/learn", "en"],
+      ] as const;
 
-    for (const [pathname, locale] of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(locale);
-    }
-  });
+      for (const [pathname, locale] of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBe(locale);
+      }
+    })
+  );
 
-  it("rejects impossible Quran and article HTML paths", async () => {
-    const paths = [
-      "/id/quran/999",
-      "/id/quran/abc",
-      "/id/quran/01",
-      "/id/quran/1/extra",
-      "/en/articles/Invalid_Category",
-      "/en/articles/politics/Invalid_Slug",
-      "/en/articles/politics/article/extra",
-    ];
+  it.effect("rejects impossible Quran and article HTML paths", () =>
+    Effect.gen(function* () {
+      const paths = [
+        "/id/quran/999",
+        "/id/quran/abc",
+        "/id/quran/01",
+        "/id/quran/1/extra",
+        "/en/articles/Invalid_Category",
+        "/en/articles/politics/Invalid_Slug",
+        "/en/articles/politics/article/extra",
+      ];
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(pathname.startsWith("/id/") ? "id" : "en");
-    }
-  });
+      for (const pathname of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBe(pathname.startsWith("/id/") ? "id" : "en");
+      }
+    })
+  );
 
-  it("accepts signed articles and rejects missing or unmanaged routes", async () => {
-    publishedMocks.readActiveContentRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
+  it.effect(
+    "accepts signed articles and rejects missing or unmanaged routes",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.readActiveContentRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "found",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "missing",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "unmanaged",
+            })
+          );
+
+        const paths = [
+          "/en/articles/public-affairs/new-article",
+          "/en/articles/public-affairs/deleted-article",
+          "/en/articles/public-affairs/unmanaged-article",
+        ];
+        const results = yield* Effect.all(
+          paths.map((pathname) =>
+            readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
+          ),
+          { concurrency: "unbounded" }
+        );
+
+        expect(results).toEqual([null, "en", "en"]);
+        expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
           activeReleaseId: "release-active",
-          kind: "found",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "missing",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "unmanaged",
-        })
-      );
+          appLocale: "en",
+          family: "article",
+          publicPath: "articles/public-affairs/new-article",
+        });
+      })
+  );
 
-    const paths = [
-      "/en/articles/public-affairs/new-article",
-      "/en/articles/public-affairs/deleted-article",
-      "/en/articles/public-affairs/unmanaged-article",
-    ];
-    const results = await Promise.all(
-      paths.map((pathname) =>
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      )
-    );
+  it.effect(
+    "accepts signed Pages and rejects missing or unmanaged Page routes",
+    () =>
+      Effect.gen(function* () {
+        publishedMocks.readActiveContentRoute
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "found",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "missing",
+            })
+          )
+          .mockReturnValueOnce(
+            Effect.succeed({
+              activeReleaseId: "release-active",
+              kind: "unmanaged",
+            })
+          );
 
-    expect(results).toEqual([null, "en", "en"]);
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId: "release-active",
-      appLocale: "en",
-      family: "article",
-      publicPath: "articles/public-affairs/new-article",
-    });
-  });
-
-  it("accepts signed Pages and rejects missing or unmanaged Page routes", async () => {
-    publishedMocks.readActiveContentRoute
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "found",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "missing",
-        })
-      )
-      .mockReturnValueOnce(
-        Effect.succeed({
-          activeReleaseId: "release-active",
-          kind: "unmanaged",
-        })
-      );
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        const found = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/impressum",
-        })
-      )
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        });
+        const missing = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/fabricated-page",
-        })
-      )
-    ).resolves.toBe("de");
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        });
+        const unmanaged = yield* readSourceBackedHtmlRouteRejection({
           method: "HEAD",
           pathname: "/en/missing/page",
-        })
-      )
-    ).resolves.toBe("en");
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenNthCalledWith(1, {
-      activeReleaseId: "release-active",
-      appLocale: "de",
-      family: "page",
-      publicPath: "impressum",
-    });
-  });
+        });
 
-  it("accepts the exact selected local preview before publication lookup", async () => {
-    previewMocks.matchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
+        expect(found).toBeNull();
+        expect(missing).toBe("de");
+        expect(unmanaged).toBe("en");
+        expect(publishedMocks.readActiveContentRoute).toHaveBeenNthCalledWith(
+          1,
+          {
+            activeReleaseId: "release-active",
+            appLocale: "de",
+            family: "page",
+            publicPath: "impressum",
+          }
+        );
+      })
+  );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+  it.effect(
+    "accepts the exact selected local preview before publication lookup",
+    () =>
+      Effect.gen(function* () {
+        previewMocks.matchesPreviewRoute.mockReturnValueOnce(
+          Effect.succeed(true)
+        );
+
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/en/articles/public-affairs/new-preview",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
-      appLocale: "en",
-      publicPath: "articles/public-affairs/new-preview",
-    });
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+        });
+        expect(rejection).toBeNull();
+        expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
+          appLocale: "en",
+          publicPath: "articles/public-affairs/new-preview",
+        });
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
 
-  it("accepts the exact selected Page preview before publication lookup", async () => {
-    previewMocks.matchesPreviewRoute.mockReturnValueOnce(Effect.succeed(true));
+  it.effect(
+    "accepts the exact selected Page preview before publication lookup",
+    () =>
+      Effect.gen(function* () {
+        previewMocks.matchesPreviewRoute.mockReturnValueOnce(
+          Effect.succeed(true)
+        );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
           method: "GET",
           pathname: "/de/neue-rechtliche-seite",
-        })
-      )
-    ).resolves.toBeNull();
-    expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
-      appLocale: "de",
-      publicPath: "neue-rechtliche-seite",
-    });
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+        });
+        expect(rejection).toBeNull();
+        expect(previewMocks.matchesPreviewRoute).toHaveBeenCalledWith({
+          appLocale: "de",
+          publicPath: "neue-rechtliche-seite",
+        });
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
 
-  it("rejects article details when no active publication exists", async () => {
-    publishedMocks.readActiveContentIdentity.mockReturnValueOnce(
-      Effect.succeed(null)
-    );
-    publishedMocks.readActiveContentRoute.mockReturnValueOnce(
-      Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
-    );
+  it.effect("rejects article details when no active publication exists", () =>
+    Effect.gen(function* () {
+      publishedMocks.readActiveContentIdentity.mockReturnValueOnce(
+        Effect.succeed(null)
+      );
+      publishedMocks.readActiveContentRoute.mockReturnValueOnce(
+        Effect.succeed({ activeReleaseId: null, kind: "unmanaged" })
+      );
 
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/public-affairs/unmanaged-article",
-        })
-      )
-    ).resolves.toBe("en");
-    expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
-      activeReleaseId: null,
-      appLocale: "en",
-      family: "article",
-      publicPath: "articles/public-affairs/unmanaged-article",
-    });
-  });
-
-  it("uses exact signed ownership for category pages", async () => {
-    publishedMocks.hasArticleCategory
-      .mockReturnValueOnce(Effect.succeed(true))
-      .mockReturnValueOnce(Effect.succeed(false));
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/public-affairs",
-        })
-      )
-    ).resolves.toBeNull();
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "GET",
-          pathname: "/en/articles/deleted-category",
-        })
-      )
-    ).resolves.toBe("en");
-  });
-
-  it("propagates signed article lookup failures", async () => {
-    publishedMocks.readActiveContentRoute.mockReturnValueOnce(
-      Effect.fail(
-        new TestPublishedRouteError({ message: "publication unavailable" })
-      )
-    );
-
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
-          method: "HEAD",
-          pathname: "/en/articles/politics/published-article",
-        })
-      )
-    ).rejects.toThrow("publication unavailable");
-  });
-
-  it("delegates indexes, markdown, and non-read requests", async () => {
-    const requests = [
-      { method: "GET", pathname: "/id/quran" },
-      { method: "GET", pathname: "/en/articles" },
-      { method: "GET", pathname: "/id/quran/1.md" },
-      {
+      const rejection = yield* readSourceBackedHtmlRouteRejection({
         method: "GET",
-        pathname: "/en/articles/politics/published-article.md",
-      },
-      { method: "GET", pathname: "/de/datenschutz.md" },
-      { method: "POST", pathname: "/en/articles/politics/not-a-read-check" },
-    ];
+        pathname: "/en/articles/public-affairs/unmanaged-article",
+      });
+      expect(rejection).toBe("en");
+      expect(publishedMocks.readActiveContentRoute).toHaveBeenCalledWith({
+        activeReleaseId: null,
+        appLocale: "en",
+        family: "article",
+        publicPath: "articles/public-affairs/unmanaged-article",
+      });
+    })
+  );
 
-    for (const request of requests) {
-      await expect(
-        Effect.runPromise(readSourceBackedHtmlRouteRejection(request))
-      ).resolves.toBeNull();
-    }
-    expect(publishedMocks.hasArticleCategory).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+  it.effect("uses exact signed ownership for category pages", () =>
+    Effect.gen(function* () {
+      publishedMocks.hasArticleCategory
+        .mockReturnValueOnce(Effect.succeed(true))
+        .mockReturnValueOnce(Effect.succeed(false));
 
-  it("delegates concrete application roots without Page lookups", async () => {
-    const paths = [
-      "/de",
-      "/de/search",
-      "/de/chat/new",
-      "/de/lehrplaene/merdeka",
-      "/de/faecher/mathematik/algebra",
-      "/de/try-out/indonesien/snbt",
-      "/en/school/onboarding",
-    ];
+      const found = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/en/articles/public-affairs",
+      });
+      const missing = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/en/articles/deleted-category",
+      });
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
+      expect(found).toBeNull();
+      expect(missing).toBe("en");
+    })
+  );
+
+  it.effect("propagates signed article lookup failures", () =>
+    Effect.gen(function* () {
+      publishedMocks.readActiveContentRoute.mockReturnValueOnce(
+        Effect.fail(
+          new TestPublishedRouteError({ message: "publication unavailable" })
         )
-      ).resolves.toBeNull();
-    }
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+      );
 
-  it("rejects invalid descendants inside reserved application roots", async () => {
-    const paths = [
-      "/de/search/fabricated",
-      "/de/auth/fabricated",
-      "/de/onboarding/fabricated",
-      "/de/home/fabricated",
-      "/de/contributor/fabricated",
-      "/de/user",
-      "/de/user/settings/fabricated",
-      "/en/school/select/fabricated",
-      "/de/og",
-      "/de/faecher",
-      "/en/subjects/mathematics",
-      "/de/try-out/a/b/c/d/e/f",
-    ];
+      const failure = yield* readSourceBackedHtmlRouteRejection({
+        method: "HEAD",
+        pathname: "/en/articles/politics/published-article",
+      }).pipe(Effect.flip);
+      expect(failure).toMatchObject({
+        _tag: "TestPublishedRouteError",
+        message: "publication unavailable",
+      });
+    })
+  );
 
-    for (const pathname of paths) {
-      await expect(
-        Effect.runPromise(
-          readSourceBackedHtmlRouteRejection({ method: "GET", pathname })
-        )
-      ).resolves.toBe(pathname.startsWith("/en/") ? "en" : "de");
-    }
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
-
-  it("rejects malformed Page paths without a publication lookup", async () => {
-    await expect(
-      Effect.runPromise(
-        readSourceBackedHtmlRouteRejection({
+  it.effect("delegates indexes, markdown, and non-read requests", () =>
+    Effect.gen(function* () {
+      const requests = [
+        { method: "GET", pathname: "/id/quran" },
+        { method: "GET", pathname: "/en/articles" },
+        { method: "GET", pathname: "/id/quran/1.md" },
+        {
           method: "GET",
-          pathname: "/de/Invalid_Page",
-        })
-      )
-    ).resolves.toBe("de");
-    expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
-    expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
-  });
+          pathname: "/en/articles/politics/published-article.md",
+        },
+        { method: "GET", pathname: "/de/datenschutz.md" },
+        {
+          method: "POST",
+          pathname: "/en/articles/politics/not-a-read-check",
+        },
+      ];
+
+      for (const request of requests) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection(request);
+        expect(rejection).toBeNull();
+      }
+      expect(publishedMocks.hasArticleCategory).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("delegates concrete application roots without Page lookups", () =>
+    Effect.gen(function* () {
+      const paths = [
+        "/de",
+        "/de/search",
+        "/de/chat/new",
+        "/de/lehrplaene/merdeka",
+        "/de/faecher/mathematik/algebra",
+        "/de/try-out/indonesien/snbt",
+        "/en/school/onboarding",
+      ];
+
+      for (const pathname of paths) {
+        const rejection = yield* readSourceBackedHtmlRouteRejection({
+          method: "GET",
+          pathname,
+        });
+        expect(rejection).toBeNull();
+      }
+      expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "rejects invalid descendants inside reserved application roots",
+    () =>
+      Effect.gen(function* () {
+        const paths = [
+          "/de/search/fabricated",
+          "/de/auth/fabricated",
+          "/de/onboarding/fabricated",
+          "/de/home/fabricated",
+          "/de/contributor/fabricated",
+          "/de/user",
+          "/de/user/settings/fabricated",
+          "/en/school/select/fabricated",
+          "/de/og",
+          "/de/faecher",
+          "/en/subjects/mathematics",
+          "/de/try-out/a/b/c/d/e/f",
+        ];
+
+        for (const pathname of paths) {
+          const rejection = yield* readSourceBackedHtmlRouteRejection({
+            method: "GET",
+            pathname,
+          });
+          expect(rejection).toBe(pathname.startsWith("/en/") ? "en" : "de");
+        }
+        expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+        expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+      })
+  );
+
+  it.effect("rejects malformed Page paths without a publication lookup", () =>
+    Effect.gen(function* () {
+      const rejection = yield* readSourceBackedHtmlRouteRejection({
+        method: "GET",
+        pathname: "/de/Invalid_Page",
+      });
+      expect(rejection).toBe("de");
+      expect(publishedMocks.readActiveContentIdentity).not.toHaveBeenCalled();
+      expect(publishedMocks.readActiveContentRoute).not.toHaveBeenCalled();
+    })
+  );
 });

--- a/packages/backend/convex/contentRelease/ingress/group.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/group.test.ts
@@ -7,6 +7,7 @@ import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signatu
 import { StageGroupRequestSchema } from "@nakafa/aksara-contracts/transport/group";
 import { stagePublicationGroup } from "@repo/backend/convex/contentRelease/ingress/group";
 import { stagePublication } from "@repo/backend/convex/contentRelease/ingress/stage";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -20,91 +21,120 @@ import { testPublicationScope } from "@repo/backend/test/content/release";
 import { insertSignedCandidate } from "@repo/backend/test/content/stage";
 import { makeProgramSnapshotData } from "@repo/backend/test/program/snapshot";
 import { convexTest } from "convex-test";
-import { Effect, Schema } from "effect";
+import { Data, Effect, Schema } from "effect";
 
 const releaseId = ReleaseIdSchema.make("release-stage-group");
 
-describe("content release staging groups", () => {
-  it("resumes a committed prefix and retries the complete group", async () => {
-    const data = await Effect.runPromise(makeProgramSnapshotData());
-    const firstRow = data.rows[0];
-    if (!firstRow) {
-      throw new Error("Expected one program snapshot row.");
-    }
-    const release = testSignedRelease(
-      ContentReleaseManifestSchema.make({
-        ...testEmptyManifest(releaseId),
-        scope: testPublicationScope({ snapshots: data.snapshots }),
-        snapshots: data.snapshots,
-      })
-    );
-    const request = Schema.decodeSync(StageGroupRequestSchema)({
-      operation: "stageGroup",
-      releaseId,
-      requests: [
-        {
-          operation: "stageSnapshot",
-          releaseId,
-          snapshot: data.snapshot,
-        },
-        {
-          batchIndex: 0,
-          family: "program",
-          operation: "stageSnapshotBatch",
-          releaseId,
-          rows: [firstRow],
-          snapshotId: data.snapshotId,
-        },
-      ],
-    });
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        releaseId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
+class UnexpectedGroupTestState extends Data.TaggedError(
+  "UnexpectedGroupTestState"
+)<{
+  readonly operation: "select-program-row";
+}> {}
 
-    const firstRequest = request.requests[0];
-    await t.action((ctx) =>
-      Effect.runPromise(
-        stagePublication(ctx, firstRequest, TEST_KEY_ID).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+describe("content release staging groups", () => {
+  it.effect("resumes a committed prefix and retries the complete group", () =>
+    Effect.gen(function* () {
+      const data = yield* makeProgramSnapshotData();
+      const firstRow = data.rows[0];
+      if (!firstRow) {
+        return yield* Effect.die(
+          new UnexpectedGroupTestState({ operation: "select-program-row" })
+        );
+      }
+      const release = testSignedRelease(
+        ContentReleaseManifestSchema.make({
+          ...testEmptyManifest(releaseId),
+          scope: testPublicationScope({ snapshots: data.snapshots }),
+          snapshots: data.snapshots,
+        })
+      );
+      const request = yield* Schema.decodeEffect(StageGroupRequestSchema)({
+        operation: "stageGroup",
+        releaseId,
+        requests: [
+          {
+            operation: "stageSnapshot",
+            releaseId,
+            snapshot: data.snapshot,
+          },
+          {
+            batchIndex: 0,
+            family: "program",
+            operation: "stageSnapshotBatch",
+            releaseId,
+            rows: [firstRow],
+            snapshotId: data.snapshotId,
+          },
+        ],
+      });
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          insertSignedCandidate(
+            ctx,
+            releaseId,
+            release,
+            JSON.stringify(TEST_PROOF_RENDERER)
           )
         )
-      )
-    );
+      );
 
-    /** Executes the same authenticated group against the durable test store. */
-    const run = () =>
-      t.action((ctx) =>
-        Effect.runPromise(
-          stagePublicationGroup(ctx, request, TEST_KEY_ID).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
+      const firstRequest = request.requests[0];
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(
+            stagePublication(ctx, firstRequest, TEST_KEY_ID).pipe(
+              Effect.provideService(
+                ContentVerificationKeyResolver,
+                TEST_KEY_RESOLVER
+              )
             )
           )
         )
       );
-    await expect(run()).resolves.toEqual({
-      ok: true,
-      operation: "stageGroup",
-      value: { releaseId, requestCount: 2 },
-    });
-    await expect(run()).resolves.toMatchObject({ ok: true });
-    await expect(
-      t.run(async (ctx) => ({
-        batches: await ctx.db.query("snapshotBatches").collect(),
-        snapshots: await ctx.db.query("contentSnapshots").collect(),
-      }))
-    ).resolves.toMatchObject({
-      batches: [expect.objectContaining({ batchIndex: 0 })],
-      snapshots: [expect.objectContaining({ family: "program" })],
-    });
-  });
+
+      /** Executes the same authenticated group against the durable test store. */
+      const runGroup = Effect.fn("contentRelease.ingress.test.runGroup")(
+        function* () {
+          return yield* Effect.promise(() =>
+            t.action((ctx) =>
+              runConvexProgram(
+                stagePublicationGroup(ctx, request, TEST_KEY_ID).pipe(
+                  Effect.provideService(
+                    ContentVerificationKeyResolver,
+                    TEST_KEY_RESOLVER
+                  )
+                )
+              )
+            )
+          );
+        }
+      );
+      expect(yield* runGroup()).toEqual({
+        ok: true,
+        operation: "stageGroup",
+        value: { releaseId, requestCount: 2 },
+      });
+      expect(yield* runGroup()).toMatchObject({ ok: true });
+
+      const stored = yield* Effect.promise(() =>
+        t.run((ctx) =>
+          runConvexProgram(
+            Effect.all({
+              batches: Effect.promise(() =>
+                ctx.db.query("snapshotBatches").collect()
+              ),
+              snapshots: Effect.promise(() =>
+                ctx.db.query("contentSnapshots").collect()
+              ),
+            })
+          )
+        )
+      );
+      expect(stored).toMatchObject({
+        batches: [expect.objectContaining({ batchIndex: 0 })],
+        snapshots: [expect.objectContaining({ family: "program" })],
+      });
+    })
+  );
 });

--- a/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
@@ -12,9 +12,18 @@ import {
 } from "@nakafa/aksara-contracts/release";
 import { PublicationScopeSchema } from "@nakafa/aksara-contracts/release/snapshot/scope";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
-import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type {
+  ActionCtx,
+  MutationCtx,
+} from "@repo/backend/convex/_generated/server";
 import { advancePublication } from "@repo/backend/convex/contentRelease/ingress/lifecycle";
 import { encodeRendererJson } from "@repo/backend/convex/contentRelease/wire";
+import {
+  type ConvexTaggedError,
+  getUnknownErrorMessage,
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -30,8 +39,8 @@ import {
   insertZeroRelease,
 } from "@repo/backend/test/content/state";
 import { completeContentProof } from "@repo/backend/test/content/verify";
-import { convexTest } from "convex-test";
-import { Effect } from "effect";
+import { convexTest, type TestConvex } from "convex-test";
+import { Data, Effect, Schema } from "effect";
 import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
@@ -47,46 +56,65 @@ const recoveryReleaseId = ReleaseIdSchema.make(
   "release-lifecycle-ingress-recovery"
 );
 
+class ObservedLifecycleActionFailure extends Schema.TaggedError<ObservedLifecycleActionFailure>()(
+  "ObservedLifecycleActionFailure",
+  { cause: Schema.Unknown }
+) {}
+
+class UnexpectedLifecycleTestState extends Data.TaggedError(
+  "UnexpectedLifecycleTestState"
+)<{
+  readonly operation: "mark-proof-failed";
+}> {}
+
 /** Inserts one verified release with explicit frozen renderer bytes. */
-async function insertRelease(ctx: MutationCtx, rendererJson: string) {
-  const now = Date.UTC(2026, 6, 22, 12, 0, 0);
-  await ctx.db.insert("contentReleases", {
-    baseFamilies: [],
-    checkedIndex: -1,
-    checkedItems: 0,
-    createdAt: now,
-    proofAt: now,
-    proofJson: "{}",
-    releaseId,
-    releaseJson: JSON.stringify(release),
-    rendererJson,
-    resultFamilies: [...release.manifest.scope.families],
-    role: "candidate",
-    sequence: 1,
-    stagedArtifacts: 0,
-    stagedDeletes: 0,
-    stagedItems: 0,
-    stagedProjections: 0,
-    stagedRoutes: 0,
-    stagedSnapshotBatches: 0,
-    stagedSnapshotRows: 0,
-    stagedUpserts: 0,
-    status: "verified",
-    updatedAt: now,
-    verifiedAt: now,
-  });
-  await ctx.db.insert("contentState", {
-    candidateManifestHash: release.manifestHash,
-    candidateReleaseId: releaseId,
-    candidateSequence: 1,
-    key: "primary",
-    nextSequence: 2,
-    updatedAt: now,
-  });
-}
+const insertRelease = Effect.fn("test.contentRelease.insertLifecycleRelease")(
+  function* (ctx: MutationCtx, rendererJson: string) {
+    const now = Date.UTC(2026, 6, 22, 12, 0, 0);
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentReleases", {
+        baseFamilies: [],
+        checkedIndex: -1,
+        checkedItems: 0,
+        createdAt: now,
+        proofAt: now,
+        proofJson: "{}",
+        releaseId,
+        releaseJson: JSON.stringify(release),
+        rendererJson,
+        resultFamilies: [...release.manifest.scope.families],
+        role: "candidate",
+        sequence: 1,
+        stagedArtifacts: 0,
+        stagedDeletes: 0,
+        stagedItems: 0,
+        stagedProjections: 0,
+        stagedRoutes: 0,
+        stagedSnapshotBatches: 0,
+        stagedSnapshotRows: 0,
+        stagedUpserts: 0,
+        status: "verified",
+        updatedAt: now,
+        verifiedAt: now,
+      })
+    );
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentState", {
+        candidateManifestHash: release.manifestHash,
+        candidateReleaseId: releaseId,
+        candidateSequence: 1,
+        key: "primary",
+        nextSequence: 2,
+        updatedAt: now,
+      })
+    );
+  }
+);
 
 /** Inserts one authenticated zero-impact candidate and its exact inverse. */
-async function insertActivationPair(
+const insertActivationPair = Effect.fn(
+  "test.contentRelease.insertActivationPair"
+)(function* (
   ctx: MutationCtx,
   candidate: SignedContentRelease,
   recovery: SignedContentRelease
@@ -101,40 +129,50 @@ async function insertActivationPair(
     releaseId: recovery.manifest.releaseId,
     sequence: 2,
   };
-  await insertZeroRelease(ctx, {
-    ...candidateIdentity,
-    ownership: { base: [], result: [] },
-    role: "candidate",
-    scope: candidate.manifest.scope,
-    snapshots: candidate.manifest.snapshots,
-    status: "verified",
-  });
-  await insertZeroRelease(ctx, {
-    ...recoveryIdentity,
-    base: candidateIdentity,
-    originReleaseId: candidate.manifest.releaseId,
-    ownership: { base: [], result: [] },
-    role: "recovery",
-    scope: recovery.manifest.scope,
-    snapshots: recovery.manifest.snapshots,
-    status: "verified",
-  });
+  yield* Effect.promise(() =>
+    insertZeroRelease(ctx, {
+      ...candidateIdentity,
+      ownership: { base: [], result: [] },
+      role: "candidate",
+      scope: candidate.manifest.scope,
+      snapshots: candidate.manifest.snapshots,
+      status: "verified",
+    })
+  );
+  yield* Effect.promise(() =>
+    insertZeroRelease(ctx, {
+      ...recoveryIdentity,
+      base: candidateIdentity,
+      originReleaseId: candidate.manifest.releaseId,
+      ownership: { base: [], result: [] },
+      role: "recovery",
+      scope: recovery.manifest.scope,
+      snapshots: recovery.manifest.snapshots,
+      status: "verified",
+    })
+  );
   const rendererJson = encodeRendererJson(TEST_PROOF_RENDERER);
-  const releases = await ctx.db.query("contentReleases").collect();
+  const releases = yield* Effect.promise(() =>
+    ctx.db.query("contentReleases").collect()
+  );
   for (const stored of releases) {
     const signed =
       stored.releaseId === candidate.manifest.releaseId ? candidate : recovery;
-    await ctx.db.patch("contentReleases", stored._id, {
-      releaseJson: JSON.stringify(signed),
-      rendererJson,
-    });
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", stored._id, {
+        releaseJson: JSON.stringify(signed),
+        rendererJson,
+      })
+    );
   }
-  await insertTestState(ctx, {
-    candidate: candidateIdentity,
-    nextSequence: 3,
-    recovery: recoveryIdentity,
-  });
-}
+  yield* Effect.promise(() =>
+    insertTestState(ctx, {
+      candidate: candidateIdentity,
+      nextSequence: 3,
+      recovery: recoveryIdentity,
+    })
+  );
+});
 
 /** Creates signed zero-impact manifests that complete read models immediately. */
 function makeActivationPair() {
@@ -163,197 +201,256 @@ function makeActivationPair() {
   };
 }
 
-/** Runs one lifecycle program through the explicit technical verification key. */
-function runLifecycle<A, E>(
-  program: Effect.Effect<A, E, ContentVerificationKeyResolver>
-) {
-  return Effect.runPromise(
-    program.pipe(
-      Effect.provideService(ContentVerificationKeyResolver, TEST_KEY_RESOLVER)
-    )
-  );
-}
-
-describe("content release lifecycle ingress", () => {
-  it("returns authenticated evidence after durable proof completion", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        releaseId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
+/** Marks one stored proof as terminally failed for ingress observation. */
+const markProofFailed = Effect.fn("test.contentRelease.markProofFailed")(
+  function* (ctx: MutationCtx) {
+    const stored = yield* Effect.promise(() =>
+      ctx.db.query("contentReleases").unique()
     );
-
-    await completeContentProof(t, release.manifestHash, releaseId);
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "verify", release }))
-      )
-    ).resolves.toMatchObject({
-      ok: true,
-      operation: "verify",
-      value: {
-        evidence: {
-          manifestHash: release.manifestHash,
-          releaseId,
-        },
-        phase: "verified",
-      },
-    });
-  });
-
-  it("surfaces only the stable terminal proof category", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        releaseId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-    await t.mutation(async (ctx) => {
-      const stored = await ctx.db.query("contentReleases").unique();
-      if (!stored) {
-        throw new Error("Expected proof release.");
-      }
-      await ctx.db.patch("contentReleases", stored._id, {
+    if (!stored) {
+      return yield* Effect.die(
+        new UnexpectedLifecycleTestState({
+          operation: "mark-proof-failed",
+        })
+      );
+    }
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentReleases", stored._id, {
         proofFailure: "failed",
         status: "verifying",
-      });
-    });
-
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "verify", release }))
-      )
-    ).rejects.toThrow(`Content release ${releaseId} proof workflow failed.`);
-  });
-
-  it("aborts through the server-owned cursor and returns exact evidence", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertRelease(ctx, JSON.stringify(TEST_PROOF_RENDERER))
+      })
     );
+  }
+);
 
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(advancePublication(ctx, { operation: "abort", releaseId }))
-      )
-    ).resolves.toEqual({
-      ok: true,
-      operation: "abort",
-      value: {
-        complete: true,
-        processedItems: 0,
-        releaseId,
-        totalItems: 0,
-      },
-    });
-  });
-
-  it("rejects activation when the frozen renderer identity drifted", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertRelease(ctx, JSON.stringify(testProofRenderer("h1")))
-    );
-
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(
-          advancePublication(ctx, { operation: "activate", release })
+/** Runs one lifecycle program through the explicit technical verification key. */
+const runLifecycle = Effect.fn("test.contentRelease.runLifecycle")(function* <
+  A,
+  E extends ConvexTaggedError,
+>(
+  target: TestConvex<typeof schema>,
+  makeProgram: (
+    ctx: ActionCtx
+  ) => Effect.Effect<A, E, ContentVerificationKeyResolver>
+) {
+  return yield* Effect.tryPromise({
+    catch: (cause) => new ObservedLifecycleActionFailure({ cause }),
+    try: () =>
+      target.action((ctx) =>
+        runConvexActionProgram(
+          makeProgram(ctx).pipe(
+            Effect.provideService(
+              ContentVerificationKeyResolver,
+              TEST_KEY_RESOLVER
+            )
+          )
         )
-      )
-    ).rejects.toThrow("Lifecycle renderer does not match the signed release");
-  });
-
-  it("rejects a tampered release before any lifecycle read", async () => {
-    const t = convexTest(schema, convexModules);
-    const prefix = release.signature.startsWith("A") ? "B" : "A";
-    const tampered = {
-      ...release,
-      signature: Ed25519SignatureSchema.make(
-        `${prefix}${release.signature.slice(1)}`
       ),
-    };
+  });
+});
 
-    await expect(
-      t.action((ctx) =>
-        runLifecycle(
-          advancePublication(ctx, { operation: "verify", release: tampered })
+describe("content release lifecycle ingress", () => {
+  it.effect(
+    "returns authenticated evidence after durable proof completion",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            insertSignedCandidate(
+              ctx,
+              releaseId,
+              release,
+              JSON.stringify(TEST_PROOF_RENDERER)
+            )
+          )
+        );
+
+        yield* Effect.promise(() =>
+          completeContentProof(t, release.manifestHash, releaseId)
+        );
+        const response = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "verify", release })
+        );
+        expect(response).toMatchObject({
+          ok: true,
+          operation: "verify",
+          value: {
+            evidence: {
+              manifestHash: release.manifestHash,
+              releaseId,
+            },
+            phase: "verified",
+          },
+        });
+      })
+  );
+
+  it.effect("surfaces only the stable terminal proof category", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          insertSignedCandidate(
+            ctx,
+            releaseId,
+            release,
+            JSON.stringify(TEST_PROOF_RENDERER)
+          )
         )
-      )
-    ).rejects.toThrow("Content release verification failed");
-  });
+      );
+      yield* Effect.promise(() =>
+        t.mutation((ctx) => runConvexProgram(markProofFailed(ctx)))
+      );
 
-  it("keeps the external activation receipt unchanged", async () => {
-    const t = convexTest(schema, convexModules);
-    const pair = makeActivationPair();
-    await t.mutation((ctx) =>
-      insertActivationPair(ctx, pair.candidate, pair.recovery)
-    );
+      const failure = yield* runLifecycle(t, (ctx) =>
+        advancePublication(ctx, { operation: "verify", release })
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        `Content release ${releaseId} proof workflow failed.`
+      );
+    })
+  );
 
-    const activated = await t.action((ctx) =>
-      runLifecycle(
+  it.effect(
+    "aborts through the server-owned cursor and returns exact evidence",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              insertRelease(ctx, JSON.stringify(TEST_PROOF_RENDERER))
+            )
+          )
+        );
+
+        const response = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "abort", releaseId })
+        );
+        expect(response).toEqual({
+          ok: true,
+          operation: "abort",
+          value: {
+            complete: true,
+            processedItems: 0,
+            releaseId,
+            totalItems: 0,
+          },
+        });
+      })
+  );
+
+  it.effect(
+    "rejects activation when the frozen renderer identity drifted",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              insertRelease(ctx, JSON.stringify(testProofRenderer("h1")))
+            )
+          )
+        );
+
+        const failure = yield* runLifecycle(t, (ctx) =>
+          advancePublication(ctx, { operation: "activate", release })
+        ).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "Lifecycle renderer does not match the signed release"
+        );
+      })
+  );
+
+  it.effect("rejects a tampered release before any lifecycle read", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const prefix = release.signature.startsWith("A") ? "B" : "A";
+      const tampered = {
+        ...release,
+        signature: Ed25519SignatureSchema.make(
+          `${prefix}${release.signature.slice(1)}`
+        ),
+      };
+
+      const failure = yield* runLifecycle(t, (ctx) =>
+        advancePublication(ctx, { operation: "verify", release: tampered })
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        "Content release verification failed"
+      );
+    })
+  );
+
+  it.effect("keeps the external activation receipt unchanged", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const pair = makeActivationPair();
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            insertActivationPair(ctx, pair.candidate, pair.recovery)
+          )
+        )
+      );
+
+      const activated = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activate",
           release: pair.candidate,
         })
-      )
-    );
-    const repeated = await t.action((ctx) =>
-      runLifecycle(
+      );
+      const repeated = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activate",
           release: pair.candidate,
         })
-      )
-    );
+      );
 
-    expect(activated).toEqual(repeated);
-    expect(activated).toMatchObject({
-      ok: true,
-      operation: "activate",
-      value: {
-        manifestHash: pair.candidate.manifestHash,
-        releaseId,
-      },
-    });
-    expect(activated.value).not.toHaveProperty("kind");
-    await expect(
-      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toEqual([]);
+      expect(activated).toEqual(repeated);
+      expect(activated).toMatchObject({
+        ok: true,
+        operation: "activate",
+        value: {
+          manifestHash: pair.candidate.manifestHash,
+          releaseId,
+        },
+      });
+      expect(activated.value).not.toHaveProperty("kind");
+      expect(
+        yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+        )
+      ).toEqual([]);
 
-    const recovered = await t.action((ctx) =>
-      runLifecycle(
+      const recovered = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activateRecovery",
           release: pair.recovery,
         })
-      )
-    );
-    expect(recovered).toMatchObject({
-      ok: true,
-      operation: "activateRecovery",
-      value: {
-        manifestHash: pair.recovery.manifestHash,
-        releaseId: recoveryReleaseId,
-      },
-    });
-    expect(recovered.value).not.toHaveProperty("kind");
-    const repeatedRecovery = await t.action((ctx) =>
-      runLifecycle(
+      );
+      expect(recovered).toMatchObject({
+        ok: true,
+        operation: "activateRecovery",
+        value: {
+          manifestHash: pair.recovery.manifestHash,
+          releaseId: recoveryReleaseId,
+        },
+      });
+      expect(recovered.value).not.toHaveProperty("kind");
+      const repeatedRecovery = yield* runLifecycle(t, (ctx) =>
         advancePublication(ctx, {
           operation: "activateRecovery",
           release: pair.recovery,
         })
-      )
-    );
-    expect(repeatedRecovery).toEqual(recovered);
-    await expect(
-      t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-    ).resolves.toEqual([]);
-  });
+      );
+      expect(repeatedRecovery).toEqual(recovered);
+      expect(
+        yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+        )
+      ).toEqual([]);
+    })
+  );
 });

--- a/packages/backend/convex/contentRelease/ingress/rollback.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/rollback.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from "@effect/vitest";
 import { SignedContentReleaseSchema } from "@nakafa/aksara-contracts/release";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
 import { PublicationRequestSchema } from "@nakafa/aksara-contracts/transport/request";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { readRollback } from "@repo/backend/convex/contentRelease/ingress/rollback";
 import { makePublicationReceipt } from "@repo/backend/convex/contentRelease/receipt";
 import {
   RELEASE_PAGE_LIMIT,
   ROUTE_CATALOG_PAGE_LIMIT,
 } from "@repo/backend/convex/contentRelease/spec";
+import {
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -25,133 +30,216 @@ import {
   insertRoute,
 } from "@repo/backend/test/content/rollback";
 import { convexTest, type TestConvex } from "convex-test";
-import { Effect, Schema } from "effect";
+import { Data, Effect, Schema } from "effect";
 
-/** Activates one authenticated release that the ingress may replay. */
-async function activateAuthenticatedRelease(
-  t: TestConvex<typeof schema>,
+class UnexpectedRollbackTestState extends Data.TaggedError(
+  "UnexpectedRollbackTestState"
+)<{
+  readonly operation:
+    | "activate-release"
+    | "select-body-request"
+    | "select-route-request";
+}> {}
+
+/** Stores the exact authenticated release and active identity under test. */
+const storeAuthenticatedRelease = Effect.fn(
+  "test.contentRelease.storeAuthenticatedRelease"
+)(function* (
+  ctx: MutationCtx,
   itemCount: number,
-  routeCount = itemCount
+  routeCount: number,
+  release: ReturnType<typeof testSignedRelease>
 ) {
-  const unsigned = Schema.decodeUnknownSync(SignedContentReleaseSchema)(
-    JSON.parse(
-      testReleaseJson({
-        itemCount,
-        rendererHash: TEST_PROOF_RENDERER.hash,
-        routeCount,
-      })
-    )
+  yield* Effect.promise(() =>
+    activateRollbackFixture(ctx, itemCount, routeCount)
   );
-  const release = testSignedRelease(unsigned.manifest);
-  await t.mutation(async (ctx) => {
-    await activateRollbackFixture(ctx, itemCount, routeCount);
-    const stored = await ctx.db.query("contentReleases").unique();
-    const state = await ctx.db.query("contentState").unique();
-    if (!(stored && state)) {
-      throw new Error("Expected one rollback release fixture.");
-    }
-    await ctx.db.patch("contentReleases", stored._id, {
+  const stored = yield* Effect.promise(() =>
+    ctx.db.query("contentReleases").unique()
+  );
+  const state = yield* Effect.promise(() =>
+    ctx.db.query("contentState").unique()
+  );
+  if (!(stored && state)) {
+    return yield* Effect.die(
+      new UnexpectedRollbackTestState({ operation: "activate-release" })
+    );
+  }
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentReleases", stored._id, {
       receiptJson: JSON.stringify(makePublicationReceipt(stored, release)),
       releaseJson: JSON.stringify(release),
       rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
-    });
-    await ctx.db.patch("contentState", state._id, {
+    })
+  );
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentState", state._id, {
       activeManifestHash: release.manifestHash,
-    });
-  });
+    })
+  );
+});
+
+/** Activates one authenticated release that the ingress may replay. */
+const activateAuthenticatedRelease = Effect.fn(
+  "test.contentRelease.activateAuthenticatedRelease"
+)(function* (
+  target: TestConvex<typeof schema>,
+  itemCount: number,
+  routeCount = itemCount
+) {
+  const unsigned = yield* Schema.decodeEffect(
+    Schema.fromJsonString(SignedContentReleaseSchema)
+  )(
+    testReleaseJson({
+      itemCount,
+      rendererHash: TEST_PROOF_RENDERER.hash,
+      routeCount,
+    })
+  );
+  const release = testSignedRelease(unsigned.manifest);
+  yield* Effect.promise(() =>
+    target.mutation((ctx) =>
+      runConvexProgram(
+        storeAuthenticatedRelease(ctx, itemCount, routeCount, release)
+      )
+    )
+  );
   return release;
-}
+});
+
+/** Inserts rollback body rows in the original deterministic order. */
+const insertRollbackItems = Effect.fn(
+  "test.contentRelease.insertRollbackItems"
+)(function* (ctx: MutationCtx, itemCount: number) {
+  for (let index = 0; index < itemCount; index += 1) {
+    yield* Effect.promise(() =>
+      insertRollbackItem(ctx, index, false, "return {};", {
+        authenticatedArtifact: true,
+      })
+    );
+  }
+});
+
+/** Inserts every prior and current route pair in deterministic order. */
+const insertRollbackRoutes = Effect.fn(
+  "test.contentRelease.insertRollbackRoutes"
+)(function* (ctx: MutationCtx, routeCount: number) {
+  for (let index = 0; index < routeCount; index += 1) {
+    const publicPath = `test/route-${index}`;
+    yield* Effect.promise(() =>
+      insertRoute(ctx, {
+        contentKey: `test:prior-${index}`,
+        index,
+        publicPath,
+        releaseId: "release-base",
+        sequence: 0,
+      })
+    );
+    yield* Effect.promise(() =>
+      insertRoute(ctx, {
+        contentKey: `test:current-${index}`,
+        index,
+        publicPath,
+      })
+    );
+  }
+});
 
 describe("content publication rollback reads", () => {
-  it("aggregates safe body query transactions into one external page", async () => {
-    const t = convexTest(schema, convexModules);
-    const itemCount = RELEASE_PAGE_LIMIT + 1;
-    const release = await activateAuthenticatedRelease(t, itemCount);
-    await t.mutation(async (ctx) => {
-      for (let index = 0; index < itemCount; index += 1) {
-        await insertRollbackItem(ctx, index, false, "return {};", {
-          authenticatedArtifact: true,
-        });
-      }
-    });
-
-    const request = Schema.decodeSync(PublicationRequestSchema)({
-      afterIndex: -1,
-      limit: itemCount,
-      operation: "rollbackPage",
-      rollbackOf: TEST_RELEASE_ID,
-      rollbackOfManifestHash: release.manifestHash,
-    });
-    if (request.operation !== "rollbackPage") {
-      throw new Error("Expected one rollback page request.");
-    }
-    const response = await t.action((ctx) =>
-      Effect.runPromise(
-        readRollback(ctx, request).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+  it.effect(
+    "aggregates safe body query transactions into one external page",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const itemCount = RELEASE_PAGE_LIMIT + 1;
+        const release = yield* activateAuthenticatedRelease(t, itemCount);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertRollbackItems(ctx, itemCount))
           )
-        )
-      )
-    );
+        );
 
-    expect(response).toMatchObject({
-      done: true,
-      nextIndex: itemCount - 1,
-      total: itemCount,
-    });
-    expect(response.records).toHaveLength(itemCount);
-  });
-
-  it("aggregates safe route query transactions into one external page", async () => {
-    const t = convexTest(schema, convexModules);
-    const routeCount = ROUTE_CATALOG_PAGE_LIMIT + 1;
-    const release = await activateAuthenticatedRelease(t, 0, routeCount);
-    await t.mutation(async (ctx) => {
-      for (let index = 0; index < routeCount; index += 1) {
-        const publicPath = `test/route-${index}`;
-        await insertRoute(ctx, {
-          contentKey: `test:prior-${index}`,
-          index,
-          publicPath,
-          releaseId: "release-base",
-          sequence: 0,
+        const request = yield* Schema.decodeEffect(PublicationRequestSchema)({
+          afterIndex: -1,
+          limit: itemCount,
+          operation: "rollbackPage",
+          rollbackOf: TEST_RELEASE_ID,
+          rollbackOfManifestHash: release.manifestHash,
         });
-        await insertRoute(ctx, {
-          contentKey: `test:current-${index}`,
-          index,
-          publicPath,
-        });
-      }
-    });
-
-    const request = Schema.decodeSync(PublicationRequestSchema)({
-      afterIndex: -1,
-      limit: routeCount,
-      operation: "routePage",
-      rollbackOf: TEST_RELEASE_ID,
-      rollbackOfManifestHash: release.manifestHash,
-    });
-    if (request.operation !== "routePage") {
-      throw new Error("Expected one route rollback page request.");
-    }
-    const response = await t.action((ctx) =>
-      Effect.runPromise(
-        readRollback(ctx, request).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+        if (request.operation !== "rollbackPage") {
+          return yield* Effect.die(
+            new UnexpectedRollbackTestState({
+              operation: "select-body-request",
+            })
+          );
+        }
+        const response = yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexActionProgram(
+              readRollback(ctx, request).pipe(
+                Effect.provideService(
+                  ContentVerificationKeyResolver,
+                  TEST_KEY_RESOLVER
+                )
+              )
+            )
           )
-        )
-      )
-    );
+        );
 
-    expect(response).toMatchObject({
-      done: true,
-      nextIndex: routeCount - 1,
-      total: routeCount,
-    });
-    expect(response.records).toHaveLength(routeCount);
-  });
+        expect(response).toMatchObject({
+          done: true,
+          nextIndex: itemCount - 1,
+          total: itemCount,
+        });
+        expect(response.records).toHaveLength(itemCount);
+      })
+  );
+
+  it.effect(
+    "aggregates safe route query transactions into one external page",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const routeCount = ROUTE_CATALOG_PAGE_LIMIT + 1;
+        const release = yield* activateAuthenticatedRelease(t, 0, routeCount);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertRollbackRoutes(ctx, routeCount))
+          )
+        );
+
+        const request = yield* Schema.decodeEffect(PublicationRequestSchema)({
+          afterIndex: -1,
+          limit: routeCount,
+          operation: "routePage",
+          rollbackOf: TEST_RELEASE_ID,
+          rollbackOfManifestHash: release.manifestHash,
+        });
+        if (request.operation !== "routePage") {
+          return yield* Effect.die(
+            new UnexpectedRollbackTestState({
+              operation: "select-route-request",
+            })
+          );
+        }
+        const response = yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexActionProgram(
+              readRollback(ctx, request).pipe(
+                Effect.provideService(
+                  ContentVerificationKeyResolver,
+                  TEST_KEY_RESOLVER
+                )
+              )
+            )
+          )
+        );
+
+        expect(response).toMatchObject({
+          done: true,
+          nextIndex: routeCount - 1,
+          total: routeCount,
+        });
+        expect(response.records).toHaveLength(routeCount);
+      })
+  );
 });

--- a/packages/backend/convex/contentRelease/ingress/stage.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/stage.test.ts
@@ -20,7 +20,17 @@ import type {
   ContentSnapshotRow,
 } from "@nakafa/aksara-contracts/release/snapshot/data";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
+import type {
+  ActionCtx,
+  MutationCtx,
+} from "@repo/backend/convex/_generated/server";
 import { stagePublication } from "@repo/backend/convex/contentRelease/ingress/stage";
+import {
+  type ConvexTaggedError,
+  getUnknownErrorMessage,
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -45,8 +55,8 @@ import {
   makeProgramSnapshotData,
   type ProgramSnapshotData,
 } from "@repo/backend/test/program/snapshot";
-import { convexTest } from "convex-test";
-import { Effect } from "effect";
+import { convexTest, type TestConvex } from "convex-test";
+import { Data, Effect, Schema } from "effect";
 
 const candidateId = ReleaseIdSchema.make("release-stage-candidate");
 const activeKeyId = SigningKeyIdSchema.make("test-active-key");
@@ -104,289 +114,320 @@ function snapshotRelease(snapshots: ProgramSnapshotData["snapshots"]) {
   );
 }
 
-describe("content release staging ingress", () => {
-  it("rejects a renderer not owned by the signed release", async () => {
-    const t = convexTest(schema, convexModules);
+class ObservedStageActionFailure extends Schema.TaggedError<ObservedStageActionFailure>()(
+  "ObservedStageActionFailure",
+  { cause: Schema.Unknown }
+) {}
 
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(
-            ctx,
-            {
-              operation: "stageRelease",
-              release: signedRelease(),
-              rendererManifest: testProofRenderer("h1"),
-            },
-            TEST_KEY_ID
-          ).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
-            )
+class UnexpectedStageTestState extends Data.TaggedError(
+  "UnexpectedStageTestState"
+)<{
+  readonly operation: "select-program-row" | "select-recovery-release";
+}> {}
+
+/** Stores one candidate or recovery release under the rotated-key fixture. */
+const storeIngressRelease = Effect.fn(
+  "test.contentRelease.storeIngressRelease"
+)(function* (ctx: MutationCtx, role: "candidate" | "recovery") {
+  yield* Effect.promise(() =>
+    insertSignedCandidate(
+      ctx,
+      ingressReleaseId,
+      activeSignedRelease(),
+      JSON.stringify(TEST_PROOF_RENDERER)
+    )
+  );
+  if (role === "candidate") {
+    return;
+  }
+  const [release, state] = yield* Effect.all([
+    Effect.promise(() => ctx.db.query("contentReleases").unique()),
+    Effect.promise(() => ctx.db.query("contentState").unique()),
+  ]);
+  if (!(release && state)) {
+    return yield* Effect.die(
+      new UnexpectedStageTestState({
+        operation: "select-recovery-release",
+      })
+    );
+  }
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentReleases", release._id, { role })
+  );
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentState", state._id, {
+      candidateManifestHash: undefined,
+      candidateReleaseId: undefined,
+      candidateSequence: undefined,
+      recoveryManifestHash: ingressRelease.manifestHash,
+      recoveryReleaseId: ingressReleaseId,
+      recoverySequence: release.sequence,
+    })
+  );
+});
+
+/** Runs one staging program through the real Convex action boundary. */
+const runStage = Effect.fn("test.contentRelease.runStage")(function* <
+  A,
+  E extends ConvexTaggedError,
+>(
+  target: TestConvex<typeof schema>,
+  makeProgram: (
+    ctx: ActionCtx
+  ) => Effect.Effect<A, E, ContentVerificationKeyResolver>,
+  resolver = TEST_KEY_RESOLVER
+) {
+  return yield* Effect.tryPromise({
+    catch: (cause) => new ObservedStageActionFailure({ cause }),
+    try: () =>
+      target.action((ctx) =>
+        runConvexActionProgram(
+          makeProgram(ctx).pipe(
+            Effect.provideService(ContentVerificationKeyResolver, resolver)
           )
         )
-      )
-    ).rejects.toThrow("does not own the supplied renderer snapshot");
-  });
-
-  it("rejects a stored candidate whose signed identity drifted", async () => {
-    const t = convexTest(schema, convexModules);
-    const other = signedRelease(ReleaseIdSchema.make("release-stage-other"));
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        candidateId,
-        other,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(
-            ctx,
-            {
-              artifacts: [testSignedArtifact()],
-              batchIndex: 0,
-              operation: "stageArtifactBatch",
-              releaseId: candidateId,
-            },
-            TEST_KEY_ID
-          ).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
-            )
-          )
-        )
-      )
-    ).rejects.toThrow("identity does not match its stored envelope");
-  });
-
-  it("rejects a tampered artifact before storage", async () => {
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        candidateId,
-        signedRelease(),
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-    const artifact = testSignedArtifact();
-    const prefix = artifact.signature.startsWith("A") ? "B" : "A";
-    const tampered = {
-      ...artifact,
-      signature: Ed25519SignatureSchema.make(
-        `${prefix}${artifact.signature.slice(1)}`
       ),
-    };
-
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(
-            ctx,
-            {
-              artifacts: [tampered],
-              batchIndex: 0,
-              operation: "stageArtifactBatch",
-              releaseId: candidateId,
-            },
-            TEST_KEY_ID
-          ).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
-            )
-          )
-        )
-      )
-    ).rejects.toThrow("Content release verification failed");
   });
+});
 
-  it("admits retained artifacts only for authenticated recovery rows", async () => {
-    for (const role of ["candidate", "recovery"] as const) {
+describe("content release staging ingress", () => {
+  it.effect("rejects a renderer not owned by the signed release", () =>
+    Effect.gen(function* () {
       const t = convexTest(schema, convexModules);
-      await t.mutation(async (ctx) => {
-        await insertSignedCandidate(
+      const failure = yield* runStage(t, (ctx) =>
+        stagePublication(
           ctx,
-          ingressReleaseId,
-          activeSignedRelease(),
-          JSON.stringify(TEST_PROOF_RENDERER)
-        );
-        if (role === "candidate") {
-          return;
-        }
-        const [release, state] = await Promise.all([
-          ctx.db.query("contentReleases").unique(),
-          ctx.db.query("contentState").unique(),
-        ]);
-        if (!(release && state)) {
-          throw new Error("Expected one staged release and state row.");
-        }
-        await ctx.db.patch("contentReleases", release._id, { role });
-        await ctx.db.patch("contentState", state._id, {
-          candidateManifestHash: undefined,
-          candidateReleaseId: undefined,
-          candidateSequence: undefined,
-          recoveryManifestHash: ingressRelease.manifestHash,
-          recoveryReleaseId: ingressReleaseId,
-          recoverySequence: release.sequence,
-        });
-      });
-      await t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(ctx, {
-            batchIndex: 0,
-            items: [ingressItem],
-            operation: "stageItemBatch",
-            releaseId: ingressReleaseId,
-          }).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              rotatedKeyResolver
-            )
-          )
+          {
+            operation: "stageRelease",
+            release: signedRelease(),
+            rendererManifest: testProofRenderer("h1"),
+          },
+          TEST_KEY_ID
         )
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        "does not own the supplied renderer snapshot"
       );
-      const stageArtifact = t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(
+    })
+  );
+
+  it.effect("rejects a stored candidate whose signed identity drifted", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const other = signedRelease(ReleaseIdSchema.make("release-stage-other"));
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          insertSignedCandidate(
             ctx,
-            {
-              artifacts: [ingressArtifact],
-              batchIndex: 0,
-              operation: "stageArtifactBatch",
-              releaseId: ingressReleaseId,
-            },
-            activeKeyId
-          ).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              rotatedKeyResolver
-            )
+            candidateId,
+            other,
+            JSON.stringify(TEST_PROOF_RENDERER)
           )
         )
       );
-      if (role === "candidate") {
-        await expect(stageArtifact).rejects.toThrow(
-          "must use the active content signing key"
+      const failure = yield* runStage(t, (ctx) =>
+        stagePublication(
+          ctx,
+          {
+            artifacts: [testSignedArtifact()],
+            batchIndex: 0,
+            operation: "stageArtifactBatch",
+            releaseId: candidateId,
+          },
+          TEST_KEY_ID
+        )
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        "identity does not match its stored envelope"
+      );
+    })
+  );
+
+  it.effect("rejects a tampered artifact before storage", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          insertSignedCandidate(
+            ctx,
+            candidateId,
+            signedRelease(),
+            JSON.stringify(TEST_PROOF_RENDERER)
+          )
+        )
+      );
+      const artifact = testSignedArtifact();
+      const prefix = artifact.signature.startsWith("A") ? "B" : "A";
+      const tampered = {
+        ...artifact,
+        signature: Ed25519SignatureSchema.make(
+          `${prefix}${artifact.signature.slice(1)}`
+        ),
+      };
+      const failure = yield* runStage(t, (ctx) =>
+        stagePublication(
+          ctx,
+          {
+            artifacts: [tampered],
+            batchIndex: 0,
+            operation: "stageArtifactBatch",
+            releaseId: candidateId,
+          },
+          TEST_KEY_ID
+        )
+      ).pipe(Effect.flip);
+      expect(getUnknownErrorMessage(failure.cause)).toContain(
+        "Content release verification failed"
+      );
+    })
+  );
+
+  it.effect(
+    "admits retained artifacts only for authenticated recovery rows",
+    () =>
+      Effect.gen(function* () {
+        for (const role of ["candidate", "recovery"] as const) {
+          const t = convexTest(schema, convexModules);
+          yield* Effect.promise(() =>
+            t.mutation((ctx) =>
+              runConvexProgram(storeIngressRelease(ctx, role))
+            )
+          );
+          yield* runStage(
+            t,
+            (ctx) =>
+              stagePublication(ctx, {
+                batchIndex: 0,
+                items: [ingressItem],
+                operation: "stageItemBatch",
+                releaseId: ingressReleaseId,
+              }),
+            rotatedKeyResolver
+          );
+          const stageArtifact = runStage(
+            t,
+            (ctx) =>
+              stagePublication(
+                ctx,
+                {
+                  artifacts: [ingressArtifact],
+                  batchIndex: 0,
+                  operation: "stageArtifactBatch",
+                  releaseId: ingressReleaseId,
+                },
+                activeKeyId
+              ),
+            rotatedKeyResolver
+          );
+          if (role === "candidate") {
+            const failure = yield* stageArtifact.pipe(Effect.flip);
+            expect(getUnknownErrorMessage(failure.cause)).toContain(
+              "must use the active content signing key"
+            );
+            continue;
+          }
+          expect(yield* stageArtifact).toMatchObject({
+            ok: true,
+            operation: "stageArtifactBatch",
+            value: { created: 1, unchanged: 0 },
+          });
+        }
+      })
+  );
+
+  it.effect(
+    "rejects a poisoned manifest before storage and accepts its exact retry",
+    () =>
+      Effect.gen(function* () {
+        const data = yield* makeProgramSnapshotData();
+        const release = snapshotRelease(data.snapshots);
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            insertSignedCandidate(
+              ctx,
+              candidateId,
+              release,
+              JSON.stringify(TEST_PROOF_RENDERER)
+            )
+          )
         );
-        continue;
-      }
-      await expect(stageArtifact).resolves.toMatchObject({
-        ok: true,
-        operation: "stageArtifactBatch",
-        value: { created: 1, unchanged: 0 },
-      });
-    }
-  });
-
-  it("rejects a poisoned manifest before storage and accepts its exact retry", async () => {
-    const data = await Effect.runPromise(makeProgramSnapshotData());
-    const release = snapshotRelease(data.snapshots);
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        candidateId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-    const tampered: ContentSnapshotManifest = {
-      family: "program",
-      manifest: ProgramSnapshotSchema.make({
-        ...data.snapshot.manifest,
-        rowDigest: Sha256HashSchema.make(`sha256:${"9".repeat(64)}`),
-      }),
-    };
-
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
+        const tampered: ContentSnapshotManifest = {
+          family: "program",
+          manifest: ProgramSnapshotSchema.make({
+            ...data.snapshot.manifest,
+            rowDigest: Sha256HashSchema.make(`sha256:${"9".repeat(64)}`),
+          }),
+        };
+        const failure = yield* runStage(t, (ctx) =>
           stagePublication(ctx, {
             operation: "stageSnapshot",
             releaseId: candidateId,
             snapshot: tampered,
-          }).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
+          })
+        ).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "invalid content identity"
+        );
+        expect(
+          yield* Effect.promise(() =>
+            t.run((ctx) => ctx.db.query("contentSnapshots").unique())
+          )
+        ).toBeNull();
+        expect(
+          yield* runStage(t, (ctx) =>
+            stagePublication(ctx, {
+              operation: "stageSnapshot",
+              releaseId: candidateId,
+              snapshot: data.snapshot,
+            })
+          )
+        ).toMatchObject({
+          ok: true,
+          operation: "stageSnapshot",
+          value: { created: 1, snapshotId: data.snapshotId },
+        });
+      })
+  );
+
+  it.effect(
+    "rejects poisoned rows before storage and accepts the exact batch retry",
+    () =>
+      Effect.gen(function* () {
+        const data = yield* makeProgramSnapshotData();
+        const [firstRow, ...remainingRows] = data.rows;
+        if (firstRow?.family !== "program") {
+          return yield* Effect.die(
+            new UnexpectedStageTestState({ operation: "select-program-row" })
+          );
+        }
+        const tampered: ContentSnapshotRow = {
+          ...firstRow,
+          record: {
+            ...firstRow.record,
+            rowHash: Sha256HashSchema.make(`sha256:${"9".repeat(64)}`),
+          },
+        };
+        const release = snapshotRelease(data.snapshots);
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            insertSignedCandidate(
+              ctx,
+              candidateId,
+              release,
+              JSON.stringify(TEST_PROOF_RENDERER)
             )
           )
-        )
-      )
-    ).rejects.toThrow("invalid content identity");
-    await expect(
-      t.run((ctx) => ctx.db.query("contentSnapshots").unique())
-    ).resolves.toBeNull();
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
+        );
+        yield* runStage(t, (ctx) =>
           stagePublication(ctx, {
             operation: "stageSnapshot",
             releaseId: candidateId,
             snapshot: data.snapshot,
-          }).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
-            )
-          )
-        )
-      )
-    ).resolves.toMatchObject({
-      ok: true,
-      operation: "stageSnapshot",
-      value: { created: 1, snapshotId: data.snapshotId },
-    });
-  });
-
-  it("rejects poisoned rows before storage and accepts the exact batch retry", async () => {
-    const data = await Effect.runPromise(makeProgramSnapshotData());
-    const [firstRow, ...remainingRows] = data.rows;
-    if (firstRow?.family !== "program") {
-      throw new Error("Expected one program snapshot row.");
-    }
-    const tampered: ContentSnapshotRow = {
-      ...firstRow,
-      record: {
-        ...firstRow.record,
-        rowHash: Sha256HashSchema.make(`sha256:${"9".repeat(64)}`),
-      },
-    };
-    const release = snapshotRelease(data.snapshots);
-    const t = convexTest(schema, convexModules);
-    await t.mutation((ctx) =>
-      insertSignedCandidate(
-        ctx,
-        candidateId,
-        release,
-        JSON.stringify(TEST_PROOF_RENDERER)
-      )
-    );
-    await t.action((ctx) =>
-      Effect.runPromise(
-        stagePublication(ctx, {
-          operation: "stageSnapshot",
-          releaseId: candidateId,
-          snapshot: data.snapshot,
-        }).pipe(
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
-          )
-        )
-      )
-    );
-
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
+          })
+        );
+        const failure = yield* runStage(t, (ctx) =>
           stagePublication(ctx, {
             batchIndex: 0,
             family: "program",
@@ -394,48 +435,49 @@ describe("content release staging ingress", () => {
             releaseId: candidateId,
             rows: [tampered],
             snapshotId: data.snapshotId,
-          }).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
+          })
+        ).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "invalid content identity"
+        );
+        const stored = yield* Effect.promise(() =>
+          t.run((ctx) =>
+            runConvexProgram(
+              Effect.all({
+                batches: Effect.promise(() =>
+                  ctx.db.query("snapshotBatches").collect()
+                ),
+                curriculum: Effect.promise(() =>
+                  ctx.db.query("curriculumRoutes").collect()
+                ),
+                programs: Effect.promise(() =>
+                  ctx.db.query("programCatalog").collect()
+                ),
+              })
             )
           )
-        )
-      )
-    ).rejects.toThrow("invalid content identity");
-    await expect(
-      t.run(async (ctx) => ({
-        batches: await ctx.db.query("snapshotBatches").collect(),
-        curriculum: await ctx.db.query("curriculumRoutes").collect(),
-        programs: await ctx.db.query("programCatalog").collect(),
-      }))
-    ).resolves.toEqual({ batches: [], curriculum: [], programs: [] });
-    await expect(
-      t.action((ctx) =>
-        Effect.runPromise(
-          stagePublication(ctx, {
+        );
+        expect(stored).toEqual({ batches: [], curriculum: [], programs: [] });
+        expect(
+          yield* runStage(t, (ctx) =>
+            stagePublication(ctx, {
+              batchIndex: 0,
+              family: "program",
+              operation: "stageSnapshotBatch",
+              releaseId: candidateId,
+              rows: [firstRow, ...remainingRows],
+              snapshotId: data.snapshotId,
+            })
+          )
+        ).toMatchObject({
+          ok: true,
+          operation: "stageSnapshotBatch",
+          value: {
             batchIndex: 0,
             family: "program",
-            operation: "stageSnapshotBatch",
-            releaseId: candidateId,
-            rows: [firstRow, ...remainingRows],
             snapshotId: data.snapshotId,
-          }).pipe(
-            Effect.provideService(
-              ContentVerificationKeyResolver,
-              TEST_KEY_RESOLVER
-            )
-          )
-        )
-      )
-    ).resolves.toMatchObject({
-      ok: true,
-      operation: "stageSnapshotBatch",
-      value: {
-        batchIndex: 0,
-        family: "program",
-        snapshotId: data.snapshotId,
-      },
-    });
-  });
+          },
+        });
+      })
+  );
 });

--- a/packages/backend/convex/contentRelease/program/context.test.ts
+++ b/packages/backend/convex/contentRelease/program/context.test.ts
@@ -127,65 +127,68 @@ function mappingRoute(
 }
 
 /** Stages additional immutable curriculum rows into one technical snapshot. */
-async function stageRoutes(
+const stageRoutes = Effect.fn("test.stageProgramContextRoutes")(function* (
   target: TestConvex<typeof schema>,
   data: ProgramSnapshotData,
   routes: readonly CurriculumRoute[]
 ) {
-  const rows = await Effect.runPromise(
-    Effect.forEach(routes, (route) =>
+  yield* Effect.forEach(
+    routes,
+    (route, offset) =>
       Effect.gen(function* () {
         const record = yield* makeCurriculumSnapshotRow(route);
         const source = {
           family: "program",
           record,
         } satisfies ContentSnapshotRow;
-        return {
-          rowJson: canonicalizeContentSnapshotRow(source),
-          source,
-        };
-      })
-    )
+        const rowJson = canonicalizeContentSnapshotRow(source);
+        yield* Effect.promise(() =>
+          target.mutation((ctx) =>
+            runConvexProgram(
+              stageProgramRow(
+                ctx,
+                data.snapshotId,
+                data.rowJson.length + offset,
+                source,
+                rowJson
+              )
+            )
+          )
+        );
+      }),
+    { discard: true }
   );
-  for (const [offset, row] of rows.entries()) {
-    await target.mutation((ctx) =>
-      runConvexProgram(
-        stageProgramRow(
-          ctx,
-          data.snapshotId,
-          data.rowJson.length + offset,
-          row.source,
-          row.rowJson
-        )
-      )
-    );
-  }
-}
+});
 
 describe("contentRelease/program/context", () => {
-  it("returns unmanaged before program publication", async () => {
-    const t = convexTest(schema, convexModules);
+  it.effect("returns unmanaged before program publication", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const result = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(readProgramContext(ctx, "en", CONTEXT_INPUT))
+        )
+      );
 
-    await expect(
-      t.query((ctx) =>
-        runConvexProgram(readProgramContext(ctx, "en", CONTEXT_INPUT))
-      )
-    ).resolves.toEqual({
-      context: null,
-      managed: false,
-    });
-  });
+      expect(result).toEqual({
+        context: null,
+        managed: false,
+      });
+    })
+  );
 
-  it.live(
+  it.effect(
     "resolves one verified material context and its card-list parent",
     () =>
       Effect.gen(function* () {
         const data = yield* makeProgramSnapshotData();
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
-        yield* Effect.promise(() =>
-          stageRoutes(t, data, [subjectRoute(), groupRoute(), mappingRoute()])
-        );
+        yield* stageRoutes(t, data, [
+          subjectRoute(),
+          groupRoute(),
+          mappingRoute(),
+        ]);
 
         yield* Effect.promise(() =>
           expect(
@@ -204,7 +207,7 @@ describe("contentRelease/program/context", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "resolves a moved exact lesson from the current signed projection",
     () =>
       Effect.gen(function* () {
@@ -222,17 +225,13 @@ describe("contentRelease/program/context", () => {
           ),
         });
         yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* stageRoutes(target, data, [
+          subjectRoute(),
+          groupRoute(),
+          mappingRoute(1, renamed.parentPath),
+        ]);
         yield* Effect.promise(() =>
-          stageRoutes(target, data, [
-            subjectRoute(),
-            groupRoute(),
-            mappingRoute(1, renamed.parentPath),
-          ])
-        );
-        yield* Effect.promise(() =>
-          target.mutation(async (ctx) => {
-            await insertMaterialProjection(ctx, renamed);
-          })
+          target.mutation((ctx) => insertMaterialProjection(ctx, renamed))
         );
 
         yield* Effect.promise(() =>
@@ -257,14 +256,12 @@ describe("contentRelease/program/context", () => {
       })
   );
 
-  it.live("ignores missing, root, and unmapped context hints", () =>
+  it.effect("ignores missing, root, and unmapped context hints", () =>
     Effect.gen(function* () {
       const data = yield* makeProgramSnapshotData();
       const t = convexTest(schema, convexModules);
       yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      yield* Effect.promise(() =>
-        stageRoutes(t, data, [subjectRoute(), groupRoute()])
-      );
+      yield* stageRoutes(t, data, [subjectRoute(), groupRoute()]);
 
       for (const nodeKey of [
         "missing-group",
@@ -290,7 +287,7 @@ describe("contentRelease/program/context", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "ignores a context whose direct parent is not a card-list route",
     () =>
       Effect.gen(function* () {
@@ -298,15 +295,13 @@ describe("contentRelease/program/context", () => {
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
         const directPath = PublicPathSchema.make(`${ROOT_PATH}/direct-group`);
-        yield* Effect.promise(() =>
-          stageRoutes(t, data, [
-            groupRoute(
-              ROOT_PATH,
-              directPath,
-              CurriculumNodeKeySchema.make("direct-group")
-            ),
-          ])
-        );
+        yield* stageRoutes(t, data, [
+          groupRoute(
+            ROOT_PATH,
+            directPath,
+            CurriculumNodeKeySchema.make("direct-group")
+          ),
+        ]);
 
         yield* Effect.promise(() =>
           expect(
@@ -326,7 +321,7 @@ describe("contentRelease/program/context", () => {
       })
   );
 
-  it.live("rejects a context group whose stored parent disappeared", () =>
+  it.effect("rejects a context group whose stored parent disappeared", () =>
     Effect.gen(function* () {
       const data = yield* makeProgramSnapshotData();
       const t = convexTest(schema, convexModules);
@@ -335,15 +330,13 @@ describe("contentRelease/program/context", () => {
         `${ROOT_PATH}/missing-parent`
       );
       const orphanPath = PublicPathSchema.make(`${missingParent}/orphan-group`);
-      yield* Effect.promise(() =>
-        stageRoutes(t, data, [
-          groupRoute(
-            missingParent,
-            orphanPath,
-            CurriculumNodeKeySchema.make("orphan-group")
-          ),
-        ])
-      );
+      yield* stageRoutes(t, data, [
+        groupRoute(
+          missingParent,
+          orphanPath,
+          CurriculumNodeKeySchema.make("orphan-group")
+        ),
+      ]);
 
       yield* Effect.promise(() =>
         expect(
@@ -362,22 +355,18 @@ describe("contentRelease/program/context", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "rejects a context relationship beyond its bounded read contract",
     () =>
       Effect.gen(function* () {
         const data = yield* makeProgramSnapshotData();
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
-        yield* Effect.promise(() =>
-          stageRoutes(t, data, [
-            subjectRoute(),
-            groupRoute(),
-            ...Array.from({ length: 101 }, (_, index) =>
-              mappingRoute(index + 1)
-            ),
-          ])
-        );
+        yield* stageRoutes(t, data, [
+          subjectRoute(),
+          groupRoute(),
+          ...Array.from({ length: 101 }, (_, index) => mappingRoute(index + 1)),
+        ]);
 
         yield* Effect.promise(() =>
           expect(
@@ -391,7 +380,7 @@ describe("contentRelease/program/context", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "rejects a sibling lesson when a mapping names one exact lesson",
     () =>
       Effect.gen(function* () {
@@ -399,13 +388,11 @@ describe("contentRelease/program/context", () => {
         const t = convexTest(schema, convexModules);
         const sibling = makeMaterialProjection("en", 2);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
-        yield* Effect.promise(() =>
-          stageRoutes(t, data, [
-            subjectRoute(),
-            groupRoute(),
-            mappingRoute(1, MATERIAL_PUBLIC_PATH),
-          ])
-        );
+        yield* stageRoutes(t, data, [
+          subjectRoute(),
+          groupRoute(),
+          mappingRoute(1, MATERIAL_PUBLIC_PATH),
+        ]);
         yield* Effect.promise(() =>
           t.mutation((ctx) => insertMaterialProjection(ctx, sibling))
         );
@@ -437,19 +424,17 @@ describe("contentRelease/program/context", () => {
       })
   );
 
-  it.live("rejects ambiguous mappings for one exact material context", () =>
+  it.effect("rejects ambiguous mappings for one exact material context", () =>
     Effect.gen(function* () {
       const data = yield* makeProgramSnapshotData();
       const t = convexTest(schema, convexModules);
       yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      yield* Effect.promise(() =>
-        stageRoutes(t, data, [
-          subjectRoute(),
-          groupRoute(),
-          mappingRoute(1),
-          mappingRoute(2),
-        ])
-      );
+      yield* stageRoutes(t, data, [
+        subjectRoute(),
+        groupRoute(),
+        mappingRoute(1),
+        mappingRoute(2),
+      ]);
 
       yield* Effect.promise(() =>
         expect(

--- a/packages/backend/convex/contentRelease/program/route.test.ts
+++ b/packages/backend/convex/contentRelease/program/route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { CurriculumRouteSchema } from "@nakafa/aksara-contracts/program/curriculum";
 import { makeCurriculumSnapshotRow } from "@nakafa/aksara-contracts/program/snapshot/row-hash";
 import { canonicalizeContentSnapshotRow } from "@nakafa/aksara-contracts/release/snapshot/data";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { decodeSnapshotRowJson } from "@repo/backend/convex/contentRelease/parse";
 import { readProgramRoute } from "@repo/backend/convex/contentRelease/program/route";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -25,6 +26,16 @@ import { convexTest, type TestConvex } from "convex-test";
 import { Effect, Schema } from "effect";
 
 const PROGRAM_ROOT = "curriculum/technical-program-1";
+
+class ProgramRouteQueryRejected extends Schema.TaggedError<ProgramRouteQueryRejected>()(
+  "ProgramRouteQueryRejected",
+  { cause: Schema.Unknown }
+) {}
+
+class UnexpectedProgramRouteTestState extends Schema.TaggedError<UnexpectedProgramRouteTestState>()(
+  "UnexpectedProgramRouteTestState",
+  { operation: Schema.Literal("load-active-curriculum-route") }
+) {}
 
 /** Creates one authored material group under the technical root. */
 function materialGroup(groupIndex: number, order: number) {
@@ -74,42 +85,54 @@ function materialContext(
 }
 
 /** Adds exact authored curriculum routes to one active test snapshot. */
-async function insertCurriculumRoutes(
+const insertCurriculumRoutes = Effect.fn(
+  "contentRelease.program.route.test.insertCurriculumRoutes"
+)(function* (
   target: TestConvex<typeof schema>,
   snapshotId: string,
   routes: readonly ReturnType<typeof materialContext>[]
 ) {
-  const records = await Effect.runPromise(
-    Effect.forEach(routes, makeCurriculumSnapshotRow)
+  const records = yield* Effect.forEach(routes, makeCurriculumSnapshotRow);
+  yield* Effect.promise(() =>
+    target.mutation((ctx) =>
+      runConvexProgram(
+        Effect.forEach(
+          records,
+          (record, offset) => {
+            const row = record.row;
+            return Effect.promise(() =>
+              ctx.db.insert("curriculumRoutes", {
+                appLocale: row.appLocale,
+                index: 10 + offset,
+                level: row.level,
+                contextPath: row.materialContextParentPath,
+                materialKey: row.materialKey,
+                nodeKey: row.nodeKey,
+                order: row.order,
+                parentPath: row.parentPath,
+                programKey: row.programKey,
+                path: row.publicPath,
+                rowHash: record.rowHash,
+                rowJson: canonicalizeContentSnapshotRow({
+                  family: "program",
+                  record,
+                }),
+                snapshotId,
+                sourcePath: row.sourcePath,
+              })
+            );
+          },
+          { discard: true }
+        )
+      )
+    )
   );
-  await target.mutation(async (ctx) => {
-    for (const [offset, record] of records.entries()) {
-      const row = record.row;
-      await ctx.db.insert("curriculumRoutes", {
-        appLocale: row.appLocale,
-        index: 10 + offset,
-        level: row.level,
-        contextPath: row.materialContextParentPath,
-        materialKey: row.materialKey,
-        nodeKey: row.nodeKey,
-        order: row.order,
-        parentPath: row.parentPath,
-        programKey: row.programKey,
-        path: row.publicPath,
-        rowHash: record.rowHash,
-        rowJson: canonicalizeContentSnapshotRow({
-          family: "program",
-          record,
-        }),
-        snapshotId,
-        sourcePath: row.sourcePath,
-      });
-    }
-  });
-}
+});
 
 /** Inserts material projections in bounded test transactions. */
-async function insertMaterialGroups(
+const insertMaterialGroups = Effect.fn(
+  "contentRelease.program.route.test.insertMaterialGroups"
+)(function* (
   target: TestConvex<typeof schema>,
   groups: readonly {
     readonly materialIndex: number;
@@ -122,238 +145,274 @@ async function insertMaterialGroups(
     )
   );
   for (let first = 0; first < projections.length; first += 32) {
-    await target.mutation(async (ctx) => {
-      for (const projection of projections.slice(first, first + 32)) {
-        await insertMaterialProjection(ctx, projection);
-      }
-    });
-  }
-}
-
-describe("contentRelease/program/route", () => {
-  it.live("returns one exact verified route and its program provenance", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const t = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      const result = yield* Effect.promise(() =>
-        t.query((ctx) =>
-          runConvexProgram(
-            readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+    yield* Effect.promise(() =>
+      target.mutation((ctx) =>
+        runConvexProgram(
+          Effect.forEach(
+            projections.slice(first, first + 32),
+            (projection) =>
+              Effect.promise(() => insertMaterialProjection(ctx, projection)),
+            { discard: true }
           )
         )
-      );
-      const [program, route] = yield* Effect.all([
-        decodeSnapshotRowJson(result.programJson ?? ""),
-        decodeSnapshotRowJson(result.routeJson ?? ""),
-      ]);
+      )
+    );
+  }
+});
 
-      expect(result).toMatchObject({
-        activeManifestHash: TEST_MANIFEST_HASH,
-        activeReleaseId: TEST_RELEASE_ID,
-        ancestorJson: [],
-        childJson: [],
-        contextJson: [],
-        groupJson: [],
-        managed: true,
-        materialJson: [],
-        snapshotId: data.snapshotId,
-        sourceRevision: "a".repeat(40),
-      });
-      expect(program).toMatchObject({
-        family: "program",
-        record: {
-          kind: "program",
-          row: { key: "technical-program-1" },
-        },
-      });
-      expect(route).toMatchObject({
-        family: "program",
-        record: {
-          kind: "curriculum",
-          row: { appLocale: "en", programKey: "technical-program-1" },
-        },
-      });
+/** Corrupts one indexed identity to exercise the read integrity boundary. */
+const tamperCurriculumRoute = Effect.fn(
+  "contentRelease.program.route.test.tamperCurriculumRoute"
+)(function* (ctx: MutationCtx, snapshotId: string) {
+  const row = yield* Effect.promise(() =>
+    ctx.db
+      .query("curriculumRoutes")
+      .withIndex("by_snapshotId_and_index", (index) =>
+        index.eq("snapshotId", snapshotId).eq("index", 2)
+      )
+      .unique()
+  );
+  if (!row) {
+    return yield* Effect.die(
+      new UnexpectedProgramRouteTestState({
+        operation: "load-active-curriculum-route",
+      })
+    );
+  }
+  yield* Effect.promise(() =>
+    ctx.db.patch("curriculumRoutes", row._id, {
+      programKey: "tampered-program",
     })
   );
+});
 
-  it.live(
-    "distinguishes a managed missing route from an unmanaged source",
-    () =>
-      Effect.gen(function* () {
+describe("contentRelease/program/route", () => {
+  it.effect(
+    "returns one exact verified route and its program provenance",
+    Effect.fn("contentRelease.program.route.test.returnsExactRoute")(
+      function* () {
         const data = yield* makeProgramSnapshotData();
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() => activateProgramSnapshot(t, data));
-
-        yield* Effect.promise(() =>
-          expect(
-            t.query((ctx) =>
-              runConvexProgram(readProgramRoute(ctx, "id", "kurikulum/missing"))
-            )
-          ).resolves.toMatchObject({
-            managed: true,
-            programJson: null,
-            routeJson: null,
-          })
-        );
-      })
-  );
-
-  it("preserves the active release while programs remain source-owned", async () => {
-    const target = convexTest(schema, convexModules);
-    await activateMaterialCatalog(target);
-
-    await expect(
-      target.query((ctx) =>
-        runConvexProgram(
-          readProgramRoute(ctx, "en", "curriculum/technical-program-1")
-        )
-      )
-    ).resolves.toMatchObject({
-      activeReleaseId: MATERIAL_IDENTITY.releaseId,
-      managed: false,
-      routeJson: null,
-    });
-  });
-
-  it.live("rejects a curriculum row whose indexed identity drifted", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const t = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(t, data));
-      yield* Effect.promise(() =>
-        t.mutation(async (ctx) => {
-          const row = await ctx.db
-            .query("curriculumRoutes")
-            .withIndex("by_snapshotId_and_index", (index) =>
-              index.eq("snapshotId", data.snapshotId).eq("index", 2)
-            )
-            .unique();
-          if (!row) {
-            throw new Error("Expected one active curriculum route.");
-          }
-          await ctx.db.patch("curriculumRoutes", row._id, {
-            programKey: "tampered-program",
-          });
-        })
-      );
-
-      yield* Effect.promise(() =>
-        expect(
+        const result = yield* Effect.promise(() =>
           t.query((ctx) =>
             runConvexProgram(
               readProgramRoute(ctx, "en", "curriculum/technical-program-1")
             )
           )
-        ).rejects.toMatchObject({
-          data: { code: "CONTENT_RELEASE_INTEGRITY" },
-        })
-      );
-    })
+        );
+        const [program, route] = yield* Effect.all([
+          decodeSnapshotRowJson(result.programJson ?? ""),
+          decodeSnapshotRowJson(result.routeJson ?? ""),
+        ]);
+
+        expect(result).toMatchObject({
+          activeManifestHash: TEST_MANIFEST_HASH,
+          activeReleaseId: TEST_RELEASE_ID,
+          ancestorJson: [],
+          childJson: [],
+          contextJson: [],
+          groupJson: [],
+          managed: true,
+          materialJson: [],
+          snapshotId: data.snapshotId,
+          sourceRevision: "a".repeat(40),
+        });
+        expect(program).toMatchObject({
+          family: "program",
+          record: {
+            kind: "program",
+            row: { key: "technical-program-1" },
+          },
+        });
+        expect(route).toMatchObject({
+          family: "program",
+          record: {
+            kind: "curriculum",
+            row: { appLocale: "en", programKey: "technical-program-1" },
+          },
+        });
+      }
+    )
   );
 
-  it.live("omits material projections removed after the program snapshot", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [materialContext(1)])
-      );
+  it.effect(
+    "distinguishes a managed missing route from an unmanaged source",
+    Effect.fn("contentRelease.program.route.test.distinguishesMissingRoute")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(t, data));
 
-      yield* Effect.promise(() =>
-        expect(
+        const result = yield* Effect.promise(() =>
+          t.query((ctx) =>
+            runConvexProgram(readProgramRoute(ctx, "id", "kurikulum/missing"))
+          )
+        );
+        expect(result).toMatchObject({
+          managed: true,
+          programJson: null,
+          routeJson: null,
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "preserves the active release while programs remain source-owned",
+    Effect.fn("contentRelease.program.route.test.preservesActiveRelease")(
+      function* () {
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateMaterialCatalog(target));
+
+        const result = yield* Effect.promise(() =>
+          target.query((ctx) =>
+            runConvexProgram(
+              readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+            )
+          )
+        );
+        expect(result).toMatchObject({
+          activeReleaseId: MATERIAL_IDENTITY.releaseId,
+          managed: false,
+          routeJson: null,
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "rejects a curriculum row whose indexed identity drifted",
+    Effect.fn("contentRelease.program.route.test.rejectsDriftedIdentity")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const t = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(t, data));
+        yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(tamperCurriculumRoute(ctx, data.snapshotId))
+          )
+        );
+
+        const failure = yield* Effect.tryPromise({
+          try: () =>
+            t.query((ctx) =>
+              runConvexProgram(
+                readProgramRoute(ctx, "en", "curriculum/technical-program-1")
+              )
+            ),
+          catch: (cause) => new ProgramRouteQueryRejected({ cause }),
+        }).pipe(Effect.flip);
+        expect(failure.cause).toMatchObject({
+          data: { code: "CONTENT_RELEASE_INTEGRITY" },
+        });
+      }
+    )
+  );
+
+  it.effect(
+    "omits material projections removed after the program snapshot",
+    Effect.fn("contentRelease.program.route.test.omitsRemovedMaterials")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
+          materialContext(1),
+        ]);
+
+        const result = yield* Effect.promise(() =>
           target.query((ctx) =>
             runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
           )
-        ).resolves.toMatchObject({
+        );
+        expect(result).toMatchObject({
           managed: true,
           materialJson: [],
-        })
-      );
-    })
+        });
+      }
+    )
   );
 
-  it.live("rejects aggregate material fan-out beyond one route budget", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [
+  it.effect(
+    "rejects aggregate material fan-out beyond one route budget",
+    Effect.fn("contentRelease.program.route.test.rejectsMaterialFanOut")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
           materialContext(1),
           materialContext(2),
           materialContext(3),
-        ])
-      );
-      yield* Effect.promise(() =>
-        insertMaterialGroups(target, [
+        ]);
+        yield* insertMaterialGroups(target, [
           { materialIndex: 1, rowCount: 79 },
           { materialIndex: 2, rowCount: 78 },
           { materialIndex: 3, rowCount: 100 },
-        ])
-      );
+        ]);
 
-      yield* Effect.promise(() =>
-        expect(
-          target.query((ctx) =>
-            runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
-          )
-        ).rejects.toMatchObject({
+        const failure = yield* Effect.tryPromise({
+          try: () =>
+            target.query((ctx) =>
+              runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
+            ),
+          catch: (cause) => new ProgramRouteQueryRejected({ cause }),
+        }).pipe(Effect.flip);
+        expect(failure.cause).toMatchObject({
           data: { code: "CONTENT_RELEASE_LIMIT" },
-        })
-      );
-    })
+        });
+      }
+    )
   );
 
-  it.live("orders material groups by their authored route order", () =>
-    Effect.gen(function* () {
-      const data = yield* makeProgramSnapshotData();
-      const target = convexTest(schema, convexModules);
-      const earlierGroup = materialGroup(1, 10);
-      const laterGroup = materialGroup(2, 20);
-      yield* Effect.promise(() => activateProgramSnapshot(target, data));
-      yield* Effect.promise(() =>
-        insertCurriculumRoutes(target, data.snapshotId, [
+  it.effect(
+    "orders material groups by their authored route order",
+    Effect.fn("contentRelease.program.route.test.ordersAuthoredGroups")(
+      function* () {
+        const data = yield* makeProgramSnapshotData();
+        const target = convexTest(schema, convexModules);
+        const earlierGroup = materialGroup(1, 10);
+        const laterGroup = materialGroup(2, 20);
+        yield* Effect.promise(() => activateProgramSnapshot(target, data));
+        yield* insertCurriculumRoutes(target, data.snapshotId, [
           earlierGroup,
           laterGroup,
           materialContext(1, laterGroup),
           materialContext(2, earlierGroup),
-        ])
-      );
-      yield* Effect.promise(() =>
-        insertMaterialGroups(target, [
+        ]);
+        yield* insertMaterialGroups(target, [
           { materialIndex: 1, rowCount: 1 },
           { materialIndex: 2, rowCount: 1 },
-        ])
-      );
+        ]);
 
-      const result = yield* Effect.promise(() =>
-        target.query((ctx) =>
-          runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
-        )
-      );
-      const groups = yield* Effect.forEach(
-        result.groupJson,
-        decodeSnapshotRowJson
-      );
+        const result = yield* Effect.promise(() =>
+          target.query((ctx) =>
+            runConvexProgram(readProgramRoute(ctx, "en", PROGRAM_ROOT))
+          )
+        );
+        const groups = yield* Effect.forEach(
+          result.groupJson,
+          decodeSnapshotRowJson
+        );
 
-      expect(groups).toMatchObject([
-        {
-          family: "program",
-          record: {
-            kind: "curriculum",
-            row: { publicPath: earlierGroup.publicPath },
+        expect(groups).toMatchObject([
+          {
+            family: "program",
+            record: {
+              kind: "curriculum",
+              row: { publicPath: earlierGroup.publicPath },
+            },
           },
-        },
-        {
-          family: "program",
-          record: {
-            kind: "curriculum",
-            row: { publicPath: laterGroup.publicPath },
+          {
+            family: "program",
+            record: {
+              kind: "curriculum",
+              row: { publicPath: laterGroup.publicPath },
+            },
           },
-        },
-      ]);
-    })
+        ]);
+      }
+    )
   );
 });

--- a/packages/backend/convex/contentRelease/proof/verify.test.ts
+++ b/packages/backend/convex/contentRelease/proof/verify.test.ts
@@ -23,6 +23,11 @@ import { contentKeyResolver } from "@repo/backend/content/trust";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { recomputeProgram } from "@repo/backend/convex/contentRelease/proof/verify";
 import { encodeArtifactJson } from "@repo/backend/convex/contentRelease/wire";
+import {
+  getUnknownErrorMessage,
+  runConvexActionProgram,
+  runConvexProgram,
+} from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -38,64 +43,97 @@ import {
   stageUpsertFixture,
 } from "@repo/backend/test/content/verify";
 import { convexTest, type TestConvex } from "convex-test";
-import { Effect, Schema, Stream } from "effect";
+import { Data, Effect, Schema, Stream } from "effect";
 
 const releaseId = ReleaseIdSchema.make("release-proof");
 const manifest = testEmptyManifest(releaseId);
 const signedRelease = testSignedRelease(manifest);
 const manifestHash = signedRelease.manifestHash;
 
+class ObservedProofFailure extends Schema.TaggedError<ObservedProofFailure>()(
+  "ObservedProofFailure",
+  { cause: Schema.Unknown }
+) {}
+
+class UnexpectedProofTestState extends Data.TaggedError(
+  "UnexpectedProofTestState"
+)<{
+  readonly operation:
+    | "load-candidate-manifest"
+    | "load-proof-release"
+    | "load-staged-artifact";
+}> {}
+
 /** Creates one isolated database for the production proof program. */
 function createProofTest() {
   return convexTest(schema, convexModules);
 }
 
-/** Runs the production proof inline across convex-test's component limitation. */
-function runProof(
-  t: TestConvex<typeof schema>,
-  hash = manifestHash,
-  resolver = TEST_KEY_RESOLVER
-) {
-  return recomputeContentProof(t, hash, releaseId, resolver);
-}
+/** Observes the production proof across convex-test's component limitation. */
+const runProof = Effect.fn("contentRelease.proof.verify.test.runProof")(
+  function* (
+    t: TestConvex<typeof schema>,
+    options: {
+      readonly hash?: string;
+      readonly releaseId?: string;
+      readonly resolver?: typeof TEST_KEY_RESOLVER;
+    } = {}
+  ) {
+    const hash = options.hash ?? manifestHash;
+    const proofReleaseId = options.releaseId ?? releaseId;
+    const resolver = options.resolver ?? TEST_KEY_RESOLVER;
+    return yield* Effect.tryPromise({
+      catch: (cause) => new ObservedProofFailure({ cause }),
+      try: () => recomputeContentProof(t, hash, proofReleaseId, resolver),
+    });
+  }
+);
 
 /** Inserts one empty but fully authenticated staged release. */
-async function insertRelease(ctx: MutationCtx) {
+const insertRelease = Effect.fn(
+  "contentRelease.proof.verify.test.insertRelease"
+)(function* (ctx: MutationCtx) {
   const now = Date.UTC(2026, 6, 22, 12, 0, 0);
-  await ctx.db.insert("contentReleases", {
-    baseFamilies: [],
-    checkedIndex: -1,
-    checkedItems: 0,
-    createdAt: now,
-    releaseId,
-    releaseJson: JSON.stringify(signedRelease),
-    rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
-    resultFamilies: [...signedRelease.manifest.scope.families],
-    role: "candidate",
-    sequence: 1,
-    stagedArtifacts: 0,
-    stagedDeletes: 0,
-    stagedItems: 0,
-    stagedProjections: 0,
-    stagedRoutes: 0,
-    stagedSnapshotBatches: 0,
-    stagedSnapshotRows: 0,
-    stagedUpserts: 0,
-    status: "staging",
-    updatedAt: now,
-  });
-  await ctx.db.insert("contentState", {
-    candidateManifestHash: manifestHash,
-    candidateReleaseId: releaseId,
-    candidateSequence: 1,
-    key: "primary",
-    nextSequence: 2,
-    updatedAt: now,
-  });
-}
+  yield* Effect.promise(() =>
+    ctx.db.insert("contentReleases", {
+      baseFamilies: [],
+      checkedIndex: -1,
+      checkedItems: 0,
+      createdAt: now,
+      releaseId,
+      releaseJson: JSON.stringify(signedRelease),
+      rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
+      resultFamilies: [...signedRelease.manifest.scope.families],
+      role: "candidate",
+      sequence: 1,
+      stagedArtifacts: 0,
+      stagedDeletes: 0,
+      stagedItems: 0,
+      stagedProjections: 0,
+      stagedRoutes: 0,
+      stagedSnapshotBatches: 0,
+      stagedSnapshotRows: 0,
+      stagedUpserts: 0,
+      status: "staging",
+      updatedAt: now,
+    })
+  );
+  yield* Effect.promise(() =>
+    ctx.db.insert("contentState", {
+      candidateManifestHash: manifestHash,
+      candidateReleaseId: releaseId,
+      candidateSequence: 1,
+      key: "primary",
+      nextSequence: 2,
+      updatedAt: now,
+    })
+  );
+});
 
 /** Inserts a multi-page authenticated delete-only release. */
-async function insertDeleteRelease(ctx: MutationCtx, count: number) {
+const insertDeleteRelease = Effect.fn(
+  "contentRelease.proof.verify.test.insertDeleteRelease"
+)(function* (ctx: MutationCtx, count: number) {
   const items = Array.from({ length: count }, (_, index) =>
     ContentReleaseItemSchema.make({
       change: {
@@ -108,11 +146,12 @@ async function insertDeleteRelease(ctx: MutationCtx, count: number) {
       releaseId,
     })
   );
-  const digest = Effect.runSync(
-    digestItems(releaseId, Stream.fromIterable(items))
+  const digest = yield* digestItems(releaseId, Stream.fromIterable(items)).pipe(
+    Effect.orDie
   );
-  const rollbackEntries = items.map((item) =>
-    RollbackSnapshotEntrySchema.make({
+  const entries = items.map((item) => ({
+    item,
+    rollbackEntry: RollbackSnapshotEntrySchema.make({
       index: item.index,
       releaseId,
       snapshot: {
@@ -121,11 +160,12 @@ async function insertDeleteRelease(ctx: MutationCtx, count: number) {
         artifactLocale: item.change.artifactLocale,
         state: "absent",
       },
-    })
-  );
-  const rollback = Effect.runSync(
-    digestRollbackSnapshot(releaseId, Stream.fromIterable(rollbackEntries))
-  );
+    }),
+  }));
+  const rollback = yield* digestRollbackSnapshot(
+    releaseId,
+    Stream.fromIterable(entries.map(({ rollbackEntry }) => rollbackEntry))
+  ).pipe(Effect.orDie);
   const nextManifest = ContentReleaseManifestSchema.make({
     ...manifest,
     deleteCount: count,
@@ -137,195 +177,310 @@ async function insertDeleteRelease(ctx: MutationCtx, count: number) {
   });
   const signed = testSignedRelease(nextManifest);
   const now = Date.UTC(2026, 6, 22, 12, 0, 0);
-  await ctx.db.insert("contentReleases", {
-    baseFamilies: [],
-    checkedIndex: -1,
-    checkedItems: 0,
-    createdAt: now,
-    releaseId,
-    releaseJson: JSON.stringify(signed),
-    rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
-    resultFamilies: [...signed.manifest.scope.families],
-    role: "candidate",
-    sequence: 1,
-    stagedArtifacts: 0,
-    stagedDeletes: count,
-    stagedItems: count,
-    stagedProjections: 0,
-    stagedRoutes: 0,
-    stagedSnapshotBatches: 0,
-    stagedSnapshotRows: 0,
-    stagedUpserts: 0,
-    status: "staging",
-    updatedAt: now,
-  });
-  await ctx.db.insert("contentState", {
-    candidateManifestHash: signed.manifestHash,
-    candidateReleaseId: releaseId,
-    candidateSequence: 1,
-    key: "primary",
-    nextSequence: 2,
-    updatedAt: now,
-  });
-  for (const [index, item] of items.entries()) {
-    const rollbackEntry = rollbackEntries[index];
-    if (!rollbackEntry) {
-      throw new Error(`Expected rollback entry ${index}.`);
-    }
-    await ctx.db.insert("contentItems", {
-      artifactReady: false,
-      contentKey: item.change.contentKey,
-      index: item.index,
-      itemBatchHash: digest.digest,
-      itemBatchIndex: Math.floor(item.index / 4),
-      itemJson: JSON.stringify(item),
-      artifactLocale: item.change.artifactLocale,
-      projectionReady: false,
+  yield* Effect.promise(() =>
+    ctx.db.insert("contentReleases", {
+      baseFamilies: [],
+      checkedIndex: -1,
+      checkedItems: 0,
+      createdAt: now,
       releaseId,
-      rollbackJson: canonicalizeRollbackSnapshotEntry(rollbackEntry),
+      releaseJson: JSON.stringify(signed),
+      rendererJson: JSON.stringify(TEST_PROOF_RENDERER),
+      resultFamilies: [...signed.manifest.scope.families],
+      role: "candidate",
       sequence: 1,
-      stagedAt: now,
-    });
-  }
+      stagedArtifacts: 0,
+      stagedDeletes: count,
+      stagedItems: count,
+      stagedProjections: 0,
+      stagedRoutes: 0,
+      stagedSnapshotBatches: 0,
+      stagedSnapshotRows: 0,
+      stagedUpserts: 0,
+      status: "staging",
+      updatedAt: now,
+    })
+  );
+  yield* Effect.promise(() =>
+    ctx.db.insert("contentState", {
+      candidateManifestHash: signed.manifestHash,
+      candidateReleaseId: releaseId,
+      candidateSequence: 1,
+      key: "primary",
+      nextSequence: 2,
+      updatedAt: now,
+    })
+  );
+  yield* Effect.forEach(
+    entries,
+    ({ item, rollbackEntry }) =>
+      Effect.promise(() =>
+        ctx.db.insert("contentItems", {
+          artifactReady: false,
+          contentKey: item.change.contentKey,
+          index: item.index,
+          itemBatchHash: digest.digest,
+          itemBatchIndex: Math.floor(item.index / 4),
+          itemJson: JSON.stringify(item),
+          artifactLocale: item.change.artifactLocale,
+          projectionReady: false,
+          releaseId,
+          rollbackJson: canonicalizeRollbackSnapshotEntry(rollbackEntry),
+          sequence: 1,
+          stagedAt: now,
+        })
+      ),
+    { discard: true }
+  );
   return signed.manifestHash;
-}
+});
 
 /** Changes only the stored signature while preserving its claimed identity. */
-function tamperArtifactSignature(artifactJson: string) {
-  const artifact = Schema.decodeUnknownSync(SignedContentArtifactSchema)(
-    JSON.parse(artifactJson)
-  );
+const tamperArtifactSignature = Effect.fn(
+  "contentRelease.proof.verify.test.tamperArtifactSignature"
+)(function* (artifactJson: string) {
+  const artifact = yield* Schema.decodeEffect(
+    Schema.fromJsonString(SignedContentArtifactSchema)
+  )(artifactJson);
   const firstCharacter = artifact.signature.startsWith("A") ? "B" : "A";
   const signature = Ed25519SignatureSchema.make(
     `${firstCharacter}${artifact.signature.slice(1)}`
   );
   return encodeArtifactJson({ ...artifact, signature });
-}
+});
+
+/** Loads one staged proof release or defects on an invalid fixture. */
+const loadProofRelease = Effect.fn(
+  "contentRelease.proof.verify.test.loadProofRelease"
+)(function* (ctx: MutationCtx) {
+  const release = yield* Effect.promise(() =>
+    ctx.db.query("contentReleases").unique()
+  );
+  if (!release) {
+    return yield* Effect.die(
+      new UnexpectedProofTestState({ operation: "load-proof-release" })
+    );
+  }
+  return release;
+});
+
+/** Corrupts the frozen renderer while preserving the release identity. */
+const driftStoredRenderer = Effect.fn(
+  "contentRelease.proof.verify.test.driftStoredRenderer"
+)(function* (ctx: MutationCtx) {
+  const release = yield* loadProofRelease(ctx);
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentReleases", release._id, {
+      rendererJson: JSON.stringify(testProofRenderer("h1")),
+    })
+  );
+});
+
+/** Corrupts durable counters after the release entered verification. */
+const driftDurableCounters = Effect.fn(
+  "contentRelease.proof.verify.test.driftDurableCounters"
+)(function* (ctx: MutationCtx) {
+  const release = yield* loadProofRelease(ctx);
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentReleases", release._id, {
+      stagedItems: 1,
+      status: "verifying",
+    })
+  );
+});
+
+/** Corrupts one staged artifact signature inside the real test transaction. */
+const tamperStoredArtifact = Effect.fn(
+  "contentRelease.proof.verify.test.tamperStoredArtifact"
+)(function* (ctx: MutationCtx) {
+  const artifact = yield* Effect.promise(() =>
+    ctx.db.query("contentArtifacts").unique()
+  );
+  if (!artifact) {
+    return yield* Effect.die(
+      new UnexpectedProofTestState({ operation: "load-staged-artifact" })
+    );
+  }
+  const artifactJson = yield* tamperArtifactSignature(
+    artifact.artifactJson
+  ).pipe(Effect.orDie);
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentArtifacts", artifact._id, { artifactJson })
+  );
+});
 
 describe("contentRelease/proof/verify", () => {
-  it("recomputes an authenticated empty proof and commits it exactly once", async () => {
-    const t = createProofTest();
-    await t.mutation(insertRelease);
+  it.effect(
+    "recomputes an authenticated empty proof and commits it exactly once",
+    Effect.fn("contentRelease.proof.verify.test.recomputesEmptyProof")(
+      function* () {
+        const t = createProofTest();
+        yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(insertRelease(ctx)))
+        );
 
-    const proof = await runProof(t);
-    const release = await t.run((ctx) =>
-      ctx.db.query("contentReleases").unique()
-    );
+        const proof = yield* runProof(t);
+        const release = yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.query("contentReleases").unique())
+        );
 
-    expect(proof).toMatchObject({
-      itemCount: 0,
-      manifestHash,
-      releaseId,
-      stagedArtifacts: 0,
-    });
-    expect(release).toMatchObject({
-      checkedItems: 0,
-      proofJson: JSON.stringify(proof),
-      status: "verifying",
-    });
-  });
+        expect(proof).toMatchObject({
+          itemCount: 0,
+          manifestHash,
+          releaseId,
+          stagedArtifacts: 0,
+        });
+        expect(release).toMatchObject({
+          checkedItems: 0,
+          proofJson: JSON.stringify(proof),
+          status: "verifying",
+        });
+      }
+    )
+  );
 
-  it("fails closed when no production key has been reviewed", async () => {
-    const t = createProofTest();
-    await t.mutation(insertRelease);
+  it.effect(
+    "fails closed when no production key has been reviewed",
+    Effect.fn("contentRelease.proof.verify.test.rejectsMissingKey")(
+      function* () {
+        const t = createProofTest();
+        yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(insertRelease(ctx)))
+        );
 
-    await expect(runProof(t, manifestHash, contentKeyResolver)).rejects.toThrow(
-      "Content release verification failed with SigningKeyNotFoundError."
-    );
-  });
+        const failure = yield* runProof(t, {
+          resolver: contentKeyResolver,
+        }).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "Content release verification failed with SigningKeyNotFoundError."
+        );
+      }
+    )
+  );
 
-  it("recovers stable internal failures into the typed channel", async () => {
-    const t = createProofTest();
+  it.effect(
+    "recovers stable internal failures into the typed channel",
+    Effect.fn("contentRelease.proof.verify.test.recoversTypedFailure")(
+      function* () {
+        const t = createProofTest();
 
-    const result = await t.action((ctx) =>
-      Effect.runPromise(
-        recomputeProgram(ctx, manifestHash, releaseId, 0).pipe(
-          Effect.match({
-            onFailure: (error) => ({ code: error.code, tag: error._tag }),
-            onSuccess: () => ({ code: null, tag: null }),
-          }),
-          Effect.provideService(
-            ContentVerificationKeyResolver,
-            TEST_KEY_RESOLVER
+        const result = yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexActionProgram(
+              recomputeProgram(ctx, manifestHash, releaseId, 0).pipe(
+                Effect.match({
+                  onFailure: (error) => ({
+                    code: error.code,
+                    tag: error._tag,
+                  }),
+                  onSuccess: () => ({ code: null, tag: null }),
+                }),
+                Effect.provideService(
+                  ContentVerificationKeyResolver,
+                  TEST_KEY_RESOLVER
+                )
+              )
+            )
           )
-        )
-      )
-    );
+        );
 
-    expect(result).toEqual({
-      code: "CONTENT_RELEASE_MISSING",
-      tag: "ReleaseError",
-    });
-  });
-
-  it("replays multi-page item and proof streams before committing", async () => {
-    const t = createProofTest();
-    const hash = await t.mutation((ctx) => insertDeleteRelease(ctx, 9));
-
-    const proof = await runProof(t, hash);
-    expect(proof).toMatchObject({
-      deleteHeads: 9,
-      itemCount: 9,
-      stagedArtifacts: 0,
-      upsertHeads: 0,
-    });
-  });
-
-  it("rejects renderer and durable counter drift", async () => {
-    const rendererDrift = createProofTest();
-    await rendererDrift.mutation(insertRelease);
-    const changedRenderer = testProofRenderer("h1");
-    await rendererDrift.mutation(async (ctx) => {
-      const release = await ctx.db.query("contentReleases").unique();
-      if (!release) {
-        throw new Error("Expected proof release.");
+        expect(result).toEqual({
+          code: "CONTENT_RELEASE_MISSING",
+          tag: "ReleaseError",
+        });
       }
-      await ctx.db.patch("contentReleases", release._id, {
-        rendererJson: JSON.stringify(changedRenderer),
-      });
-    });
-    await expect(runProof(rendererDrift)).rejects.toThrow(
-      "no longer matches its frozen renderer"
-    );
+    )
+  );
 
-    const counters = createProofTest();
-    await counters.mutation(insertRelease);
-    await counters.mutation(async (ctx) => {
-      const release = await ctx.db.query("contentReleases").unique();
-      if (!release) {
-        throw new Error("Expected proof release.");
+  it.effect(
+    "replays multi-page item and proof streams before committing",
+    Effect.fn("contentRelease.proof.verify.test.replaysPagedProof")(
+      function* () {
+        const t = createProofTest();
+        const hash = yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(insertDeleteRelease(ctx, 9)))
+        );
+
+        const proof = yield* runProof(t, { hash });
+        expect(proof).toMatchObject({
+          deleteHeads: 9,
+          itemCount: 9,
+          stagedArtifacts: 0,
+          upsertHeads: 0,
+        });
       }
-      await ctx.db.patch("contentReleases", release._id, {
-        stagedItems: 1,
-        status: "verifying",
-      });
-    });
-    await expect(runProof(counters)).rejects.toThrow("lost durable progress");
-  });
+    )
+  );
 
-  it("reauthenticates stored artifacts before committing proof", async () => {
-    const t = createProofTest();
-    await stageUpsertFixture(t);
-    const state = await t.run((ctx) => ctx.db.query("contentState").unique());
-    if (!state?.candidateManifestHash) {
-      throw new Error("Expected a candidate manifest for artifact proof.");
-    }
-    await t.mutation(async (ctx) => {
-      const artifact = await ctx.db.query("contentArtifacts").unique();
-      if (!artifact) {
-        throw new Error("Expected one staged artifact.");
+  it.effect(
+    "rejects renderer and durable counter drift",
+    Effect.fn("contentRelease.proof.verify.test.rejectsDurableDrift")(
+      function* () {
+        const rendererDrift = createProofTest();
+        yield* Effect.promise(() =>
+          rendererDrift.mutation((ctx) => runConvexProgram(insertRelease(ctx)))
+        );
+        yield* Effect.promise(() =>
+          rendererDrift.mutation((ctx) =>
+            runConvexProgram(driftStoredRenderer(ctx))
+          )
+        );
+        const rendererFailure = yield* runProof(rendererDrift).pipe(
+          Effect.flip
+        );
+        expect(getUnknownErrorMessage(rendererFailure.cause)).toContain(
+          "no longer matches its frozen renderer"
+        );
+
+        const counters = createProofTest();
+        yield* Effect.promise(() =>
+          counters.mutation((ctx) => runConvexProgram(insertRelease(ctx)))
+        );
+        yield* Effect.promise(() =>
+          counters.mutation((ctx) =>
+            runConvexProgram(driftDurableCounters(ctx))
+          )
+        );
+        const counterFailure = yield* runProof(counters).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(counterFailure.cause)).toContain(
+          "lost durable progress"
+        );
       }
-      await ctx.db.patch("contentArtifacts", artifact._id, {
-        artifactJson: tamperArtifactSignature(artifact.artifactJson),
-      });
-    });
+    )
+  );
 
-    await expect(
-      recomputeContentProof(t, state.candidateManifestHash, TEST_RELEASE_ID)
-    ).rejects.toThrow("Content release verification failed");
-    const release = await t.run((ctx) =>
-      ctx.db.query("contentReleases").unique()
-    );
-    expect(release?.proofJson).toBeUndefined();
-  });
+  it.effect(
+    "reauthenticates stored artifacts before committing proof",
+    Effect.fn("contentRelease.proof.verify.test.reauthenticatesArtifacts")(
+      function* () {
+        const t = createProofTest();
+        yield* Effect.promise(() => stageUpsertFixture(t));
+        const state = yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.query("contentState").unique())
+        );
+        if (!state?.candidateManifestHash) {
+          return yield* Effect.die(
+            new UnexpectedProofTestState({
+              operation: "load-candidate-manifest",
+            })
+          );
+        }
+        yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(tamperStoredArtifact(ctx)))
+        );
+
+        const failure = yield* runProof(t, {
+          hash: state.candidateManifestHash,
+          releaseId: TEST_RELEASE_ID,
+        }).pipe(Effect.flip);
+        expect(getUnknownErrorMessage(failure.cause)).toContain(
+          "Content release verification failed"
+        );
+        const release = yield* Effect.promise(() =>
+          t.run((ctx) => ctx.db.query("contentReleases").unique())
+        );
+        expect(release?.proofJson).toBeUndefined();
+      }
+    )
+  );
 });

--- a/packages/backend/convex/customers/deletion/billing.test.ts
+++ b/packages/backend/convex/customers/deletion/billing.test.ts
@@ -1,13 +1,17 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
 import { cleanupDeletedUserBilling } from "@repo/backend/convex/customers/deletion/billing";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const polarGateway = vi.hoisted(() => ({
   deleteCustomer: vi.fn(),
@@ -18,42 +22,64 @@ vi.mock("@repo/backend/convex/customers/polar/live", () => ({
   polarGateway,
 }));
 
-function insertDeletedUser(ctx: MutationCtx, suffix: string) {
-  return ctx.db.insert("users", {
-    authId: `deleted:${suffix}`,
-    credits: 0,
-    creditsResetAt: 1,
-    deletedAt: 1,
-    email: `deleted-${suffix}@example.invalid`,
-    name: "Deleted User",
-    plan: "free",
-  });
-}
+const insertDeletedUser = Effect.fn(
+  "customers.deletion.test.insertDeletedUser"
+)(function* (ctx: MutationCtx, suffix: string) {
+  return yield* Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: `deleted:${suffix}`,
+      credits: 0,
+      creditsResetAt: 1,
+      deletedAt: 1,
+      email: `deleted-${suffix}@example.invalid`,
+      name: "Deleted User",
+      plan: "free",
+    })
+  );
+});
 
-function insertOrphanSubscription(
-  ctx: MutationCtx,
-  userId: Id<"users">,
-  polarCustomerId: string
-) {
-  return ctx.db.insert("subscriptions", {
-    amount: null,
-    cancelAtPeriodEnd: false,
-    checkoutId: null,
-    createdAt: "2026-07-29T00:00:00.000Z",
-    currency: null,
-    currentPeriodEnd: null,
-    currentPeriodStart: "2026-07-29T00:00:00.000Z",
-    customerId: polarCustomerId,
-    endedAt: null,
-    id: `subscription-${userId}`,
-    metadata: {},
-    modifiedAt: null,
-    productId: "product-deleted-user",
-    recurringInterval: null,
-    startedAt: "2026-07-29T00:00:00.000Z",
-    status: "active",
-  });
-}
+const insertOrphanSubscription = Effect.fn(
+  "customers.deletion.test.insertOrphanSubscription"
+)(function* (ctx: MutationCtx, userId: Id<"users">, polarCustomerId: string) {
+  return yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: "2026-07-29T00:00:00.000Z",
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: "2026-07-29T00:00:00.000Z",
+      customerId: polarCustomerId,
+      endedAt: null,
+      id: `subscription-${userId}`,
+      metadata: {},
+      modifiedAt: null,
+      productId: "product-deleted-user",
+      recurringInterval: null,
+      startedAt: "2026-07-29T00:00:00.000Z",
+      status: "active",
+    })
+  );
+});
+
+const readBillingState = Effect.fn("customers.deletion.test.readBillingState")(
+  function* (ctx: QueryCtx, polarCustomerId: string) {
+    const subscriptions = yield* Effect.promise(() =>
+      ctx.db.query("subscriptions").collect()
+    );
+    const tombstone = yield* Effect.promise(() =>
+      ctx.db
+        .query("customerDeletionTombstones")
+        .withIndex("by_polarCustomerId", (query) =>
+          query.eq("polarCustomerId", polarCustomerId)
+        )
+        .unique()
+    );
+
+    return { subscriptions, tombstone };
+  }
+);
 
 describe("customers/deletion/billing", () => {
   beforeEach(() => {
@@ -63,119 +89,162 @@ describe("customers/deletion/billing", () => {
     polarGateway.getCustomerByExternalId.mockReturnValue(Effect.succeed(null));
   });
 
-  it("checkpoints a discovered Polar ID before external deletion", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await insertDeletedUser(ctx, "checkpoint");
-      await insertOrphanSubscription(ctx, insertedUserId, "polar-checkpoint");
-      return insertedUserId;
-    });
+  it.effect("checkpoints a discovered Polar ID before external deletion", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.sync(() => posthogTest.register(t));
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* insertDeletedUser(
+                ctx,
+                "checkpoint"
+              );
+              yield* insertOrphanSubscription(
+                ctx,
+                insertedUserId,
+                "polar-checkpoint"
+              );
+              return insertedUserId;
+            })
+          )
+        )
+      );
 
-    polarGateway.getCustomerByExternalId.mockReturnValue(
-      Effect.succeed({ id: "polar-checkpoint" })
-    );
-    polarGateway.deleteCustomer.mockImplementation((polarCustomerId) =>
-      Effect.tryPromise(async () => {
-        const checkpoint = await t.query((ctx) =>
-          ctx.db
-            .query("customerDeletionTombstones")
-            .withIndex("by_cleanupUserId", (query) =>
-              query.eq("cleanupUserId", userId)
+      polarGateway.getCustomerByExternalId.mockReturnValue(
+        Effect.succeed({ id: "polar-checkpoint" })
+      );
+      polarGateway.deleteCustomer.mockImplementation((polarCustomerId) =>
+        Effect.gen(function* () {
+          const checkpoint = yield* Effect.promise(() =>
+            t.query((ctx) =>
+              runConvexProgram(
+                Effect.promise(() =>
+                  ctx.db
+                    .query("customerDeletionTombstones")
+                    .withIndex("by_cleanupUserId", (query) =>
+                      query.eq("cleanupUserId", userId)
+                    )
+                    .unique()
+                )
+              )
             )
-            .unique()
+          );
+
+          expect(checkpoint).toMatchObject({
+            cleanupUserId: userId,
+            polarCustomerId,
+          });
+          return null;
+        })
+      );
+
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(
+            cleanupDeletedUserBilling(ctx, userId, "original-auth-checkpoint")
+          )
+        )
+      );
+
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(readBillingState(ctx, "polar-checkpoint"))
+        )
+      );
+
+      expect(state.subscriptions).toEqual([]);
+      expect(state.tombstone).toMatchObject({
+        polarCustomerId: "polar-checkpoint",
+      });
+      expect(state.tombstone).not.toHaveProperty("cleanupUserId");
+    })
+  );
+
+  it.effect("resumes local cleanup when Polar is no longer discoverable", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.sync(() => posthogTest.register(t));
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* insertDeletedUser(ctx, "resume");
+              yield* Effect.promise(() =>
+                ctx.db.insert("customerDeletionTombstones", {
+                  cleanupUserId: insertedUserId,
+                  polarCustomerId: "polar-resume",
+                })
+              );
+              yield* insertOrphanSubscription(
+                ctx,
+                insertedUserId,
+                "polar-resume"
+              );
+              return insertedUserId;
+            })
+          )
+        )
+      );
+
+      yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexProgram(
+            cleanupDeletedUserBilling(ctx, userId, "original-auth-resume")
+          )
+        )
+      );
+
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(readBillingState(ctx, "polar-resume"))
+        )
+      );
+
+      expect(polarGateway.getCustomerByExternalId).not.toHaveBeenCalled();
+      expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-resume");
+      expect(state.subscriptions).toEqual([]);
+      expect(state.tombstone).not.toHaveProperty("cleanupUserId");
+    })
+  );
+
+  it.effect(
+    "removes a Polar customer created after the first cleanup pass",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        yield* Effect.sync(() => posthogTest.register(t));
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(insertDeletedUser(ctx, "late-polar-sync"))
+          )
+        );
+        polarGateway.getCustomerByExternalId
+          .mockReturnValueOnce(Effect.succeed(null))
+          .mockReturnValueOnce(Effect.succeed({ id: "polar-late-sync" }));
+
+        yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(
+              cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
+            )
+          )
+        );
+        expect(polarGateway.deleteCustomer).not.toHaveBeenCalled();
+
+        yield* Effect.promise(() =>
+          t.action((ctx) =>
+            runConvexProgram(
+              cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
+            )
+          )
         );
 
-        expect(checkpoint).toMatchObject({
-          cleanupUserId: userId,
-          polarCustomerId,
-        });
-        return null;
+        expect(polarGateway.deleteCustomer).toHaveBeenCalledOnce();
+        expect(polarGateway.deleteCustomer).toHaveBeenCalledWith(
+          "polar-late-sync"
+        );
       })
-    );
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-checkpoint")
-      )
-    );
-
-    const state = await t.query(async (ctx) => ({
-      subscriptions: await ctx.db.query("subscriptions").collect(),
-      tombstone: await ctx.db
-        .query("customerDeletionTombstones")
-        .withIndex("by_polarCustomerId", (query) =>
-          query.eq("polarCustomerId", "polar-checkpoint")
-        )
-        .unique(),
-    }));
-
-    expect(state.subscriptions).toEqual([]);
-    expect(state.tombstone).toMatchObject({
-      polarCustomerId: "polar-checkpoint",
-    });
-    expect(state.tombstone).not.toHaveProperty("cleanupUserId");
-  });
-
-  it("resumes local cleanup when Polar is no longer discoverable", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await insertDeletedUser(ctx, "resume");
-      await ctx.db.insert("customerDeletionTombstones", {
-        cleanupUserId: insertedUserId,
-        polarCustomerId: "polar-resume",
-      });
-      await insertOrphanSubscription(ctx, insertedUserId, "polar-resume");
-      return insertedUserId;
-    });
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-resume")
-      )
-    );
-
-    const state = await t.query(async (ctx) => ({
-      subscriptions: await ctx.db.query("subscriptions").collect(),
-      tombstone: await ctx.db
-        .query("customerDeletionTombstones")
-        .withIndex("by_polarCustomerId", (query) =>
-          query.eq("polarCustomerId", "polar-resume")
-        )
-        .unique(),
-    }));
-
-    expect(polarGateway.getCustomerByExternalId).not.toHaveBeenCalled();
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-resume");
-    expect(state.subscriptions).toEqual([]);
-    expect(state.tombstone).not.toHaveProperty("cleanupUserId");
-  });
-
-  it("removes a Polar customer created after the first cleanup pass", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-    const userId = await t.mutation((ctx) =>
-      insertDeletedUser(ctx, "late-polar-sync")
-    );
-    polarGateway.getCustomerByExternalId
-      .mockReturnValueOnce(Effect.succeed(null))
-      .mockReturnValueOnce(Effect.succeed({ id: "polar-late-sync" }));
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
-      )
-    );
-    expect(polarGateway.deleteCustomer).not.toHaveBeenCalled();
-
-    await t.action((ctx) =>
-      runConvexProgram(
-        cleanupDeletedUserBilling(ctx, userId, "original-auth-late-sync")
-      )
-    );
-
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledOnce();
-    expect(polarGateway.deleteCustomer).toHaveBeenCalledWith("polar-late-sync");
-  });
+  );
 });

--- a/packages/backend/convex/customers/deletion/workflow.test.ts
+++ b/packages/backend/convex/customers/deletion/workflow.test.ts
@@ -1,156 +1,214 @@
+import { assert, describe, expect, it, vi } from "@effect/vitest";
 import { launchDeletedUserCleanupProgram } from "@repo/backend/convex/customers/deletion/workflow";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
+import { Clock, Data, Effect } from "effect";
+
+class WorkflowUnavailable extends Data.TaggedError("WorkflowUnavailable")<{
+  readonly message: string;
+}> {}
+
+class CleanupMutationRejected extends Data.TaggedError(
+  "CleanupMutationRejected"
+)<{
+  readonly cause: unknown;
+}> {}
+
+/** Creates isolated adapters for the four independent cleanup workflows. */
+function createCleanupStarters() {
+  return {
+    startAnalytics: vi.fn(() => Promise.resolve()),
+    startAuth: vi.fn(() => Promise.resolve()),
+    startCustomer: vi.fn(() => Promise.resolve()),
+    startData: vi.fn(() => Promise.resolve()),
+  };
+}
 
 describe("customers/deletion/workflow", () => {
-  it("starts cleanup for the matching app user", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () => undefined);
-    const deletedAt = Date.now();
+  it.effect("starts cleanup for the matching app user", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      const deletedAt = yield* Clock.currentTimeMillis;
 
-    const user = await t.mutation(async (ctx) => {
-      const insertedUserId = await ctx.db.insert("users", {
-        authId: "deleted-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        deletedAt,
-        email: "deleted@example.com",
-        name: "Deleted User",
-        plan: "free",
-      });
-      await ctx.db.insert("accountDeletionPreparations", {
-        authId: "deleted-auth-user",
-        finalizedAt: Date.now(),
-        recoveryGeneration: 0,
-        userId: insertedUserId,
-      });
+      const user = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const insertedUserId = yield* Effect.promise(() =>
+                ctx.db.insert("users", {
+                  authId: "deleted-auth-user",
+                  credits: 0,
+                  creditsResetAt: 0,
+                  deletedAt,
+                  email: "deleted@example.com",
+                  name: "Deleted User",
+                  plan: "free",
+                })
+              );
+              yield* Effect.promise(() =>
+                ctx.db.insert("accountDeletionPreparations", {
+                  authId: "deleted-auth-user",
+                  finalizedAt: deletedAt,
+                  recoveryGeneration: 0,
+                  userId: insertedUserId,
+                })
+              );
 
-      await runConvexProgram(
-        launchDeletedUserCleanupProgram(
-          ctx,
-          "deleted-auth-user",
-          insertedUserId,
-          { startAnalytics, startAuth, startCustomer, startData }
+              yield* launchDeletedUserCleanupProgram(
+                ctx,
+                "deleted-auth-user",
+                insertedUserId,
+                starters
+              );
+
+              return yield* Effect.promise(() =>
+                ctx.db.get("users", insertedUserId)
+              );
+            })
+          )
         )
       );
 
-      return await ctx.db.get("users", insertedUserId);
-    });
+      assert(user !== null);
+      expect(user.deletionCleanupStartedAt).toEqual(expect.any(Number));
+      expect(starters.startAnalytics).toHaveBeenCalledOnce();
+      expect(starters.startAuth).toHaveBeenCalledOnce();
+      expect(starters.startCustomer).toHaveBeenCalledOnce();
+      expect(starters.startData).toHaveBeenCalledOnce();
+      const expectedIdentity = {
+        authId: "deleted-auth-user",
+        userId: user._id,
+      };
+      expect(starters.startAnalytics).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startAuth).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startCustomer).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+      expect(starters.startData).toHaveBeenCalledWith(
+        expect.any(Object),
+        expectedIdentity
+      );
+    })
+  );
 
-    expect(user?.deletionCleanupStartedAt).toEqual(expect.any(Number));
-    expect(startAnalytics).toHaveBeenCalledOnce();
-    expect(startAuth).toHaveBeenCalledOnce();
-    expect(startCustomer).toHaveBeenCalledOnce();
-    expect(startData).toHaveBeenCalledOnce();
-    const expectedIdentity = {
-      authId: "deleted-auth-user",
-      userId: user?._id,
-    };
-    expect(startAnalytics).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startAuth).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startCustomer).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-    expect(startData).toHaveBeenCalledWith(
-      expect.any(Object),
-      expectedIdentity
-    );
-  });
-
-  it("does nothing when the app user is already absent", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () => undefined);
-    const missingUserId = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "removed-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        email: "removed@example.com",
-        name: "Removed User",
-        plan: "free",
-      });
-      await ctx.db.delete("users", userId);
-      return userId;
-    });
-
-    await t.mutation((ctx) =>
-      runConvexProgram(
-        launchDeletedUserCleanupProgram(
-          ctx,
-          "missing-auth-user",
-          missingUserId,
-          { startAnalytics, startAuth, startCustomer, startData }
-        )
-      )
-    );
-
-    expect(startAnalytics).not.toHaveBeenCalled();
-    expect(startAuth).not.toHaveBeenCalled();
-    expect(startCustomer).not.toHaveBeenCalled();
-    expect(startData).not.toHaveBeenCalled();
-  });
-
-  it("returns a typed failure when any workflow cannot start", async () => {
-    const t = convexTest(schema, convexModules);
-    const startAnalytics = vi.fn(async () => undefined);
-    const startAuth = vi.fn(async () => undefined);
-    const startCustomer = vi.fn(async () => undefined);
-    const startData = vi.fn(async () =>
-      Promise.reject(new Error("workflow unavailable"))
-    );
-    const userId = await t.mutation((ctx) =>
-      ctx.db.insert("users", {
-        authId: "failing-auth-user",
-        credits: 0,
-        creditsResetAt: 0,
-        deletedAt: Date.now(),
-        email: "failing@example.com",
-        name: "Failing User",
-        plan: "free",
-      })
-    );
-
-    await expect(
-      t.mutation(
-        async (ctx) =>
-          await runConvexProgram(
-            launchDeletedUserCleanupProgram(ctx, "failing-auth-user", userId, {
-              startAnalytics,
-              startAuth,
-              startCustomer,
-              startData,
+  it.effect("does nothing when the app user is already absent", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      const missingUserId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const userId = yield* Effect.promise(() =>
+                ctx.db.insert("users", {
+                  authId: "removed-auth-user",
+                  credits: 0,
+                  creditsResetAt: 0,
+                  email: "removed@example.com",
+                  name: "Removed User",
+                  plan: "free",
+                })
+              );
+              yield* Effect.promise(() => ctx.db.delete("users", userId));
+              return userId;
             })
           )
-      )
-    ).rejects.toMatchObject({
-      data: {
-        code: "USER_CLEANUP_FAILED",
-        message: "workflow unavailable",
-      },
-    });
+        )
+      );
 
-    const user = await t.query(async (ctx) => await ctx.db.get(userId));
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            launchDeletedUserCleanupProgram(
+              ctx,
+              "missing-auth-user",
+              missingUserId,
+              starters
+            )
+          )
+        )
+      );
 
-    expect(startAnalytics).toHaveBeenCalledOnce();
-    expect(startAuth).toHaveBeenCalledOnce();
-    expect(startCustomer).toHaveBeenCalledOnce();
-    expect(startData).toHaveBeenCalledOnce();
-    expect(user).not.toHaveProperty("deletionCleanupStartedAt");
-  });
+      expect(starters.startAnalytics).not.toHaveBeenCalled();
+      expect(starters.startAuth).not.toHaveBeenCalled();
+      expect(starters.startCustomer).not.toHaveBeenCalled();
+      expect(starters.startData).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect("returns a typed failure when any workflow cannot start", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const starters = createCleanupStarters();
+      starters.startData.mockRejectedValue(
+        new WorkflowUnavailable({ message: "workflow unavailable" })
+      );
+      const deletedAt = yield* Clock.currentTimeMillis;
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.insert("users", {
+                authId: "failing-auth-user",
+                credits: 0,
+                creditsResetAt: 0,
+                deletedAt,
+                email: "failing@example.com",
+                name: "Failing User",
+                plan: "free",
+              })
+            )
+          )
+        )
+      );
+
+      const failure = yield* Effect.flip(
+        Effect.tryPromise({
+          catch: (cause) => new CleanupMutationRejected({ cause }),
+          try: () =>
+            t.mutation((ctx) =>
+              runConvexProgram(
+                launchDeletedUserCleanupProgram(
+                  ctx,
+                  "failing-auth-user",
+                  userId,
+                  starters
+                )
+              )
+            ),
+        })
+      );
+      expect(failure).toMatchObject({
+        _tag: "CleanupMutationRejected",
+        cause: {
+          data: {
+            code: "USER_CLEANUP_FAILED",
+            message: "workflow unavailable",
+          },
+        },
+      });
+
+      const user = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(Effect.promise(() => ctx.db.get("users", userId)))
+        )
+      );
+
+      expect(starters.startAnalytics).toHaveBeenCalledOnce();
+      expect(starters.startAuth).toHaveBeenCalledOnce();
+      expect(starters.startCustomer).toHaveBeenCalledOnce();
+      expect(starters.startData).toHaveBeenCalledOnce();
+      expect(user).not.toHaveProperty("deletionCleanupStartedAt");
+    })
+  );
 });

--- a/packages/backend/convex/customers/integrity/internal.test.ts
+++ b/packages/backend/convex/customers/integrity/internal.test.ts
@@ -1,120 +1,154 @@
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
 
 const NOW = new Date(Date.UTC(2026, 3, 5, 12, 0, 0)).toISOString();
 
+const seedCustomerIntegrityState = Effect.fn(
+  "customers.integrity.test.seedState"
+)(function* (ctx: MutationCtx) {
+  const userId = yield* Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: "auth-customer-integrity",
+      credits: 10,
+      creditsResetAt: 1,
+      email: "integrity@example.com",
+      name: "Integrity User",
+      plan: "free",
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("customers", {
+      id: "polar-integrity",
+      externalId: "auth-customer-integrity",
+      metadata: { userId },
+      userId,
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: NOW,
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: NOW,
+      customerCancellationComment: null,
+      customerCancellationReason: null,
+      customerId: "polar-integrity",
+      endedAt: null,
+      id: "active-subscription",
+      metadata: {},
+      modifiedAt: null,
+      productId: "pro-product",
+      recurringInterval: null,
+      startedAt: NOW,
+      status: "active",
+    })
+  );
+
+  yield* Effect.promise(() =>
+    ctx.db.insert("subscriptions", {
+      amount: null,
+      cancelAtPeriodEnd: false,
+      checkoutId: null,
+      createdAt: NOW,
+      currency: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: NOW,
+      customerCancellationComment: null,
+      customerCancellationReason: null,
+      customerId: "polar-integrity",
+      endedAt: null,
+      id: "canceled-subscription",
+      metadata: {},
+      modifiedAt: null,
+      productId: "pro-product",
+      recurringInterval: null,
+      startedAt: NOW,
+      status: "canceled",
+    })
+  );
+
+  return userId;
+});
+
 describe("customers/integrity/internal", () => {
-  it("lists integrity pages for users, customers, and active subscriptions", async () => {
-    const t = convexTest(schema, convexModules);
+  it.effect(
+    "lists integrity pages for users, customers, and active subscriptions",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const userId = yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(seedCustomerIntegrityState(ctx)))
+        );
 
-    const state = await t.mutation(async (ctx) => {
-      const userId = await ctx.db.insert("users", {
-        authId: "auth-customer-integrity",
-        credits: 10,
-        creditsResetAt: 1,
-        email: "integrity@example.com",
-        name: "Integrity User",
-        plan: "free",
-      });
-
-      await ctx.db.insert("customers", {
-        id: "polar-integrity",
-        externalId: "auth-customer-integrity",
-        metadata: { userId },
-        userId,
-      });
-
-      await ctx.db.insert("subscriptions", {
-        amount: null,
-        cancelAtPeriodEnd: false,
-        checkoutId: null,
-        createdAt: NOW,
-        currency: null,
-        currentPeriodEnd: null,
-        currentPeriodStart: NOW,
-        customerCancellationComment: null,
-        customerCancellationReason: null,
-        customerId: "polar-integrity",
-        endedAt: null,
-        id: "active-subscription",
-        metadata: {},
-        modifiedAt: null,
-        productId: "pro-product",
-        recurringInterval: null,
-        startedAt: NOW,
-        status: "active",
-      });
-      await ctx.db.insert("subscriptions", {
-        amount: null,
-        cancelAtPeriodEnd: false,
-        checkoutId: null,
-        createdAt: NOW,
-        currency: null,
-        currentPeriodEnd: null,
-        currentPeriodStart: NOW,
-        customerCancellationComment: null,
-        customerCancellationReason: null,
-        customerId: "polar-integrity",
-        endedAt: null,
-        id: "canceled-subscription",
-        metadata: {},
-        modifiedAt: null,
-        productId: "pro-product",
-        recurringInterval: null,
-        startedAt: NOW,
-        status: "canceled",
-      });
-
-      return userId;
-    });
-
-    const [users, customers, subscriptions] = await Promise.all([
-      t.query(
-        internal.customers.integrity.internal.listUsersForCustomerIntegrity,
-        {
-          paginationOpts: {
-            cursor: null,
-            numItems: 100,
+        const { customers, subscriptions, users } = yield* Effect.all(
+          {
+            customers: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal.listCustomersForIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
+            subscriptions: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal
+                  .listActiveSubscriptionsForIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
+            users: Effect.promise(() =>
+              t.query(
+                internal.customers.integrity.internal
+                  .listUsersForCustomerIntegrity,
+                {
+                  paginationOpts: {
+                    cursor: null,
+                    numItems: 100,
+                  },
+                }
+              )
+            ),
           },
-        }
-      ),
-      t.query(internal.customers.integrity.internal.listCustomersForIntegrity, {
-        paginationOpts: {
-          cursor: null,
-          numItems: 100,
-        },
-      }),
-      t.query(
-        internal.customers.integrity.internal
-          .listActiveSubscriptionsForIntegrity,
-        {
-          paginationOpts: {
-            cursor: null,
-            numItems: 100,
-          },
-        }
-      ),
-    ]);
+          { concurrency: "unbounded" }
+        );
 
-    expect(users.page).toEqual([
-      expect.objectContaining({
-        userId: state,
-      }),
-    ]);
-    expect(customers.page).toEqual([
-      expect.objectContaining({
-        polarCustomerId: "polar-integrity",
-        userId: state,
-      }),
-    ]);
-    expect(subscriptions.page).toEqual([
-      expect.objectContaining({
-        customerId: "polar-integrity",
-        subscriptionId: "active-subscription",
-      }),
-    ]);
-  });
+        expect(users.page).toEqual([
+          expect.objectContaining({
+            userId,
+          }),
+        ]);
+        expect(customers.page).toEqual([
+          expect.objectContaining({
+            polarCustomerId: "polar-integrity",
+            userId,
+          }),
+        ]);
+        expect(subscriptions.page).toEqual([
+          expect.objectContaining({
+            customerId: "polar-integrity",
+            subscriptionId: "active-subscription",
+          }),
+        ]);
+      })
+  );
 });

--- a/packages/backend/convex/customers/mutations/internal.test.ts
+++ b/packages/backend/convex/customers/mutations/internal.test.ts
@@ -1,391 +1,499 @@
+import { describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { getPlanCreditConfig } from "@repo/backend/convex/credits/constants";
 import type { CustomerUpsertResult } from "@repo/backend/convex/customers/mutations/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { products } from "@repo/backend/convex/utils/polar/products";
-import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import type { FunctionArgs } from "convex/server";
+import { convexTest, type TestConvex } from "convex-test";
+import { Data, Effect } from "effect";
+
+const {
+  completeCustomerDeletionCheckpoint,
+  deleteCustomerById,
+  recordCustomerDeletionCheckpoint,
+  upsertCustomer,
+} = internal.customers.mutations.internal;
+type CustomerTest = TestConvex<typeof schema>;
+type CustomerInput = FunctionArgs<typeof upsertCustomer>["customer"];
+
+class ExpectedStoredCustomer extends Data.TaggedError(
+  "ExpectedStoredCustomer"
+)<{
+  readonly result: Exclude<CustomerUpsertResult, { readonly kind: "stored" }>;
+}> {}
 
 /** Inserts a user row for customer reconciliation tests. */
-function insertCustomerUser(ctx: MutationCtx, suffix: string) {
-  return ctx.db.insert("users", {
-    authId: `auth-${suffix}`,
-    credits: 10,
-    creditsResetAt: 1,
-    email: `${suffix}@example.com`,
-    name: suffix,
-    plan: "free",
-  });
-}
+const insertUser = Effect.fn("customers.mutations.test.insertUser")(function* (
+  ctx: MutationCtx,
+  suffix: string
+) {
+  return yield* Effect.promise(() =>
+    ctx.db.insert("users", {
+      authId: `auth-${suffix}`,
+      credits: 10,
+      creditsResetAt: 1,
+      email: `${suffix}@example.com`,
+      name: suffix,
+      plan: "free",
+    })
+  );
+});
 
 /** Inserts a local customer row owned by one user. */
-function insertCustomerRow(
-  ctx: MutationCtx,
-  {
-    polarId,
-    userId,
-  }: {
-    polarId: string;
-    userId: Id<"users">;
+const insertCustomer = Effect.fn("customers.mutations.test.insertCustomer")(
+  function* (ctx: MutationCtx, polarId: string, userId: Id<"users">) {
+    return yield* Effect.promise(() =>
+      ctx.db.insert("customers", {
+        id: polarId,
+        externalId: null,
+        metadata: {},
+        userId,
+      })
+    );
   }
+);
+
+const createUser = Effect.fn("customers.mutations.test.createUser")(function* (
+  t: CustomerTest,
+  suffix: string
 ) {
-  return ctx.db.insert("customers", {
-    id: polarId,
-    externalId: null,
-    metadata: {},
-    userId,
-  });
-}
+  return yield* Effect.promise(() =>
+    t.mutation((ctx) => runConvexProgram(insertUser(ctx, suffix)))
+  );
+});
+
+const writeCustomer = Effect.fn("customers.mutations.test.writeCustomer")(
+  function* (t: CustomerTest, customer: CustomerInput) {
+    return yield* Effect.promise(() =>
+      t.mutation(upsertCustomer, { customer })
+    );
+  }
+);
+
+const readCustomer = Effect.fn("customers.mutations.test.readCustomer")(
+  function* (t: CustomerTest, customerId: Id<"customers">) {
+    return yield* Effect.promise(() =>
+      t.query((ctx) =>
+        runConvexProgram(Effect.promise(() => ctx.db.get(customerId)))
+      )
+    );
+  }
+);
+
+const readCustomers = Effect.fn("customers.mutations.test.readCustomers")(
+  function* (t: CustomerTest) {
+    return yield* Effect.promise(() =>
+      t.query((ctx) =>
+        runConvexProgram(
+          Effect.promise(() => ctx.db.query("customers").collect())
+        )
+      )
+    );
+  }
+);
 
 /** Narrows one successful customer upsert after asserting its contract. */
-function getStoredCustomerId(result: CustomerUpsertResult) {
-  expect(result.kind).toBe("stored");
-
+const getStoredCustomerId = Effect.fn(
+  "customers.mutations.test.getStoredCustomerId"
+)(function* (result: CustomerUpsertResult) {
   if (result.kind !== "stored") {
-    throw new Error(`Expected stored customer, received ${result.kind}`);
+    return yield* new ExpectedStoredCustomer({ result });
   }
 
   return result.customerId;
-}
+});
 
 describe("customers/mutations", () => {
-  it("inserts a new customer when no local row exists", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation((ctx) => insertCustomerUser(ctx, "new"));
-
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
-          id: "polar-new",
-          externalId: "auth-new",
-          metadata: { userId },
-          userId,
-        },
-      }
-    );
-    const customerId = getStoredCustomerId(result);
-
-    const customer = await t.query((ctx) => ctx.db.get(customerId));
-
-    expect(customer).toMatchObject({
-      externalId: "auth-new",
-      id: "polar-new",
-      metadata: { userId },
-      userId,
-    });
-  });
-
-  it("patches the same row when user and Polar id both match", async () => {
-    const t = convexTest(schema, convexModules);
-
-    const state = await t.mutation(async (ctx) => {
-      const userId = await insertCustomerUser(ctx, "same");
-      const customerId = await insertCustomerRow(ctx, {
-        polarId: "polar-same",
+  it.effect("inserts a new customer when no local row exists", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* createUser(t, "new");
+      const input = {
+        id: "polar-new",
+        externalId: "auth-new",
+        metadata: { userId },
         userId,
-      });
+      };
+      const result = yield* writeCustomer(t, input);
+      const customerId = yield* getStoredCustomerId(result);
+      const customer = yield* readCustomer(t, customerId);
+      expect(customer).toMatchObject(input);
+    })
+  );
 
-      return { customerId, userId };
-    });
+  it.effect("patches the same row when user and Polar id both match", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const state = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const userId = yield* insertUser(ctx, "same");
+              const customerId = yield* insertCustomer(
+                ctx,
+                "polar-same",
+                userId
+              );
+              return { customerId, userId };
+            })
+          )
+        )
+      );
+      const input = {
+        id: "polar-same",
+        externalId: "auth-same",
+        metadata: { tier: "pro" },
+        userId: state.userId,
+      };
+      const result = yield* writeCustomer(t, input);
+      const resultId = yield* getStoredCustomerId(result);
+      const customer = yield* readCustomer(t, resultId);
+      expect(resultId).toBe(state.customerId);
+      expect(customer).toMatchObject(input);
+    })
+  );
 
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
-          id: "polar-same",
-          externalId: "auth-same",
-          metadata: { tier: "pro" },
-          userId: state.userId,
-        },
-      }
-    );
-    const resultId = getStoredCustomerId(result);
-
-    const customer = await t.query((ctx) => ctx.db.get(resultId));
-
-    expect(resultId).toBe(state.customerId);
-    expect(customer).toMatchObject({
-      externalId: "auth-same",
-      id: "polar-same",
-      metadata: { tier: "pro" },
-      userId: state.userId,
-    });
-  });
-
-  it("patches an existing Polar row when only the Polar id matches", async () => {
-    const t = convexTest(schema, convexModules);
-
-    const state = await t.mutation(async (ctx) => {
-      const oldUserId = await insertCustomerUser(ctx, "old-polar");
-      const newUserId = await insertCustomerUser(ctx, "new-polar");
-      const customerId = await insertCustomerRow(ctx, {
-        polarId: "polar-only",
-        userId: oldUserId,
-      });
-
-      return { customerId, newUserId };
-    });
-
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
+  it.effect(
+    "patches an existing Polar row when only the Polar id matches",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const state = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const oldUserId = yield* insertUser(ctx, "old-polar");
+                const newUserId = yield* insertUser(ctx, "new-polar");
+                const customerId = yield* insertCustomer(
+                  ctx,
+                  "polar-only",
+                  oldUserId
+                );
+                return { customerId, newUserId };
+              })
+            )
+          )
+        );
+        const input = {
           id: "polar-only",
           externalId: "auth-new-polar",
           metadata: { userId: state.newUserId },
           userId: state.newUserId,
-        },
-      }
-    );
-    const resultId = getStoredCustomerId(result);
+        };
+        const result = yield* writeCustomer(t, input);
+        const resultId = yield* getStoredCustomerId(result);
+        const customer = yield* readCustomer(t, resultId);
+        expect(resultId).toBe(state.customerId);
+        expect(customer).toMatchObject(input);
+      })
+  );
 
-    const customer = await t.query((ctx) => ctx.db.get(resultId));
-
-    expect(resultId).toBe(state.customerId);
-    expect(customer).toMatchObject({
-      externalId: "auth-new-polar",
-      id: "polar-only",
-      userId: state.newUserId,
-    });
-  });
-
-  it("patches an existing user row when only the user matches", async () => {
-    const t = convexTest(schema, convexModules);
-
-    const state = await t.mutation(async (ctx) => {
-      const userId = await insertCustomerUser(ctx, "user-only");
-      const customerId = await insertCustomerRow(ctx, {
-        polarId: "polar-stale",
-        userId,
-      });
-
-      return { customerId, userId };
-    });
-
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
-          id: "polar-fresh",
-          externalId: "auth-user-only",
-          metadata: { userId: state.userId },
-          userId: state.userId,
-        },
-      }
-    );
-    const resultId = getStoredCustomerId(result);
-
-    const customer = await t.query((ctx) => ctx.db.get(resultId));
-
-    expect(resultId).toBe(state.customerId);
-    expect(customer).toMatchObject({
-      externalId: "auth-user-only",
-      id: "polar-fresh",
-      userId: state.userId,
-    });
-  });
-
-  it("reconciles local rows by Polar customer id and removes stale duplicates", async () => {
-    const t = convexTest(schema, convexModules);
-
-    const state = await t.mutation(async (ctx) => {
-      const staleUserId = await insertCustomerUser(ctx, "stale");
-      const currentUserId = await insertCustomerUser(ctx, "current");
-      const stalePolarRowId = await insertCustomerRow(ctx, {
-        polarId: "polar-target",
-        userId: staleUserId,
-      });
-      const staleUserRowId = await insertCustomerRow(ctx, {
-        polarId: "polar-stale-user",
-        userId: currentUserId,
-      });
-
-      return {
-        currentUserId,
-        stalePolarRowId,
-        staleUserRowId,
+  it.effect("patches an existing user row when only the user matches", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const state = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const userId = yield* insertUser(ctx, "user-only");
+              const customerId = yield* insertCustomer(
+                ctx,
+                "polar-stale",
+                userId
+              );
+              return { customerId, userId };
+            })
+          )
+        )
+      );
+      const input = {
+        id: "polar-fresh",
+        externalId: "auth-user-only",
+        metadata: { userId: state.userId },
+        userId: state.userId,
       };
-    });
+      const result = yield* writeCustomer(t, input);
+      const resultId = yield* getStoredCustomerId(result);
+      const customer = yield* readCustomer(t, resultId);
+      expect(resultId).toBe(state.customerId);
+      expect(customer).toMatchObject(input);
+    })
+  );
 
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
+  it.effect(
+    "reconciles local rows by Polar customer id and removes stale duplicates",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const state = yield* Effect.promise(() =>
+          t.mutation((ctx) =>
+            runConvexProgram(
+              Effect.gen(function* () {
+                const staleUserId = yield* insertUser(ctx, "stale");
+                const currentUserId = yield* insertUser(ctx, "current");
+                yield* insertCustomer(ctx, "polar-target", staleUserId);
+                yield* insertCustomer(ctx, "polar-stale-user", currentUserId);
+                return { currentUserId };
+              })
+            )
+          )
+        );
+        const result = yield* writeCustomer(t, {
           id: "polar-target",
           externalId: "auth-current",
           metadata: { userId: state.currentUserId },
           userId: state.currentUserId,
-        },
+        });
+        const reconciledId = yield* getStoredCustomerId(result);
+        const customers = yield* readCustomers(t);
+        expect(customers).toHaveLength(1);
+        expect(customers[0]).toMatchObject({
+          _id: reconciledId,
+          externalId: "auth-current",
+          id: "polar-target",
+          userId: state.currentUserId,
+        });
+      })
+  );
+
+  it.effect("drains every subscription batch before deleting a customer", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      yield* Effect.sync(() => posthogTest.register(t));
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.gen(function* () {
+              const userId = yield* insertUser(ctx, "delete");
+              yield* Effect.promise(() =>
+                ctx.db.patch("users", userId, {
+                  credits: getPlanCreditConfig("pro").amount,
+                  plan: "pro",
+                })
+              );
+              yield* insertCustomer(ctx, "polar-delete", userId);
+              for (let index = 0; index <= 50; index += 1) {
+                yield* Effect.promise(() =>
+                  ctx.db.insert("subscriptions", {
+                    amount: null,
+                    cancelAtPeriodEnd: false,
+                    checkoutId: null,
+                    createdAt: "2026-07-27T00:00:00.000Z",
+                    currency: null,
+                    currentPeriodEnd: null,
+                    currentPeriodStart: "2026-07-27T00:00:00.000Z",
+                    customerId: "polar-delete",
+                    endedAt: null,
+                    id: `subscription-delete-${index}`,
+                    metadata: {},
+                    modifiedAt: null,
+                    productId: products.pro.id,
+                    recurringInterval: null,
+                    startedAt: "2026-07-27T00:00:00.000Z",
+                    status: "active",
+                  })
+                );
+              }
+              return userId;
+            })
+          )
+        )
+      );
+      let hasMore = true;
+      let mutationCount = 0;
+      while (hasMore) {
+        hasMore = yield* Effect.promise(() =>
+          t.mutation(deleteCustomerById, {
+            id: "polar-delete",
+          })
+        );
+        mutationCount += 1;
       }
-    );
-    const reconciledId = getStoredCustomerId(result);
-
-    const customers = await t.query(
-      async (ctx) => await ctx.db.query("customers").collect()
-    );
-
-    expect(customers).toHaveLength(1);
-    expect(customers[0]).toMatchObject({
-      _id: reconciledId,
-      externalId: "auth-current",
-      id: "polar-target",
-      userId: state.currentUserId,
-    });
-  });
-
-  it("drains every subscription batch before deleting a customer", async () => {
-    const t = convexTest(schema, convexModules);
-    posthogTest.register(t);
-
-    const userId = await t.mutation(async (ctx) => {
-      const userId = await insertCustomerUser(ctx, "delete");
-      await ctx.db.patch("users", userId, {
-        credits: getPlanCreditConfig("pro").amount,
-        plan: "pro",
+      expect(mutationCount).toBe(2);
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.all({
+              customers: Effect.promise(() =>
+                ctx.db.query("customers").collect()
+              ),
+              subscriptions: Effect.promise(() =>
+                ctx.db.query("subscriptions").collect()
+              ),
+              tombstones: Effect.promise(() =>
+                ctx.db.query("customerDeletionTombstones").collect()
+              ),
+              user: Effect.promise(() => ctx.db.get("users", userId)),
+            })
+          )
+        )
+      );
+      expect(state).toEqual({
+        customers: [],
+        subscriptions: [],
+        tombstones: [
+          expect.objectContaining({ polarCustomerId: "polar-delete" }),
+        ],
+        user: expect.objectContaining({
+          credits: getPlanCreditConfig("free").amount,
+          plan: "free",
+        }),
       });
-      await insertCustomerRow(ctx, {
-        polarId: "polar-delete",
+    })
+  );
+
+  it.effect("records and completes a customer deletion checkpoint", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* createUser(t, "checkpoint");
+      const checkpoint = {
+        polarCustomerId: "polar-checkpoint",
+        userId,
+      };
+      expect(
+        yield* Effect.promise(() =>
+          t.mutation(recordCustomerDeletionCheckpoint, checkpoint)
+        )
+      ).toBeNull();
+      expect(
+        yield* Effect.promise(() =>
+          t.mutation(completeCustomerDeletionCheckpoint, checkpoint)
+        )
+      ).toBeNull();
+      const [completed] = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.query("customerDeletionTombstones").collect()
+            )
+          )
+        )
+      );
+      expect(completed).toMatchObject({
+        polarCustomerId: checkpoint.polarCustomerId,
+      });
+      expect(completed).not.toHaveProperty("cleanupUserId");
+    })
+  );
+
+  it.effect("does not recreate customer data for a prepared user", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* createUser(t, "prepared");
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.patch("users", userId, { deletionPreparedAt: 1 })
+            )
+          )
+        )
+      );
+      const result = yield* writeCustomer(t, {
+        id: "polar-prepared",
+        externalId: "auth-prepared",
+        metadata: { userId },
         userId,
       });
-      for (let index = 0; index <= 50; index += 1) {
-        await ctx.db.insert("subscriptions", {
-          amount: null,
-          cancelAtPeriodEnd: false,
-          checkoutId: null,
-          createdAt: "2026-07-27T00:00:00.000Z",
-          currency: null,
-          currentPeriodEnd: null,
-          currentPeriodStart: "2026-07-27T00:00:00.000Z",
-          customerId: "polar-delete",
-          endedAt: null,
-          id: `subscription-delete-${index}`,
-          metadata: {},
-          modifiedAt: null,
-          productId: products.pro.id,
-          recurringInterval: null,
-          startedAt: "2026-07-27T00:00:00.000Z",
-          status: "active",
-        });
-      }
+      const customers = yield* readCustomers(t);
+      expect(result).toEqual({ kind: "prepared" });
+      expect(customers).toEqual([]);
+    })
+  );
 
-      return userId;
-    });
-    let hasMore = true;
-    let mutationCount = 0;
-
-    while (hasMore) {
-      hasMore = await t.mutation(
-        internal.customers.mutations.internal.deleteCustomerById,
-        {
-          id: "polar-delete",
-        }
+  it.effect("returns missing for a missing user", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* createUser(t, "missing");
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(Effect.promise(() => ctx.db.delete("users", userId)))
+        )
       );
-      mutationCount += 1;
-    }
-
-    expect(mutationCount).toBe(2);
-
-    const state = await t.query(async (ctx) => ({
-      customers: await ctx.db.query("customers").collect(),
-      subscriptions: await ctx.db.query("subscriptions").collect(),
-      tombstones: await ctx.db.query("customerDeletionTombstones").collect(),
-      user: await ctx.db.get("users", userId),
-    }));
-
-    expect(state).toEqual({
-      customers: [],
-      subscriptions: [],
-      tombstones: [
-        expect.objectContaining({
-          polarCustomerId: "polar-delete",
-        }),
-      ],
-      user: expect.objectContaining({
-        credits: getPlanCreditConfig("free").amount,
-        plan: "free",
-      }),
-    });
-  });
-
-  it("does not recreate customer data for a prepared user", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation(async (ctx) => {
-      const insertedUserId = await insertCustomerUser(ctx, "deleted");
-      await ctx.db.patch("users", insertedUserId, {
-        deletionPreparedAt: 1,
+      const result = yield* writeCustomer(t, {
+        id: "polar-missing",
+        externalId: "auth-missing",
+        metadata: { userId },
+        userId,
       });
-      return insertedUserId;
-    });
+      expect(result).toEqual({ kind: "missing" });
+    })
+  );
 
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
-          id: "polar-deleted",
-          externalId: "auth-deleted",
-          metadata: { userId },
-          userId,
-        },
-      }
-    );
-    const customers = await t.query(
-      async (ctx) => await ctx.db.query("customers").collect()
-    );
+  it.effect("returns deleted for a deleted user", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* createUser(t, "deleted");
+      yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.patch("users", userId, { deletedAt: 1 })
+            )
+          )
+        )
+      );
+      const result = yield* writeCustomer(t, {
+        id: "polar-deleted-user",
+        externalId: "auth-deleted-user",
+        metadata: { userId },
+        userId,
+      });
+      expect(result).toEqual({ kind: "deleted" });
+    })
+  );
 
-    expect(result).toEqual({ kind: "prepared" });
-    expect(customers).toEqual([]);
-  });
-
-  it("does not recreate a customer after its Polar deletion tombstone", async () => {
-    const t = convexTest(schema, convexModules);
-    const userId = await t.mutation((ctx) =>
-      insertCustomerUser(ctx, "terminal")
-    );
-
-    await t.mutation(internal.customers.mutations.internal.deleteCustomerById, {
-      id: "polar-terminal",
-    });
-    const result = await t.mutation(
-      internal.customers.mutations.internal.upsertCustomer,
-      {
-        customer: {
+  it.effect(
+    "does not recreate a customer after its Polar deletion tombstone",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const userId = yield* createUser(t, "terminal");
+        yield* Effect.promise(() =>
+          t.mutation(deleteCustomerById, {
+            id: "polar-terminal",
+          })
+        );
+        const result = yield* writeCustomer(t, {
           id: "polar-terminal",
           externalId: "auth-terminal",
           metadata: { userId },
           userId,
-        },
-      }
-    );
-    const customers = await t.query(
-      async (ctx) => await ctx.db.query("customers").collect()
-    );
-
-    expect(result).toEqual({ kind: "deleted" });
-    expect(customers).toEqual([]);
-  });
-
-  it("ignores delete requests for unknown Polar ids", async () => {
-    const t = convexTest(schema, convexModules);
-
-    await expect(
-      t.mutation(internal.customers.mutations.internal.deleteCustomerById, {
-        id: "missing-polar",
+        });
+        const customers = yield* readCustomers(t);
+        expect(result).toEqual({ kind: "deleted" });
+        expect(customers).toEqual([]);
       })
-    ).resolves.toBe(false);
+  );
 
-    const tombstones = await t.query(
-      async (ctx) => await ctx.db.query("customerDeletionTombstones").collect()
-    );
-
-    expect(tombstones).toEqual([
-      expect.objectContaining({
-        polarCustomerId: "missing-polar",
-      }),
-    ]);
-  });
+  it.effect("ignores delete requests for unknown Polar ids", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      expect(
+        yield* Effect.promise(() =>
+          t.mutation(deleteCustomerById, {
+            id: "missing-polar",
+          })
+        )
+      ).toBe(false);
+      const tombstones = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            Effect.promise(() =>
+              ctx.db.query("customerDeletionTombstones").collect()
+            )
+          )
+        )
+      );
+      expect(tombstones).toEqual([
+        expect.objectContaining({ polarCustomerId: "missing-polar" }),
+      ]);
+    })
+  );
 });

--- a/packages/backend/convex/customers/sync/settlement.test.ts
+++ b/packages/backend/convex/customers/sync/settlement.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { settleCustomerSync } from "@repo/backend/convex/customers/sync/settlement";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 /** Creates observable cleanup operations for settlement tests. */
 function createOperations() {
@@ -15,34 +16,37 @@ function createOperations() {
 }
 
 /** Creates real typed Convex IDs without test-only assertions. */
-function createSettlementIds() {
-  const t = convexTest(schema, convexModules);
-
-  return t.mutation(async (ctx) => {
-    const userId = await ctx.db.insert("users", {
-      authId: "auth-customer-settlement",
-      credits: 0,
-      creditsResetAt: 1,
-      email: "customer-settlement@example.com",
-      name: "Customer Settlement",
-      plan: "free",
-    });
-    const customerId = await ctx.db.insert("customers", {
-      externalId: "auth-customer-settlement",
-      id: "polar-customer-settlement",
-      metadata: {},
-      userId,
-    });
+const createSettlementIds = Effect.fn("customers.sync.test.createIds")(
+  function* (ctx: MutationCtx) {
+    const userId = yield* Effect.promise(() =>
+      ctx.db.insert("users", {
+        authId: "auth-customer-settlement",
+        credits: 0,
+        creditsResetAt: 1,
+        email: "customer-settlement@example.com",
+        name: "Customer Settlement",
+        plan: "free",
+      })
+    );
+    const customerId = yield* Effect.promise(() =>
+      ctx.db.insert("customers", {
+        externalId: "auth-customer-settlement",
+        id: "polar-customer-settlement",
+        metadata: {},
+        userId,
+      })
+    );
 
     return { customerId, userId };
-  });
-}
+  }
+);
 
 describe("customers/sync/settlement", () => {
   it.effect("returns the stored customer without cleanup", () =>
     Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
       const { customerId, userId } = yield* Effect.promise(() =>
-        createSettlementIds()
+        t.mutation((ctx) => runConvexProgram(createSettlementIds(ctx)))
       );
       const operations = createOperations();
 
@@ -62,7 +66,10 @@ describe("customers/sync/settlement", () => {
     "preserves Polar and local state during cancelable preparation",
     () =>
       Effect.gen(function* () {
-        const { userId } = yield* Effect.promise(() => createSettlementIds());
+        const t = convexTest(schema, convexModules);
+        const { userId } = yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(createSettlementIds(ctx)))
+        );
         const operations = createOperations();
 
         const failure = yield* settleCustomerSync(
@@ -84,7 +91,10 @@ describe("customers/sync/settlement", () => {
     "cleans irreversible $kind state",
     (result) =>
       Effect.gen(function* () {
-        const { userId } = yield* Effect.promise(() => createSettlementIds());
+        const t = convexTest(schema, convexModules);
+        const { userId } = yield* Effect.promise(() =>
+          t.mutation((ctx) => runConvexProgram(createSettlementIds(ctx)))
+        );
         const operations = createOperations();
 
         const failure = yield* settleCustomerSync(

--- a/packages/backend/convex/routes/polar.test.ts
+++ b/packages/backend/convex/routes/polar.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment edge-runtime
 
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { SDKValidationError } from "@polar-sh/sdk/models/errors/sdkvalidationerror";
 import { WebhookVerificationError } from "@polar-sh/sdk/webhooks";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
@@ -7,7 +8,7 @@ import { registerPolarRoutes } from "@repo/backend/convex/routes/polar";
 import type { HonoWithConvex } from "convex-helpers/server/hono";
 import { Effect, Schema } from "effect";
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   processEvent: vi.fn(),
@@ -34,13 +35,21 @@ function createApp() {
   return app;
 }
 
-function postWebhook(body = "{}") {
-  return createApp().request("/polar/events", {
-    body,
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
-}
+const postWebhook = Effect.fn("routes.polar.test.postWebhook")((body = "{}") =>
+  Effect.promise(() =>
+    Promise.resolve(
+      createApp().request("/polar/events", {
+        body,
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      })
+    )
+  )
+);
+
+const readResponseText = Effect.fn("routes.polar.test.readResponseText")(
+  (response: Response) => Effect.promise(() => response.text())
+);
 
 beforeEach(() => {
   mocks.validateEvent.mockReset();
@@ -54,95 +63,113 @@ afterEach(() => {
 });
 
 describe("Polar webhook route", () => {
-  it("accepts one verified and handled event", async () => {
-    const response = await postWebhook('{"type":"test.event"}');
+  it.effect("accepts one verified and handled event", () =>
+    Effect.gen(function* () {
+      const response = yield* postWebhook('{"type":"test.event"}');
 
-    expect(response.status).toBe(202);
-    await expect(response.text()).resolves.toBe("Accepted");
-    expect(mocks.processEvent).toHaveBeenCalledOnce();
-  });
+      expect(response.status).toBe(202);
+      expect(yield* readResponseText(response)).toBe("Accepted");
+      expect(mocks.processEvent).toHaveBeenCalledOnce();
+    })
+  );
 
-  it("returns a retryable bad request for a missing user", async () => {
-    mocks.processEvent.mockReturnValue(Effect.succeed(false));
+  it.effect("returns a retryable bad request for a missing user", () =>
+    Effect.gen(function* () {
+      mocks.processEvent.mockReturnValue(Effect.succeed(false));
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(400);
-    await expect(response.text()).resolves.toBe("Bad Request: Missing User");
-  });
+      expect(response.status).toBe(400);
+      expect(yield* readResponseText(response)).toBe(
+        "Bad Request: Missing User"
+      );
+    })
+  );
 
-  it("rejects an invalid signature before processing", async () => {
-    mocks.validateEvent.mockImplementation(() => {
-      throw new WebhookVerificationError("Invalid signature");
-    });
+  it.effect("rejects an invalid signature before processing", () =>
+    Effect.gen(function* () {
+      mocks.validateEvent.mockImplementation(() => {
+        throw new WebhookVerificationError("Invalid signature");
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(403);
-    await expect(response.text()).resolves.toBe("Forbidden");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(403);
+      expect(yield* readResponseText(response)).toBe("Forbidden");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("rejects a signed malformed payload before processing", async () => {
-    mocks.validateEvent.mockImplementation(() => {
-      throw new SDKValidationError("Invalid payload", undefined, {});
-    });
+  it.effect("rejects a signed malformed payload before processing", () =>
+    Effect.gen(function* () {
+      mocks.validateEvent.mockImplementation(() => {
+        throw new SDKValidationError("Invalid payload", undefined, {});
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(400);
-    await expect(response.text()).resolves.toBe("Bad Request");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(yield* readResponseText(response)).toBe("Bad Request");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps an unexpected SDK failure to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.validateEvent.mockImplementation(() => {
-      throw new Error("Unexpected SDK failure");
-    });
+  it.effect("maps an unexpected SDK failure to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.validateEvent.mockImplementation(() => {
+        throw new Error("Unexpected SDK failure");
+      });
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps a body read failure to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(Request.prototype, "text").mockRejectedValue(
-      new Error("Unreadable body")
-    );
+  it.effect("maps a body read failure to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.spyOn(Request.prototype, "text").mockRejectedValue(
+        new Error("Unreadable body")
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-    expect(mocks.validateEvent).not.toHaveBeenCalled();
-    expect(mocks.processEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+      expect(mocks.validateEvent).not.toHaveBeenCalled();
+      expect(mocks.processEvent).not.toHaveBeenCalled();
+    })
+  );
 
-  it("maps typed processing failures to a server response", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.processEvent.mockReturnValue(
-      Effect.fail(new TestProcessingError({ message: "Database down" }))
-    );
+  it.effect("maps typed processing failures to a server response", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.processEvent.mockReturnValue(
+        Effect.fail(new TestProcessingError({ message: "Database down" }))
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+    })
+  );
 
-  it("contains unexpected processing defects at the HTTP boundary", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.processEvent.mockReturnValue(
-      Effect.die(new Error("Unexpected processing defect"))
-    );
+  it.effect("contains unexpected processing defects at the HTTP boundary", () =>
+    Effect.gen(function* () {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.processEvent.mockReturnValue(
+        Effect.die(new Error("Unexpected processing defect"))
+      );
 
-    const response = await postWebhook();
+      const response = yield* postWebhook();
 
-    expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe("Internal server error");
-  });
+      expect(response.status).toBe(500);
+      expect(yield* readResponseText(response)).toBe("Internal server error");
+    })
+  );
 });


### PR DESCRIPTION
## Outcome

Completes the remaining Effect Vitest test migration as one reviewed release unit instead of 16 independent one-file pull requests and 16 serialized merge-queue waves.

## Exact consolidation proof

This commit is the exact non-overlapping union of the reviewed heads from #485, #487, #490, #492, #493, #494, #495, #496, #497, #501, #502, #503, #505, #506, #507, and #508.

- all 19 resulting file blobs exactly match their source pull-request heads
- no production module, dependency, lockfile, schema, generated file, or workflow changes
- no conflict-resolution rewrite or compatibility layer
- one cohesive migration commit replaces 16 delivery lanes

## Verification

- backend focused migration set: 13 files, 68 tests
- www focused migration set: 6 files, 58 tests
- full backend serialized suite: 380 files, 1,633 tests
- full www suite: 209 files, 1,518 tests, 100 percent coverage
- backend TypeScript 7 typecheck
- www TypeScript 7 typecheck with inert local configuration values
- root lint, Effect RC110 source parity, patch policy, and test ownership
- format and diff check

One parallel local backend attempt overlapped the full www suite and hit three independent five-second timeouts. The required serialized backend rerun passed all 380 files and 1,633 tests.

## Superseded pull requests

After this ready pull request is created, the 16 source pull requests will be closed as exact superseded delivery lanes. Their branches remain recoverable until this consolidation is protected-merged and final cleanup proves they have no unique value.

No Vercel Preview was created. Production remains protected-main only.
