### PR TITLE
ci: remove duplicate production validation

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -6,17 +6,15 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
-  push:
-    branches: [main]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  # Pull request heads supersede their own predecessor runs. Protected-main
-  # and merge-group runs use the immutable commit SHA so a later independent
-  # change cannot cancel an already-admitted production acceptance.
+  # Pull request heads supersede their own predecessor runs. Merge-group runs
+  # use the immutable commit SHA so a later independent change cannot cancel
+  # an already-admitted production acceptance.
   group: Agent-Friendly Docs-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -26,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      DIRECT_TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih') }}
+      DIRECT_TRUSTED_CONTENT_ENVIRONMENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'nabilfatih' && github.actor == 'nabilfatih' }}
     outputs:
       required: ${{ steps.classify.outputs.required || steps.default.outputs.required }}
       trusted: ${{ steps.trust.outputs.trusted }}
@@ -152,8 +150,8 @@ jobs:
         if: steps.trust.outputs.trusted == 'true'
         id: classify
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: pnpm ci:production-acceptance
 
   quality:
@@ -188,9 +186,9 @@ jobs:
 
   production:
     name: Production
-    # Signed acceptance runs only for protected main and owner-authored
-    # same-repository candidates with production-relevant changes. In-place
-    # test-only candidates retain Quality while Production is skipped.
+    # Signed acceptance runs only for trusted same-repository candidates and
+    # their merge-group trees when they contain production-relevant changes.
+    # Test-only candidates retain Quality while Production is skipped.
     needs: production-scope
     if: needs.production-scope.outputs.required == 'true' && needs.production-scope.outputs.trusted == 'true'
     runs-on: ubuntu-latest
@@ -499,7 +497,7 @@ jobs:
         run: pnpm --silent --dir packages/backend runtime:ci verify-generations
 
       - name: Save verified encrypted signed content snapshot
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.signed-content-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'merge_group' && steps.signed-content-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/agent-docs-content-cache

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -496,13 +496,6 @@ jobs:
           CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
         run: pnpm --silent --dir packages/backend runtime:ci verify-generations
 
-      - name: Save verified encrypted signed content snapshot
-        if: github.event_name == 'merge_group' && steps.signed-content-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/agent-docs-content-cache
-          key: ${{ steps.signed-content-cache.outputs.cache-primary-key }}
-
       - name: Stop local services and erase temporary state
         if: always()
         run: |

--- a/.github/workflows/content-snapshot-cache.yml
+++ b/.github/workflows/content-snapshot-cache.yml
@@ -1,0 +1,106 @@
+name: Content Snapshot Cache
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: content-snapshot-cache-main
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup toolchain
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fingerprint signed runtime contract
+        run: |
+          output="$RUNNER_TEMP/agent-docs-fingerprint.env"
+          rm -f -- "$output"
+          pnpm --silent --dir packages/backend runtime:ci fingerprint
+
+          if [ ! -f "$output" ] || [ -L "$output" ] || \
+            [ "$(stat -c '%a' "$output")" != "600" ] || \
+            [ "$(wc -l < "$output")" -ne 2 ] || \
+            ! grep -Exq 'AGENT_DOCS_CONTENT_CACHE_VERSION=v[0-9]+' "$output" || \
+            ! grep -Exq 'AGENT_DOCS_RUNTIME_SCHEMA_FINGERPRINT=[a-f0-9]{64}' "$output"; then
+            echo "Invalid signed runtime fingerprint output." >&2
+            exit 1
+          fi
+
+          cat "$output" >> "$GITHUB_ENV"
+          rm -f -- "$output"
+
+      - name: Fingerprint production runtime generations
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
+        run: |
+          output="$RUNNER_TEMP/agent-docs-generations.env"
+          rm -f -- "$output"
+          pnpm --silent --dir packages/backend runtime:ci generations
+
+          if [ ! -f "$output" ] || [ -L "$output" ] || \
+            [ "$(stat -c '%a' "$output")" != "600" ] || \
+            [ "$(wc -l < "$output")" -ne 2 ] || \
+            ! grep -Exq 'AGENT_DOCS_CONTENT_STATE_HASH=[a-f0-9]{64}' "$output" || \
+            ! grep -Exq 'AGENT_DOCS_RUNTIME_SELECTION_HASH=[a-f0-9]{64}' "$output"; then
+            echo "Invalid production runtime generation output." >&2
+            exit 1
+          fi
+
+          cat "$output" >> "$GITHUB_ENV"
+          rm -f -- "$output"
+
+      - name: Verify selected production runtime generation
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
+        run: pnpm --silent --dir packages/backend runtime:ci verify-generations
+
+      - name: Restore encrypted signed content snapshot
+        id: signed-content-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/agent-docs-content-cache
+          key: agent-docs-content-${{ env.AGENT_DOCS_CONTENT_CACHE_VERSION }}-${{ env.AGENT_DOCS_CONTENT_STATE_HASH }}-${{ env.AGENT_DOCS_RUNTIME_SCHEMA_FINGERPRINT }}
+
+      - name: Export encrypted signed content snapshot
+        if: steps.signed-content-cache.outputs.cache-hit != 'true'
+        env:
+          AGENT_DOCS_CONTENT_CACHE_KEY: ${{ secrets.AGENT_DOCS_CONTENT_CACHE_KEY_V1 }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.AGENT_DOCS_CONVEX_DEPLOY_KEY }}
+        run: pnpm --silent --dir packages/backend runtime:ci export
+
+      - name: Save encrypted signed content snapshot
+        if: steps.signed-content-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/agent-docs-content-cache
+          key: ${{ steps.signed-content-cache.outputs.cache-primary-key }}
+
+      - name: Erase temporary state
+        if: always()
+        run: |
+          rm -rf -- "$RUNNER_TEMP/agent-docs-content-cache"
+          rm -f -- \
+            "$RUNNER_TEMP/agent-docs-fingerprint.env" \
+            "$RUNNER_TEMP/agent-docs-generations.env"
+
+          find "$RUNNER_TEMP" -mindepth 1 -maxdepth 1 -type d \
+            \( -name 'agent-docs-export-*' \
+            -o -name 'agent-docs-generations-*' \) \
+            -exec rm -rf -- {} +

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -29,7 +29,11 @@ jobs:
           install: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run React Doctor for candidate
+      - name: Run React Doctor for pull request
+        if: github.event_name == 'pull_request'
         env:
-          DOCTOR_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || 'origin/main' }}
+          DOCTOR_BASE: origin/main
         run: pnpm run doctor --verbose --scope changed --base "$DOCTOR_BASE" --include-untracked --blocking warning
+      - name: Run full React Doctor for merge group
+        if: github.event_name == 'merge_group'
+        run: pnpm run doctor --verbose --scope full --blocking warning

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -6,8 +6,6 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
-  push:
-    branches: [main]
 
 permissions:
   contents: read
@@ -32,10 +30,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run React Doctor for candidate
-        if: github.event_name != 'push'
         env:
           DOCTOR_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || 'origin/main' }}
         run: pnpm run doctor --verbose --scope changed --base "$DOCTOR_BASE" --include-untracked --blocking warning
-      - name: Run React Doctor for push
-        if: github.event_name == 'push'
-        run: pnpm run doctor --verbose --scope full --blocking warning

--- a/apps/api/vercel.test.ts
+++ b/apps/api/vercel.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { config } from "@/vercel";
+
+describe("API Vercel configuration", () => {
+  it("skips test-only production commits before affected-package analysis", () => {
+    const ignoreCommand = config.ignoreCommand ?? "";
+
+    expect(ignoreCommand).toContain(
+      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
+    );
+    expect(ignoreCommand).toContain(
+      "node ../../scripts/production-acceptance.ts vercel && exit 0"
+    );
+    expect(ignoreCommand).toContain(
+      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1'
+    );
+    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
+      ignoreCommand.indexOf("turbo query affected")
+    );
+  });
+});

--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -2,7 +2,7 @@ import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
   ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1',
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/mcp/vercel.test.ts
+++ b/apps/mcp/vercel.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { config } from "@/vercel";
+
+describe("MCP Vercel configuration", () => {
+  it("skips test-only production commits before affected-package analysis", () => {
+    const ignoreCommand = config.ignoreCommand ?? "";
+
+    expect(ignoreCommand).toContain(
+      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
+    );
+    expect(ignoreCommand).toContain(
+      "node ../../scripts/production-acceptance.ts vercel && exit 0"
+    );
+    expect(ignoreCommand).toContain(
+      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1'
+    );
+    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
+      ignoreCommand.indexOf("turbo query affected")
+    );
+  });
+});

--- a/apps/mcp/vercel.ts
+++ b/apps/mcp/vercel.ts
@@ -2,7 +2,7 @@ import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
   ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1',
+    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1',
   git: {
     deploymentEnabled: {
       "**": false,

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
@@ -7,6 +8,7 @@ import {
   type HttpClientRequest,
   HttpClientResponse,
 } from "effect/unstable/http";
+import { parse as yamlParse } from "yaml";
 import {
   fetchLatestGithubActionTag,
   GITHUB_ACTION_REVIEWS,
@@ -41,6 +43,32 @@ function makeHttpClient(
 }
 
 describe("GitHub Action policy", () => {
+  it("runs candidate validation before merge without repeating it on main", () => {
+    for (const fileName of ["agent-docs.yml", "react-doctor.yml"]) {
+      const source = readFileSync(
+        fileURLToPath(
+          new URL(`../.github/workflows/${fileName}`, import.meta.url)
+        ),
+        "utf8"
+      );
+      const workflow: unknown = yamlParse(source);
+
+      expect(workflow).toEqual(
+        expect.objectContaining({
+          on: expect.objectContaining({
+            merge_group: expect.any(Object),
+            pull_request: expect.any(Object),
+          }),
+        })
+      );
+      expect(workflow).not.toEqual(
+        expect.objectContaining({
+          on: expect.objectContaining({ push: expect.anything() }),
+        })
+      );
+    }
+  });
+
   it.effect("accepts every reviewed immutable GitHub Action", () =>
     Effect.gen(function* () {
       expect(validateGithubActionPolicy(validActionUses())).toEqual([]);

--- a/scripts/github-action-policy.test.ts
+++ b/scripts/github-action-policy.test.ts
@@ -67,6 +67,52 @@ describe("GitHub Action policy", () => {
         })
       );
     }
+
+    const cacheSource = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../.github/workflows/content-snapshot-cache.yml",
+          import.meta.url
+        )
+      ),
+      "utf8"
+    );
+    const cacheWorkflow: unknown = yamlParse(cacheSource);
+    expect(cacheWorkflow).toEqual(
+      expect.objectContaining({
+        jobs: {
+          publish: expect.objectContaining({ name: "Publish" }),
+        },
+        on: {
+          push: { branches: ["main"] },
+        },
+      })
+    );
+    expect(cacheWorkflow).not.toEqual(
+      expect.objectContaining({
+        on: expect.objectContaining({ merge_group: expect.anything() }),
+      })
+    );
+    expect(cacheWorkflow).not.toEqual(
+      expect.objectContaining({
+        on: expect.objectContaining({ pull_request: expect.anything() }),
+      })
+    );
+  });
+
+  it("runs changed React checks on pull requests and full checks in the queue", () => {
+    const source = readFileSync(
+      fileURLToPath(
+        new URL("../.github/workflows/react-doctor.yml", import.meta.url)
+      ),
+      "utf8"
+    );
+    expect(source).toContain(
+      'pnpm run doctor --verbose --scope changed --base "$DOCTOR_BASE"'
+    );
+    expect(source).toContain(
+      "pnpm run doctor --verbose --scope full --blocking warning"
+    );
   });
 
   it.effect("accepts every reviewed immutable GitHub Action", () =>

--- a/scripts/github-action-policy.ts
+++ b/scripts/github-action-policy.ts
@@ -32,7 +32,7 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     action: "actions/checkout",
     approvedSha: "3d3c42e5aac5ba805825da76410c181273ba90b1",
     expectedTag: "v7.0.1",
-    expectedUsages: 6,
+    expectedUsages: 7,
     reason: "Checkout is pinned to the latest reviewed stable release.",
   },
   {
@@ -47,7 +47,7 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     approvedSha: "84cb39b217b10273981911c288cd62326dc7c6d2",
     expectedInputs: { cache: "true", install: "false" },
     expectedTag: "v2.0.2",
-    expectedUsages: 6,
+    expectedUsages: 7,
     reason:
       "The signed successor action owns Node, pnpm, and dependency caching.",
   },
@@ -69,7 +69,7 @@ export const GITHUB_ACTION_REVIEWS: readonly GithubActionReview[] = [
     action: "actions/cache/restore",
     approvedSha: "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
     expectedTag: "v6.1.0",
-    expectedUsages: 1,
+    expectedUsages: 2,
     reason: "The cache restore and save actions move as one cohort.",
   },
   {


### PR DESCRIPTION
## Summary

- run CI and React validation on pull-request heads and merge-group trees only
- run changed-scope Doctor on pull requests and full Doctor on the synthetic queue tree
- publish the encrypted signed-content cache through one narrow protected-main workflow so later branches can reuse the default-branch cache
- skip API and MCP production builds for exact test-only main changes before Turborepo affected-package analysis
- lock the event split, action inventory, and Vercel behavior with regressions

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm test:scripts`
- `pnpm --filter api exec vitest run vercel.test.ts`
- `pnpm --filter mcp exec vitest run vercel.test.ts`
- `pnpm --filter api typecheck`
- `pnpm --filter mcp typecheck`
- `pnpm typecheck:scripts`