### PR TITLE
fix(agent): define frameworkless output

### DIFF
--- a/apps/api/public/robots.txt
+++ b/apps/api/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -6,6 +6,7 @@ export const config: VercelConfig = {
   buildCommand: "pnpm build",
   framework: null,
   ignoreCommand: "sh ../../scripts/vercel/scope.sh api",
+  outputDirectory: "public",
   git: {
     deploymentEnabled: {
       "**": false,

--- a/apps/mcp/public/robots.txt
+++ b/apps/mcp/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/apps/mcp/vercel.ts
+++ b/apps/mcp/vercel.ts
@@ -6,6 +6,7 @@ export const config: VercelConfig = {
   buildCommand: "pnpm build",
   framework: null,
   ignoreCommand: "sh ../../scripts/vercel/scope.sh mcp",
+  outputDirectory: "public",
   git: {
     deploymentEnabled: {
       "**": false,


### PR DESCRIPTION
## Summary

- declare public as the explicit output directory for both frameworkless gateway projects
- ship a real robots policy from each isolated deployment root
- keep the API and MCP edge routing config self-contained without restoring Next.js wrappers

## Root cause

The merged frameworkless projects still ran a custom validation build but produced no configured output directory. Vercel therefore applied the Other-framework public default and rejected both exact-main production builds after configuration validation.

## Verification

- pnpm format
- pnpm lint
- pnpm --filter api build
- pnpm --filter mcp build
- pnpm --filter api typecheck
- pnpm --filter mcp typecheck
- pnpm --filter @repo/backend exec vitest run agent/route.test.ts
- pnpm boundaries
- config compile contains outputDirectory public for both projects
- git diff --check

No Preview deployment was created. Production remains protected-main only.