### PR TITLE
feat(www): show pricing for free accounts

### DIFF
--- a/apps/www/components/school/sidebar/user.tsx
+++ b/apps/www/components/school/sidebar/user.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { AccountPricing } from "@/components/sidebar/menu/pricing";
 import { NavUserGuest } from "@/components/sidebar/user/guest/panel";
 import { NavUserSkeleton } from "@/components/sidebar/user/skeleton";
 import { useUser } from "@/lib/context/use-user";
@@ -27,5 +28,10 @@ export function SchoolSidebarNavUser() {
   if (!user) {
     return <NavUserGuest />;
   }
-  return <SchoolSidebarAccount user={user} />;
+  return (
+    <>
+      <AccountPricing plan={user.appUser.plan} />
+      <SchoolSidebarAccount user={user} />
+    </>
+  );
 }

--- a/apps/www/components/sidebar/menu/pricing.tsx
+++ b/apps/www/components/sidebar/menu/pricing.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Diamond02Icon } from "@hugeicons/core-free-icons";
+import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
+import NavigationLink from "@repo/design-system/components/ui/navigation-link";
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@repo/design-system/components/ui/sidebar-menu";
+import { useTranslations } from "next-intl";
+import type { CurrentUser } from "@/lib/context/use-user";
+
+/** Links a sidebar footer to the localized pricing section. */
+export function PricingItem() {
+  const t = useTranslations("Auth");
+  const label = t("pricing-cta");
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        render={
+          <NavigationLink
+            href={{ pathname: "/", hash: "pricing" }}
+            title={label}
+          />
+        }
+      >
+        <HugeIcons icon={Diamond02Icon} />
+        <span>{label}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+/** Keeps the upgrade path visible for authenticated accounts without Pro. */
+export function AccountPricing({
+  plan,
+}: {
+  plan: CurrentUser["appUser"]["plan"];
+}) {
+  if (plan === "pro") {
+    return null;
+  }
+
+  return <PricingItem />;
+}

--- a/apps/www/components/sidebar/user/guest/panel.tsx
+++ b/apps/www/components/sidebar/user/guest/panel.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { Diamond02Icon } from "@hugeicons/core-free-icons";
-import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
-import NavigationLink from "@repo/design-system/components/ui/navigation-link";
-import {
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from "@repo/design-system/components/ui/sidebar-menu";
+import { SidebarMenuItem } from "@repo/design-system/components/ui/sidebar-menu";
 import { useTranslations } from "next-intl";
 import { AnalyticsConsentSidebarItem } from "@/components/analytics/consent/actions";
 import { GuestLanguageMenu } from "@/components/sidebar/menu/preference";
+import { PricingItem } from "@/components/sidebar/menu/pricing";
 import { NavUserGuestButton } from "@/components/sidebar/user/guest/button";
 
 /** Renders guest utilities and the signed-out account call to action. */
@@ -18,19 +13,7 @@ export function NavUserGuest() {
 
   return (
     <>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          render={
-            <NavigationLink
-              href={{ pathname: "/", hash: "pricing" }}
-              title={t("pricing-cta")}
-            />
-          }
-        >
-          <HugeIcons icon={Diamond02Icon} />
-          <span>{t("pricing-cta")}</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
+      <PricingItem />
       <GuestLanguageMenu />
       <AnalyticsConsentSidebarItem />
       <SidebarMenuItem

--- a/apps/www/components/sidebar/user/nav.tsx
+++ b/apps/www/components/sidebar/user/nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { AccountPricing } from "@/components/sidebar/menu/pricing";
 import { NavUserGuest } from "@/components/sidebar/user/guest/panel";
 import { NavUserSkeleton } from "@/components/sidebar/user/skeleton";
 import { useUser } from "@/lib/context/use-user";
@@ -27,5 +28,10 @@ export function NavUser() {
   if (!user) {
     return <NavUserGuest />;
   }
-  return <NavUserAccount user={user} />;
+  return (
+    <>
+      <AccountPricing plan={user.appUser.plan} />
+      <NavUserAccount user={user} />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

- reuse one localized pricing item across guest and authenticated sidebar footers
- show the pricing action for Free accounts in the regular and school sidebars
- keep Pro account footers unchanged

## Verification

- `pnpm format`
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` with 100/100
- `pnpm --filter www test` with 211 files, 1,502 tests, and 100% coverage
- `pnpm boundaries`
- guest sidebar Browser checks passed on desktop and compact viewports
- `codex review --commit HEAD` found no actionable defects

The local monorepo build compiled WWW and completed TypeScript, then stopped at page-data collection because the ignored Aksara publication token is unavailable in the isolated worktree. Exact-head protected CI remains the production build gate. No Vercel Preview was created.