### PR TITLE
Switch protected runtime to the canonical route

### DIFF
--- a/packages/backend/client/content/protected.test.ts
+++ b/packages/backend/client/content/protected.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@effect/vitest";
 import {
   ContentKeySchema,
   ReleaseIdSchema,
@@ -23,7 +30,7 @@ import { readProtectedContent } from "@repo/backend/client/content/protected";
 import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
-  PROTECTED_CONTENT_RUNTIME_V2_PATH,
+  PROTECTED_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
 import {
   TEST_PROOF_RENDERER,
@@ -36,7 +43,7 @@ import { testPublicationScope } from "@repo/backend/test/content/release";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
-const endpoint = `https://example.convex.site${PROTECTED_CONTENT_RUNTIME_V2_PATH}`;
+const endpoint = `https://example.convex.site${PROTECTED_CONTENT_RUNTIME_PATH}`;
 const target = {
   siteUrl: "https://example.convex.site",
   token: "runtime-test-token",
@@ -146,9 +153,10 @@ describe("protected content runtime client", () => {
       ).toMatchObject({ items: [{ delivery: "authenticated" }] });
       expect(fetchMock).toHaveBeenCalledOnce();
       const call = fetchMock.mock.calls.at(0);
-      if (!call || typeof call[1]?.body !== "string") {
-        throw new Error("Expected one JSON protected runtime request.");
-      }
+      assert(
+        call && typeof call[1]?.body === "string",
+        "Expected one JSON protected runtime request."
+      );
       expect(call[0]).toBe(endpoint);
       expect(JSON.parse(call[1].body)).toEqual(request);
       expect(verifyProtectedContentRuntimeExchange).toHaveBeenCalledOnce();

--- a/packages/backend/client/content/protected.ts
+++ b/packages/backend/client/content/protected.ts
@@ -25,7 +25,7 @@ import {
   requestContentResponse,
   validateContentRuntimeStatus,
 } from "@repo/backend/client/content/transport";
-import { PROTECTED_CONTENT_RUNTIME_V2_PATH } from "@repo/backend/content/endpoint";
+import { PROTECTED_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
 import { contentKeyResolver } from "@repo/backend/content/trust";
 import { Effect } from "effect";
 
@@ -62,7 +62,7 @@ export const readProtectedContent = Effect.fn(
   );
   const endpoint = yield* createContentEndpoint(
     target.siteUrl,
-    PROTECTED_CONTENT_RUNTIME_V2_PATH
+    PROTECTED_CONTENT_RUNTIME_PATH
   );
   const { response, value: decoded } = yield* requestContentResponse(
     { endpoint, source, target },


### PR DESCRIPTION
## Summary

- switch the sole Nakafa server caller from `/internal/content/runtime/v2/protected` to `/internal/content/runtime/protected`
- keep the request and response contract unchanged
- use `assert` from `@effect/vitest` instead of a raw test throw

## Rollout proof

PR #526 is exact protected main `d3060bba2b6a1e3bb490cf2994fbeaf4c09fc16b`. WWW, API, MCP, and Convex are live from that SHA. Both protected routes return the authenticated runtime boundary, API health and MCP discovery return the exact SHA, ID, EN, and DE routes return 200, the active read model is completed, and the current Vercel runtime-error window is empty.

This PR changes only the sole caller. After this exact head reaches protected production, the next contract change deletes the v2 constant, route registration, and tests. No fixed wait and no Vercel Preview are part of the rollout.

## Verification

- `pnpm --filter @repo/backend exec vitest run client/content/protected.test.ts`
- `pnpm --filter @repo/backend typecheck`
- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm effect:source:check`
- full backend suite: 337 files, 1,472 tests
- handwritten relative-import and local TypeScript or JavaScript suffix scans are clean