### PR TITLE
Expand atomic read-model slots

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -195,6 +195,11 @@ import type * as contentRelease_material_write from "../contentRelease/material/
 import type * as contentRelease_model from "../contentRelease/model.js";
 import type * as contentRelease_models from "../contentRelease/models.js";
 import type * as contentRelease_models_impact from "../contentRelease/models/impact.js";
+import type * as contentRelease_models_migrate from "../contentRelease/models/migrate.js";
+import type * as contentRelease_models_migration_page from "../contentRelease/models/migration/page.js";
+import type * as contentRelease_models_migration_spec from "../contentRelease/models/migration/spec.js";
+import type * as contentRelease_models_migration_state from "../contentRelease/models/migration/state.js";
+import type * as contentRelease_models_slot from "../contentRelease/models/slot.js";
 import type * as contentRelease_ownership from "../contentRelease/ownership.js";
 import type * as contentRelease_page from "../contentRelease/page.js";
 import type * as contentRelease_page_catalog from "../contentRelease/page/catalog.js";
@@ -753,6 +758,11 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/model": typeof contentRelease_model;
   "contentRelease/models": typeof contentRelease_models;
   "contentRelease/models/impact": typeof contentRelease_models_impact;
+  "contentRelease/models/migrate": typeof contentRelease_models_migrate;
+  "contentRelease/models/migration/page": typeof contentRelease_models_migration_page;
+  "contentRelease/models/migration/spec": typeof contentRelease_models_migration_spec;
+  "contentRelease/models/migration/state": typeof contentRelease_models_migration_state;
+  "contentRelease/models/slot": typeof contentRelease_models_slot;
   "contentRelease/ownership": typeof contentRelease_ownership;
   "contentRelease/page": typeof contentRelease_page;
   "contentRelease/page/catalog": typeof contentRelease_page_catalog;

--- a/packages/backend/convex/contentRelease/article/schema.ts
+++ b/packages/backend/convex/contentRelease/article/schema.ts
@@ -48,19 +48,10 @@ const tables = {
       fields: ["slot", "appLocale", "datePublished", "contentKey"],
       staged: true,
     })
-    .index(
-      "by_slot_and_appLocale_and_category_and_datePublished_and_contentKey",
-      {
-        fields: [
-          "slot",
-          "appLocale",
-          "category",
-          "datePublished",
-          "contentKey",
-        ],
-        staged: true,
-      }
-    )
+    .index("by_slot_appLocale_category_datePublished_contentKey", {
+      fields: ["slot", "appLocale", "category", "datePublished", "contentKey"],
+      staged: true,
+    })
     .index("by_slot_and_appLocale_and_bucket_and_publicPath", {
       fields: ["slot", "appLocale", "bucket", "publicPath"],
       staged: true,

--- a/packages/backend/convex/contentRelease/article/schema.ts
+++ b/packages/backend/convex/contentRelease/article/schema.ts
@@ -1,3 +1,4 @@
+import { modelSlotValidator } from "@repo/backend/convex/contentRelease/models/slot";
 import {
   appLocaleValidator,
   rendererDomainValidator,
@@ -17,6 +18,7 @@ const articleFields = {
   releaseId: v.string(),
   rendererDomain: rendererDomainValidator,
   sequence: v.number(),
+  slot: v.optional(modelSlotValidator),
 };
 
 const tables = {
@@ -26,6 +28,34 @@ const tables = {
     dateModified: v.optional(v.string()),
     datePublished: v.string(),
   })
+    .index("by_slot_and_contentKey_and_appLocale", {
+      fields: ["slot", "contentKey", "appLocale"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_assetId", {
+      fields: ["slot", "appLocale", "assetId"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_contentKey", {
+      fields: ["slot", "appLocale", "contentKey"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_publicPath", {
+      fields: ["slot", "appLocale", "publicPath"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_datePublished_and_contentKey", {
+      fields: ["slot", "appLocale", "datePublished", "contentKey"],
+      staged: true,
+    })
+    .index("by_slot_locale_category_datePublished_contentKey", {
+      fields: ["slot", "appLocale", "category", "datePublished", "contentKey"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_bucket_and_publicPath", {
+      fields: ["slot", "appLocale", "bucket", "publicPath"],
+      staged: true,
+    })
     .index("by_contentKey_and_appLocale", ["contentKey", "appLocale"])
     .index("by_appLocale_and_assetId", ["appLocale", "assetId"])
     .index("by_appLocale_and_contentKey", ["appLocale", "contentKey"])
@@ -58,8 +88,21 @@ const tables = {
     rendererDomain: rendererDomainValidator,
     route: v.optional(v.string()),
     sequence: v.number(),
+    slot: v.optional(modelSlotValidator),
     title: v.string(),
   })
+    .index("by_slot_and_appLocale_and_category", {
+      fields: ["slot", "appLocale", "category"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_route", {
+      fields: ["slot", "appLocale", "route"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_bucket_and_category", {
+      fields: ["slot", "appLocale", "bucket", "category"],
+      staged: true,
+    })
     .index("by_appLocale_and_category", ["appLocale", "category"])
     .index("by_appLocale_and_route", ["appLocale", "route"])
     .index("by_appLocale_and_bucket_and_category", [
@@ -74,7 +117,13 @@ const tables = {
     articleCount: v.number(),
     bucket: v.string(),
     categoryCount: v.number(),
-  }).index("by_appLocale_and_bucket", ["appLocale", "bucket"]),
+    slot: v.optional(modelSlotValidator),
+  })
+    .index("by_slot_and_appLocale_and_bucket", {
+      fields: ["slot", "appLocale", "bucket"],
+      staged: true,
+    })
+    .index("by_appLocale_and_bucket", ["appLocale", "bucket"]),
 };
 
 export default tables;

--- a/packages/backend/convex/contentRelease/article/schema.ts
+++ b/packages/backend/convex/contentRelease/article/schema.ts
@@ -48,10 +48,19 @@ const tables = {
       fields: ["slot", "appLocale", "datePublished", "contentKey"],
       staged: true,
     })
-    .index("by_slot_locale_category_datePublished_contentKey", {
-      fields: ["slot", "appLocale", "category", "datePublished", "contentKey"],
-      staged: true,
-    })
+    .index(
+      "by_slot_and_appLocale_and_category_and_datePublished_and_contentKey",
+      {
+        fields: [
+          "slot",
+          "appLocale",
+          "category",
+          "datePublished",
+          "contentKey",
+        ],
+        staged: true,
+      }
+    )
     .index("by_slot_and_appLocale_and_bucket_and_publicPath", {
       fields: ["slot", "appLocale", "bucket", "publicPath"],
       staged: true,

--- a/packages/backend/convex/contentRelease/manifest.ts
+++ b/packages/backend/convex/contentRelease/manifest.ts
@@ -11,6 +11,7 @@ import {
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { ensureState } from "@repo/backend/convex/contentRelease/model";
+import { requireModelMigrationAbsent } from "@repo/backend/convex/contentRelease/models/migration/state";
 import {
   decodeReleaseJson,
   decodeRendererJson,
@@ -126,6 +127,7 @@ const stageProgram = Effect.fn("contentRelease.stageRelease")(function* (
   releaseJson: string,
   rendererJson: string
 ) {
+  yield* requireModelMigrationAbsent(ctx);
   const signed = yield* decodeReleaseJson(releaseJson);
   const renderer = yield* decodeRendererJson(rendererJson);
   const canonicalRelease = encodeReleaseJson(signed);

--- a/packages/backend/convex/contentRelease/manifest.ts
+++ b/packages/backend/convex/contentRelease/manifest.ts
@@ -11,7 +11,7 @@ import {
 import { ensureDocumentSize } from "@repo/backend/convex/contentRelease/document";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { ensureState } from "@repo/backend/convex/contentRelease/model";
-import { requireModelMigrationAbsent } from "@repo/backend/convex/contentRelease/models/migration/state";
+import { requirePreMigrationModels } from "@repo/backend/convex/contentRelease/models/migration/state";
 import {
   decodeReleaseJson,
   decodeRendererJson,
@@ -127,7 +127,7 @@ const stageProgram = Effect.fn("contentRelease.stageRelease")(function* (
   releaseJson: string,
   rendererJson: string
 ) {
-  yield* requireModelMigrationAbsent(ctx);
+  yield* requirePreMigrationModels(ctx);
   const signed = yield* decodeReleaseJson(releaseJson);
   const renderer = yield* decodeRendererJson(rendererJson);
   const canonicalRelease = encodeReleaseJson(signed);

--- a/packages/backend/convex/contentRelease/material/schema.ts
+++ b/packages/backend/convex/contentRelease/material/schema.ts
@@ -1,3 +1,4 @@
+import { modelSlotValidator } from "@repo/backend/convex/contentRelease/models/slot";
 import {
   appLocaleValidator,
   rendererDomainValidator,
@@ -21,6 +22,7 @@ const materialFields = {
   sequence: v.number(),
   sourcePath: v.string(),
   topicAssetId: v.string(),
+  slot: v.optional(modelSlotValidator),
 };
 
 const tables = {
@@ -30,6 +32,42 @@ const tables = {
     dateModified: v.optional(v.string()),
     datePublished: v.string(),
   })
+    .index("by_slot_and_contentKey_and_appLocale", {
+      fields: ["slot", "contentKey", "appLocale"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_contentKey", {
+      fields: ["slot", "appLocale", "contentKey"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_assetId", {
+      fields: ["slot", "appLocale", "assetId"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_topicAssetId_and_assetId", {
+      fields: ["slot", "appLocale", "topicAssetId", "assetId"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_publicPath", {
+      fields: ["slot", "appLocale", "publicPath"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_datePublished_and_contentKey", {
+      fields: ["slot", "appLocale", "datePublished", "contentKey"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_bucket_and_publicPath", {
+      fields: ["slot", "appLocale", "bucket", "publicPath"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_parentPath_and_order_and_publicPath", {
+      fields: ["slot", "appLocale", "parentPath", "order", "publicPath"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_materialKey_and_order_and_publicPath", {
+      fields: ["slot", "appLocale", "materialKey", "order", "publicPath"],
+      staged: true,
+    })
     .index("by_contentKey_and_appLocale", ["contentKey", "appLocale"])
     .index("by_appLocale_and_contentKey", ["appLocale", "contentKey"])
     .index("by_appLocale_and_assetId", ["appLocale", "assetId"])
@@ -67,7 +105,13 @@ const tables = {
     appLocale: appLocaleValidator,
     bucket: v.string(),
     count: v.number(),
-  }).index("by_appLocale_and_bucket", ["appLocale", "bucket"]),
+    slot: v.optional(modelSlotValidator),
+  })
+    .index("by_slot_and_appLocale_and_bucket", {
+      fields: ["slot", "appLocale", "bucket"],
+      staged: true,
+    })
+    .index("by_appLocale_and_bucket", ["appLocale", "bucket"]),
 };
 
 export default tables;

--- a/packages/backend/convex/contentRelease/models/migrate.test.ts
+++ b/packages/backend/convex/contentRelease/models/migrate.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { migrateModelPage } from "@repo/backend/convex/contentRelease/models/migration/page";
-import { requireModelMigrationAbsent } from "@repo/backend/convex/contentRelease/models/migration/state";
-import { alternateModelSlot } from "@repo/backend/convex/contentRelease/models/slot";
+import { requirePreMigrationModels } from "@repo/backend/convex/contentRelease/models/migration/state";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
@@ -131,7 +130,7 @@ describe("contentRelease/models/migrate", () => {
     });
     expect(first.scannedRows).toBeGreaterThan(0);
     await expect(
-      t.mutation((ctx) => runConvexProgram(requireModelMigrationAbsent(ctx)))
+      t.mutation((ctx) => runConvexProgram(requirePreMigrationModels(ctx)))
     ).rejects.toMatchObject({
       data: { code: "CONTENT_RELEASE_STATE" },
     });
@@ -152,7 +151,7 @@ describe("contentRelease/models/migrate", () => {
       complete: true,
       phase: "complete",
       scannedRows: 150,
-      table: "contentIndex",
+      table: "contentReleases",
     });
     const stored = await t.run(async (ctx) => ({
       articles: await ctx.db.query("articleCatalog").collect(),
@@ -178,6 +177,11 @@ describe("contentRelease/models/migrate", () => {
     await expect(
       t.query(internal.contentRelease.models.migrate.status, {})
     ).resolves.toEqual({ phase: "absent" });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(requirePreMigrationModels(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
   });
 
   it("preserves rows already assigned to the initial buffer", async () => {
@@ -283,14 +287,9 @@ describe("contentRelease/models/migrate", () => {
     });
 
     await expect(
-      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+      t.action(internal.contentRelease.models.migrate.run, {})
     ).rejects.toMatchObject({
       data: { code: "CONTENT_RELEASE_INTEGRITY" },
     });
-  });
-
-  it("selects the opposite bounded buffer", () => {
-    expect(alternateModelSlot("blue")).toBe("green");
-    expect(alternateModelSlot("green")).toBe("blue");
   });
 });

--- a/packages/backend/convex/contentRelease/models/migrate.test.ts
+++ b/packages/backend/convex/contentRelease/models/migrate.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "@effect/vitest";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { migrateModelPage } from "@repo/backend/convex/contentRelease/models/migration/page";
+import { requireModelMigrationAbsent } from "@repo/backend/convex/contentRelease/models/migration/state";
+import { alternateModelSlot } from "@repo/backend/convex/contentRelease/models/slot";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import {
+  insertTestState,
+  type TestIdentity,
+} from "@repo/backend/test/content/state";
+import { convexTest } from "convex-test";
+
+const ACTIVE = {
+  manifestHash: `sha256:${"a".repeat(64)}`,
+  releaseId: "release-model-migration-active",
+  sequence: 1,
+} satisfies TestIdentity;
+
+const CHANGED = {
+  manifestHash: `sha256:${"b".repeat(64)}`,
+  releaseId: "release-model-migration-changed",
+  sequence: 2,
+} satisfies TestIdentity;
+
+/** Inserts every model table plus one page boundary worth of article rows. */
+async function seedModels(ctx: MutationCtx, slot?: "blue" | "green") {
+  for (let index = 0; index < 70; index += 1) {
+    await ctx.db.insert("articleCatalog", {
+      appLocale: "en",
+      assetId: `asset:article:${index}`,
+      bucket: "aaa",
+      category: "news",
+      categoryTitle: "News",
+      contentKey: `articles/news/${index}`,
+      datePublished: "2026-08-29",
+      projectionHash: ACTIVE.manifestHash,
+      publicPath: `articles/news/${index}`,
+      releaseId: ACTIVE.releaseId,
+      rendererDomain: "politics",
+      sequence: ACTIVE.sequence,
+      ...(slot === undefined ? {} : { slot }),
+    });
+  }
+  await ctx.db.insert("articleCategories", {
+    appLocale: "en",
+    bucket: "aaa",
+    category: "news",
+    contentKey: "articles/news/0",
+    projectionHash: ACTIVE.manifestHash,
+    releaseId: ACTIVE.releaseId,
+    rendererDomain: "politics",
+    sequence: ACTIVE.sequence,
+    ...(slot === undefined ? {} : { slot }),
+    title: "News",
+  });
+  await ctx.db.insert("articleBuckets", {
+    appLocale: "en",
+    articleCount: 70,
+    bucket: "aaa",
+    categoryCount: 1,
+    ...(slot === undefined ? {} : { slot }),
+  });
+  await ctx.db.insert("materialCatalog", {
+    appLocale: "en",
+    assetId: "asset:material:1",
+    bucket: "bbb",
+    contentKey: "materials/math/algebra/lesson",
+    datePublished: "2026-08-29",
+    materialKey: "materials/math/algebra",
+    order: 1,
+    parentPath: "materials/math/algebra",
+    projectionHash: ACTIVE.manifestHash,
+    projectionJson: "{}",
+    publicPath: "materials/math/algebra/lesson",
+    releaseId: ACTIVE.releaseId,
+    rendererDomain: "mathematics",
+    sequence: ACTIVE.sequence,
+    ...(slot === undefined ? {} : { slot }),
+    sourcePath: "materials/math/algebra/lesson.mdx",
+    topicAssetId: "asset:material:topic",
+  });
+  await ctx.db.insert("materialBuckets", {
+    appLocale: "en",
+    bucket: "bbb",
+    count: 1,
+    ...(slot === undefined ? {} : { slot }),
+  });
+  await ctx.db.insert("contentIndex", {
+    appLocale: "en",
+    contentKey: "articles/news/0",
+    family: "article",
+    projectionHash: ACTIVE.manifestHash,
+    publicPath: "articles/news/0",
+    releaseId: ACTIVE.releaseId,
+    sequence: ACTIVE.sequence,
+    ...(slot === undefined ? {} : { slot }),
+    text: "News",
+  });
+}
+
+/** Inserts the exact converged active state required by the migration. */
+function seedState(ctx: MutationCtx, candidate?: TestIdentity) {
+  return insertTestState(ctx, {
+    active: ACTIVE,
+    article: ACTIVE,
+    candidate,
+    material: ACTIVE,
+    nextSequence: candidate ? candidate.sequence + 1 : 2,
+    search: ACTIVE,
+  });
+}
+
+describe("contentRelease/models/migrate", () => {
+  it("backfills, verifies, publishes, and accepts one resumable slot cycle", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx);
+      await seedModels(ctx);
+    });
+
+    const first = await t.mutation((ctx) =>
+      runConvexProgram(migrateModelPage(ctx))
+    );
+    expect(first).toMatchObject({
+      complete: false,
+      phase: "backfill",
+      table: "articleCatalog",
+    });
+    expect(first.scannedRows).toBeGreaterThan(0);
+    await expect(
+      t.mutation((ctx) => runConvexProgram(requireModelMigrationAbsent(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
+    await expect(
+      t.run((ctx) => ctx.db.query("contentState").unique())
+    ).resolves.not.toHaveProperty("articleSlot");
+
+    const paused = await t.action(
+      internal.contentRelease.models.migrate.run,
+      {}
+    );
+    expect(paused).toMatchObject({ complete: false, phase: "verify" });
+    const completed = await t.action(
+      internal.contentRelease.models.migrate.run,
+      {}
+    );
+    expect(completed).toEqual({
+      complete: true,
+      phase: "complete",
+      scannedRows: 150,
+      table: "contentIndex",
+    });
+    const stored = await t.run(async (ctx) => ({
+      articles: await ctx.db.query("articleCatalog").collect(),
+      migration: await ctx.db.query("contentModelMigrations").unique(),
+      state: await ctx.db.query("contentState").unique(),
+    }));
+    expect(stored.articles).toHaveLength(70);
+    expect(stored.articles.every(({ slot }) => slot === "blue")).toBe(true);
+    expect(stored.migration).toMatchObject({ phase: "complete" });
+    expect(stored.state).toMatchObject({
+      articleSlot: "blue",
+      materialSlot: "blue",
+      searchSlot: "blue",
+    });
+    await expect(
+      t.query(internal.contentRelease.models.migrate.status, {})
+    ).resolves.toEqual(completed);
+    await expect(
+      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+    ).resolves.toEqual(completed);
+
+    await t.mutation(internal.contentRelease.models.migrate.accept, {});
+    await expect(
+      t.query(internal.contentRelease.models.migrate.status, {})
+    ).resolves.toEqual({ phase: "absent" });
+  });
+
+  it("preserves rows already assigned to the initial buffer", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx);
+      await seedModels(ctx, "blue");
+    });
+
+    await t.action(internal.contentRelease.models.migrate.run, {});
+    await expect(
+      t.action(internal.contentRelease.models.migrate.run, {})
+    ).resolves.toMatchObject({ complete: true });
+  });
+
+  it("rejects migration while a candidate owns publication state", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx, CHANGED);
+      await seedModels(ctx);
+    });
+
+    await expect(
+      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
+    await expect(
+      t.run((ctx) => ctx.db.query("contentModelMigrations").collect())
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects a conflicting preexisting buffer", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx);
+      await seedModels(ctx, "green");
+    });
+
+    await expect(
+      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it("rejects active identity drift between durable pages", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx);
+      await seedModels(ctx);
+    });
+    await t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)));
+    await t.mutation(async (ctx) => {
+      const state = await ctx.db.query("contentState").unique();
+      expect(state).not.toBeNull();
+      if (state) {
+        await ctx.db.patch("contentState", state._id, {
+          activeManifestHash: CHANGED.manifestHash,
+          activeReleaseId: CHANGED.releaseId,
+          activeSequence: CHANGED.sequence,
+          articleManifestHash: CHANGED.manifestHash,
+          articleReleaseId: CHANGED.releaseId,
+          articleSequence: CHANGED.sequence,
+          materialManifestHash: CHANGED.manifestHash,
+          materialReleaseId: CHANGED.releaseId,
+          materialSequence: CHANGED.sequence,
+          searchManifestHash: CHANGED.manifestHash,
+          searchReleaseId: CHANGED.releaseId,
+          searchSequence: CHANGED.sequence,
+        });
+      }
+    });
+
+    await expect(
+      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STALE_BASE" },
+    });
+  });
+
+  it("rejects verification drift and premature acceptance", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await seedState(ctx);
+      await seedModels(ctx);
+    });
+    await expect(
+      t.mutation(internal.contentRelease.models.migrate.accept, {})
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_STATE" },
+    });
+    await t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)));
+    await t.action(internal.contentRelease.models.migrate.run, {});
+    await t.mutation(async (ctx) => {
+      const category = await ctx.db.query("articleCategories").unique();
+      expect(category).not.toBeNull();
+      if (category) {
+        await ctx.db.patch("articleCategories", category._id, {
+          slot: "green",
+        });
+      }
+    });
+
+    await expect(
+      t.mutation((ctx) => runConvexProgram(migrateModelPage(ctx)))
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it("selects the opposite bounded buffer", () => {
+    expect(alternateModelSlot("blue")).toBe("green");
+    expect(alternateModelSlot("green")).toBe("blue");
+  });
+});

--- a/packages/backend/convex/contentRelease/models/migrate.ts
+++ b/packages/backend/convex/contentRelease/models/migrate.ts
@@ -17,7 +17,6 @@ import {
   acceptModelMigration,
   loadModelMigration,
 } from "@repo/backend/convex/contentRelease/models/migration/state";
-import type { ModelMigrationTable } from "@repo/backend/convex/contentRelease/models/schema";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { makeFunctionReference } from "convex/server";
 import { v } from "convex/values";
@@ -26,12 +25,7 @@ import { Effect } from "effect";
 const pageReference = makeFunctionReference<
   "mutation",
   Record<string, never>,
-  {
-    complete: boolean;
-    phase: "backfill" | "complete" | "verify";
-    scannedRows: number;
-    table: ModelMigrationTable;
-  }
+  ModelMigrationReceipt
 >("contentRelease/models/migrate:page");
 
 /** Drains bounded transactions and remains safely resumable after interruption. */

--- a/packages/backend/convex/contentRelease/models/migrate.ts
+++ b/packages/backend/convex/contentRelease/models/migrate.ts
@@ -1,0 +1,96 @@
+import type { ActionCtx } from "@repo/backend/convex/_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "@repo/backend/convex/_generated/server";
+import { callInternal } from "@repo/backend/convex/contentRelease/ingress/call";
+import { migrateModelPage } from "@repo/backend/convex/contentRelease/models/migration/page";
+import {
+  FIRST_MODEL_TABLE,
+  MODEL_MIGRATION_RUN_PAGES,
+  type ModelMigrationReceipt,
+  modelMigrationReceiptValidator,
+  modelMigrationStatusValidator,
+} from "@repo/backend/convex/contentRelease/models/migration/spec";
+import {
+  acceptModelMigration,
+  loadModelMigration,
+} from "@repo/backend/convex/contentRelease/models/migration/state";
+import type { ModelMigrationTable } from "@repo/backend/convex/contentRelease/models/schema";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { makeFunctionReference } from "convex/server";
+import { v } from "convex/values";
+import { Effect } from "effect";
+
+const pageReference = makeFunctionReference<
+  "mutation",
+  Record<string, never>,
+  {
+    complete: boolean;
+    phase: "backfill" | "complete" | "verify";
+    scannedRows: number;
+    table: ModelMigrationTable;
+  }
+>("contentRelease/models/migrate:page");
+
+/** Drains bounded transactions and remains safely resumable after interruption. */
+const runModelMigration = Effect.fn("contentRelease.runModelMigration")(
+  function* (ctx: ActionCtx) {
+    let latest: ModelMigrationReceipt = {
+      complete: false,
+      phase: "backfill",
+      scannedRows: 0,
+      table: FIRST_MODEL_TABLE,
+    };
+    for (let index = 0; index < MODEL_MIGRATION_RUN_PAGES; index += 1) {
+      latest = yield* callInternal(() => ctx.runMutation(pageReference, {}));
+      if (latest.complete) {
+        return latest;
+      }
+    }
+    return latest;
+  }
+);
+
+/** Internal bounded page invoked only through Convex admin orchestration. */
+export const page = internalMutation({
+  args: {},
+  returns: modelMigrationReceiptValidator,
+  handler: (ctx) => runConvexProgram(migrateModelPage(ctx)),
+});
+
+/** Internal resumable runner invoked through authenticated Convex admin access. */
+export const run = internalAction({
+  args: {},
+  returns: modelMigrationReceiptValidator,
+  handler: (ctx) => runConvexProgram(runModelMigration(ctx)),
+});
+
+/** Internal status proof for the current one-time migration cycle. */
+export const status = internalQuery({
+  args: {},
+  returns: modelMigrationStatusValidator,
+  handler: (ctx) =>
+    runConvexProgram(
+      Effect.gen(function* () {
+        const migration = yield* loadModelMigration(ctx);
+        if (!migration) {
+          return { phase: "absent" as const };
+        }
+        return {
+          complete: migration.phase === "complete",
+          phase: migration.phase,
+          scannedRows: migration.scannedRows,
+          table: migration.table,
+        };
+      })
+    ),
+});
+
+/** Internal terminal acceptance after explicit production proof. */
+export const accept = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: (ctx) => runConvexProgram(acceptModelMigration(ctx)),
+});

--- a/packages/backend/convex/contentRelease/models/migration/page.ts
+++ b/packages/backend/convex/contentRelease/models/migration/page.ts
@@ -1,0 +1,217 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  FIRST_MODEL_TABLE,
+  MODEL_MIGRATION_PAGE_BYTES,
+  MODEL_MIGRATION_PAGE_ROWS,
+  type ModelMigrationCycle,
+  type ModelMigrationReceipt,
+} from "@repo/backend/convex/contentRelease/models/migration/spec";
+import {
+  ensureModelMigration,
+  stableModelState,
+  validateModelMigrationState,
+} from "@repo/backend/convex/contentRelease/models/migration/state";
+import type { ModelMigrationTable } from "@repo/backend/convex/contentRelease/models/schema";
+import { INITIAL_MODEL_SLOT } from "@repo/backend/convex/contentRelease/models/slot";
+import { Effect } from "effect";
+
+/** Returns the next bounded read-model table in dependency-free order. */
+function nextModelTable(
+  table: ModelMigrationTable
+): ModelMigrationTable | null {
+  if (table === "articleCatalog") {
+    return "articleCategories";
+  }
+  if (table === "articleCategories") {
+    return "articleBuckets";
+  }
+  if (table === "articleBuckets") {
+    return "materialCatalog";
+  }
+  if (table === "materialCatalog") {
+    return "materialBuckets";
+  }
+  if (table === "materialBuckets") {
+    return "contentIndex";
+  }
+  return null;
+}
+
+/** Reads one bounded table page without relying on the new slot indexes. */
+function readModelPage(
+  ctx: MutationCtx,
+  table: ModelMigrationTable,
+  cursor: string | undefined
+) {
+  const options = {
+    cursor: cursor ?? null,
+    maximumBytesRead: MODEL_MIGRATION_PAGE_BYTES,
+    maximumRowsRead: MODEL_MIGRATION_PAGE_ROWS,
+    numItems: MODEL_MIGRATION_PAGE_ROWS,
+  };
+  if (table === "articleCatalog") {
+    return Effect.promise(() => ctx.db.query(table).paginate(options));
+  }
+  if (table === "articleCategories") {
+    return Effect.promise(() => ctx.db.query(table).paginate(options));
+  }
+  if (table === "articleBuckets") {
+    return Effect.promise(() => ctx.db.query(table).paginate(options));
+  }
+  if (table === "materialCatalog") {
+    return Effect.promise(() => ctx.db.query(table).paginate(options));
+  }
+  if (table === "materialBuckets") {
+    return Effect.promise(() => ctx.db.query(table).paginate(options));
+  }
+  return Effect.promise(() => ctx.db.query("contentIndex").paginate(options));
+}
+
+/** Backfills one bounded page while rejecting any conflicting buffer value. */
+const backfillModelPage = Effect.fn("contentRelease.backfillModelSlot")(
+  function* (ctx: MutationCtx, migration: ModelMigrationCycle) {
+    const page = yield* readModelPage(ctx, migration.table, migration.cursor);
+    for (const row of page.page) {
+      if (row.slot !== undefined && row.slot !== INITIAL_MODEL_SLOT) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_INTEGRITY",
+          `Read-model table ${migration.table} contains a conflicting slot.`
+        );
+      }
+      if (row.slot === undefined) {
+        yield* Effect.promise(() =>
+          ctx.db.patch(row._id, { slot: INITIAL_MODEL_SLOT })
+        );
+      }
+    }
+    return page;
+  }
+);
+
+/** Proves one bounded page contains only the canonical initial buffer. */
+const verifyModelPage = Effect.fn("contentRelease.verifyModelSlot")(function* (
+  ctx: MutationCtx,
+  migration: ModelMigrationCycle
+) {
+  const page = yield* readModelPage(ctx, migration.table, migration.cursor);
+  if (page.page.some((row) => row.slot !== INITIAL_MODEL_SLOT)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Read-model table ${migration.table} failed slot verification.`
+    );
+  }
+  return page;
+});
+
+/** Advances one completed table or atomically publishes migrated slot state. */
+const advanceModelMigration = Effect.fn("contentRelease.advanceModelMigration")(
+  function* (
+    ctx: MutationCtx,
+    state: Doc<"contentState">,
+    migration: ModelMigrationCycle,
+    scannedRows: number
+  ) {
+    const table = nextModelTable(migration.table);
+    const now = Date.now();
+    if (table) {
+      yield* Effect.promise(() =>
+        ctx.db.patch("contentModelMigrations", migration._id, {
+          cursor: undefined,
+          scannedRows,
+          table,
+          updatedAt: now,
+        })
+      );
+      return {
+        complete: false,
+        phase: migration.phase,
+        scannedRows,
+        table,
+      } satisfies ModelMigrationReceipt;
+    }
+    if (migration.phase === "backfill") {
+      yield* Effect.promise(() =>
+        ctx.db.patch("contentModelMigrations", migration._id, {
+          cursor: undefined,
+          phase: "verify",
+          scannedRows,
+          table: FIRST_MODEL_TABLE,
+          updatedAt: now,
+        })
+      );
+      return {
+        complete: false,
+        phase: "verify" as const,
+        scannedRows,
+        table: FIRST_MODEL_TABLE,
+      } satisfies ModelMigrationReceipt;
+    }
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentState", state._id, {
+        articleSlot: INITIAL_MODEL_SLOT,
+        materialSlot: INITIAL_MODEL_SLOT,
+        searchSlot: INITIAL_MODEL_SLOT,
+        updatedAt: now,
+      })
+    );
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentModelMigrations", migration._id, {
+        cursor: undefined,
+        phase: "complete",
+        scannedRows,
+        updatedAt: now,
+      })
+    );
+    return {
+      complete: true,
+      phase: "complete" as const,
+      scannedRows,
+      table: migration.table,
+    } satisfies ModelMigrationReceipt;
+  }
+);
+
+/** Runs one transactional, resumable backfill or verification page. */
+export const migrateModelPage = Effect.fn("contentRelease.migrateModelPage")(
+  function* (ctx: MutationCtx) {
+    const stable = yield* stableModelState(ctx);
+    const migration = yield* ensureModelMigration(ctx, stable);
+    yield* validateModelMigrationState(stable, migration);
+    if (migration.phase === "complete") {
+      return {
+        complete: true,
+        phase: migration.phase,
+        scannedRows: migration.scannedRows,
+        table: migration.table,
+      } satisfies ModelMigrationReceipt;
+    }
+    const result =
+      migration.phase === "backfill"
+        ? yield* backfillModelPage(ctx, migration)
+        : yield* verifyModelPage(ctx, migration);
+    const scannedRows = migration.scannedRows + result.page.length;
+    if (result.isDone) {
+      return yield* advanceModelMigration(
+        ctx,
+        stable.state,
+        migration,
+        scannedRows
+      );
+    }
+    yield* Effect.promise(() =>
+      ctx.db.patch("contentModelMigrations", migration._id, {
+        cursor: result.continueCursor,
+        scannedRows,
+        updatedAt: Date.now(),
+      })
+    );
+    return {
+      complete: false,
+      phase: migration.phase,
+      scannedRows,
+      table: migration.table,
+    } satisfies ModelMigrationReceipt;
+  }
+);

--- a/packages/backend/convex/contentRelease/models/migration/page.ts
+++ b/packages/backend/convex/contentRelease/models/migration/page.ts
@@ -2,6 +2,10 @@ import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import {
+  cleanReleasePage,
+  verifyReleasePage,
+} from "@repo/backend/convex/contentRelease/models/migration/release";
+import {
   FIRST_MODEL_TABLE,
   MODEL_MIGRATION_PAGE_BYTES,
   MODEL_MIGRATION_PAGE_ROWS,
@@ -36,13 +40,16 @@ function nextModelTable(
   if (table === "materialBuckets") {
     return "contentIndex";
   }
+  if (table === "contentIndex") {
+    return "contentReleases";
+  }
   return null;
 }
 
 /** Reads one bounded table page without relying on the new slot indexes. */
 function readModelPage(
   ctx: MutationCtx,
-  table: ModelMigrationTable,
+  table: Exclude<ModelMigrationTable, "contentReleases">,
   cursor: string | undefined
 ) {
   const options = {
@@ -72,6 +79,9 @@ function readModelPage(
 /** Backfills one bounded page while rejecting any conflicting buffer value. */
 const backfillModelPage = Effect.fn("contentRelease.backfillModelSlot")(
   function* (ctx: MutationCtx, migration: ModelMigrationCycle) {
+    if (migration.table === "contentReleases") {
+      return yield* cleanReleasePage(ctx, migration);
+    }
     const page = yield* readModelPage(ctx, migration.table, migration.cursor);
     for (const row of page.page) {
       if (row.slot !== undefined && row.slot !== INITIAL_MODEL_SLOT) {
@@ -95,6 +105,9 @@ const verifyModelPage = Effect.fn("contentRelease.verifyModelSlot")(function* (
   ctx: MutationCtx,
   migration: ModelMigrationCycle
 ) {
+  if (migration.table === "contentReleases") {
+    return yield* verifyReleasePage(ctx, migration);
+  }
   const page = yield* readModelPage(ctx, migration.table, migration.cursor);
   if (page.page.some((row) => row.slot !== INITIAL_MODEL_SLOT)) {
     return yield* releaseFail(

--- a/packages/backend/convex/contentRelease/models/migration/release.test.ts
+++ b/packages/backend/convex/contentRelease/models/migration/release.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "@effect/vitest";
+import { internal } from "@repo/backend/convex/_generated/api";
+import {
+  cleanReleasePage,
+  verifyReleasePage,
+} from "@repo/backend/convex/contentRelease/models/migration/release";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { insertZeroRelease } from "@repo/backend/test/content/state";
+import { convexTest } from "convex-test";
+
+const ACTIVE = {
+  manifestHash: `sha256:${"a".repeat(64)}`,
+  releaseId: "release-model-progress",
+  sequence: 1,
+} as const;
+
+const LEGACY_FIELDS = [
+  "articleCursor",
+  "articleIndex",
+  "articleSyncedAt",
+  "materialCursor",
+  "materialIndex",
+  "materialSyncedAt",
+  "searchIndex",
+  "searchSyncedAt",
+  "syncGeneration",
+  "syncJobId",
+] as const;
+
+describe("contentRelease/models/migration/release", () => {
+  it("removes and verifies every predecessor read-model progress field", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertZeroRelease(ctx, {
+        ...ACTIVE,
+        ownership: { base: [], result: [] },
+        role: "candidate",
+        status: "completed",
+      });
+      const release = await ctx.db.query("contentReleases").unique();
+      expect(release).not.toBeNull();
+      if (release) {
+        const syncJobId = await ctx.scheduler.runAfter(
+          60_000,
+          internal.contentRelease.models.migrate.run,
+          {}
+        );
+        await ctx.db.patch("contentReleases", release._id, {
+          articleCursor: "article-cursor",
+          articleIndex: 1,
+          articleSyncedAt: 1,
+          materialCursor: "material-cursor",
+          materialIndex: 1,
+          materialSyncedAt: 1,
+          searchIndex: 1,
+          searchSyncedAt: 1,
+          syncGeneration: 1,
+          syncJobId,
+        });
+      }
+      await ctx.db.insert("contentModelMigrations", {
+        activeManifestHash: ACTIVE.manifestHash,
+        activeReleaseId: ACTIVE.releaseId,
+        activeSequence: ACTIVE.sequence,
+        key: "primary",
+        phase: "backfill",
+        scannedRows: 0,
+        table: "contentReleases",
+        updatedAt: 1,
+      });
+    });
+
+    await expect(
+      t.mutation(async (ctx) => {
+        const migration = await ctx.db.query("contentModelMigrations").unique();
+        expect(migration).not.toBeNull();
+        if (migration) {
+          await runConvexProgram(verifyReleasePage(ctx, migration));
+        }
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    await t.mutation(async (ctx) => {
+      const migration = await ctx.db.query("contentModelMigrations").unique();
+      expect(migration).not.toBeNull();
+      if (migration) {
+        await runConvexProgram(cleanReleasePage(ctx, migration));
+      }
+    });
+    await t.mutation(async (ctx) => {
+      const migration = await ctx.db.query("contentModelMigrations").unique();
+      expect(migration).not.toBeNull();
+      if (migration) {
+        await runConvexProgram(verifyReleasePage(ctx, migration));
+      }
+    });
+    const release = await t.run((ctx) =>
+      ctx.db.query("contentReleases").unique()
+    );
+    for (const field of LEGACY_FIELDS) {
+      expect(release).not.toHaveProperty(field);
+    }
+  });
+});

--- a/packages/backend/convex/contentRelease/models/migration/release.ts
+++ b/packages/backend/convex/contentRelease/models/migration/release.ts
@@ -1,0 +1,81 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  MODEL_MIGRATION_PAGE_BYTES,
+  MODEL_MIGRATION_PAGE_ROWS,
+  type ModelMigrationCycle,
+} from "@repo/backend/convex/contentRelease/models/migration/spec";
+import { Effect } from "effect";
+
+/** Detects predecessor read-model progress on one release row. */
+function hasModelProgress(
+  row: Awaited<ReturnType<typeof readReleasePage>>["page"][number]
+) {
+  return (
+    row.articleCursor !== undefined ||
+    row.articleIndex !== undefined ||
+    row.articleSyncedAt !== undefined ||
+    row.materialCursor !== undefined ||
+    row.materialIndex !== undefined ||
+    row.materialSyncedAt !== undefined ||
+    row.searchIndex !== undefined ||
+    row.searchSyncedAt !== undefined ||
+    row.syncGeneration !== undefined ||
+    row.syncJobId !== undefined
+  );
+}
+
+/** Reads one bounded release page before terminal progress-field removal. */
+function readReleasePage(ctx: MutationCtx, cursor: string | undefined) {
+  return ctx.db.query("contentReleases").paginate({
+    cursor: cursor ?? null,
+    maximumBytesRead: MODEL_MIGRATION_PAGE_BYTES,
+    maximumRowsRead: MODEL_MIGRATION_PAGE_ROWS,
+    numItems: MODEL_MIGRATION_PAGE_ROWS,
+  });
+}
+
+/** Removes predecessor read-model progress from one bounded release page. */
+export const cleanReleasePage = Effect.fn("contentRelease.cleanModelProgress")(
+  function* (ctx: MutationCtx, migration: ModelMigrationCycle) {
+    const page = yield* Effect.promise(() =>
+      readReleasePage(ctx, migration.cursor)
+    );
+    for (const row of page.page) {
+      if (hasModelProgress(row)) {
+        yield* Effect.promise(() =>
+          ctx.db.patch("contentReleases", row._id, {
+            articleCursor: undefined,
+            articleIndex: undefined,
+            articleSyncedAt: undefined,
+            materialCursor: undefined,
+            materialIndex: undefined,
+            materialSyncedAt: undefined,
+            searchIndex: undefined,
+            searchSyncedAt: undefined,
+            syncGeneration: undefined,
+            syncJobId: undefined,
+            updatedAt: Date.now(),
+          })
+        );
+      }
+    }
+    return page;
+  }
+);
+
+/** Proves predecessor read-model progress is absent from one release page. */
+export const verifyReleasePage = Effect.fn(
+  "contentRelease.verifyModelProgress"
+)(function* (ctx: MutationCtx, migration: ModelMigrationCycle) {
+  const page = yield* Effect.promise(() =>
+    readReleasePage(ctx, migration.cursor)
+  );
+  if (page.page.some(hasModelProgress)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Content releases retained predecessor read-model progress."
+    );
+  }
+  return page;
+});

--- a/packages/backend/convex/contentRelease/models/migration/spec.ts
+++ b/packages/backend/convex/contentRelease/models/migration/spec.ts
@@ -1,0 +1,34 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import {
+  type ModelMigrationTable,
+  modelMigrationPhaseValidator,
+  modelMigrationTableValidator,
+} from "@repo/backend/convex/contentRelease/models/schema";
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+
+export const MODEL_MIGRATION_PAGE_ROWS = 64;
+export const MODEL_MIGRATION_PAGE_BYTES = 512 * 1024;
+export const MODEL_MIGRATION_RUN_PAGES = 8;
+export const FIRST_MODEL_TABLE = "articleCatalog" satisfies ModelMigrationTable;
+
+export const modelMigrationReceiptValidator = v.object({
+  complete: v.boolean(),
+  phase: modelMigrationPhaseValidator,
+  scannedRows: v.number(),
+  table: modelMigrationTableValidator,
+});
+
+export const modelMigrationStatusValidator = v.union(
+  v.object({ phase: v.literal("absent") }),
+  modelMigrationReceiptValidator
+);
+
+export type ModelMigrationReceipt = Infer<
+  typeof modelMigrationReceiptValidator
+>;
+
+export type ModelMigrationCycle = Omit<
+  Doc<"contentModelMigrations">,
+  "_creationTime"
+>;

--- a/packages/backend/convex/contentRelease/models/migration/state.ts
+++ b/packages/backend/convex/contentRelease/models/migration/state.ts
@@ -1,0 +1,151 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadState } from "@repo/backend/convex/contentRelease/model";
+import {
+  FIRST_MODEL_TABLE,
+  type ModelMigrationCycle,
+} from "@repo/backend/convex/contentRelease/models/migration/spec";
+import { INITIAL_MODEL_SLOT } from "@repo/backend/convex/contentRelease/models/slot";
+import { Effect } from "effect";
+
+export interface StableModelState {
+  readonly active: {
+    readonly manifestHash: string;
+    readonly releaseId: string;
+    readonly sequence: number;
+  };
+  readonly state: Doc<"contentState">;
+}
+
+/** Requires one complete active identity with no concurrent publication. */
+export const stableModelState = Effect.fn("contentRelease.modelMigrationState")(
+  function* (ctx: MutationCtx | QueryCtx) {
+    const state = yield* loadState(ctx);
+    if (
+      !(state?.activeManifestHash && state.activeReleaseId) ||
+      state.activeSequence === undefined ||
+      state.candidateManifestHash !== undefined ||
+      state.candidateReleaseId !== undefined ||
+      state.candidateSequence !== undefined ||
+      state.recoveryManifestHash !== undefined ||
+      state.recoveryReleaseId !== undefined ||
+      state.recoverySequence !== undefined ||
+      state.articleManifestHash !== state.activeManifestHash ||
+      state.articleReleaseId !== state.activeReleaseId ||
+      state.articleSequence !== state.activeSequence ||
+      state.materialManifestHash !== state.activeManifestHash ||
+      state.materialReleaseId !== state.activeReleaseId ||
+      state.materialSequence !== state.activeSequence ||
+      state.searchManifestHash !== state.activeManifestHash ||
+      state.searchReleaseId !== state.activeReleaseId ||
+      state.searchSequence !== state.activeSequence
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_STATE",
+        "Read-model slot migration requires one fully converged active release with no candidate or recovery."
+      );
+    }
+    return {
+      active: {
+        manifestHash: state.activeManifestHash,
+        releaseId: state.activeReleaseId,
+        sequence: state.activeSequence,
+      },
+      state,
+    } satisfies StableModelState;
+  }
+);
+
+/** Rejects active-state drift across every crash-safe migration page. */
+export const validateModelMigrationState = Effect.fn(
+  "contentRelease.validateModelMigrationState"
+)(function* (stable: StableModelState, migration: ModelMigrationCycle) {
+  if (
+    stable.active.manifestHash !== migration.activeManifestHash ||
+    stable.active.releaseId !== migration.activeReleaseId ||
+    stable.active.sequence !== migration.activeSequence
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STALE_BASE",
+      "Read-model slot migration lost its exact active release."
+    );
+  }
+});
+
+/** Loads the singleton migration cycle when one is already in progress. */
+export function loadModelMigration(ctx: MutationCtx | QueryCtx) {
+  return Effect.promise(() =>
+    ctx.db
+      .query("contentModelMigrations")
+      .withIndex("by_key", (index) => index.eq("key", "primary"))
+      .unique()
+  );
+}
+
+/** Blocks publication while the one-time model migration owns production. */
+export const requireModelMigrationAbsent = Effect.fn(
+  "contentRelease.requireModelMigrationAbsent"
+)(function* (ctx: MutationCtx | QueryCtx) {
+  if (yield* loadModelMigration(ctx)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Content publication is paused while read-model slots are migrating."
+    );
+  }
+});
+
+/** Starts one exact migration cycle after proving the production baseline. */
+export const ensureModelMigration = Effect.fn(
+  "contentRelease.ensureModelMigration"
+)(function* (ctx: MutationCtx, stable: StableModelState) {
+  const existing = yield* loadModelMigration(ctx);
+  if (existing) {
+    yield* validateModelMigrationState(stable, existing);
+    return existing;
+  }
+  const fields = {
+    activeManifestHash: stable.active.manifestHash,
+    activeReleaseId: stable.active.releaseId,
+    activeSequence: stable.active.sequence,
+    key: "primary" as const,
+    phase: "backfill" as const,
+    scannedRows: 0,
+    table: FIRST_MODEL_TABLE,
+    updatedAt: Date.now(),
+  } satisfies Omit<ModelMigrationCycle, "_id">;
+  const id = yield* Effect.promise(() =>
+    ctx.db.insert("contentModelMigrations", fields)
+  );
+  return { _id: id, ...fields } satisfies ModelMigrationCycle;
+});
+
+/** Removes only a fully proven one-time migration receipt. */
+export const acceptModelMigration = Effect.fn(
+  "contentRelease.acceptModelMigration"
+)(function* (ctx: MutationCtx) {
+  const stable = yield* stableModelState(ctx);
+  const migration = yield* loadModelMigration(ctx);
+  const slots = [
+    stable.state.articleSlot,
+    stable.state.materialSlot,
+    stable.state.searchSlot,
+  ];
+  if (
+    migration?.phase !== "complete" ||
+    slots.some((slot) => slot !== INITIAL_MODEL_SLOT)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "Read-model slot migration is not ready for terminal acceptance."
+    );
+  }
+  yield* validateModelMigrationState(stable, migration);
+  yield* Effect.promise(() =>
+    ctx.db.delete("contentModelMigrations", migration._id)
+  );
+  return null;
+});

--- a/packages/backend/convex/contentRelease/models/migration/state.ts
+++ b/packages/backend/convex/contentRelease/models/migration/state.ts
@@ -77,14 +77,16 @@ export const validateModelMigrationState = Effect.fn(
 });
 
 /** Loads the singleton migration cycle when one is already in progress. */
-export function loadModelMigration(ctx: MutationCtx | QueryCtx) {
-  return Effect.promise(() =>
+export const loadModelMigration = Effect.fn(
+  "contentRelease.loadModelMigration"
+)((ctx: MutationCtx | QueryCtx) =>
+  Effect.promise(() =>
     ctx.db
       .query("contentModelMigrations")
       .withIndex("by_key", (index) => index.eq("key", "primary"))
       .unique()
-  );
-}
+  )
+);
 
 /** Blocks legacy publication once the one-time slot transition begins. */
 export const requirePreMigrationModels = Effect.fn(

--- a/packages/backend/convex/contentRelease/models/migration/state.ts
+++ b/packages/backend/convex/contentRelease/models/migration/state.ts
@@ -86,14 +86,23 @@ export function loadModelMigration(ctx: MutationCtx | QueryCtx) {
   );
 }
 
-/** Blocks publication while the one-time model migration owns production. */
-export const requireModelMigrationAbsent = Effect.fn(
-  "contentRelease.requireModelMigrationAbsent"
+/** Blocks legacy publication once the one-time slot transition begins. */
+export const requirePreMigrationModels = Effect.fn(
+  "contentRelease.requirePreMigrationModels"
 )(function* (ctx: MutationCtx | QueryCtx) {
-  if (yield* loadModelMigration(ctx)) {
+  const [migration, state] = yield* Effect.all([
+    loadModelMigration(ctx),
+    loadState(ctx),
+  ]);
+  if (
+    migration ||
+    state?.articleSlot !== undefined ||
+    state?.materialSlot !== undefined ||
+    state?.searchSlot !== undefined
+  ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_STATE",
-      "Content publication is paused while read-model slots are migrating."
+      "Content publication is paused while read-model slots transition to atomic switching."
     );
   }
 });

--- a/packages/backend/convex/contentRelease/models/schema.ts
+++ b/packages/backend/convex/contentRelease/models/schema.ts
@@ -8,7 +8,8 @@ export const modelMigrationTableValidator = v.union(
   v.literal("articleBuckets"),
   v.literal("materialCatalog"),
   v.literal("materialBuckets"),
-  v.literal("contentIndex")
+  v.literal("contentIndex"),
+  v.literal("contentReleases")
 );
 
 export type ModelMigrationTable = Infer<typeof modelMigrationTableValidator>;

--- a/packages/backend/convex/contentRelease/models/schema.ts
+++ b/packages/backend/convex/contentRelease/models/schema.ts
@@ -1,0 +1,37 @@
+import { defineTable } from "convex/server";
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+
+export const modelMigrationTableValidator = v.union(
+  v.literal("articleCatalog"),
+  v.literal("articleCategories"),
+  v.literal("articleBuckets"),
+  v.literal("materialCatalog"),
+  v.literal("materialBuckets"),
+  v.literal("contentIndex")
+);
+
+export type ModelMigrationTable = Infer<typeof modelMigrationTableValidator>;
+
+export const modelMigrationPhaseValidator = v.union(
+  v.literal("backfill"),
+  v.literal("verify"),
+  v.literal("complete")
+);
+
+const tables = {
+  /** One temporary crash-safe expansion cycle for the bounded model buffers. */
+  contentModelMigrations: defineTable({
+    activeManifestHash: v.string(),
+    activeReleaseId: v.string(),
+    activeSequence: v.number(),
+    cursor: v.optional(v.string()),
+    key: v.literal("primary"),
+    phase: modelMigrationPhaseValidator,
+    scannedRows: v.number(),
+    table: modelMigrationTableValidator,
+    updatedAt: v.number(),
+  }).index("by_key", ["key"]),
+};
+
+export default tables;

--- a/packages/backend/convex/contentRelease/models/slot.test.ts
+++ b/packages/backend/convex/contentRelease/models/slot.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "@effect/vitest";
+import { alternateModelSlot } from "@repo/backend/convex/contentRelease/models/slot";
+
+it("selects the opposite bounded read-model buffer", () => {
+  expect(alternateModelSlot("blue")).toBe("green");
+  expect(alternateModelSlot("green")).toBe("blue");
+});

--- a/packages/backend/convex/contentRelease/models/slot.ts
+++ b/packages/backend/convex/contentRelease/models/slot.ts
@@ -1,0 +1,16 @@
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+
+export const modelSlotValidator = v.union(
+  v.literal("blue"),
+  v.literal("green")
+);
+
+export type ModelSlot = Infer<typeof modelSlotValidator>;
+
+export const INITIAL_MODEL_SLOT = "blue" satisfies ModelSlot;
+
+/** Selects the inactive bounded buffer without mutable naming semantics. */
+export function alternateModelSlot(slot: ModelSlot): ModelSlot {
+  return slot === "blue" ? "green" : "blue";
+}

--- a/packages/backend/convex/contentRelease/schema.ts
+++ b/packages/backend/convex/contentRelease/schema.ts
@@ -1,6 +1,8 @@
 import { vWorkflowId } from "@convex-dev/workflow";
 import articleSchema from "@repo/backend/convex/contentRelease/article/schema";
 import materialSchema from "@repo/backend/convex/contentRelease/material/schema";
+import modelSchema from "@repo/backend/convex/contentRelease/models/schema";
+import { modelSlotValidator } from "@repo/backend/convex/contentRelease/models/slot";
 import { proofFailureValidator } from "@repo/backend/convex/contentRelease/proof/spec";
 import { searchFamilyValidator } from "@repo/backend/convex/contentRelease/search/spec";
 import snapshotSchema from "@repo/backend/convex/contentRelease/snapshot/schema";
@@ -122,8 +124,22 @@ const tables = {
     publicPath: v.string(),
     releaseId: v.string(),
     sequence: v.number(),
+    slot: v.optional(modelSlotValidator),
     text: v.string(),
   })
+    .index("by_slot_and_contentKey_and_appLocale", {
+      fields: ["slot", "contentKey", "appLocale"],
+      staged: true,
+    })
+    .index("by_slot_and_appLocale_and_family_and_publicPath", {
+      fields: ["slot", "appLocale", "family", "publicPath"],
+      staged: true,
+    })
+    .searchIndex("search_text_by_slot_and_family_and_appLocale", {
+      searchField: "text",
+      filterFields: ["slot", "family", "appLocale"],
+      staged: true,
+    })
     .index("by_contentKey_and_appLocale", ["contentKey", "appLocale"])
     .index("by_appLocale_and_family_and_publicPath", [
       "appLocale",
@@ -137,6 +153,7 @@ const tables = {
 
   ...articleSchema,
   ...materialSchema,
+  ...modelSchema,
 
   /** Immutable route versions resolved before access policy enforcement. */
   contentBindings: defineTable({
@@ -261,6 +278,7 @@ const tables = {
     articleManifestHash: v.optional(v.string()),
     articleReleaseId: v.optional(v.string()),
     articleSequence: v.optional(v.number()),
+    articleSlot: v.optional(modelSlotValidator),
     candidateManifestHash: v.optional(v.string()),
     candidateReleaseId: v.optional(v.string()),
     candidateSequence: v.optional(v.number()),
@@ -274,6 +292,7 @@ const tables = {
     materialManifestHash: v.optional(v.string()),
     materialReleaseId: v.optional(v.string()),
     materialSequence: v.optional(v.number()),
+    materialSlot: v.optional(modelSlotValidator),
     nextSequence: v.number(),
     recoveryManifestHash: v.optional(v.string()),
     recoveryReleaseId: v.optional(v.string()),
@@ -281,6 +300,7 @@ const tables = {
     searchManifestHash: v.optional(v.string()),
     searchReleaseId: v.optional(v.string()),
     searchSequence: v.optional(v.number()),
+    searchSlot: v.optional(modelSlotValidator),
     updatedAt: v.number(),
   }).index("by_key", ["key"]),
 };

--- a/packages/backend/scripts/content/runtime/tables.test.ts
+++ b/packages/backend/scripts/content/runtime/tables.test.ts
@@ -14,7 +14,7 @@ import { v } from "convex/values";
 import { Effect } from "effect";
 
 const EXPECTED_RUNTIME_SCHEMA_FINGERPRINT =
-  "0e3ef84c04266162e641297abc853400a1bc37d166f4f4c9b59515a3d7ed4568";
+  "91d4e4530403bcb873059f314d68330cd3b531827077b413de7839a73427650d";
 
 describe("content runtime tables", () => {
   it.live(

--- a/packages/backend/scripts/content/runtime/tables.test.ts
+++ b/packages/backend/scripts/content/runtime/tables.test.ts
@@ -14,7 +14,7 @@ import { v } from "convex/values";
 import { Effect } from "effect";
 
 const EXPECTED_RUNTIME_SCHEMA_FINGERPRINT =
-  "17f41a6f2e9ad7d7f1cbf846f41f6538c0314a2ff4648c7e95cbd60a41848e54";
+  "0e3ef84c04266162e641297abc853400a1bc37d166f4f4c9b59515a3d7ed4568";
 
 describe("content runtime tables", () => {
   it.live(

--- a/packages/backend/scripts/content/runtime/tables.test.ts
+++ b/packages/backend/scripts/content/runtime/tables.test.ts
@@ -14,7 +14,7 @@ import { v } from "convex/values";
 import { Effect } from "effect";
 
 const EXPECTED_RUNTIME_SCHEMA_FINGERPRINT =
-  "91d4e4530403bcb873059f314d68330cd3b531827077b413de7839a73427650d";
+  "e5780b60f87b96987ba71758af423a3ca3eea58fbfa991d666aa720cd6221cc6";
 
 describe("content runtime tables", () => {
   it.live(


### PR DESCRIPTION
## Summary

- add inactive blue and green slots to Article, Material, and Search read models
- add one bounded, resumable migration that backfills existing rows and initializes the active slots
- block publication after slot migration begins until the atomic switch implementation is deployed
- include slots in signed runtime identity and cache fingerprinting

## Release order

1. Merge through protected main.
2. Run the migration to completion against production.
3. Verify and accept the migration.
4. Merge the separate atomic switch PR.

## Local proof

- backend typecheck
- backend 340 files and 1,479 tests
- lint
- boundaries
- Effect source parity
- dependency security audit
- diff check

No Vercel Preview was created.