### PR TITLE
Retire versioned protected runtime route

### DIFF
--- a/packages/backend/content/endpoint.test.ts
+++ b/packages/backend/content/endpoint.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
   PROTECTED_CONTENT_RUNTIME_PATH,
-  PROTECTED_CONTENT_RUNTIME_V2_PATH,
   PUBLIC_CONTENT_RUNTIME_BATCH_PATH,
   PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
@@ -16,12 +15,9 @@ describe("public content runtime endpoints", () => {
 });
 
 describe("protected content runtime endpoints", () => {
-  it("owns one unversioned contract and its active rollout predecessor", () => {
+  it("owns one unversioned contract", () => {
     expect(PROTECTED_CONTENT_RUNTIME_PATH).toBe(
       "/internal/content/runtime/protected"
-    );
-    expect(PROTECTED_CONTENT_RUNTIME_V2_PATH).toBe(
-      "/internal/content/runtime/v2/protected"
     );
   });
 });

--- a/packages/backend/content/endpoint.ts
+++ b/packages/backend/content/endpoint.ts
@@ -9,9 +9,6 @@ export const PUBLIC_CONTENT_RUNTIME_BATCH_PATH = `${PUBLIC_CONTENT_RUNTIME_PATH}
 /** Canonical unversioned endpoint for protected content reads. */
 export const PROTECTED_CONTENT_RUNTIME_PATH = `${CONTENT_RUNTIME_PATH}/protected`;
 
-/** Active route retained only until every server caller uses the canonical path. */
-export const PROTECTED_CONTENT_RUNTIME_V2_PATH = `${CONTENT_RUNTIME_PATH}/v2/protected`;
-
 /**
  * Marks responses built by the private runtime route after contract encoding.
  * This diagnostic signal does not replace signed response verification.

--- a/packages/backend/convex/contentRelease/http/runtime/protected.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/protected.test.ts
@@ -6,7 +6,6 @@ import {
   CONTENT_RUNTIME_RESPONSE_HEADER,
   CONTENT_RUNTIME_RESPONSE_MARKER,
   PROTECTED_CONTENT_RUNTIME_PATH,
-  PROTECTED_CONTENT_RUNTIME_V2_PATH,
 } from "@repo/backend/content/endpoint";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { insertRuntimeRelease } from "@repo/backend/test/content/runtime";
@@ -57,22 +56,23 @@ afterEach(() => {
 });
 
 describe("protected content runtime HTTP route", () => {
-  it.each([PROTECTED_CONTENT_RUNTIME_PATH, PROTECTED_CONTENT_RUNTIME_V2_PATH])(
-    "returns exact absence for a valid permanent batch at %s",
-    async (path) => {
-      const target = createConvexTestWithBetterAuth();
-      await target.mutation((ctx) => insertRuntimeRelease(ctx));
-      const response = await post(target, path, JSON.stringify(request));
+  it("returns exact absence for a valid permanent batch", async () => {
+    const target = createConvexTestWithBetterAuth();
+    await target.mutation((ctx) => insertRuntimeRelease(ctx));
+    const response = await post(
+      target,
+      PROTECTED_CONTENT_RUNTIME_PATH,
+      JSON.stringify(request)
+    );
 
-      expect(response.status).toBe(404);
-      await expect(response.json()).resolves.toEqual({ kind: "missing" });
-      expect(response.headers.get("cache-control")).toBe("private, no-store");
-      expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
-        CONTENT_RUNTIME_RESPONSE_MARKER
-      );
-      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
-    }
-  );
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ kind: "missing" });
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
+      CONTENT_RUNTIME_RESPONSE_MARKER
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
 
   it("rejects unauthorized, malformed, and oversized requests", async () => {
     const target = createConvexTestWithBetterAuth();

--- a/packages/backend/convex/contentRelease/http/runtime/protected.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/protected.ts
@@ -1,8 +1,5 @@
 import { MAX_PROTECTED_RUNTIME_REQUEST_BYTES } from "@nakafa/aksara-contracts/runtime/protected/limits";
-import {
-  PROTECTED_CONTENT_RUNTIME_PATH,
-  PROTECTED_CONTENT_RUNTIME_V2_PATH,
-} from "@repo/backend/content/endpoint";
+import { PROTECTED_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
 import { type ActionCtx, env } from "@repo/backend/convex/_generated/server";
 import { readRuntimeRequest } from "@repo/backend/convex/contentRelease/http/runtime/request";
 import { privateRuntimeResponse } from "@repo/backend/convex/contentRelease/http/runtime/response";
@@ -58,19 +55,14 @@ const protectedRuntimeRoute = Effect.fn("contentRelease.protectedRuntimeRoute")(
   }
 );
 
-/** Registers the server-authenticated retained protected content read route. */
+/** Registers the server-authenticated protected content read route. */
 export function registerProtectedContentRuntimeRoute<
   Variables extends Record<string, unknown>,
 >(app: HonoWithConvex<ActionCtx, Variables>) {
-  for (const path of [
-    PROTECTED_CONTENT_RUNTIME_PATH,
-    PROTECTED_CONTENT_RUNTIME_V2_PATH,
-  ]) {
-    app.post(path, async (context) => {
-      const result = await runConvexProgram(
-        protectedRuntimeRoute(context.env, context.req.raw)
-      );
-      return privateRuntimeResponse(result);
-    });
-  }
+  app.post(PROTECTED_CONTENT_RUNTIME_PATH, async (context) => {
+    const result = await runConvexProgram(
+      protectedRuntimeRoute(context.env, context.req.raw)
+    );
+    return privateRuntimeResponse(result);
+  });
 }


### PR DESCRIPTION
## Summary

- delete the transitional /internal/content/runtime/v2/protected constant and route
- retain /internal/content/runtime/protected as the single canonical contract
- remove predecessor-only tests and simplify route registration

## Production gate

- protected main 0d7c61d8e6155ad1a90dd0eb19db7cdecff1cd35 is READY in WWW, API, and MCP production
- the canonical route returns the authenticated 401 contract without a token
- the sole WWW caller is live on the canonical route
- API and MCP report the exact protected-main release SHA
- ID, EN, and DE production routes return 200
- Convex active is corpus-humanized-34ba5d27 with candidate and recovery empty
- no Vercel Preview exists

## Verification

- focused endpoint and protected HTTP route tests: 4 passed
- backend native TypeScript typecheck
- full local proof was completed at this exact head before push
- repository scan finds no remaining v2 protected runtime reference