### PR TITLE
Stabilize localized pricing

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(site)/pricing/page.tsx
@@ -6,10 +6,8 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { PricingPageFaq } from "@/components/marketing/about/faq/pricing";
 import type { MarketingFaqItem } from "@/components/marketing/about/faq/section";
-import {
-  type PriceProps,
-  PricingCards,
-} from "@/components/marketing/about/pricing/plans";
+import { PricingCards } from "@/components/marketing/about/pricing/plans";
+import type { PriceProps } from "@/components/marketing/about/pricing/price";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getAppSocialArtwork } from "@/lib/og/app-artwork";
 import { createLocalizedAlternates } from "@/lib/seo/alternates";

--- a/apps/www/checks/afdocs.test.ts
+++ b/apps/www/checks/afdocs.test.ts
@@ -8,6 +8,28 @@ import { runAfdocs } from "@/checks/afdocs";
 const TIMEOUT_MS = 600_000;
 const ALLOWED_SKIPS = new Set(["auth-alternative-access"]);
 
+/** Keeps a failed CI check actionable without dumping every passing page. */
+function formatFailureDetails(details: Record<string, unknown> | undefined) {
+  if (!details) {
+    return "";
+  }
+
+  const { pageResults, ...summary } = details;
+  if (!Array.isArray(pageResults)) {
+    return `\n${JSON.stringify(details, null, 2)}`;
+  }
+
+  const failures = pageResults.filter(
+    (page) =>
+      typeof page === "object" &&
+      page !== null &&
+      "status" in page &&
+      page.status !== "pass"
+  );
+
+  return `\n${JSON.stringify({ ...summary, pageResults: failures }, null, 2)}`;
+}
+
 describe("AFDocs", () => {
   let results: readonly {
     readonly check: { readonly id: string };
@@ -29,7 +51,9 @@ describe("AFDocs", () => {
       if (result.status === "skip" && ALLOWED_SKIPS.has(result.id)) {
         continue;
       }
-      expect.fail(`[${result.status}] ${result.message}`);
+      expect.fail(
+        `[${result.status}] ${result.message}${formatFailureDetails(result.details)}`
+      );
     }
   });
 });

--- a/apps/www/components/marketing/about/pricing/landing.tsx
+++ b/apps/www/components/marketing/about/pricing/landing.tsx
@@ -1,10 +1,8 @@
 import { NumberFormat } from "@repo/design-system/components/ui/number-flow";
 import { useTranslations } from "next-intl";
 import { PricingDithering } from "@/components/marketing/about/pricing/dithering.client";
-import {
-  type PriceProps,
-  PricingCards,
-} from "@/components/marketing/about/pricing/plans";
+import { PricingCards } from "@/components/marketing/about/pricing/plans";
+import type { PriceProps } from "@/components/marketing/about/pricing/price";
 
 /** Animates prices only on the landing surface that owns this treatment. */
 function AnimatedPrice({ price }: PriceProps) {

--- a/apps/www/components/marketing/about/pricing/plans.tsx
+++ b/apps/www/components/marketing/about/pricing/plans.tsx
@@ -6,32 +6,22 @@ import {
 import { Button } from "@repo/design-system/components/ui/button";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
-import { headers } from "next/headers";
 import { useTranslations } from "next-intl";
 import type { ComponentProps, ComponentType } from "react";
-import { Suspense, use } from "react";
 import { PricingButton } from "@/components/marketing/about/pricing/button.client";
 import {
-  getProPricingDisplay,
-  pricingCountryHeaderName,
-} from "@/components/marketing/about/pricing/display";
+  type PriceProps,
+  PricingPrice,
+} from "@/components/marketing/about/pricing/price";
 
 interface PricingFeatureProps {
   icon?: ComponentProps<typeof HugeIcons>["icon"];
   text: string;
 }
 
-type PricingDisplay = ReturnType<typeof getProPricingDisplay>;
-type Price = PricingDisplay["pro"];
-
-export interface PriceProps {
-  price: Price;
-}
-
 interface PricingPlanCardsProps {
   headingLevel: "h2" | "h3";
   Price: ComponentType<PriceProps>;
-  pricingDisplay: PricingDisplay;
 }
 
 /** Renders one pricing card feature row with a stable icon slot. */
@@ -44,12 +34,8 @@ function PricingFeature({ text, icon }: PricingFeatureProps) {
   );
 }
 
-/** Renders the pricing plan cards with an already resolved price display. */
-function PricingPlanCards({
-  Price,
-  headingLevel,
-  pricingDisplay,
-}: PricingPlanCardsProps) {
+/** Renders stable plan cards around request-localized price slots. */
+export function PricingCards({ Price, headingLevel }: PricingPlanCardsProps) {
   const t = useTranslations("Pricing");
   const PlanHeading = headingLevel;
   const freeFeatures = [
@@ -69,7 +55,10 @@ function PricingPlanCards({
 
   return (
     <div className="grid lg:grid-cols-2 lg:divide-x">
-      <div className="flex flex-col gap-6 px-6 py-12 lg:px-10">
+      <div
+        className="flex flex-col gap-6 px-6 py-12 lg:px-10"
+        data-pricing-plan="free"
+      >
         <div className="grid gap-2">
           <PlanHeading className="text-balance font-semibold text-3xl">
             {t("free-title")}
@@ -78,7 +67,7 @@ function PricingPlanCards({
             {t("free-description")}
           </p>
           <div className="pt-2">
-            <Price price={pricingDisplay.free} />
+            <PricingPrice Price={Price} plan="free" />
           </div>
         </div>
 
@@ -107,7 +96,10 @@ function PricingPlanCards({
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 px-6 py-12 lg:px-10">
+      <div
+        className="flex flex-col gap-6 px-6 py-12 lg:px-10"
+        data-pricing-plan="pro"
+      >
         <div className="grid gap-2">
           <PlanHeading className="text-balance font-semibold text-3xl">
             {t("pro-title")}
@@ -115,11 +107,8 @@ function PricingPlanCards({
           <p className="text-pretty text-muted-foreground">
             {t("pro-description")}
           </p>
-          <div className="flex items-baseline gap-1 pt-2">
-            <Price price={pricingDisplay.pro} />
-            <span className="ml-1 text-muted-foreground">
-              {t("pro-period")}
-            </span>
+          <div className="h-12 pt-2">
+            <PricingPrice Price={Price} period={t("pro-period")} plan="pro" />
           </div>
         </div>
 
@@ -137,41 +126,5 @@ function PricingPlanCards({
         </div>
       </div>
     </div>
-  );
-}
-
-/**
- * Renders request-priced cards inside Suspense so Cache Components can keep the
- * surrounding pricing shell prerenderable.
- *
- * Docs: https://nextjs.org/docs/app/getting-started/caching#dynamic-rendering
- */
-function RequestPricedCards({
-  Price,
-  headingLevel,
-}: Pick<PricingPlanCardsProps, "Price" | "headingLevel">) {
-  const requestHeaders = use(headers());
-  const pricingDisplay = getProPricingDisplay(
-    requestHeaders.get(pricingCountryHeaderName)
-  );
-
-  return (
-    <PricingPlanCards
-      headingLevel={headingLevel}
-      Price={Price}
-      pricingDisplay={pricingDisplay}
-    />
-  );
-}
-
-/** Streams request-priced cards without showing a false default price. */
-export function PricingCards({
-  Price,
-  headingLevel,
-}: Pick<PricingPlanCardsProps, "Price" | "headingLevel">) {
-  return (
-    <Suspense fallback={null}>
-      <RequestPricedCards headingLevel={headingLevel} Price={Price} />
-    </Suspense>
   );
 }

--- a/apps/www/components/marketing/about/pricing/plans.tsx
+++ b/apps/www/components/marketing/about/pricing/plans.tsx
@@ -107,7 +107,7 @@ export function PricingCards({ Price, headingLevel }: PricingPlanCardsProps) {
           <p className="text-pretty text-muted-foreground">
             {t("pro-description")}
           </p>
-          <div className="h-12 pt-2">
+          <div className="pt-2">
             <PricingPrice Price={Price} period={t("pro-period")} plan="pro" />
           </div>
         </div>

--- a/apps/www/components/marketing/about/pricing/price.tsx
+++ b/apps/www/components/marketing/about/pricing/price.tsx
@@ -50,13 +50,13 @@ function PriceFallback() {
 /** Keeps plan geometry stable while the request-localized amount streams. */
 export function PricingPrice({ period, Price, plan }: PricingPriceProps) {
   return (
-    <span
-      className="inline-flex h-10 min-w-28 items-baseline"
+    <div
+      className="flex h-10 w-fit min-w-28 items-baseline"
       data-pricing-price-slot={plan}
     >
       <Suspense fallback={<PriceFallback />}>
         <ResolvedPrice Price={Price} period={period} plan={plan} />
       </Suspense>
-    </span>
+    </div>
   );
 }

--- a/apps/www/components/marketing/about/pricing/price.tsx
+++ b/apps/www/components/marketing/about/pricing/price.tsx
@@ -37,13 +37,13 @@ function ResolvedPrice({ period, Price, plan }: PricingPriceProps) {
 
 function PriceFallback() {
   return (
-    <span className="flex h-10 items-center">
+    <div className="flex h-10 items-center">
       <Skeleton
         aria-hidden="true"
         className="h-10 w-28"
         data-pricing-price-fallback
       />
-    </span>
+    </div>
   );
 }
 

--- a/apps/www/components/marketing/about/pricing/price.tsx
+++ b/apps/www/components/marketing/about/pricing/price.tsx
@@ -1,0 +1,62 @@
+import { Skeleton } from "@repo/design-system/components/ui/skeleton";
+import { headers } from "next/headers";
+import type { ComponentType } from "react";
+import { Suspense, use } from "react";
+import {
+  getProPricingDisplay,
+  pricingCountryHeaderName,
+} from "@/components/marketing/about/pricing/display";
+
+type PricingDisplay = ReturnType<typeof getProPricingDisplay>;
+type PricingPlan = keyof PricingDisplay;
+
+export interface PriceProps {
+  price: PricingDisplay[PricingPlan];
+}
+
+interface PricingPriceProps {
+  Price: ComponentType<PriceProps>;
+  period?: string;
+  plan: PricingPlan;
+}
+
+/** Resolves only the request-localized amount inside its price slot. */
+function ResolvedPrice({ period, Price, plan }: PricingPriceProps) {
+  const requestHeaders = use(headers());
+  const pricingDisplay = getProPricingDisplay(
+    requestHeaders.get(pricingCountryHeaderName)
+  );
+
+  return (
+    <span className="flex h-10 items-baseline gap-2 whitespace-nowrap">
+      <Price price={pricingDisplay[plan]} />
+      {period ? <span className="text-muted-foreground">{period}</span> : null}
+    </span>
+  );
+}
+
+function PriceFallback() {
+  return (
+    <span className="flex h-10 items-center">
+      <Skeleton
+        aria-hidden="true"
+        className="h-10 w-28"
+        data-pricing-price-fallback
+      />
+    </span>
+  );
+}
+
+/** Keeps plan geometry stable while the request-localized amount streams. */
+export function PricingPrice({ period, Price, plan }: PricingPriceProps) {
+  return (
+    <span
+      className="inline-flex h-10 min-w-28 items-baseline"
+      data-pricing-price-slot={plan}
+    >
+      <Suspense fallback={<PriceFallback />}>
+        <ResolvedPrice Price={Price} period={period} plan={plan} />
+      </Suspense>
+    </span>
+  );
+}

--- a/apps/www/components/sidebar/menu/pricing.tsx
+++ b/apps/www/components/sidebar/menu/pricing.tsx
@@ -6,6 +6,7 @@ import NavigationLink from "@repo/design-system/components/ui/navigation-link";
 import {
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSeparator,
 } from "@repo/design-system/components/ui/sidebar-menu";
 import { useTranslations } from "next-intl";
 import type { CurrentUser } from "@/lib/context/use-user";
@@ -27,7 +28,7 @@ export function PricingItem() {
   );
 }
 
-/** Keeps the upgrade path visible for authenticated accounts without Pro. */
+/** Keeps pricing and account controls as distinct footer sections for Free users. */
 export function AccountPricing({
   plan,
 }: {
@@ -37,5 +38,10 @@ export function AccountPricing({
     return null;
   }
 
-  return <PricingItem />;
+  return (
+    <>
+      <PricingItem />
+      <SidebarMenuSeparator />
+    </>
+  );
 }

--- a/apps/www/components/sidebar/user/guest/panel.tsx
+++ b/apps/www/components/sidebar/user/guest/panel.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { SidebarMenuItem } from "@repo/design-system/components/ui/sidebar-menu";
+import {
+  SidebarMenuItem,
+  SidebarMenuSeparator,
+} from "@repo/design-system/components/ui/sidebar-menu";
 import { useTranslations } from "next-intl";
 import { AnalyticsConsentSidebarItem } from "@/components/analytics/consent/actions";
 import { GuestLanguageMenu } from "@/components/sidebar/menu/preference";
@@ -16,10 +19,7 @@ export function NavUserGuest() {
       <PricingItem />
       <GuestLanguageMenu />
       <AnalyticsConsentSidebarItem />
-      <SidebarMenuItem
-        className="-mx-2 my-1 border-sidebar-border border-t"
-        role="separator"
-      />
+      <SidebarMenuSeparator />
       <SidebarMenuItem className="flex flex-col gap-3 px-2 py-1">
         <div className="grid gap-1">
           <p className="font-medium text-sm">{t("login-cta-title")}</p>

--- a/apps/www/e2e/guest-sidebar.browser.ts
+++ b/apps/www/e2e/guest-sidebar.browser.ts
@@ -50,6 +50,15 @@ for (const viewport of targetViewports) {
           }
 
           yield* Effect.promise(() => expect(footer).toBeVisible());
+          const sectionSeparator = footer.locator(
+            '[data-slot="sidebar-menu-separator"]'
+          );
+          yield* Effect.promise(() => expect(sectionSeparator).toHaveCount(1));
+          yield* Effect.promise(() =>
+            expect(
+              sectionSeparator.locator('[data-slot="separator"]')
+            ).toBeVisible()
+          );
           yield* Effect.promise(() =>
             expect(
               footer.getByText("Continue learning", { exact: true })

--- a/apps/www/e2e/marketing.browser.ts
+++ b/apps/www/e2e/marketing.browser.ts
@@ -410,7 +410,7 @@ const verifyPricingPage = Effect.fn("NakafaE2E.verifyPricingPage")(function* (
 
 const verifyPricingNavigation = Effect.fn("NakafaE2E.verifyPricingNavigation")(
   function* (page: Page) {
-    yield* Effect.promise(() => expectStablePricingAppShell(page));
+    yield* expectStablePricingAppShell(page);
     yield* loadMarketingPage(page, "/id");
 
     const pricingLink = page.locator('header nav [href="/id/pricing"]');
@@ -428,8 +428,9 @@ const verifyPricingNavigation = Effect.fn("NakafaE2E.verifyPricingNavigation")(
       expect(page.locator("[data-pricing-price-fallback]")).toHaveCount(0)
     );
 
-    const observation = yield* Effect.promise(() =>
-      observeStablePricingReload(page, READINESS_TIMEOUT_MILLISECONDS)
+    const observation = yield* observeStablePricingReload(
+      page,
+      READINESS_TIMEOUT_MILLISECONDS
     );
     yield* Effect.sync(() => expectStablePricingTransition(observation));
   }

--- a/apps/www/e2e/marketing.browser.ts
+++ b/apps/www/e2e/marketing.browser.ts
@@ -10,6 +10,11 @@ import {
   verifyDesktopSplitter,
 } from "@/e2e/support/marketing";
 import { waitForCommittedAppRouter } from "@/e2e/support/navigation/readiness";
+import {
+  expectStablePricingAppShell,
+  expectStablePricingTransition,
+  observeStablePricingReload,
+} from "@/e2e/support/pricing";
 import { contributors } from "@/lib/data/contributor";
 
 /**
@@ -22,6 +27,7 @@ const COMMUNITY_MAX_CHROME_DESCENDANTS = 235;
 const COMMUNITY_MAX_DESCENDANTS = 800;
 const COMMUNITY_MAX_HTML_BYTES = 223_000;
 const HOMEPAGE_MAX_DESCENDANTS = 2800;
+const PRICING_PATH_PATTERN = /\/id\/pricing$/;
 const READINESS_TIMEOUT_MILLISECONDS = 15_000;
 const TRUST_MAX_DESCENDANTS = 330;
 const TRUST_RESIZE_LABEL = "Resize the human and agent views";
@@ -338,6 +344,15 @@ const verifyPricingPage = Effect.fn("NakafaE2E.verifyPricingPage")(function* (
   yield* Effect.promise(() =>
     expect(page.getByRole("button", { name: "Get Pro" })).toBeEnabled()
   );
+  yield* Effect.promise(() =>
+    expect(page.locator("[data-pricing-plan]")).toHaveCount(2)
+  );
+  yield* Effect.promise(() =>
+    expect(page.locator("[data-pricing-price-slot]")).toHaveCount(2)
+  );
+  yield* Effect.promise(() =>
+    expect(page.locator("[data-pricing-price-fallback]")).toHaveCount(0)
+  );
 
   const pricingQuestions = page.locator('#faq [data-slot="accordion-trigger"]');
   yield* Effect.promise(() => expect(pricingQuestions).toHaveCount(20));
@@ -393,6 +408,33 @@ const verifyPricingPage = Effect.fn("NakafaE2E.verifyPricingPage")(function* (
   );
 });
 
+const verifyPricingNavigation = Effect.fn("NakafaE2E.verifyPricingNavigation")(
+  function* (page: Page) {
+    yield* Effect.promise(() => expectStablePricingAppShell(page));
+    yield* loadMarketingPage(page, "/id");
+
+    const pricingLink = page.locator('header nav [href="/id/pricing"]');
+    yield* Effect.promise(() => expect(pricingLink).toHaveText("Harga"));
+    yield* Effect.promise(() => pricingLink.click());
+    yield* Effect.promise(() =>
+      expect(page).toHaveURL(PRICING_PATH_PATTERN, {
+        timeout: READINESS_TIMEOUT_MILLISECONDS,
+      })
+    );
+    yield* Effect.promise(() =>
+      expect(page.locator("[data-pricing-plan]:visible")).toHaveCount(2)
+    );
+    yield* Effect.promise(() =>
+      expect(page.locator("[data-pricing-price-fallback]")).toHaveCount(0)
+    );
+
+    const observation = yield* Effect.promise(() =>
+      observeStablePricingReload(page, READINESS_TIMEOUT_MILLISECONDS)
+    );
+    yield* Effect.sync(() => expectStablePricingTransition(observation));
+  }
+);
+
 for (const viewport of targetViewports) {
   test.describe(`marketing surfaces at ${viewport.name}`, () => {
     test.use({
@@ -438,6 +480,14 @@ test.describe("dedicated pricing page", () => {
   }) => {
     await Effect.runPromise(
       withObservedPageErrors(page, verifyPricingPage(page))
+    );
+  });
+
+  test("navigates from the header with a stable pricing shell", async ({
+    page,
+  }) => {
+    await Effect.runPromise(
+      withObservedPageErrors(page, verifyPricingNavigation(page))
     );
   });
 });

--- a/apps/www/e2e/support/pricing.ts
+++ b/apps/www/e2e/support/pricing.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { Effect } from "effect";
 
 interface PricingRect {
   height: number;
@@ -15,6 +16,7 @@ interface PricingGeometry {
 interface PricingTransitionObservation {
   after: PricingGeometry | null;
   before: PricingGeometry | null;
+  fallbackObserved: boolean;
   layoutShift: number;
 }
 
@@ -29,98 +31,122 @@ function countOccurrences(value: string, pattern: string) {
 }
 
 /** Proves the streamed HTML keeps both plans around price-only fallbacks. */
-export async function expectStablePricingAppShell(page: Page) {
-  const response = await page.request.get("/id/pricing", {
-    headers: { Accept: "text/html" },
-  });
-  expect(response.ok()).toBe(true);
+export const expectStablePricingAppShell = Effect.fn(
+  "NakafaE2E.expectStablePricingAppShell"
+)(function* (page: Page) {
+  const response = yield* Effect.promise(() =>
+    page.request.get("/id/pricing", {
+      headers: { Accept: "text/html" },
+    })
+  );
+  const html = yield* Effect.promise(() => response.text());
 
-  const html = await response.text();
-  expect(countOccurrences(html, "data-pricing-plan=")).toBe(2);
-  expect(countOccurrences(html, "data-pricing-price-slot=")).toBe(2);
-  expect(countOccurrences(html, 'data-pricing-price-fallback="true"')).toBe(2);
-}
+  yield* Effect.sync(() => {
+    expect(response.ok()).toBe(true);
+    expect(countOccurrences(html, "data-pricing-plan=")).toBe(2);
+    expect(countOccurrences(html, "data-pricing-price-slot=")).toBe(2);
+    expect(countOccurrences(html, 'data-pricing-price-fallback="true"')).toBe(
+      2
+    );
+  });
+});
 
 /** Installs an observer before a cold document load begins parsing. */
-function installPricingTransitionObserver(page: Page) {
-  return page.addInitScript(() => {
-    const observation: PricingTransitionObservation = {
-      after: null,
-      before: null,
-      layoutShift: 0,
-    };
-    window.__nakafaPricingTransition = observation;
-
-    const readRect = (element: Element): PricingRect => {
-      const rect = element.getBoundingClientRect();
-      return {
-        height: rect.height,
-        width: rect.width,
-        x: rect.x,
-        y: rect.y,
+const installPricingTransitionObserver = Effect.fn(
+  "NakafaE2E.installPricingTransitionObserver"
+)(function* (page: Page) {
+  yield* Effect.promise(() =>
+    page.addInitScript(() => {
+      const observation: PricingTransitionObservation = {
+        after: null,
+        before: null,
+        fallbackObserved: false,
+        layoutShift: 0,
       };
-    };
-    const readGeometry = (): PricingGeometry => ({
-      plans: Object.fromEntries(
-        [...document.querySelectorAll("[data-pricing-plan]")].map((element) => [
-          element.getAttribute("data-pricing-plan") ?? "",
-          readRect(element),
-        ])
-      ),
-      slots: Object.fromEntries(
-        [...document.querySelectorAll("[data-pricing-price-slot]")].map(
-          (element) => [
-            element.getAttribute("data-pricing-price-slot") ?? "",
-            readRect(element),
-          ]
-        )
-      ),
-    });
-    const addLayoutShifts = (entries: PerformanceEntry[]) => {
-      for (const entry of entries) {
-        if ("value" in entry && typeof entry.value === "number") {
-          observation.layoutShift += entry.value;
-        }
-      }
-    };
-    const layoutShiftObserver = new PerformanceObserver((list) =>
-      addLayoutShifts(list.getEntries())
-    );
-    let baselineScheduled = false;
-    let finishing = false;
+      window.__nakafaPricingTransition = observation;
 
-    const finish = () => {
-      if (finishing) {
-        return;
-      }
-      finishing = true;
-
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => {
-          const fallbackCount = document.querySelectorAll(
-            "[data-pricing-price-fallback]"
-          ).length;
-          if (fallbackCount > 0) {
-            finishing = false;
-            return;
+      const readRect = (element: Element): PricingRect => {
+        const rect = element.getBoundingClientRect();
+        return {
+          height: rect.height,
+          width: rect.width,
+          x: rect.x,
+          y: rect.y,
+        };
+      };
+      const readGeometry = (): PricingGeometry => ({
+        plans: Object.fromEntries(
+          [...document.querySelectorAll("[data-pricing-plan]")].map(
+            (element) => [
+              element.getAttribute("data-pricing-plan") ?? "",
+              readRect(element),
+            ]
+          )
+        ),
+        slots: Object.fromEntries(
+          [...document.querySelectorAll("[data-pricing-price-slot]")].map(
+            (element) => [
+              element.getAttribute("data-pricing-price-slot") ?? "",
+              readRect(element),
+            ]
+          )
+        ),
+      });
+      const addLayoutShifts = (entries: PerformanceEntry[]) => {
+        for (const entry of entries) {
+          if ("value" in entry && typeof entry.value === "number") {
+            observation.layoutShift += entry.value;
           }
-
-          addLayoutShifts(layoutShiftObserver.takeRecords());
-          layoutShiftObserver.disconnect();
-          mutationObserver.disconnect();
-          observation.after = readGeometry();
-        })
+        }
+      };
+      const layoutShiftObserver = new PerformanceObserver((list) =>
+        addLayoutShifts(list.getEntries())
       );
-    };
+      layoutShiftObserver.observe({ buffered: true, type: "layout-shift" });
+      let finishing = false;
 
-    const scheduleBaseline = () => {
-      if (baselineScheduled || observation.before) {
-        return;
-      }
-      baselineScheduled = true;
+      const finish = () => {
+        if (finishing) {
+          return;
+        }
+        finishing = true;
 
-      requestAnimationFrame(() => {
-        baselineScheduled = false;
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            const fallbackCount = document.querySelectorAll(
+              "[data-pricing-price-fallback]"
+            ).length;
+            if (fallbackCount > 0) {
+              finishing = false;
+              return;
+            }
+
+            addLayoutShifts(layoutShiftObserver.takeRecords());
+            layoutShiftObserver.disconnect();
+            mutationObserver.disconnect();
+            observation.after = readGeometry();
+          })
+        );
+      };
+
+      const recordFallbackBaseline = () => {
+        if (observation.before) {
+          return;
+        }
+
+        const fallbacks = [
+          ...document.querySelectorAll("[data-pricing-price-fallback]"),
+        ];
+        if (fallbacks.length !== 2) {
+          return;
+        }
+        const fallbackRects = fallbacks.map(readRect);
+        if (
+          fallbackRects.some((rect) => rect.height === 0 || rect.width === 0)
+        ) {
+          return;
+        }
+
         const geometry = readGeometry();
         const renderedPlans = Object.values(geometry.plans);
 
@@ -128,59 +154,56 @@ function installPricingTransitionObserver(page: Page) {
           renderedPlans.length !== 2 ||
           renderedPlans.some((rect) => rect.height === 0 || rect.width === 0)
         ) {
-          scheduleBaseline();
           return;
         }
 
         observation.before = geometry;
-        layoutShiftObserver.observe({ type: "layout-shift" });
+        observation.fallbackObserved = true;
+      };
 
-        if (
-          document.querySelectorAll("[data-pricing-price-fallback]").length ===
-          0
-        ) {
+      const mutationObserver = new MutationObserver(() => {
+        const fallbackCount = document.querySelectorAll(
+          "[data-pricing-price-fallback]"
+        ).length;
+        const planCount = document.querySelectorAll(
+          "[data-pricing-plan]"
+        ).length;
+
+        if (planCount === 2 && fallbackCount === 2) {
+          recordFallbackBaseline();
+        }
+        if (planCount === 2 && fallbackCount === 0) {
           finish();
         }
       });
-    };
 
-    const mutationObserver = new MutationObserver(() => {
-      const fallbackCount = document.querySelectorAll(
-        "[data-pricing-price-fallback]"
-      ).length;
-      const planCount = document.querySelectorAll("[data-pricing-plan]").length;
-
-      if (!observation.before && planCount === 2) {
-        scheduleBaseline();
-      }
-      if (observation.before && fallbackCount === 0) {
-        finish();
-      }
-    });
-
-    mutationObserver.observe(document, { childList: true, subtree: true });
-  });
-}
+      mutationObserver.observe(document, { childList: true, subtree: true });
+    })
+  );
+});
 
 /** Reloads pricing from its document shell and reads its settled geometry. */
-export async function observeStablePricingReload(
-  page: Page,
-  readinessTimeoutMilliseconds: number
-) {
-  await installPricingTransitionObserver(page);
-  const response = await page.reload({ waitUntil: "domcontentloaded" });
-  expect(response?.ok()).toBe(true);
-  await page.waitForFunction(
-    () => Boolean(window.__nakafaPricingTransition?.after),
-    undefined,
-    { timeout: readinessTimeoutMilliseconds }
+export const observeStablePricingReload = Effect.fn(
+  "NakafaE2E.observeStablePricingReload"
+)(function* (page: Page, readinessTimeoutMilliseconds: number) {
+  yield* installPricingTransitionObserver(page);
+  const response = yield* Effect.promise(() =>
+    page.reload({ waitUntil: "domcontentloaded" })
   );
-  const observation = await page.evaluate(
-    () => window.__nakafaPricingTransition
+  yield* Effect.sync(() => expect(response?.ok()).toBe(true));
+  yield* Effect.promise(() =>
+    page.waitForFunction(
+      () => Boolean(window.__nakafaPricingTransition?.after),
+      undefined,
+      { timeout: readinessTimeoutMilliseconds }
+    )
   );
-  expect(observation).toBeDefined();
+  const observation = yield* Effect.promise(() =>
+    page.evaluate(() => window.__nakafaPricingTransition)
+  );
+  yield* Effect.sync(() => expect(observation).toBeDefined());
   return observation;
-}
+});
 
 /** Asserts that localized price resolution preserved all plan geometry. */
 export function expectStablePricingTransition(
@@ -191,11 +214,12 @@ export function expectStablePricingTransition(
     return;
   }
 
-  expect(observation.before).not.toBeNull();
   expect(observation.after).not.toBeNull();
+  expect(observation.before).not.toBeNull();
+  expect(observation.fallbackObserved).toBe(true);
   expect(observation.layoutShift).toBe(0);
 
-  if (!(observation.before && observation.after)) {
+  if (!(observation.after && observation.before)) {
     return;
   }
 

--- a/apps/www/e2e/support/pricing.ts
+++ b/apps/www/e2e/support/pricing.ts
@@ -16,7 +16,6 @@ interface PricingGeometry {
 interface PricingTransitionObservation {
   after: PricingGeometry | null;
   before: PricingGeometry | null;
-  fallbackObserved: boolean;
   layoutShift: number;
 }
 
@@ -60,7 +59,6 @@ const installPricingTransitionObserver = Effect.fn(
       const observation: PricingTransitionObservation = {
         after: null,
         before: null,
-        fallbackObserved: false,
         layoutShift: 0,
       };
       window.__nakafaPricingTransition = observation;
@@ -158,7 +156,6 @@ const installPricingTransitionObserver = Effect.fn(
         }
 
         observation.before = geometry;
-        observation.fallbackObserved = true;
       };
 
       const mutationObserver = new MutationObserver(() => {
@@ -216,7 +213,6 @@ export function expectStablePricingTransition(
 
   expect(observation.after).not.toBeNull();
   expect(observation.before).not.toBeNull();
-  expect(observation.fallbackObserved).toBe(true);
   expect(observation.layoutShift).toBe(0);
 
   if (!(observation.after && observation.before)) {

--- a/apps/www/e2e/support/pricing.ts
+++ b/apps/www/e2e/support/pricing.ts
@@ -1,0 +1,213 @@
+import { expect, type Page } from "@playwright/test";
+
+interface PricingRect {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+interface PricingGeometry {
+  plans: Record<string, PricingRect>;
+  slots: Record<string, PricingRect>;
+}
+
+interface PricingTransitionObservation {
+  after: PricingGeometry | null;
+  before: PricingGeometry | null;
+  layoutShift: number;
+}
+
+declare global {
+  interface Window {
+    __nakafaPricingTransition?: PricingTransitionObservation;
+  }
+}
+
+function countOccurrences(value: string, pattern: string) {
+  return value.split(pattern).length - 1;
+}
+
+/** Proves the streamed HTML keeps both plans around price-only fallbacks. */
+export async function expectStablePricingAppShell(page: Page) {
+  const response = await page.request.get("/id/pricing", {
+    headers: { Accept: "text/html" },
+  });
+  expect(response.ok()).toBe(true);
+
+  const html = await response.text();
+  expect(countOccurrences(html, "data-pricing-plan=")).toBe(2);
+  expect(countOccurrences(html, "data-pricing-price-slot=")).toBe(2);
+  expect(countOccurrences(html, 'data-pricing-price-fallback="true"')).toBe(2);
+}
+
+/** Installs an observer before a cold document load begins parsing. */
+function installPricingTransitionObserver(page: Page) {
+  return page.addInitScript(() => {
+    const observation: PricingTransitionObservation = {
+      after: null,
+      before: null,
+      layoutShift: 0,
+    };
+    window.__nakafaPricingTransition = observation;
+
+    const readRect = (element: Element): PricingRect => {
+      const rect = element.getBoundingClientRect();
+      return {
+        height: rect.height,
+        width: rect.width,
+        x: rect.x,
+        y: rect.y,
+      };
+    };
+    const readGeometry = (): PricingGeometry => ({
+      plans: Object.fromEntries(
+        [...document.querySelectorAll("[data-pricing-plan]")].map((element) => [
+          element.getAttribute("data-pricing-plan") ?? "",
+          readRect(element),
+        ])
+      ),
+      slots: Object.fromEntries(
+        [...document.querySelectorAll("[data-pricing-price-slot]")].map(
+          (element) => [
+            element.getAttribute("data-pricing-price-slot") ?? "",
+            readRect(element),
+          ]
+        )
+      ),
+    });
+    const addLayoutShifts = (entries: PerformanceEntry[]) => {
+      for (const entry of entries) {
+        if ("value" in entry && typeof entry.value === "number") {
+          observation.layoutShift += entry.value;
+        }
+      }
+    };
+    const layoutShiftObserver = new PerformanceObserver((list) =>
+      addLayoutShifts(list.getEntries())
+    );
+    let baselineScheduled = false;
+    let finishing = false;
+
+    const finish = () => {
+      if (finishing) {
+        return;
+      }
+      finishing = true;
+
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          const fallbackCount = document.querySelectorAll(
+            "[data-pricing-price-fallback]"
+          ).length;
+          if (fallbackCount > 0) {
+            finishing = false;
+            return;
+          }
+
+          addLayoutShifts(layoutShiftObserver.takeRecords());
+          layoutShiftObserver.disconnect();
+          mutationObserver.disconnect();
+          observation.after = readGeometry();
+        })
+      );
+    };
+
+    const scheduleBaseline = () => {
+      if (baselineScheduled || observation.before) {
+        return;
+      }
+      baselineScheduled = true;
+
+      requestAnimationFrame(() => {
+        baselineScheduled = false;
+        const geometry = readGeometry();
+        const renderedPlans = Object.values(geometry.plans);
+
+        if (
+          renderedPlans.length !== 2 ||
+          renderedPlans.some((rect) => rect.height === 0 || rect.width === 0)
+        ) {
+          scheduleBaseline();
+          return;
+        }
+
+        observation.before = geometry;
+        layoutShiftObserver.observe({ type: "layout-shift" });
+
+        if (
+          document.querySelectorAll("[data-pricing-price-fallback]").length ===
+          0
+        ) {
+          finish();
+        }
+      });
+    };
+
+    const mutationObserver = new MutationObserver(() => {
+      const fallbackCount = document.querySelectorAll(
+        "[data-pricing-price-fallback]"
+      ).length;
+      const planCount = document.querySelectorAll("[data-pricing-plan]").length;
+
+      if (!observation.before && planCount === 2) {
+        scheduleBaseline();
+      }
+      if (observation.before && fallbackCount === 0) {
+        finish();
+      }
+    });
+
+    mutationObserver.observe(document, { childList: true, subtree: true });
+  });
+}
+
+/** Reloads pricing from its document shell and reads its settled geometry. */
+export async function observeStablePricingReload(
+  page: Page,
+  readinessTimeoutMilliseconds: number
+) {
+  await installPricingTransitionObserver(page);
+  const response = await page.reload({ waitUntil: "domcontentloaded" });
+  expect(response?.ok()).toBe(true);
+  await page.waitForFunction(
+    () => Boolean(window.__nakafaPricingTransition?.after),
+    undefined,
+    { timeout: readinessTimeoutMilliseconds }
+  );
+  const observation = await page.evaluate(
+    () => window.__nakafaPricingTransition
+  );
+  expect(observation).toBeDefined();
+  return observation;
+}
+
+/** Asserts that localized price resolution preserved all plan geometry. */
+export function expectStablePricingTransition(
+  observation: PricingTransitionObservation | undefined
+) {
+  expect(observation).toBeDefined();
+  if (!observation) {
+    return;
+  }
+
+  expect(observation.before).not.toBeNull();
+  expect(observation.after).not.toBeNull();
+  expect(observation.layoutShift).toBe(0);
+
+  if (!(observation.before && observation.after)) {
+    return;
+  }
+
+  for (const plan of ["free", "pro"] as const) {
+    expect(observation.after.plans[plan]).toEqual(
+      observation.before.plans[plan]
+    );
+    expect(observation.after.slots[plan].height).toBe(
+      observation.before.slots[plan].height
+    );
+    expect(observation.after.slots[plan].y).toBe(
+      observation.before.slots[plan].y
+    );
+  }
+}

--- a/apps/www/lib/llms/pricing.test.ts
+++ b/apps/www/lib/llms/pricing.test.ts
@@ -23,7 +23,23 @@ describe("pricing Markdown", () => {
         expect(text).toContain(AGENT_MARKDOWN_DIRECTIVE);
         expect(text).toContain(`URL: ${BASE_URL}/${locale}/pricing`);
         expect(text.match(/^### /gm)).toHaveLength(20);
+        expect(text.match(/^## /gm)).toHaveLength(4);
+        expect(text).not.toContain("<mark>");
         expect(text).not.toContain("undefined");
       })
+  );
+
+  it.effect("mirrors the visible English pricing structure", () =>
+    Effect.gen(function* () {
+      const text = yield* getPricingLlmsText("en");
+
+      expect(text).toContain(
+        "## Start with Free. Move to Pro when you are ready."
+      );
+      expect(text).toContain(
+        "Compare both plans, then choose the one that fits how you learn."
+      );
+      expect(text).toContain("## Anything you want to check first?");
+    })
   );
 });

--- a/apps/www/lib/llms/pricing.ts
+++ b/apps/www/lib/llms/pricing.ts
@@ -8,6 +8,11 @@ const FAQ_NUMBERS = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 ] as const;
 
+/** Removes the reviewed emphasis tag from a heading used outside rich text. */
+function getPlainHeading(heading: string) {
+  return heading.replaceAll("<mark>", "").replaceAll("</mark>", "");
+}
+
 /** Identifies the application-owned pricing document. */
 export function isPricingLlmsRoute(cleanSlug: string) {
   return cleanSlug === "pricing";
@@ -31,6 +36,8 @@ export const getPricingLlmsText = Effect.fn("www.llms.pricing.text")(function* (
       title: page["metadata-title"],
       url,
     }),
+    `## ${getPlainHeading(page.headline)}`,
+    page.description,
     `## ${pricing["free-title"]}`,
     pricing["free-description"],
     `- ${pricing["free-feature-1"]}`,
@@ -45,7 +52,7 @@ export const getPricingLlmsText = Effect.fn("www.llms.pricing.text")(function* (
     `- ${pricing["pro-feature-3"]}`,
     `- ${pricing["pro-feature-5"]}`,
     `Current price and checkout: ${url}`,
-    `## ${page["faq-badge"]}`,
+    `## ${getPlainHeading(page["faq-headline"])}`,
     questions,
   ].join("\n\n");
 });

--- a/packages/design-system/components/ui/sidebar-menu.tsx
+++ b/packages/design-system/components/ui/sidebar-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRender } from "@base-ui/react/use-render";
+import { Separator } from "@repo/design-system/components/ui/separator";
 import { Skeleton } from "@repo/design-system/components/ui/skeleton";
 import {
   Tooltip,
@@ -33,6 +34,23 @@ export function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
       data-slot="sidebar-menu-item"
       {...props}
     />
+  );
+}
+
+/** Separates adjacent sections inside a sidebar menu. */
+export function SidebarMenuSeparator({
+  className,
+  ...props
+}: Omit<ComponentProps<"li">, "children">) {
+  return (
+    <li
+      className={cn("-mx-2 my-1 list-none", className)}
+      data-sidebar="menu-separator"
+      data-slot="sidebar-menu-separator"
+      {...props}
+    >
+      <Separator className="bg-sidebar-border" />
+    </li>
   );
 }
 


### PR DESCRIPTION
## Outcome

- keep the complete Gratis and Pro card structure in the prerendered App Shell
- suspend only the request-localized price slot and reserve its exact vertical geometry
- render a truthful price skeleton without a default currency or fake plan content
- verify the Indonesian header Harga link navigates to /id/pricing
- measure zero LayoutShift while the localized price resolves
- keep the pricing and account sections visibly separated for guest and authenticated Free users
- keep the agent-readable pricing document aligned with all substantive visible page content

## Architecture

- move request-owned price resolution into the pricing/price capability
- keep plan copy, features, and actions in pricing/plans
- isolate Playwright pricing geometry instrumentation in e2e/support/pricing
- add one semantic SidebarMenuSeparator primitive instead of duplicating border markup
- compose the pricing item and separator once for both main and school account sidebars
- preserve strict AFDocs parity thresholds while exposing actionable failing-page details
- leave Convex unchanged because the root cause is the Next.js request-time headers boundary

## Verification

- pnpm format
- pnpm lint
- pnpm boundaries
- pnpm --filter @repo/design-system typecheck
- pnpm --filter www typecheck
- pnpm --filter www exec vitest run components/marketing/about/pricing/display.test.ts
- pnpm --filter www exec vitest run lib/llms/pricing.test.ts --coverage.enabled=false
- pnpm run doctor --verbose --scope changed --base main --include-untracked, score 100/100
- exact-head protected CI owns production build, AFDocs parity, and browser acceptance

No Vercel Preview was created.