### PR TITLE
fix(www): simplify article reference list

### DIFF
--- a/apps/www/components/sidebar/reference-button.tsx
+++ b/apps/www/components/sidebar/reference-button.tsx
@@ -10,13 +10,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { useDisclosure } from "@mantine/hooks";
 import type { Reference } from "@repo/contents/_types/content";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@repo/design-system/components/ui/card";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import { ScrollArea } from "@repo/design-system/components/ui/scroll-area";
 import { Separator } from "@repo/design-system/components/ui/separator";
@@ -81,89 +74,102 @@ export function ReferenceButton({ references, title }: Props) {
 
             <div className="flex flex-1 flex-col overflow-hidden">
               <ScrollArea className="h-full px-4">
-                <div className="flex flex-col gap-4 py-4">
-                  {references.map((reference) => {
+                <ul data-slot="reference-list">
+                  {references.map((reference, index) => {
                     const url = reference.url
                       ? formatUrl(reference.url)
                       : t("no-website");
                     const cleanUrl = cleanupUrl(url).split("/")[0];
 
                     return (
-                      <Card key={reference.title} size="sm">
-                        <CardHeader>
-                          <CardTitle
-                            className="line-clamp-2 capitalize"
-                            title={reference.title}
-                          >
-                            {reference.title.toLowerCase()}
-                          </CardTitle>
-                          <CardDescription className="flex items-center gap-1">
-                            <HugeIcons
-                              className="size-4 shrink-0"
-                              icon={Globe02Icon}
-                            />
-                            {reference.url ? (
-                              <a
-                                className="underline-offset-4 hover:underline"
-                                href={reference.url}
-                                rel="noopener noreferrer"
-                                target="_blank"
-                              >
-                                {cleanUrl}
-                              </a>
-                            ) : (
-                              <span>{t("no-website")}</span>
-                            )}
-                          </CardDescription>
-                        </CardHeader>
-
-                        <CardContent>
-                          <div className="flex items-center gap-1">
-                            <HugeIcons
-                              className="size-4 shrink-0"
-                              icon={QuillWrite01Icon}
-                            />
-                            <span className="line-clamp-1 text-sm">
-                              {reference.authors}
-                            </span>
+                      <li
+                        className="pt-4 last:pb-4"
+                        data-slot="reference-item"
+                        key={reference.title}
+                      >
+                        <div
+                          className="flex flex-col gap-4"
+                          data-slot="reference-item-content"
+                        >
+                          <div className="flex flex-col gap-1">
+                            <h3
+                              className="line-clamp-2 font-medium text-sm capitalize leading-normal"
+                              title={reference.title}
+                            >
+                              {reference.title.toLowerCase()}
+                            </h3>
+                            <div className="flex items-center gap-1 text-muted-foreground text-sm">
+                              <HugeIcons
+                                className="size-4 shrink-0"
+                                icon={Globe02Icon}
+                              />
+                              {reference.url ? (
+                                <a
+                                  className="underline-offset-4 hover:underline"
+                                  href={reference.url}
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  {cleanUrl}
+                                </a>
+                              ) : (
+                                <span>{t("no-website")}</span>
+                              )}
+                            </div>
                           </div>
 
-                          <div className="flex items-center gap-1">
-                            <HugeIcons
-                              className="size-4 shrink-0"
-                              icon={Calendar03Icon}
-                            />
-                            <span className="text-sm">{reference.year}</span>
-                          </div>
-
-                          {!!reference.publication && (
+                          <div className="flex flex-col gap-3">
                             <div className="flex items-center gap-1">
                               <HugeIcons
                                 className="size-4 shrink-0"
-                                icon={BookOpen02Icon}
+                                icon={QuillWrite01Icon}
                               />
                               <span className="line-clamp-1 text-sm">
-                                {reference.publication}
+                                {reference.authors}
                               </span>
                             </div>
-                          )}
 
-                          {!!reference.details && (
                             <div className="flex items-center gap-1">
                               <HugeIcons
                                 className="size-4 shrink-0"
-                                icon={Book03Icon}
+                                icon={Calendar03Icon}
                               />
-                              <span className="text-sm">
-                                {reference.details}
-                              </span>
+                              <span className="text-sm">{reference.year}</span>
                             </div>
-                          )}
-                        </CardContent>
-                      </Card>
+
+                            {!!reference.publication && (
+                              <div className="flex items-center gap-1">
+                                <HugeIcons
+                                  className="size-4 shrink-0"
+                                  icon={BookOpen02Icon}
+                                />
+                                <span className="line-clamp-1 text-sm">
+                                  {reference.publication}
+                                </span>
+                              </div>
+                            )}
+
+                            {!!reference.details && (
+                              <div className="flex items-center gap-1">
+                                <HugeIcons
+                                  className="size-4 shrink-0"
+                                  icon={Book03Icon}
+                                />
+                                <span className="text-sm">
+                                  {reference.details}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+
+                        {index < references.length - 1 && (
+                          <Separator className="mt-4" />
+                        )}
+                      </li>
                     );
                   })}
-                </div>
+                </ul>
               </ScrollArea>
             </div>
           </div>

--- a/apps/www/components/sidebar/reference-button.tsx
+++ b/apps/www/components/sidebar/reference-button.tsx
@@ -73,7 +73,7 @@ export function ReferenceButton({ references, title }: Props) {
             <Separator />
 
             <div className="flex flex-1 flex-col overflow-hidden">
-              <ScrollArea className="h-full px-4">
+              <ScrollArea className="h-full">
                 <ul data-slot="reference-list">
                   {references.map((reference, index) => {
                     const url = reference.url
@@ -88,7 +88,7 @@ export function ReferenceButton({ references, title }: Props) {
                         key={reference.title}
                       >
                         <div
-                          className="flex flex-col gap-4"
+                          className="flex flex-col gap-4 px-4"
                           data-slot="reference-item-content"
                         >
                           <div className="flex flex-col gap-1">

--- a/apps/www/components/sidebar/reference-button.tsx
+++ b/apps/www/components/sidebar/reference-button.tsx
@@ -89,7 +89,7 @@ export function ReferenceButton({ references, title }: Props) {
                     const cleanUrl = cleanupUrl(url).split("/")[0];
 
                     return (
-                      <Card key={reference.title}>
+                      <Card key={reference.title} size="sm">
                         <CardHeader>
                           <CardTitle
                             className="line-clamp-2 capitalize"
@@ -117,7 +117,7 @@ export function ReferenceButton({ references, title }: Props) {
                           </CardDescription>
                         </CardHeader>
 
-                        <CardContent className="space-y-2">
+                        <CardContent>
                           <div className="flex items-center gap-1">
                             <HugeIcons
                               className="size-4 shrink-0"

--- a/apps/www/components/sidebar/reference-button.tsx
+++ b/apps/www/components/sidebar/reference-button.tsx
@@ -83,12 +83,12 @@ export function ReferenceButton({ references, title }: Props) {
 
                     return (
                       <li
-                        className="pt-4 last:pb-4"
+                        className="min-w-0 pt-4 last:pb-4"
                         data-slot="reference-item"
                         key={reference.title}
                       >
                         <div
-                          className="flex flex-col gap-4 px-4"
+                          className="flex min-w-0 flex-col gap-4 overflow-hidden px-4"
                           data-slot="reference-item-content"
                         >
                           <div className="flex flex-col gap-1">
@@ -98,14 +98,14 @@ export function ReferenceButton({ references, title }: Props) {
                             >
                               {reference.title.toLowerCase()}
                             </h3>
-                            <div className="flex items-center gap-1 text-muted-foreground text-sm">
+                            <div className="flex min-w-0 items-center gap-1 text-muted-foreground text-sm">
                               <HugeIcons
                                 className="size-4 shrink-0"
                                 icon={Globe02Icon}
                               />
                               {reference.url ? (
                                 <a
-                                  className="underline-offset-4 hover:underline"
+                                  className="min-w-0 truncate underline-offset-4 hover:underline"
                                   href={reference.url}
                                   rel="noopener noreferrer"
                                   target="_blank"
@@ -113,7 +113,9 @@ export function ReferenceButton({ references, title }: Props) {
                                   {cleanUrl}
                                 </a>
                               ) : (
-                                <span>{t("no-website")}</span>
+                                <span className="min-w-0 truncate">
+                                  {t("no-website")}
+                                </span>
                               )}
                             </div>
                           </div>
@@ -155,7 +157,7 @@ export function ReferenceButton({ references, title }: Props) {
                                   className="size-4 shrink-0"
                                   icon={Book03Icon}
                                 />
-                                <span className="text-sm">
+                                <span className="min-w-0 truncate text-sm">
                                   {reference.details}
                                 </span>
                               </div>

--- a/apps/www/e2e/reference-sheet.browser.ts
+++ b/apps/www/e2e/reference-sheet.browser.ts
@@ -1,0 +1,92 @@
+import { expect, type Page, test } from "@playwright/test";
+import { Effect } from "effect";
+import { withObservedPageErrors } from "@/e2e/support/browser-context";
+import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
+import { waitForCommittedAppRouter } from "@/e2e/support/navigation/readiness";
+
+const articleHref = "/id/articles/politics/regional-elections-turmoil";
+const readinessTimeoutMilliseconds = 15_000;
+
+const verifyCompactReferenceSheet = Effect.fn(
+  "NakafaE2E.verifyCompactReferenceSheet"
+)(function* (page: Page) {
+  yield* seedDeniedAnalyticsConsent(page);
+  const response = yield* Effect.promise(() =>
+    page.goto(articleHref, { waitUntil: "domcontentloaded" })
+  );
+  yield* Effect.sync(() => expect(response?.ok()).toBe(true));
+  yield* waitForCommittedAppRouter(
+    page,
+    articleHref,
+    articleHref,
+    readinessTimeoutMilliseconds
+  );
+
+  const rightSidebar = page.locator("aside").filter({
+    has: page.locator('[data-slot="sidebar"][data-side="right"]'),
+  });
+  const sidebarTrigger = rightSidebar.getByRole("button", {
+    exact: true,
+    name: "Toggle Sidebar",
+  });
+  yield* Effect.promise(() => expect(sidebarTrigger).toBeVisible());
+  yield* Effect.promise(() => sidebarTrigger.click());
+
+  const mobileSidebar = page
+    .locator('[role="dialog"][data-sidebar="sidebar"]')
+    .filter({ visible: true });
+  yield* Effect.promise(() => expect(mobileSidebar).toBeVisible());
+  const trigger = mobileSidebar.getByRole("button", {
+    exact: true,
+    name: "Daftar pustaka",
+  });
+  yield* Effect.promise(() => expect(trigger).toBeVisible());
+  yield* Effect.promise(() => trigger.click());
+
+  const sheet = page.locator('[data-slot="sheet-popup"]');
+  yield* Effect.promise(() =>
+    expect(sheet).toBeVisible({ timeout: readinessTimeoutMilliseconds })
+  );
+  const cards = sheet.locator('[data-slot="card"]');
+  yield* Effect.promise(() => expect(cards).toHaveCount(11));
+
+  const metrics = yield* Effect.promise(() =>
+    cards.first().evaluate((card) => {
+      const cardStyle = getComputedStyle(card);
+      const content = card.querySelector('[data-slot="card-content"]');
+      const contentStyle = content ? getComputedStyle(content) : null;
+      const title = card.querySelector('[data-slot="card-title"]');
+
+      return {
+        cardGap: cardStyle.gap,
+        cardHeight: card.getBoundingClientRect().height,
+        cardPaddingBlock: `${cardStyle.paddingTop} ${cardStyle.paddingBottom}`,
+        contentGap: contentStyle?.gap,
+        titleFontSize: title ? getComputedStyle(title).fontSize : null,
+      };
+    })
+  );
+  yield* Effect.sync(() => {
+    expect(metrics).toMatchObject({
+      cardGap: "16px",
+      cardPaddingBlock: "16px 16px",
+      contentGap: "12px",
+      titleFontSize: "14px",
+    });
+    expect(metrics.cardHeight).toBeLessThanOrEqual(248);
+  });
+
+  yield* Effect.promise(() => page.keyboard.press("Escape"));
+  yield* Effect.promise(() => expect(sheet).toHaveCount(0));
+  yield* Effect.promise(() => expect(trigger).toBeFocused());
+});
+
+test.describe("article bibliography", () => {
+  test.use({ viewport: { height: 957, width: 665 } });
+
+  test("keeps reference cards compact in the side sheet", async ({ page }) => {
+    await Effect.runPromise(
+      withObservedPageErrors(page, verifyCompactReferenceSheet(page))
+    );
+  });
+});

--- a/apps/www/e2e/reference-sheet.browser.ts
+++ b/apps/www/e2e/reference-sheet.browser.ts
@@ -66,11 +66,18 @@ const verifyCompactReferenceSheet = Effect.fn(
       const contentStyle = content ? getComputedStyle(content) : null;
       const metadata = content?.lastElementChild;
       const title = item.querySelector("h3");
+      const separator = item.querySelector('[data-slot="separator"]');
+      const list = item.closest('[data-slot="reference-list"]');
 
       return {
         contentGap: contentStyle?.gap,
+        contentPaddingInline: contentStyle
+          ? `${contentStyle.paddingLeft} ${contentStyle.paddingRight}`
+          : null,
+        dividerWidth: separator?.getBoundingClientRect().width,
         itemHeight: item.getBoundingClientRect().height,
         itemPaddingTop: itemStyle.paddingTop,
+        listWidth: list?.getBoundingClientRect().width,
         metadataGap: metadata ? getComputedStyle(metadata).gap : null,
         titleFontSize: title ? getComputedStyle(title).fontSize : null,
       };
@@ -79,6 +86,8 @@ const verifyCompactReferenceSheet = Effect.fn(
   yield* Effect.sync(() => {
     expect(metrics).toMatchObject({
       contentGap: "16px",
+      contentPaddingInline: "16px 16px",
+      dividerWidth: metrics.listWidth,
       itemPaddingTop: "16px",
       metadataGap: "12px",
       titleFontSize: "14px",

--- a/apps/www/e2e/reference-sheet.browser.ts
+++ b/apps/www/e2e/reference-sheet.browser.ts
@@ -47,33 +47,43 @@ const verifyCompactReferenceSheet = Effect.fn(
   yield* Effect.promise(() =>
     expect(sheet).toBeVisible({ timeout: readinessTimeoutMilliseconds })
   );
-  const cards = sheet.locator('[data-slot="card"]');
-  yield* Effect.promise(() => expect(cards).toHaveCount(11));
+  const list = sheet.locator('[data-slot="reference-list"]');
+  const items = list.locator('[data-slot="reference-item"]');
+  yield* Effect.promise(() => expect(items).toHaveCount(11));
+  yield* Effect.promise(() =>
+    expect(list.locator('[data-slot="separator"]')).toHaveCount(10)
+  );
+  yield* Effect.promise(() =>
+    expect(list.locator('[data-slot="card"]')).toHaveCount(0)
+  );
 
   const metrics = yield* Effect.promise(() =>
-    cards.first().evaluate((card) => {
-      const cardStyle = getComputedStyle(card);
-      const content = card.querySelector('[data-slot="card-content"]');
+    items.first().evaluate((item) => {
+      const itemStyle = getComputedStyle(item);
+      const content = item.querySelector(
+        '[data-slot="reference-item-content"]'
+      );
       const contentStyle = content ? getComputedStyle(content) : null;
-      const title = card.querySelector('[data-slot="card-title"]');
+      const metadata = content?.lastElementChild;
+      const title = item.querySelector("h3");
 
       return {
-        cardGap: cardStyle.gap,
-        cardHeight: card.getBoundingClientRect().height,
-        cardPaddingBlock: `${cardStyle.paddingTop} ${cardStyle.paddingBottom}`,
         contentGap: contentStyle?.gap,
+        itemHeight: item.getBoundingClientRect().height,
+        itemPaddingTop: itemStyle.paddingTop,
+        metadataGap: metadata ? getComputedStyle(metadata).gap : null,
         titleFontSize: title ? getComputedStyle(title).fontSize : null,
       };
     })
   );
   yield* Effect.sync(() => {
     expect(metrics).toMatchObject({
-      cardGap: "16px",
-      cardPaddingBlock: "16px 16px",
-      contentGap: "12px",
+      contentGap: "16px",
+      itemPaddingTop: "16px",
+      metadataGap: "12px",
       titleFontSize: "14px",
     });
-    expect(metrics.cardHeight).toBeLessThanOrEqual(248);
+    expect(metrics.itemHeight).toBeLessThanOrEqual(232);
   });
 
   yield* Effect.promise(() => page.keyboard.press("Escape"));
@@ -84,7 +94,7 @@ const verifyCompactReferenceSheet = Effect.fn(
 test.describe("article bibliography", () => {
   test.use({ viewport: { height: 957, width: 665 } });
 
-  test("keeps reference cards compact in the side sheet", async ({ page }) => {
+  test("presents references as a compact divided list", async ({ page }) => {
     await Effect.runPromise(
       withObservedPageErrors(page, verifyCompactReferenceSheet(page))
     );

--- a/apps/www/e2e/reference-sheet.browser.ts
+++ b/apps/www/e2e/reference-sheet.browser.ts
@@ -49,9 +49,10 @@ const verifyCompactReferenceSheet = Effect.fn(
   );
   const list = sheet.locator('[data-slot="reference-list"]');
   const items = list.locator('[data-slot="reference-item"]');
-  yield* Effect.promise(() => expect(items).toHaveCount(11));
+  const itemCount = yield* Effect.promise(() => items.count());
+  yield* Effect.sync(() => expect(itemCount).toBeGreaterThan(0));
   yield* Effect.promise(() =>
-    expect(list.locator('[data-slot="separator"]')).toHaveCount(10)
+    expect(list.locator('[data-slot="separator"]')).toHaveCount(itemCount - 1)
   );
   yield* Effect.promise(() =>
     expect(list.locator('[data-slot="card"]')).toHaveCount(0)
@@ -68,9 +69,12 @@ const verifyCompactReferenceSheet = Effect.fn(
       const title = item.querySelector("h3");
       const separator = item.querySelector('[data-slot="separator"]');
       const list = item.closest('[data-slot="reference-list"]');
+      const url = item.querySelector("a");
+      const urlStyle = url ? getComputedStyle(url) : null;
 
       return {
         contentGap: contentStyle?.gap,
+        contentOverflowX: contentStyle?.overflowX,
         contentPaddingInline: contentStyle
           ? `${contentStyle.paddingLeft} ${contentStyle.paddingRight}`
           : null,
@@ -80,17 +84,22 @@ const verifyCompactReferenceSheet = Effect.fn(
         listWidth: list?.getBoundingClientRect().width,
         metadataGap: metadata ? getComputedStyle(metadata).gap : null,
         titleFontSize: title ? getComputedStyle(title).fontSize : null,
+        urlOverflowX: urlStyle?.overflowX,
+        urlTextOverflow: urlStyle?.textOverflow,
       };
     })
   );
   yield* Effect.sync(() => {
     expect(metrics).toMatchObject({
       contentGap: "16px",
+      contentOverflowX: "hidden",
       contentPaddingInline: "16px 16px",
       dividerWidth: metrics.listWidth,
       itemPaddingTop: "16px",
       metadataGap: "12px",
       titleFontSize: "14px",
+      urlOverflowX: "hidden",
+      urlTextOverflow: "ellipsis",
     });
     expect(metrics.itemHeight).toBeLessThanOrEqual(232);
   });


### PR DESCRIPTION
## Summary

- render the article bibliography as one semantic list inside the existing sheet
- use the shared Separator between references instead of nested Card surfaces
- let every divider span the full scroll surface while keeping 16 px padding on item content
- constrain long URLs and metadata to the sheet width
- add focused browser acceptance at the reported 665 by 957 viewport without coupling it to Aksara-owned reference counts

## Root cause

Git history traces the visual change to PR #286, which restored the current shadcn Card primitive. That changed the primitive from a real border and shadow to a subtle ring and moved its default density to 24 px spacing with 16 px titles. The bibliography kept rendering every reference as a default Card inside an already-contained Sheet, so the ring became hard to perceive while the larger spacing made the list feel broken and deeply nested.

The final fix removes Card from this dense-list context. The Sheet remains the containing surface and the default design-system Separator is the only boundary between references. Horizontal padding belongs to item content, not the list, so dividers run edge to edge. Item content restores width containment that Card previously supplied.

## Verification

- `pnpm format`
- `pnpm --filter www test`: 210 files and 1,511 tests passed with 100% coverage
- `PLAYWRIGHT_BASE_URL=http://localhost:3107 pnpm --filter www exec playwright test e2e/reference-sheet.browser.ts`: passed
- `pnpm --filter www typecheck`: passed with the required local environment contract
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked`: 100/100
- `pnpm boundaries`: 3,047 files in 19 packages passed
- local browser inspection confirms a nonempty list with one fewer divider than items, zero Cards, and no item border or shadow
- local browser geometry confirms each divider has the same left edge, right edge, and width as the list
- browser acceptance asserts item overflow containment and URL ellipsis
- the protected exact-head Production job remains the authoritative full-build gate

No Vercel Preview or Convex mutation was created.