### PR TITLE
fix(tryout): verify cleanup question order as a set

### DIFF
--- a/packages/backend/convex/tryouts/migration/cleanup/placement.test.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.test.ts
@@ -1,0 +1,74 @@
+import { assert, describe, it } from "@effect/vitest";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import type schema from "@repo/backend/convex/schema";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import {
+  countScaleRepairRows,
+  type ScaleRepairEvidence,
+} from "@repo/backend/convex/tryouts/migration/cleanup/evidence";
+import { cleanupProgram } from "@repo/backend/convex/tryouts/migration/cleanup/run";
+import { seedUnorderedScalePlacements } from "@repo/backend/test/migration/repair";
+import {
+  CLEANUP_MIGRATION_ID,
+  CLEANUP_PROOF,
+  CLEANUP_RECEIPT_HASH,
+} from "@repo/backend/test/migration/state";
+import type { TestConvex } from "convex-test";
+import { Effect } from "effect";
+
+type CleanupTest = TestConvex<typeof schema>;
+
+function runCleanup(t: CleanupTest, evidence: ScaleRepairEvidence) {
+  return t.mutation((ctx) =>
+    runConvexProgram(
+      cleanupProgram(
+        ctx,
+        CLEANUP_MIGRATION_ID,
+        CLEANUP_RECEIPT_HASH,
+        CLEANUP_PROOF,
+        evidence
+      )
+    )
+  );
+}
+
+describe("tryouts/migration/cleanup/placement", () => {
+  it.effect(
+    "accepts exact question ownership independent of source index order",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        const seeded = yield* Effect.promise(() =>
+          seedUnorderedScalePlacements(t)
+        );
+        const { evidence, repair } = seeded;
+
+        const result = yield* Effect.promise(() => runCleanup(t, evidence));
+        const state = yield* Effect.promise(() =>
+          t.query(async (ctx) => ({
+            items: await Promise.all(
+              repair.itemIds.map((id) => ctx.db.get(id))
+            ),
+            receipt: await ctx.db
+              .query("tryoutHistoryMigrationReceipts")
+              .unique(),
+            runs: await Promise.all(repair.runIds.map((id) => ctx.db.get(id))),
+            scale: await ctx.db.get(repair.scaleVersionId),
+          }))
+        );
+
+        assert.deepStrictEqual(result, {
+          deleted: 0,
+          done: false,
+          repaired: countScaleRepairRows(evidence),
+        });
+        assert.strictEqual(state.scale, null);
+        assert.ok(state.items.every((item) => item === null));
+        assert.ok(state.runs.every((run) => run === null));
+        assert.strictEqual(
+          state.receipt?.repair?.deletedRows,
+          countScaleRepairRows(evidence)
+        );
+      })
+  );
+});

--- a/packages/backend/convex/tryouts/migration/cleanup/placement.ts
+++ b/packages/backend/convex/tryouts/migration/cleanup/placement.ts
@@ -67,9 +67,16 @@ export const verifyRepairPlacements = Effect.fn(
   >();
   for (const run of runs) {
     const source = placementsBySection[run.sectionIdentity] ?? [];
+    const questionOrders = new Set(
+      source.map(({ record }) => record.row.questionOrder)
+    );
     if (
       source.length !== run.questionCount ||
-      source.some(({ record }, index) => record.row.questionOrder !== index + 1)
+      questionOrders.size !== run.questionCount ||
+      [...questionOrders].some(
+        (order) =>
+          !Number.isSafeInteger(order) || order < 1 || order > run.questionCount
+      )
     ) {
       return yield* repairPlacementFailure();
     }

--- a/packages/backend/test/migration/repair.ts
+++ b/packages/backend/test/migration/repair.ts
@@ -277,8 +277,14 @@ export async function seedRepair(
   return { cleanup, repair, source };
 }
 
-/** Seeds two exact placements whose stored items duplicate one identity. */
-export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
+/** Seeds two placements into one section with selectable storage drift. */
+async function seedCombinedRepairSection(
+  test: CleanupTest,
+  options: {
+    readonly duplicateItemIdentity: boolean;
+    readonly reverseStorageOrder: boolean;
+  }
+) {
   const seeded = await seedRepair(test, 0, [
     "general-reasoning",
     "english-language",
@@ -307,6 +313,15 @@ export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
           .eq("rowHash", firstSource.section.record.rowHash)
       )
       .unique();
+    const firstPlacement = await ctx.db
+      .query("tryoutHistoryRows")
+      .withIndex("by_snapshotId_and_rowKind_and_rowHash", (query) =>
+        query
+          .eq("snapshotId", CLEANUP_SOURCE_SNAPSHOT)
+          .eq("rowKind", "placement")
+          .eq("rowHash", firstSource.placement.record.rowHash)
+      )
+      .unique();
     const secondPlacement = await ctx.db
       .query("tryoutHistoryRows")
       .withIndex("by_snapshotId_and_rowKind_and_rowHash", (query) =>
@@ -316,7 +331,7 @@ export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
           .eq("rowHash", secondSource.placement.record.rowHash)
       )
       .unique();
-    assert.ok(firstItem && firstCatalog && secondPlacement);
+    assert.ok(firstItem && firstCatalog && firstPlacement && secondPlacement);
     const catalogRowHash =
       "sha256:a82e49366921f6bdc2e61b36ccb09bcf50eb56a352f0fe9d85f3ab40701940b8";
     const section = {
@@ -350,22 +365,31 @@ export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
         },
         rowHash: placementRowHash,
       },
-    };
+    } as const;
     await ctx.db.replace("tryoutHistoryRows", secondPlacement._id, {
       answerArtifactHash: placement.record.row.answerArtifactHash,
-      index: secondPlacement.index,
+      index: options.reverseStorageOrder
+        ? firstPlacement.index
+        : secondPlacement.index,
       questionArtifactHash: placement.record.row.questionArtifactHash,
       rowHash: placementRowHash,
       rowJson: JSON.stringify(placement),
       rowKind: "placement",
       snapshotId: CLEANUP_SOURCE_SNAPSHOT,
     });
+    if (options.reverseStorageOrder) {
+      await ctx.db.patch(firstPlacement._id, { index: secondPlacement.index });
+    }
     await ctx.db.patch(firstRunId, { questionCount: 2 });
     await ctx.db.delete(secondRunId);
     await ctx.db.patch(secondItemId, {
       calibrationRunId: firstRunId,
-      placementIdentity: firstItem.placementIdentity,
-      placementRowHash: firstItem.placementRowHash,
+      placementIdentity: options.duplicateItemIdentity
+        ? firstItem.placementIdentity
+        : historicalPlacementIdentity(placement.record.row),
+      placementRowHash: options.duplicateItemIdentity
+        ? firstItem.placementRowHash
+        : placementRowHash,
     });
   });
   return {
@@ -375,6 +399,22 @@ export async function seedDuplicateScaleItemIdentity(test: CleanupTest) {
       runs: [{ ...firstRun, questionCount: 2 }],
     },
   };
+}
+
+/** Seeds two exact placements whose stored items duplicate one identity. */
+export function seedDuplicateScaleItemIdentity(test: CleanupTest) {
+  return seedCombinedRepairSection(test, {
+    duplicateItemIdentity: true,
+    reverseStorageOrder: false,
+  });
+}
+
+/** Seeds one exact section whose source indices are not question order. */
+export function seedUnorderedScalePlacements(test: CleanupTest) {
+  return seedCombinedRepairSection(test, {
+    duplicateItemIdentity: false,
+    reverseStorageOrder: true,
+  });
 }
 
 /** Reconstructs the frozen catalog identity used by retained scale rows. */
@@ -412,10 +452,23 @@ function historicalCatalogIdentity(
   });
 }
 
+type RepairPlacementRow = Omit<
+  ReturnType<typeof makeRepairSource>["placement"]["record"]["row"],
+  | "answerContentKey"
+  | "questionContentKey"
+  | "questionOrder"
+  | "questionSourcePath"
+  | "title"
+> & {
+  readonly answerContentKey: `${string}/answer`;
+  readonly questionContentKey: `${string}/question`;
+  readonly questionOrder: number;
+  readonly questionSourcePath: string;
+  readonly title: string;
+};
+
 /** Projects one retained fixture through Aksara's placement contract. */
-function historicalPlacementIdentity(
-  row: ReturnType<typeof makeRepairSource>["placement"]["record"]["row"]
-) {
+function historicalPlacementIdentity(row: RepairPlacementRow) {
   const { locale, ...placement } = row;
   const appLocale = AppLocaleSchema.make(locale);
   return tryoutPlacementIdentity(


### PR DESCRIPTION
## Summary

Verify retained repair question ownership as an exact numeric set instead of assuming database index order is numeric question order.

## Root cause

The signed source index is canonical lexicographic order. Production therefore stores question orders such as `1, 10, 11, ..., 2`, while the cleanup guard compared each row to its array position. Read-only production reconstruction proved all 150 scale items, row hashes, placement identities, seven section owners, and section counts match exactly. The false order assumption alone rejected the valid graph.

## Change

- preserve exact section cardinality
- require every question order to be a unique safe integer in the closed range `1..questionCount`
- keep exact placement identity, row hash, item cardinality, and calibration-run ownership checks unchanged
- add a production-shaped regression whose signed source indices differ from numeric question order

## Exact-head verification

Head: `e14a8d9f0`

- focused cleanup owner tests: 12 passed
- full backend serialized: 381 files and 1,631 tests passed
- backend TypeScript passed
- repository lint, Effect source parity, test ownership, patch ownership, formatting, and package boundaries passed
- touched handwritten files remain below 500 lines
- no raw `try/catch`, assertion cast, fallback, compatibility path, dependency, or schema change was added

## Rollout

This PR performs no production write and creates no Vercel Preview. After protected merge and exact-main production deployment, rerun the existing signed Aksara cleanup workflow immediately and verify the durable receipt and emptied migration tables.
