### PR TITLE
Restore country flag try-out cards

### DIFF
--- a/apps/www/components/tryout/catalog/hub.client.tsx
+++ b/apps/www/components/tryout/catalog/hub.client.tsx
@@ -10,13 +10,11 @@ import { useTranslations } from "next-intl";
 import {
   CatalogCard,
   CatalogCardGradient,
-  CatalogCardImage,
 } from "@/components/shared/catalog/card";
 import { ComingSoon } from "@/components/shared/coming-soon";
 import { CountryFlagIcon } from "@/components/shared/country-flag";
 import { saveTryoutPreference } from "@/components/tryout/catalog/preference.client";
 import { getTryoutPublicPathHref } from "@/components/tryout/route/path";
-import { getTryoutCountryCatalogArtwork } from "@/lib/tryout/artwork";
 import { useSetPreferredTryoutMutation } from "@/lib/tryout/mutation.client";
 
 interface TryoutHubClientProps {
@@ -65,37 +63,26 @@ export function TryoutHubClient({ locale, page }: TryoutHubClientProps) {
 
   return (
     <div className="grid grid-cols-1 gap-4 pt-6 pb-24 sm:grid-cols-2">
-      {page.countries.map((country, index) => {
-        const imageSrc = getTryoutCountryCatalogArtwork(
-          locale,
-          country.countryKey
-        );
-
-        return (
-          <CatalogCard
-            action={
-              <IntentLink
-                href={getTryoutPublicPathHref(country.publicPath)}
-                onClick={() => handleCountryClick(country)}
-              />
-            }
-            actionLabel={tTryouts("open-country-cta")}
-            key={country.countryKey}
-            title={country.title}
-          >
-            {imageSrc ? (
-              <CatalogCardImage preload={index === 0} src={imageSrc} />
-            ) : (
-              <CatalogCardGradient seed={country.publicPath}>
-                <CountryFlagIcon
-                  className="relative h-6 w-9 rounded-[2px] ring-1 ring-border/60"
-                  countryCode={country.countryCode}
-                />
-              </CatalogCardGradient>
-            )}
-          </CatalogCard>
-        );
-      })}
+      {page.countries.map((country) => (
+        <CatalogCard
+          action={
+            <IntentLink
+              href={getTryoutPublicPathHref(country.publicPath)}
+              onClick={() => handleCountryClick(country)}
+            />
+          }
+          actionLabel={tTryouts("open-country-cta")}
+          key={country.countryKey}
+          title={country.title}
+        >
+          <CatalogCardGradient seed={country.publicPath}>
+            <CountryFlagIcon
+              className="relative h-6 w-9 rounded-[2px] ring-1 ring-border/60"
+              countryCode={country.countryCode}
+            />
+          </CatalogCardGradient>
+        </CatalogCard>
+      ))}
     </div>
   );
 }

--- a/apps/www/lib/tryout/artwork.test.ts
+++ b/apps/www/lib/tryout/artwork.test.ts
@@ -3,7 +3,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import {
-  getTryoutCountryCatalogArtwork,
   getTryoutTrackCatalogArtwork,
   resolveTryoutExamArtwork,
 } from "@/lib/tryout/artwork";
@@ -71,16 +70,6 @@ describe("try-out artwork", () => {
       });
     })
   );
-
-  it("resolves country cards with exact and English fallback locales", () => {
-    expect(getTryoutCountryCatalogArtwork("de", "indonesia")).toBe(
-      "/open-graph/tryout/de-index.png"
-    );
-    expect(getTryoutCountryCatalogArtwork("id", "indonesia")).toBe(
-      "/open-graph/tryout/en-index.png"
-    );
-    expect(getTryoutCountryCatalogArtwork("en", "germany")).toBeUndefined();
-  });
 
   it("scopes 2027 artwork to SNBT Indonesia", () => {
     expect(

--- a/apps/www/lib/tryout/artwork.ts
+++ b/apps/www/lib/tryout/artwork.ts
@@ -86,16 +86,6 @@ export function resolveTryoutExamArtwork(input: unknown) {
   );
 }
 
-/** Resolves the reviewed country card artwork for one stable source key. */
-export function getTryoutCountryCatalogArtwork(
-  locale: Locale,
-  countryKey: string
-) {
-  return countryKey === "indonesia"
-    ? resolveStaticArtwork("tryout/index", locale)
-    : undefined;
-}
-
 /** Resolves subject or year artwork for one signed try-out track. */
 export function getTryoutTrackCatalogArtwork(
   locale: Locale,


### PR DESCRIPTION
## Summary

- restore the try-out country catalog to its gradient and country-flag presentation
- keep the localized Try Out index artwork owned by `/try-out` social metadata instead of the Indonesia card
- delete the country-card artwork resolver and its obsolete test mapping

## Validation

- `pnpm --filter www exec vitest run lib/tryout/artwork.test.ts lib/og/artwork.test.ts lib/utils/metadata.test.ts` (20 tests, 100% coverage)
- `pnpm --filter www test` (1,498 tests, 100% coverage)
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm effect:source:check`
- `pnpm run doctor --verbose --scope changed --base origin/main --include-untracked` (100/100)
- Next.js 16.3.2 Turbopack `get_compilation_issues` (no issues)

The local `/id/try-out` render is blocked by the shared development Convex deployment still accepting the predecessor `locale` contract while current `main` sends `appLocale`. This PR does not change Convex. Protected exact-head and merge-group Browser checks remain the authoritative rendered gate.

No Vercel Preview should be created. Production remains restricted to protected `main`.