### PR TITLE
fix(www): wire signed page footer navigation

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(site)/layout.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(site)/layout.tsx
@@ -22,7 +22,7 @@ export default async function Layout({ children }: LayoutProps<"/[locale]">) {
       {children}
       <Footer
         articleNavigation={articleNavigation}
-        pageNavigation={pageNavigation?.items ?? []}
+        pageNavigation={pageNavigation}
       />
     </main>
   );

--- a/apps/www/components/marketing/shared/footer.tsx
+++ b/apps/www/components/marketing/shared/footer.tsx
@@ -20,7 +20,7 @@ import {
   subjectMenu,
 } from "@/components/sidebar/data/subject";
 import type { ArticleNavigationItem } from "@/lib/content/article/navigation";
-import type { PageNavigationItem } from "@/lib/content/page/navigation";
+import type { PageNavigation } from "@/lib/content/page/navigation";
 
 const highSchoolSubjects =
   subjectMenu.find((subject) => subject.title === "high-school")?.items || [];
@@ -34,7 +34,7 @@ export function Footer({
   pageNavigation,
 }: {
   articleNavigation: readonly ArticleNavigationItem[];
-  pageNavigation: readonly PageNavigationItem[];
+  pageNavigation: PageNavigation | null;
 }) {
   const t = useTranslations("About");
   const tLegal = useTranslations("Legal");
@@ -116,6 +116,15 @@ export function Footer({
                     label={t("community")}
                   />
                 </li>
+                {pageNavigation ? (
+                  <li>
+                    <LinkItem
+                      href={pageNavigation.developerItem.href}
+                      label={pageNavigation.developerItem.title}
+                      prefetch
+                    />
+                  </li>
+                ) : null}
               </ul>
             </div>
 
@@ -124,9 +133,9 @@ export function Footer({
                 {tLegal("terms-and-policies")}
               </span>
               <ul className="flex flex-col gap-2">
-                {pageNavigation.map((page) => (
+                {pageNavigation?.legalItems.map((page) => (
                   <li key={page.pageKey}>
-                    <LinkItem href={page.href} label={page.title} />
+                    <LinkItem href={page.href} label={page.title} prefetch />
                   </li>
                 ))}
                 <AnalyticsConsentFooterItem />
@@ -190,17 +199,19 @@ type LinkItemProps =
       href: ComponentProps<typeof NavigationLink>["href"];
       label: string;
       nativeAnchor?: false;
+      prefetch?: ComponentProps<typeof NavigationLink>["prefetch"];
     }
   | {
       href: string;
       label: string;
       nativeAnchor: true;
+      prefetch?: never;
     };
 
 /**
  * Renders one locale-aware footer destination with the shared text treatment.
  */
-function LinkItem({ href, label, nativeAnchor }: LinkItemProps) {
+function LinkItem({ href, label, nativeAnchor, prefetch }: LinkItemProps) {
   const className = "text-sm transition-colors ease-out hover:text-primary";
 
   if (nativeAnchor) {
@@ -212,7 +223,7 @@ function LinkItem({ href, label, nativeAnchor }: LinkItemProps) {
   }
 
   return (
-    <NavigationLink className={className} href={href}>
+    <NavigationLink className={className} href={href} prefetch={prefetch}>
       {label}
     </NavigationLink>
   );

--- a/apps/www/lib/content/page/navigation.test.ts
+++ b/apps/www/lib/content/page/navigation.test.ts
@@ -174,23 +174,30 @@ describe("signed Page navigation", () => {
 
   it.effect("fails closed when a required legal destination is absent", () =>
     Effect.gen(function* () {
-      catalogMock.mockReturnValue(
-        Effect.succeed({
-          activeReleaseId: "release-pages",
-          projections: germanPages.filter(
-            ({ pageKey }) => pageKey !== "privacy-policy"
-          ),
-        })
-      );
+      for (const pageKey of [
+        "imprint",
+        "privacy-policy",
+        "security-policy",
+        "terms-of-service",
+      ] as const) {
+        catalogMock.mockReturnValue(
+          Effect.succeed({
+            activeReleaseId: "release-pages",
+            projections: germanPages.filter(
+              (projection) => projection.pageKey !== pageKey
+            ),
+          })
+        );
 
-      const failure = yield* readPageNavigation("de").pipe(Effect.flip);
+        const failure = yield* readPageNavigation("de").pipe(Effect.flip);
 
-      expect(failure).toEqual(
-        new PageNavigationMissingError({
-          locale: "de",
-          pageKey: PageKeySchema.make("privacy-policy"),
-        })
-      );
+        expect(failure).toEqual(
+          new PageNavigationMissingError({
+            locale: "de",
+            pageKey: PageKeySchema.make(pageKey),
+          })
+        );
+      }
     })
   );
 

--- a/apps/www/lib/content/page/navigation.test.ts
+++ b/apps/www/lib/content/page/navigation.test.ts
@@ -32,7 +32,12 @@ function makeGermanPage({
   publicPath,
   title,
 }: {
-  pageKey: "privacy-policy" | "security-policy" | "terms-of-service";
+  pageKey:
+    | "developers"
+    | "imprint"
+    | "privacy-policy"
+    | "security-policy"
+    | "terms-of-service";
   publicPath: string;
   title: string;
 }) {
@@ -54,6 +59,16 @@ function makeGermanPage({
 }
 
 const germanPages = [
+  makeGermanPage({
+    pageKey: "developers",
+    publicPath: "developers",
+    title: "Entwicklerressourcen",
+  }),
+  makeGermanPage({
+    pageKey: "imprint",
+    publicPath: "imprint",
+    title: "Impressum",
+  }),
   makeGermanPage({
     pageKey: "privacy-policy",
     publicPath: "privacy-policy",
@@ -102,7 +117,17 @@ describe("signed Page navigation", () => {
         const navigation = yield* readPageNavigation("de");
 
         expect(navigation).toEqual({
-          items: [
+          developerItem: {
+            href: "/developers",
+            pageKey: "developers",
+            title: "Entwicklerressourcen",
+          },
+          legalItems: [
+            {
+              href: "/imprint",
+              pageKey: "imprint",
+              title: "Impressum",
+            },
             {
               href: "/privacy-policy",
               pageKey: "privacy-policy",
@@ -123,6 +148,28 @@ describe("signed Page navigation", () => {
           termsOfServiceHref: "/terms-of-service",
         });
       })
+  );
+
+  it.effect("fails closed when the developer destination is absent", () =>
+    Effect.gen(function* () {
+      catalogMock.mockReturnValue(
+        Effect.succeed({
+          activeReleaseId: "release-pages",
+          projections: germanPages.filter(
+            ({ pageKey }) => pageKey !== "developers"
+          ),
+        })
+      );
+
+      const failure = yield* readPageNavigation("de").pipe(Effect.flip);
+
+      expect(failure).toEqual(
+        new PageNavigationMissingError({
+          locale: "de",
+          pageKey: PageKeySchema.make("developers"),
+        })
+      );
+    })
   );
 
   it.effect("fails closed when a required legal destination is absent", () =>

--- a/apps/www/lib/content/page/navigation.ts
+++ b/apps/www/lib/content/page/navigation.ts
@@ -36,14 +36,10 @@ export class PageNavigationMissingError extends Schema.TaggedError<PageNavigatio
 ) {}
 
 const developerKey = PageKeySchema.make("developers");
+const imprintKey = PageKeySchema.make("imprint");
 const privacyPolicyKey = PageKeySchema.make("privacy-policy");
+const securityPolicyKey = PageKeySchema.make("security-policy");
 const termsOfServiceKey = PageKeySchema.make("terms-of-service");
-const legalPageKeys: ReadonlySet<PageKey> = new Set([
-  PageKeySchema.make("imprint"),
-  privacyPolicyKey,
-  PageKeySchema.make("security-policy"),
-  termsOfServiceKey,
-]);
 
 /** Resolves one required stable Page identity without owning its public path. */
 const readRequiredPageItem = Effect.fn("www.pages.readRequiredItem")(function* (
@@ -78,18 +74,27 @@ export const readPageNavigation = Effect.fn("www.pages.readNavigation")(
         title: metadata.title,
       });
     }
-    const [developerItem, privacyPolicyItem, termsOfServiceItem] =
-      yield* Effect.all([
-        readRequiredPageItem(localeItems, developerKey, locale),
-        readRequiredPageItem(localeItems, privacyPolicyKey, locale),
-        readRequiredPageItem(localeItems, termsOfServiceKey, locale),
-      ]);
-    const legalItems = localeItems.filter(({ pageKey }) =>
-      legalPageKeys.has(pageKey)
-    );
+    const [
+      developerItem,
+      imprintItem,
+      privacyPolicyItem,
+      securityPolicyItem,
+      termsOfServiceItem,
+    ] = yield* Effect.all([
+      readRequiredPageItem(localeItems, developerKey, locale),
+      readRequiredPageItem(localeItems, imprintKey, locale),
+      readRequiredPageItem(localeItems, privacyPolicyKey, locale),
+      readRequiredPageItem(localeItems, securityPolicyKey, locale),
+      readRequiredPageItem(localeItems, termsOfServiceKey, locale),
+    ]);
     return {
       developerItem,
-      legalItems,
+      legalItems: [
+        imprintItem,
+        privacyPolicyItem,
+        securityPolicyItem,
+        termsOfServiceItem,
+      ],
       privacyPolicyHref: privacyPolicyItem.href,
       termsOfServiceHref: termsOfServiceItem.href,
     } satisfies PageNavigation;

--- a/apps/www/lib/content/page/navigation.ts
+++ b/apps/www/lib/content/page/navigation.ts
@@ -18,14 +18,15 @@ export interface PageNavigationItem {
   readonly title: PageMetadata["title"];
 }
 
-/** Verified legal destinations and complete Page links for one locale. */
+/** Verified developer and legal destinations for one locale. */
 export interface PageNavigation {
-  readonly items: readonly PageNavigationItem[];
+  readonly developerItem: PageNavigationItem;
+  readonly legalItems: readonly PageNavigationItem[];
   readonly privacyPolicyHref: string;
   readonly termsOfServiceHref: string;
 }
 
-/** Raised when a required legal Page is absent from an active publication. */
+/** Raised when a required Page is absent from an active publication. */
 export class PageNavigationMissingError extends Schema.TaggedError<PageNavigationMissingError>()(
   "PageNavigationMissingError",
   {
@@ -34,11 +35,18 @@ export class PageNavigationMissingError extends Schema.TaggedError<PageNavigatio
   }
 ) {}
 
+const developerKey = PageKeySchema.make("developers");
 const privacyPolicyKey = PageKeySchema.make("privacy-policy");
 const termsOfServiceKey = PageKeySchema.make("terms-of-service");
+const legalPageKeys: ReadonlySet<PageKey> = new Set([
+  PageKeySchema.make("imprint"),
+  privacyPolicyKey,
+  PageKeySchema.make("security-policy"),
+  termsOfServiceKey,
+]);
 
 /** Resolves one required stable Page identity without owning its public path. */
-const readRequiredPageHref = Effect.fn("www.pages.readRequiredHref")(function* (
+const readRequiredPageItem = Effect.fn("www.pages.readRequiredItem")(function* (
   items: readonly PageNavigationItem[],
   pageKey: PageKey,
   locale: Locale
@@ -47,14 +55,14 @@ const readRequiredPageHref = Effect.fn("www.pages.readRequiredHref")(function* (
   if (!item) {
     return yield* new PageNavigationMissingError({ locale, pageKey });
   }
-  return item.href;
+  return item;
 });
 
 /** Reads every published Page owned by one application locale. */
 export const readPageNavigation = Effect.fn("www.pages.readNavigation")(
   function* (locale: Locale) {
     const catalog = yield* readPublishedPageCatalog();
-    const items: PageNavigationItem[] = [];
+    const localeItems: PageNavigationItem[] = [];
     for (const {
       appLocale,
       metadata,
@@ -64,20 +72,26 @@ export const readPageNavigation = Effect.fn("www.pages.readNavigation")(
       if (appLocale !== locale) {
         continue;
       }
-      items.push({
+      localeItems.push({
         href: `/${publicPath}`,
         pageKey,
         title: metadata.title,
       });
     }
-    const [privacyPolicyHref, termsOfServiceHref] = yield* Effect.all([
-      readRequiredPageHref(items, privacyPolicyKey, locale),
-      readRequiredPageHref(items, termsOfServiceKey, locale),
-    ]);
+    const [developerItem, privacyPolicyItem, termsOfServiceItem] =
+      yield* Effect.all([
+        readRequiredPageItem(localeItems, developerKey, locale),
+        readRequiredPageItem(localeItems, privacyPolicyKey, locale),
+        readRequiredPageItem(localeItems, termsOfServiceKey, locale),
+      ]);
+    const legalItems = localeItems.filter(({ pageKey }) =>
+      legalPageKeys.has(pageKey)
+    );
     return {
-      items,
-      privacyPolicyHref,
-      termsOfServiceHref,
+      developerItem,
+      legalItems,
+      privacyPolicyHref: privacyPolicyItem.href,
+      termsOfServiceHref: termsOfServiceItem.href,
     } satisfies PageNavigation;
   }
 );


### PR DESCRIPTION
## Summary

- source the developer footer link from the signed Page catalog and move it into Company
- keep Terms and Policies limited to legal pages
- require developer, imprint, privacy, security, and terms through one typed fail-closed Effect path
- fully prefetch the finite signed Page destinations so navigation does not pause behind the null Page suspense boundary
- preserve deterministic legal-page order without duplicating routes or copy

The routes remain statically prerendered. This change fixes the navigation handoff without making the routes dynamic or adding duplicate copy.

## Verification

Exact head: `34cb7a1706774f1a8cb43b0ab378e5d841250ef9`

- rebased onto exact protected main `927d7f681a43acb205d8abcbd63101a8ecd31b41`; range-diff preserved both patches exactly
- WWW suite: 212 files and 1,502 tests with 100% statements, branches, functions, and lines
- focused signed Page navigation: 5 assertions
- WWW typecheck
- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- React Doctor: 100/100
- `git diff --check`
- independent local Codex review at the exact head found no actionable issue
- the verified automated review finding is fixed and its thread is resolved
- exact-head GitHub CI run `33379925975`: Scope, Quality, Production, Doctor, and Required all passed
- Production CI completed the signed snapshot import, production build, browser acceptance, site checks, and final runtime-generation proof
- no Vercel Preview was created