### PR TITLE
fix(release): harden production boundaries

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -394,6 +394,7 @@ jobs:
         env:
           NEXT_EXPOSE_TESTING_API: "true"
           NODE_ENV: production
+          TURBO_CONCURRENCY: "2"
 
       - name: Classify local backend build failure
         if: failure() && steps.production_build.outcome == 'failure'

--- a/apps/api/vercel.test.ts
+++ b/apps/api/vercel.test.ts
@@ -1,21 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { config } from "@/vercel";
 
 describe("API Vercel configuration", () => {
-  it("skips test-only production commits before affected-package analysis", () => {
+  it("uses the pre-install production scope boundary", () => {
     const ignoreCommand = config.ignoreCommand ?? "";
 
-    expect(ignoreCommand).toContain(
-      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
-    );
-    expect(ignoreCommand).toContain(
-      "node ../../scripts/production-acceptance.ts vercel && exit 0"
-    );
-    expect(ignoreCommand).toContain(
-      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1'
-    );
-    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
-      ignoreCommand.indexOf("turbo query affected")
-    );
+    expect(ignoreCommand).toBe("sh ../../scripts/vercel/scope.sh api");
+    expect(ignoreCommand.length).toBeLessThanOrEqual(256);
+    expect(ignoreCommand).not.toContain("node ");
+    expect(ignoreCommand).not.toContain("production-acceptance");
   });
 });

--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -1,8 +1,7 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
-  ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages api --exit-code || exit 1',
+  ignoreCommand: "sh ../../scripts/vercel/scope.sh api",
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/mcp/vercel.test.ts
+++ b/apps/mcp/vercel.test.ts
@@ -1,21 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { config } from "@/vercel";
 
 describe("MCP Vercel configuration", () => {
-  it("skips test-only production commits before affected-package analysis", () => {
+  it("uses the pre-install production scope boundary", () => {
     const ignoreCommand = config.ignoreCommand ?? "";
 
-    expect(ignoreCommand).toContain(
-      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
-    );
-    expect(ignoreCommand).toContain(
-      "node ../../scripts/production-acceptance.ts vercel && exit 0"
-    );
-    expect(ignoreCommand).toContain(
-      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1'
-    );
-    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
-      ignoreCommand.indexOf("turbo query affected")
-    );
+    expect(ignoreCommand).toBe("sh ../../scripts/vercel/scope.sh mcp");
+    expect(ignoreCommand.length).toBeLessThanOrEqual(256);
+    expect(ignoreCommand).not.toContain("node ");
+    expect(ignoreCommand).not.toContain("production-acceptance");
   });
 });

--- a/apps/mcp/vercel.ts
+++ b/apps/mcp/vercel.ts
@@ -1,8 +1,7 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
-  ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages mcp --exit-code || exit 1',
+  ignoreCommand: "sh ../../scripts/vercel/scope.sh mcp",
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/www/vercel.test.ts
+++ b/apps/www/vercel.test.ts
@@ -1,23 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import packageJson from "@/package.json";
 import { config, hasIsolatedTypecheck } from "@/vercel";
 
 describe("www Vercel configuration", () => {
-  it("builds only affected production commits", () => {
+  it("uses the pre-install production scope boundary", () => {
     const ignoreCommand = config.ignoreCommand ?? "";
 
-    expect(ignoreCommand).toContain(
-      'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi'
-    );
-    expect(ignoreCommand).toContain(
-      "node ../../scripts/production-acceptance.ts vercel && exit 0"
-    );
-    expect(ignoreCommand).toContain(
-      'turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1'
-    );
-    expect(ignoreCommand.indexOf("production-acceptance.ts")).toBeLessThan(
-      ignoreCommand.indexOf("turbo query affected")
-    );
+    expect(ignoreCommand).toBe("sh ../../scripts/vercel/scope.sh www");
+    expect(ignoreCommand.length).toBeLessThanOrEqual(256);
+    expect(ignoreCommand).not.toContain("node ");
+    expect(ignoreCommand).not.toContain("production-acceptance");
     expect(config.git?.deploymentEnabled).toEqual({
       "**": false,
       "changeset-release/main": false,

--- a/apps/www/vercel.ts
+++ b/apps/www/vercel.ts
@@ -7,8 +7,7 @@ export function hasIsolatedTypecheck(vercel: "1" | undefined) {
 
 export const config: VercelConfig = {
   buildCommand: "pnpm run build:vercel",
-  ignoreCommand:
-    'if [ "$VERCEL_ENV" != "production" ]; then exit 0; fi; node ../../scripts/production-acceptance.ts vercel && exit 0; turbo query affected --base="$VERCEL_GIT_PREVIOUS_SHA" --packages www --exit-code || exit 1',
+  ignoreCommand: "sh ../../scripts/vercel/scope.sh www",
   git: {
     deploymentEnabled: {
       "**": false,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "turbo run start",
     "test": "pnpm check:patches && pnpm check:tests && pnpm test:scripts && turbo run test",
     "test:coverage": "pnpm check:patches && pnpm check:tests && turbo run test:coverage",
-    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependencies/policy.test.ts scripts/github/policy.test.ts scripts/github/release.test.ts scripts/effect-source.test.ts scripts/production-acceptance.test.ts",
+    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependencies/policy.test.ts scripts/github/policy.test.ts scripts/github/release.test.ts scripts/vercel/scope.test.ts scripts/effect-source.test.ts scripts/production-acceptance.test.ts",
     "test:ui": "turbo run test:ui",
     "test:watch": "turbo run test:watch",
     "translate": "turbo run translate",

--- a/scripts/production-acceptance.test.ts
+++ b/scripts/production-acceptance.test.ts
@@ -1,16 +1,11 @@
-import { fileURLToPath } from "node:url";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, FileSystem, Schema, Stream } from "effect";
+import { Effect, FileSystem, Schema } from "effect";
 import { ChildProcess } from "effect/unstable/process";
 import {
   readProductionChanges,
   requiresProductionAcceptance,
 } from "#scripts/production-acceptance";
-
-const PRODUCTION_ACCEPTANCE_SCRIPT = fileURLToPath(
-  new URL("./production-acceptance.ts", import.meta.url)
-);
 
 class GitFixtureError extends Schema.TaggedError<GitFixtureError>()(
   "GitFixtureError",
@@ -78,89 +73,6 @@ const makeRepository = Effect.fn("ProductionAcceptanceTest.makeRepository")(
     return repository;
   }
 );
-
-const readGitRevision = Effect.fn("ProductionAcceptanceTest.readGitRevision")(
-  function* (repository: string, revision: string) {
-    const command = yield* ChildProcess.make("git", ["rev-parse", revision], {
-      cwd: `${repository}/apps/www`,
-    }).pipe(
-      Effect.mapError(
-        () =>
-          new GitFixtureError({
-            message: `Unable to resolve Git revision ${revision}.`,
-          })
-      )
-    );
-    const [exitCode, output] = yield* Effect.all(
-      [
-        command.exitCode,
-        command.stdout.pipe(
-          Stream.decodeText(),
-          Stream.runFold(
-            () => "",
-            (text, chunk) => text + chunk
-          )
-        ),
-      ],
-      { concurrency: 2 }
-    ).pipe(
-      Effect.mapError(
-        () =>
-          new GitFixtureError({
-            message: `Unable to read Git revision ${revision}.`,
-          })
-      )
-    );
-    if (exitCode !== 0) {
-      return yield* new GitFixtureError({
-        message: `Git could not resolve revision ${revision}.`,
-      });
-    }
-    return output.trim();
-  }
-);
-
-const runVercelDecision = Effect.fn(
-  "ProductionAcceptanceTest.runVercelDecision"
-)(function* (
-  repository: string,
-  base: string | undefined,
-  head: string | undefined
-) {
-  const runtime = yield* Effect.sync(() => ({
-    node: process.execPath,
-    path: process.env.PATH,
-  }));
-  const command = yield* ChildProcess.make(
-    runtime.node,
-    [PRODUCTION_ACCEPTANCE_SCRIPT, "vercel"],
-    {
-      cwd: `${repository}/apps/www`,
-      env: {
-        PATH: runtime.path,
-        VERCEL_GIT_COMMIT_SHA: head,
-        VERCEL_GIT_PREVIOUS_SHA: base,
-      },
-      stderr: "ignore",
-      stdout: "ignore",
-    }
-  ).pipe(
-    Effect.mapError(
-      () =>
-        new GitFixtureError({
-          message: "Unable to run the Vercel production decision.",
-        })
-    )
-  );
-  return yield* command.exitCode.pipe(
-    Effect.mapError(
-      () =>
-        new GitFixtureError({
-          message: "Unable to finish the Vercel production decision.",
-        })
-    )
-  );
-});
 
 describe("production acceptance scope", () => {
   it.each([
@@ -252,37 +164,6 @@ describe("production acceptance scope", () => {
       );
       expect(changes).toEqual([{ path: "example.test.ts", status: "M" }]);
       expect(requiresProductionAcceptance(changes)).toBe(false);
-    }).pipe(Effect.provide(NodeServices.layer))
-  );
-
-  it.effect("skips Vercel only for an exact test-only change", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const repository = yield* makeRepository(
-        "production-acceptance-vercel-test-"
-      );
-      const initial = yield* readGitRevision(repository, "HEAD");
-
-      yield* fileSystem.writeFileString(
-        `${repository}/example.test.ts`,
-        "export const testExample = false;\n"
-      );
-      yield* commitAll(repository, "modify test");
-      const testHead = yield* readGitRevision(repository, "HEAD");
-      expect(yield* runVercelDecision(repository, initial, testHead)).toBe(0);
-
-      yield* fileSystem.writeFileString(
-        `${repository}/example.ts`,
-        "export const example = false;\n"
-      );
-      yield* commitAll(repository, "modify source");
-      const sourceHead = yield* readGitRevision(repository, "HEAD");
-      expect(yield* runVercelDecision(repository, testHead, sourceHead)).toBe(
-        1
-      );
-      expect(yield* runVercelDecision(repository, undefined, undefined)).toBe(
-        1
-      );
     }).pipe(Effect.provide(NodeServices.layer))
   );
 });

--- a/scripts/production-acceptance.ts
+++ b/scripts/production-acceptance.ts
@@ -11,7 +11,6 @@ import { ChildProcess } from "effect/unstable/process";
 import { writeOutput } from "#scripts/output";
 
 const GIT_REVISION_PATTERN = /^[0-9a-f]{40}$/u;
-const ProductionAcceptanceMode = Schema.Literals(["github", "vercel"]);
 
 interface RevisionEnvironment {
   readonly base: string;
@@ -216,47 +215,11 @@ export const writeProductionAcceptanceDecision = Effect.fn(
   return required;
 });
 
-/** Resolves whether Vercel must build the exact protected-main change. */
-const resolveVercelProductionDecision = Effect.fn(
-  "ProductionAcceptance.resolveVercelDecision"
-)(function* (repositoryRoot: string) {
-  const decision = yield* resolveProductionAcceptance(repositoryRoot, {
-    base: "VERCEL_GIT_PREVIOUS_SHA",
-    head: "VERCEL_GIT_COMMIT_SHA",
-  });
-  yield* writeOutput(
-    decision.required
-      ? `Vercel production build required for ${decision.changes.length} changed paths.\n`
-      : `Vercel production build skipped for ${decision.changes.length} modified test modules.\n`
-  );
-  return decision.required;
-});
-
-/** Runs the selected production-scope adapter at the Node CLI boundary. */
+/** Runs the production-scope adapter at the Node CLI boundary. */
 const runProductionAcceptanceMain = Effect.fn("ProductionAcceptance.runMain")(
   function* () {
-    const modeInput = yield* Effect.sync(() => process.argv[2] ?? "github");
-    const mode = yield* Schema.decodeUnknownEffect(ProductionAcceptanceMode)(
-      modeInput
-    ).pipe(
-      Effect.mapError(
-        (cause) =>
-          new ProductionAcceptanceError({
-            cause,
-            message: "Production acceptance mode is invalid.",
-          })
-      )
-    );
     const repositoryRoot = yield* Effect.sync(() => process.cwd());
-    if (mode === "github") {
-      yield* writeProductionAcceptanceDecision(repositoryRoot);
-      return;
-    }
-
-    const required = yield* resolveVercelProductionDecision(repositoryRoot);
-    yield* Effect.sync(() => {
-      process.exitCode = required ? 1 : 0;
-    });
+    yield* writeProductionAcceptanceDecision(repositoryRoot);
   }
 );
 

--- a/scripts/vercel/scope.sh
+++ b/scripts/vercel/scope.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -u
+
+package_name=${1-}
+case "$package_name" in
+  api | mcp | www) ;;
+  *) exit 1 ;;
+esac
+
+if [ "${VERCEL_ENV-}" != "production" ]; then
+  exit 0
+fi
+
+base_revision=${VERCEL_GIT_PREVIOUS_SHA-}
+head_revision=${VERCEL_GIT_COMMIT_SHA-}
+if [ -z "$base_revision" ] || [ -z "$head_revision" ]; then
+  exit 1
+fi
+
+repository_root=$(git rev-parse --show-toplevel) || exit 1
+
+git -C "$repository_root" diff --quiet "$base_revision...$head_revision" --
+change_status=$?
+case "$change_status" in
+  0) exit 1 ;;
+  1) ;;
+  *) exit 1 ;;
+esac
+
+production_required=false
+git -C "$repository_root" diff --quiet --diff-filter=ACDRTUXB \
+  "$base_revision...$head_revision" --
+non_modification_status=$?
+case "$non_modification_status" in
+  0) ;;
+  1) production_required=true ;;
+  *) exit 1 ;;
+esac
+
+if [ "$production_required" = "false" ]; then
+  git -C "$repository_root" diff --quiet --diff-filter=M \
+    "$base_revision...$head_revision" -- \
+    . ':(exclude)**/*.test.ts' ':(exclude)*.test.ts'
+  non_test_status=$?
+  case "$non_test_status" in
+    0) exit 0 ;;
+    1) ;;
+    *) exit 1 ;;
+  esac
+fi
+
+exec turbo query affected \
+  --base="$base_revision" \
+  --packages "$package_name" \
+  --exit-code

--- a/scripts/vercel/scope.test.ts
+++ b/scripts/vercel/scope.test.ts
@@ -1,0 +1,203 @@
+import { fileURLToPath } from "node:url";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Schema, Stream } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+
+const SCRIPT = fileURLToPath(new URL("./scope.sh", import.meta.url));
+
+class ScopeFixtureError extends Schema.TaggedError<ScopeFixtureError>()(
+  "ScopeFixtureError",
+  { message: Schema.String }
+) {}
+
+const runGit = Effect.fn("VercelScopeTest.runGit")(function* (
+  repository: string,
+  args: readonly string[]
+) {
+  const command = yield* ChildProcess.make("git", args, {
+    cwd: repository,
+    stderr: "inherit",
+    stdout: "ignore",
+  }).pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: `git ${args.join(" ")} failed.` })
+    )
+  );
+  const exitCode = yield* command.exitCode.pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: `git ${args.join(" ")} failed.` })
+    )
+  );
+  if (exitCode !== 0) {
+    return yield* new ScopeFixtureError({
+      message: `git ${args.join(" ")} exited with ${exitCode}.`,
+    });
+  }
+});
+
+const commitAll = Effect.fn("VercelScopeTest.commitAll")(function* (
+  repository: string,
+  message: string
+) {
+  yield* runGit(repository, ["add", "--all"]);
+  yield* runGit(repository, ["commit", "-m", message]);
+});
+
+const readRevision = Effect.fn("VercelScopeTest.readRevision")(function* (
+  repository: string
+) {
+  const command = yield* ChildProcess.make("git", ["rev-parse", "HEAD"], {
+    cwd: repository,
+  }).pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: "Unable to start git rev-parse." })
+    )
+  );
+  const [exitCode, stdout] = yield* Effect.all(
+    [command.exitCode, Stream.mkString(Stream.decodeText(command.stdout))],
+    { concurrency: 2 }
+  ).pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: "Unable to read Git revision." })
+    )
+  );
+  if (exitCode !== 0) {
+    return yield* new ScopeFixtureError({
+      message: `git rev-parse exited with ${exitCode}.`,
+    });
+  }
+  return stdout.trim();
+});
+
+const makeRepository = Effect.fn("VercelScopeTest.makeRepository")(
+  function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const repository = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: "vercel-scope-test-",
+    });
+    yield* runGit(repository, ["init", "--initial-branch=main"]);
+    yield* runGit(repository, ["config", "user.name", "CI Fixture"]);
+    yield* runGit(repository, [
+      "config",
+      "user.email",
+      "ci-fixture@example.com",
+    ]);
+    yield* fileSystem.makeDirectory(`${repository}/apps/www`, {
+      recursive: true,
+    });
+    yield* fileSystem.makeDirectory(`${repository}/bin`);
+    yield* fileSystem.makeDirectory(`${repository}/packages/shared`, {
+      recursive: true,
+    });
+    yield* fileSystem.writeFileString(
+      `${repository}/packages/shared/example.test.ts`,
+      "export const testExample = true;\n"
+    );
+    yield* fileSystem.writeFileString(
+      `${repository}/packages/shared/example.ts`,
+      "export const example = true;\n"
+    );
+    yield* fileSystem.writeFileString(
+      `${repository}/bin/turbo`,
+      `#!/bin/sh
+case "$3" in
+  --base=*) ;;
+  *) exit 2 ;;
+esac
+if [ "$1" != "query" ] || [ "$2" != "affected" ] || \
+  [ "$4" != "--packages" ] || [ "$5" != "www" ] || \
+  [ "$6" != "--exit-code" ]; then
+  exit 2
+fi
+exit "$TURBO_STUB_EXIT"
+`
+    );
+    yield* fileSystem.chmod(`${repository}/bin/turbo`, 0o700);
+    yield* commitAll(repository, "initial");
+    return repository;
+  }
+);
+
+const runScope = Effect.fn("VercelScopeTest.runScope")(function* (
+  repository: string,
+  options: {
+    readonly base?: string;
+    readonly environment?: string;
+    readonly head?: string;
+    readonly packageName?: string;
+    readonly turboExit: number;
+  }
+) {
+  const runtimePath = yield* Effect.sync(() => process.env.PATH ?? "");
+  const command = yield* ChildProcess.make(
+    "sh",
+    [SCRIPT, options.packageName ?? "www"],
+    {
+      cwd: `${repository}/apps/www`,
+      env: {
+        PATH: `${repository}/bin:${runtimePath}`,
+        TURBO_STUB_EXIT: String(options.turboExit),
+        VERCEL_ENV: options.environment ?? "production",
+        VERCEL_GIT_COMMIT_SHA: options.head,
+        VERCEL_GIT_PREVIOUS_SHA: options.base,
+      },
+      stderr: "ignore",
+      stdout: "ignore",
+    }
+  ).pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: "Unable to start scope script." })
+    )
+  );
+  return yield* command.exitCode.pipe(
+    Effect.mapError(
+      () => new ScopeFixtureError({ message: "Unable to finish scope script." })
+    )
+  );
+});
+
+describe("Vercel production scope", () => {
+  it.effect("skips only verified non-production or test-only work", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const repository = yield* makeRepository();
+      const decide = (
+        base: string | undefined,
+        head: string | undefined,
+        turboExit: number,
+        environment?: string
+      ) => runScope(repository, { base, environment, head, turboExit });
+
+      const initial = yield* readRevision(repository);
+      expect(yield* decide(initial, initial, 0)).toBe(1);
+      expect(yield* decide(undefined, undefined, 1, "preview")).toBe(0);
+      expect(yield* decide(undefined, undefined, 0)).toBe(1);
+      expect(
+        yield* runScope(repository, {
+          base: initial,
+          head: initial,
+          packageName: "unknown",
+          turboExit: 0,
+        })
+      ).toBe(1);
+
+      yield* fileSystem.writeFileString(
+        `${repository}/packages/shared/example.test.ts`,
+        "export const testExample = false;\n"
+      );
+      yield* commitAll(repository, "modify test outside app");
+      const testHead = yield* readRevision(repository);
+      expect(yield* decide(initial, testHead, 1)).toBe(0);
+
+      yield* fileSystem.writeFileString(
+        `${repository}/packages/shared/example.ts`,
+        "export const example = false;\n"
+      );
+      yield* commitAll(repository, "modify source outside app");
+      const sourceHead = yield* readRevision(repository);
+      expect(yield* decide(testHead, sourceHead, 1)).toBe(1);
+      expect(yield* decide(testHead, sourceHead, 0)).toBe(0);
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+});


### PR DESCRIPTION
## Root cause

Vercel runs Ignore Command before project dependencies are installed. The www production integration imported scripts/production-acceptance.ts, which imports @effect/platform-node, so exact main SHA 6a5b5753 failed with ERR_MODULE_NOT_FOUND before the platform could decide whether to build.

API and MCP did not have that dependency failure. Their classifiers ran successfully, Turborepo proved those apps were unaffected by #515, and both deployments correctly canceled. The prior statement that all three were accidental cancellations was wrong.

The signed GitHub production build also allowed Turborepo to schedule several top-level Next.js builds beside the anonymous Convex backend. The first #434 merge-group build ended at one terminal local Convex query boundary, while the unchanged retry passed the complete production gate.

## Change

- add the dependency-free pre-install boundary at scripts/vercel/scope.sh
- anchor Git classification at the repository root even when Vercel starts inside an app
- skip only non-production or verified modified .test.ts-only changes
- fail closed for missing revisions, empty diffs, Git errors, additions, deletions, renames, and other source changes
- delegate real app impact to the platform-provided Turborepo binary
- keep the GitHub production classifier native Effect v4 only
- prove the shell boundary through a capability-owned @effect/vitest integration test
- bound only the signed production build to TURBO_CONCURRENCY=2
- preserve all 19 Turborepo build tasks and unrestricted local developer concurrency

No Preview deployment is created or required.

## Verification

- pnpm test:scripts: 6 files, 22 tests
- focused www, api, and mcp Vercel suites
- www, api, and mcp typechecks
- pnpm lint
- pnpm boundaries
- pnpm effect:source:check
- sh -n scripts/vercel/scope.sh
- Turborepo dry graph: 19 packages and 19 build tasks with TURBO_CONCURRENCY=2
- git diff --check

References:
- https://vercel.com/docs/project-configuration/project-settings
- https://vercel.com/docs/monorepos
- https://vercel.com/kb/guide/how-do-i-use-the-ignored-build-step-field-on-vercel
- https://github.com/vercel/turborepo/blob/main/apps/docs/content/docs/reference/options-overview.mdx