### PR TITLE
Fix generated release queue admission

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start": "turbo run start",
     "test": "pnpm check:patches && pnpm check:tests && pnpm test:scripts && turbo run test",
     "test:coverage": "pnpm check:patches && pnpm check:tests && turbo run test:coverage",
-    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependencies/policy.test.ts scripts/github/cli.test.ts scripts/github/policy.test.ts scripts/github/provenance/bundle.test.ts scripts/github/provenance/verify.test.ts scripts/github/queue/admission.test.ts scripts/github/queue/remote.test.ts scripts/github/queue/result.test.ts scripts/github/queue/tree.test.ts scripts/github/release.test.ts scripts/vercel/scope.test.ts scripts/effect-source.test.ts scripts/production-acceptance.test.ts",
+    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependencies/policy.test.ts scripts/github/cli.test.ts scripts/github/policy.test.ts scripts/github/provenance/bundle.test.ts scripts/github/provenance/verify.test.ts scripts/github/queue/admission.test.ts scripts/github/queue/release.test.ts scripts/github/queue/remote.test.ts scripts/github/queue/replay.test.ts scripts/github/queue/result.test.ts scripts/github/queue/tree.test.ts scripts/github/release.test.ts scripts/vercel/scope.test.ts scripts/effect-source.test.ts scripts/production-acceptance.test.ts",
     "test:ui": "turbo run test:ui",
     "test:watch": "turbo run test:watch",
     "translate": "turbo run translate",

--- a/scripts/github/queue/admission.test.ts
+++ b/scripts/github/queue/admission.test.ts
@@ -2,12 +2,29 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Result } from "effect";
 import {
   decodeQueueIdentity,
+  validateQueueHead,
   validateQueuePull,
 } from "#scripts/github/queue/admission";
 
 const BASE_SHA = "1".repeat(40);
 const GROUP_SHA = "2".repeat(40);
 const PULL_SHA = "3".repeat(40);
+
+const ownerPull = {
+  base: {
+    ref: "main",
+    repo: { full_name: "nakafaai/nakafa.com" },
+    sha: BASE_SHA,
+  },
+  head: {
+    ref: "codex/example",
+    repo: { full_name: "nakafaai/nakafa.com" },
+    sha: PULL_SHA,
+  },
+  number: 42,
+  state: "open",
+  user: { login: "nabilfatih" },
+};
 
 const queueEvent = {
   action: "checks_requested",
@@ -69,21 +86,68 @@ describe("merge queue admission", () => {
         sha: GROUP_SHA,
       });
       const result = yield* validateQueuePull(identity, {
-        base: {
-          ref: "main",
-          repo: { full_name: "nakafaai/nakafa.com" },
-          sha: BASE_SHA,
-        },
-        head: {
-          ref: "contributor/change",
-          repo: { full_name: "nakafaai/nakafa.com" },
-          sha: PULL_SHA,
-        },
-        number: 42,
-        state: "open",
+        ...ownerPull,
+        head: { ...ownerPull.head, ref: "contributor/change" },
         user: { login: "contributor" },
       }).pipe(Effect.result);
 
+      expect(Result.isFailure(result)).toBe(true);
+    })
+  );
+
+  it.effect("admits the exact repository-generated Changesets lane", () =>
+    Effect.gen(function* () {
+      const identity = yield* decodeQueueIdentity({
+        actor: "nabilfatih",
+        event: queueEvent,
+        ref: `refs/heads/${queueEvent.merge_group.head_ref}`,
+        sha: GROUP_SHA,
+      });
+
+      expect(yield* validateQueuePull(identity, ownerPull)).toBe("owner");
+      expect(
+        yield* validateQueuePull(identity, {
+          ...ownerPull,
+          head: { ...ownerPull.head, ref: "changeset-release/main" },
+          user: { login: "github-actions[bot]" },
+        })
+      ).toBe("release");
+    })
+  );
+
+  it.effect("rejects the Actions bot outside the Changesets branch", () =>
+    Effect.gen(function* () {
+      const identity = yield* decodeQueueIdentity({
+        actor: "nabilfatih",
+        event: queueEvent,
+        ref: `refs/heads/${queueEvent.merge_group.head_ref}`,
+        sha: GROUP_SHA,
+      });
+      const result = yield* validateQueuePull(identity, {
+        ...ownerPull,
+        user: { login: "github-actions[bot]" },
+      }).pipe(Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+    })
+  );
+
+  it.effect("revalidates the generated release head at the final gate", () =>
+    Effect.gen(function* () {
+      const releasePull = {
+        ...ownerPull,
+        head: { ...ownerPull.head, ref: "changeset-release/main" },
+        user: { login: "github-actions[bot]" },
+      };
+
+      expect(
+        yield* validateQueueHead("nakafaai/nakafa.com", PULL_SHA, releasePull)
+      ).toBe("release");
+      const result = yield* validateQueueHead(
+        "nakafaai/nakafa.com",
+        "4".repeat(40),
+        releasePull
+      ).pipe(Effect.result);
       expect(Result.isFailure(result)).toBe(true);
     })
   );

--- a/scripts/github/queue/admission.ts
+++ b/scripts/github/queue/admission.ts
@@ -119,7 +119,25 @@ export const decodeQueueIdentity = Effect.fn("QueueGate.decodeIdentity")(
   }
 );
 
-/** Proves that one queued pull request belongs to the trusted release lane. */
+const identifyQueueLane = Effect.fn("QueueGate.identifyLane")(function* (
+  pull: QueuePull,
+  trustedOwner: string
+) {
+  if (pull.user?.login === trustedOwner) {
+    return "owner" as const;
+  }
+  if (
+    pull.user?.login === "github-actions[bot]" &&
+    pull.head.ref === "changeset-release/main"
+  ) {
+    return "release" as const;
+  }
+  return yield* queueGateError(
+    "Merge queue entry is not in a trusted pull-request lane."
+  );
+});
+
+/** Proves that one queued pull request belongs to an admitted lane. */
 export const validateQueuePull = Effect.fn("QueueGate.validatePull")(function* (
   identity: QueueIdentity,
   pull: QueuePull,
@@ -132,7 +150,6 @@ export const validateQueuePull = Effect.fn("QueueGate.validatePull")(function* (
     pull.base.sha !== identity.baseSha ||
     pull.base.repo.full_name !== identity.repository ||
     pull.head.repo?.full_name !== identity.repository ||
-    pull.user?.login !== trustedOwner ||
     identity.actor !== trustedOwner ||
     identity.sender !== trustedOwner
   ) {
@@ -140,4 +157,26 @@ export const validateQueuePull = Effect.fn("QueueGate.validatePull")(function* (
       "Merge queue entry is not trusted for production acceptance."
     );
   }
+  return yield* identifyQueueLane(pull, trustedOwner);
+});
+
+/** Revalidates the immutable pull identity before the final queue gate. */
+export const validateQueueHead = Effect.fn("QueueGate.validateHead")(function* (
+  repository: string,
+  expectedHead: string,
+  pull: QueuePull,
+  trustedOwner = "nabilfatih"
+) {
+  if (
+    pull.state !== "open" ||
+    pull.base.ref !== "main" ||
+    pull.base.repo.full_name !== repository ||
+    pull.head.sha !== expectedHead ||
+    pull.head.repo?.full_name !== repository
+  ) {
+    return yield* queueGateError(
+      "Queued pull request changed after its exact-head admission."
+    );
+  }
+  return yield* identifyQueueLane(pull, trustedOwner);
 });

--- a/scripts/github/queue/command.ts
+++ b/scripts/github/queue/command.ts
@@ -1,0 +1,52 @@
+import { Effect, type PlatformError, Stream } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import { queueGateError } from "#scripts/github/queue/admission";
+
+const collectText = (
+  stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>
+) =>
+  stream.pipe(
+    Stream.decodeText(),
+    Stream.runFold(
+      () => "",
+      (output, chunk) => output + chunk
+    )
+  );
+
+/** Runs one external command for exact merge-queue verification. */
+export const runCommand = Effect.fn("QueueGate.runCommand")(function* (
+  workingDirectory: string,
+  executable: string,
+  args: readonly string[],
+  options: {
+    readonly env?: Readonly<Record<string, string>>;
+  } = {}
+) {
+  const command = yield* ChildProcess.make(executable, args, {
+    cwd: workingDirectory,
+    env: options.env,
+    extendEnv: options.env !== undefined,
+  }).pipe(
+    Effect.mapError((cause) =>
+      queueGateError(`Unable to start ${executable} verification.`, cause)
+    )
+  );
+  const [exitCode, stdout, stderr] = yield* Effect.all(
+    [
+      command.exitCode,
+      collectText(command.stdout),
+      collectText(command.stderr),
+    ],
+    { concurrency: 3 }
+  ).pipe(
+    Effect.mapError((cause) =>
+      queueGateError(`Unable to read ${executable} verification.`, cause)
+    )
+  );
+  if (exitCode !== 0) {
+    return yield* queueGateError(
+      `${executable} verification failed: ${stderr.trim() || "unknown command error"}.`
+    );
+  }
+  return stdout;
+});

--- a/scripts/github/queue/main.ts
+++ b/scripts/github/queue/main.ts
@@ -5,8 +5,10 @@ import {
   decodeQueueIdentity,
   QueueEventSchema,
   queueGateError,
+  validateQueueHead,
   validateQueuePull,
 } from "#scripts/github/queue/admission";
+import { inspectReleaseTree } from "#scripts/github/queue/release";
 import {
   fetchQueuePull,
   verifyResolvedReviews,
@@ -76,9 +78,18 @@ const admit = Effect.fn("QueueGate.admit")(function* () {
   });
   const github = { repository: identity.repository, token: config.token };
   const pull = yield* fetchQueuePull(github, identity.pullNumber);
-  yield* validateQueuePull(identity, pull);
+  const lane = yield* validateQueuePull(identity, pull);
   const reviewCount = yield* verifyResolvedReviews(github, identity.pullNumber);
   const tree = yield* inspectQueueTree(process.cwd(), identity, pull.head.sha);
+  if (lane === "release") {
+    yield* inspectReleaseTree(
+      process.cwd(),
+      identity.baseSha,
+      pull.head.sha,
+      tree.changedPaths,
+      config.token
+    );
+  }
   const reuse = tree.reuse
     ? yield* verifySourceChecks(github, pull).pipe(
         Effect.as(true),
@@ -96,7 +107,7 @@ const admit = Effect.fn("QueueGate.admit")(function* () {
     trusted: true,
   });
   yield* writeOutput(
-    `Admitted pull request #${pull.number} at ${pull.head.sha}; ${reviewCount} review threads checked; static source proof reuse ${String(reuse)}.\n`
+    `Admitted ${lane} pull request #${pull.number} at ${pull.head.sha}; ${reviewCount} review threads checked; static source proof reuse ${String(reuse)}.\n`
   );
 });
 
@@ -113,18 +124,7 @@ const review = Effect.fn("QueueGate.review")(function* () {
   );
   const github = { repository: config.repository, token: config.token };
   const pull = yield* fetchQueuePull(github, config.pullNumber);
-  if (
-    pull.state !== "open" ||
-    pull.base.ref !== "main" ||
-    pull.base.repo.full_name !== config.repository ||
-    pull.head.sha !== config.expectedHead ||
-    pull.head.repo?.full_name !== config.repository ||
-    pull.user?.login !== "nabilfatih"
-  ) {
-    return yield* queueGateError(
-      "Queued pull request changed after its exact-head admission."
-    );
-  }
+  yield* validateQueueHead(config.repository, config.expectedHead, pull);
   const reviewCount = yield* verifyResolvedReviews(github, config.pullNumber);
   yield* writeOutput(
     `Final review verification passed for ${reviewCount} threads on pull request #${pull.number}.\n`

--- a/scripts/github/queue/release.test.ts
+++ b/scripts/github/queue/release.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Result } from "effect";
+import {
+  type ReleaseEvidence,
+  validateReleaseTree,
+} from "#scripts/github/queue/release";
+
+const releaseEvidence = {
+  changes: [
+    {
+      afterMode: "000000",
+      beforeMode: "100644",
+      path: ".changeset/cli.md",
+      status: "D",
+    },
+    {
+      afterMode: "100644",
+      beforeMode: "100644",
+      path: "packages/cli/CHANGELOG.md",
+      status: "M",
+    },
+    {
+      afterMode: "100644",
+      beforeMode: "100644",
+      path: "packages/cli/package.json",
+      status: "M",
+    },
+  ],
+} satisfies ReleaseEvidence;
+
+const expectFailure = (evidence: ReleaseEvidence) =>
+  validateReleaseTree(evidence).pipe(
+    Effect.result,
+    Effect.tap((result) =>
+      Effect.sync(() => {
+        expect(Result.isFailure(result)).toBe(true);
+      })
+    )
+  );
+
+describe("generated release queue", () => {
+  it.effect("accepts paired Changesets release paths", () =>
+    validateReleaseTree(releaseEvidence)
+  );
+
+  it.effect("rejects executable source changes", () =>
+    expectFailure({
+      ...releaseEvidence,
+      changes: [
+        ...releaseEvidence.changes,
+        {
+          afterMode: "100644",
+          beforeMode: "100644",
+          path: "packages/cli/main.ts",
+          status: "M",
+        },
+      ],
+    })
+  );
+
+  it.effect("rejects an unpaired package changelog", () =>
+    expectFailure({
+      ...releaseEvidence,
+      changes: releaseEvidence.changes.filter(
+        (change) => change.path !== "packages/cli/CHANGELOG.md"
+      ),
+    })
+  );
+});

--- a/scripts/github/queue/release.ts
+++ b/scripts/github/queue/release.ts
@@ -1,0 +1,181 @@
+import { isDeepStrictEqual } from "node:util";
+import { Effect, type Redacted } from "effect";
+import { queueGateError } from "#scripts/github/queue/admission";
+import { runCommand } from "#scripts/github/queue/command";
+import { replayRelease } from "#scripts/github/queue/replay";
+
+const CHANGESET_PATTERN = /^\.changeset\/(?!README\.md$)[^/]+\.md$/u;
+const CHANGELOG_PATTERN = /^(?:apps|packages)\/[^/]+\/CHANGELOG\.md$/u;
+const MANIFEST_PATTERN = /^(?:apps|packages)\/[^/]+\/package\.json$/u;
+const RAW_CHANGE_PATTERN =
+  /^:(\d{6}) (\d{6}) [0-9a-f]{40} [0-9a-f]{40} ([AMD])$/u;
+const REGULAR_FILE_MODE = "100644";
+const MISSING_FILE_MODE = "000000";
+
+export interface ReleaseChange {
+  readonly afterMode: string;
+  readonly beforeMode: string;
+  readonly path: string;
+  readonly status: "A" | "D" | "M";
+}
+
+export interface ReleaseEvidence {
+  readonly changes: readonly ReleaseChange[];
+}
+
+const packageDirectory = (path: string) =>
+  path.slice(0, -"/package.json".length);
+
+const changelogDirectory = (path: string) =>
+  path.slice(0, -"/CHANGELOG.md".length);
+
+const parseChanges = Effect.fn("QueueGate.parseReleaseChanges")(function* (
+  raw: string
+) {
+  const tokens = raw.split("\0");
+  if (tokens.at(-1) === "") {
+    tokens.pop();
+  }
+  if (tokens.length === 0 || tokens.length % 2 !== 0) {
+    return yield* queueGateError(
+      "Generated release diff did not contain complete Git records."
+    );
+  }
+
+  const changes: ReleaseChange[] = [];
+  for (let index = 0; index < tokens.length; index += 2) {
+    const metadata = tokens[index];
+    const path = tokens[index + 1];
+    const match = metadata ? RAW_CHANGE_PATTERN.exec(metadata) : null;
+    if (!(match && path)) {
+      return yield* queueGateError(
+        "Generated release diff contains an unsupported Git record."
+      );
+    }
+    const status = match[3];
+    if (status !== "A" && status !== "D" && status !== "M") {
+      return yield* queueGateError(
+        "Generated release diff contains an unsupported file status."
+      );
+    }
+    changes.push({
+      afterMode: match[2] ?? "",
+      beforeMode: match[1] ?? "",
+      path,
+      status,
+    });
+  }
+  return changes;
+});
+
+/** Allows only pending Changesets, package changelogs, and package manifests. */
+export const validateReleaseTree = Effect.fn("QueueGate.validateReleaseTree")(
+  function* (evidence: ReleaseEvidence) {
+    const paths = new Set<string>();
+    const manifestDirectories = new Set<string>();
+    const changelogDirectories = new Set<string>();
+    let changesetCount = 0;
+
+    for (const change of evidence.changes) {
+      if (paths.has(change.path)) {
+        return yield* queueGateError(
+          "Generated release diff contains a duplicate path."
+        );
+      }
+      paths.add(change.path);
+
+      if (CHANGESET_PATTERN.test(change.path)) {
+        if (
+          change.status !== "D" ||
+          change.beforeMode !== REGULAR_FILE_MODE ||
+          change.afterMode !== MISSING_FILE_MODE
+        ) {
+          return yield* queueGateError(
+            "Generated release may only delete regular pending changesets."
+          );
+        }
+        changesetCount += 1;
+        continue;
+      }
+
+      if (CHANGELOG_PATTERN.test(change.path)) {
+        if (
+          (change.status !== "A" && change.status !== "M") ||
+          change.afterMode !== REGULAR_FILE_MODE ||
+          (change.status === "A"
+            ? change.beforeMode !== MISSING_FILE_MODE
+            : change.beforeMode !== REGULAR_FILE_MODE)
+        ) {
+          return yield* queueGateError(
+            "Generated release changelogs must be regular added or modified files."
+          );
+        }
+        changelogDirectories.add(changelogDirectory(change.path));
+        continue;
+      }
+
+      if (MANIFEST_PATTERN.test(change.path)) {
+        if (
+          change.status !== "M" ||
+          change.beforeMode !== REGULAR_FILE_MODE ||
+          change.afterMode !== REGULAR_FILE_MODE
+        ) {
+          return yield* queueGateError(
+            "Generated release package manifests must remain regular files."
+          );
+        }
+        manifestDirectories.add(packageDirectory(change.path));
+        continue;
+      }
+
+      return yield* queueGateError(
+        `Generated release changed prohibited path ${change.path}.`
+      );
+    }
+
+    if (
+      changesetCount === 0 ||
+      manifestDirectories.size === 0 ||
+      changelogDirectories.size !== manifestDirectories.size ||
+      [...manifestDirectories].some(
+        (directory) => !changelogDirectories.has(directory)
+      )
+    ) {
+      return yield* queueGateError(
+        "Generated release must pair every versioned package with its changelog."
+      );
+    }
+  }
+);
+
+/** Reads and validates the exact generated release diff admitted by the queue. */
+export const inspectReleaseTree = Effect.fn("QueueGate.inspectReleaseTree")(
+  function* (
+    repositoryRoot: string,
+    baseSha: string,
+    sourceHead: string,
+    expectedPaths: readonly string[],
+    token: Redacted.Redacted
+  ) {
+    const raw = yield* runCommand(repositoryRoot, "git", [
+      "diff",
+      "--raw",
+      "--abbrev=40",
+      "--no-renames",
+      "-z",
+      `${baseSha}...${sourceHead}`,
+      "--",
+    ]);
+    const changes = yield* parseChanges(raw);
+    const observedPaths = changes.map((change) => change.path).sort();
+    const sortedExpectedPaths = [...expectedPaths].sort();
+    if (!isDeepStrictEqual(observedPaths, sortedExpectedPaths)) {
+      return yield* queueGateError(
+        "Generated release path evidence does not match the admitted tree."
+      );
+    }
+
+    yield* validateReleaseTree({ changes });
+    yield* replayRelease(repositoryRoot, baseSha, sourceHead, token);
+  }
+);

--- a/scripts/github/queue/replay.test.ts
+++ b/scripts/github/queue/replay.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Result } from "effect";
+import { validateReleaseReplay } from "#scripts/github/queue/replay";
+
+describe("Changesets release replay", () => {
+  it.effect("accepts the exact replayed tree", () =>
+    validateReleaseReplay("generated-tree", "generated-tree")
+  );
+
+  it.effect("rejects any generated tree difference", () =>
+    validateReleaseReplay("generated-tree", "modified-tree").pipe(
+      Effect.result,
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(Result.isFailure(result)).toBe(true);
+        })
+      )
+    )
+  );
+});

--- a/scripts/github/queue/replay.ts
+++ b/scripts/github/queue/replay.ts
@@ -1,0 +1,71 @@
+import { Effect, FileSystem, Path, Redacted } from "effect";
+import { queueGateError } from "#scripts/github/queue/admission";
+import { runCommand } from "#scripts/github/queue/command";
+
+/** Requires the pinned Changesets CLI to reproduce the release tree exactly. */
+export const validateReleaseReplay = Effect.fn(
+  "QueueGate.validateReleaseReplay"
+)(function* (generatedTree: string, sourceTree: string) {
+  if (generatedTree !== sourceTree) {
+    return yield* queueGateError(
+      "Generated release tree does not match the exact Changesets replay."
+    );
+  }
+});
+
+/** Replays the immutable base release with the pinned CLI and GitHub evidence. */
+export const replayRelease = Effect.fn("QueueGate.replayRelease")(function* (
+  repositoryRoot: string,
+  baseSha: string,
+  sourceHead: string,
+  token: Redacted.Redacted
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const temporaryRoot = yield* fileSystem.makeTempDirectoryScoped({
+    prefix: "nakafa-release-replay-",
+  });
+  const checkout = path.join(temporaryRoot, "checkout");
+  yield* runCommand(repositoryRoot, "git", [
+    "clone",
+    "--shared",
+    "--no-checkout",
+    repositoryRoot,
+    checkout,
+  ]);
+  yield* runCommand(checkout, "git", ["checkout", "--detach", baseSha]);
+  yield* runCommand(checkout, "git", ["branch", "--force", "main", baseSha]);
+
+  const linkedModules = path.join(checkout, "node_modules");
+  yield* fileSystem
+    .symlink(path.join(repositoryRoot, "node_modules"), linkedModules)
+    .pipe(
+      Effect.mapError((cause) =>
+        queueGateError(
+          "Unable to expose the pinned release toolchain to the replay.",
+          cause
+        )
+      )
+    );
+  const changesetCli = path.join(linkedModules, ".bin", "changeset");
+  yield* runCommand(checkout, changesetCli, ["version"], {
+    env: { GITHUB_TOKEN: Redacted.value(token) },
+  });
+  yield* fileSystem
+    .remove(linkedModules)
+    .pipe(
+      Effect.mapError((cause) =>
+        queueGateError("Unable to detach the replay toolchain.", cause)
+      )
+    );
+
+  yield* runCommand(checkout, "git", ["add", "--all"]);
+  const [generatedTree, sourceTree] = yield* Effect.all(
+    [
+      runCommand(checkout, "git", ["write-tree"]),
+      runCommand(repositoryRoot, "git", ["rev-parse", `${sourceHead}^{tree}`]),
+    ],
+    { concurrency: 2 }
+  );
+  yield* validateReleaseReplay(generatedTree.trim(), sourceTree.trim());
+});

--- a/scripts/github/queue/tree.ts
+++ b/scripts/github/queue/tree.ts
@@ -1,9 +1,9 @@
-import { Effect, type PlatformError, Stream } from "effect";
-import { ChildProcess } from "effect/unstable/process";
+import { Effect } from "effect";
 import {
   type QueueIdentity,
   queueGateError,
 } from "#scripts/github/queue/admission";
+import { runCommand } from "#scripts/github/queue/command";
 
 const CI_CONFIG_PATTERN =
   /(?:^|\/)(?:biome|next\.config|tsconfig|turbo|ultracite|vercel|vitest)[^/]*\.(?:[cm]?[jt]s|json|mts|yml|yaml)$/u;
@@ -76,55 +76,13 @@ export const validateQueueTree = Effect.fn("QueueGate.validateTree")(function* (
   } satisfies QueueTreeDecision;
 });
 
-const collectText = (
-  stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>
-) =>
-  stream.pipe(
-    Stream.decodeText(),
-    Stream.runFold(
-      () => "",
-      (output, chunk) => output + chunk
-    )
-  );
-
-const runGit = Effect.fn("QueueGate.runGit")(function* (
-  repositoryRoot: string,
-  args: readonly string[]
-) {
-  const command = yield* ChildProcess.make("git", args, {
-    cwd: repositoryRoot,
-  }).pipe(
-    Effect.mapError((cause) =>
-      queueGateError("Unable to start merge queue Git verification.", cause)
-    )
-  );
-  const [exitCode, stdout, stderr] = yield* Effect.all(
-    [
-      command.exitCode,
-      collectText(command.stdout),
-      collectText(command.stderr),
-    ],
-    { concurrency: 3 }
-  ).pipe(
-    Effect.mapError((cause) =>
-      queueGateError("Unable to read merge queue Git verification.", cause)
-    )
-  );
-  if (exitCode !== 0) {
-    return yield* queueGateError(
-      `Merge queue Git verification failed: ${stderr.trim() || "unknown Git error"}.`
-    );
-  }
-  return stdout;
-});
-
 /** Reads and validates exact Git tree evidence for one merge-group commit. */
 export const inspectQueueTree = Effect.fn("QueueGate.inspectTree")(function* (
   repositoryRoot: string,
   identity: QueueIdentity,
   sourceHead: string
 ) {
-  yield* runGit(repositoryRoot, [
+  yield* runCommand(repositoryRoot, "git", [
     "fetch",
     "--no-tags",
     "origin",
@@ -142,24 +100,31 @@ export const inspectQueueTree = Effect.fn("QueueGate.inspectTree")(function* (
     changedPaths,
   ] = yield* Effect.all(
     [
-      runGit(repositoryRoot, ["rev-parse", "HEAD"]),
-      runGit(repositoryRoot, [
+      runCommand(repositoryRoot, "git", ["rev-parse", "HEAD"]),
+      runCommand(repositoryRoot, "git", [
         "rev-list",
         "--parents",
         "-n",
         "1",
         identity.groupSha,
       ]),
-      runGit(repositoryRoot, [
+      runCommand(repositoryRoot, "git", [
         "merge-tree",
         "--write-tree",
         identity.baseSha,
         sourceHead,
       ]),
-      runGit(repositoryRoot, ["rev-parse", `${identity.groupSha}^{tree}`]),
-      runGit(repositoryRoot, ["rev-parse", `${sourceHead}^{tree}`]),
-      runGit(repositoryRoot, ["merge-base", identity.baseSha, sourceHead]),
-      runGit(repositoryRoot, [
+      runCommand(repositoryRoot, "git", [
+        "rev-parse",
+        `${identity.groupSha}^{tree}`,
+      ]),
+      runCommand(repositoryRoot, "git", ["rev-parse", `${sourceHead}^{tree}`]),
+      runCommand(repositoryRoot, "git", [
+        "merge-base",
+        identity.baseSha,
+        sourceHead,
+      ]),
+      runCommand(repositoryRoot, "git", [
         "diff",
         "--name-only",
         "--no-renames",


### PR DESCRIPTION
## Summary

- admit the repository-owned `changeset-release/main` bot lane without weakening the owner-authored lane
- restrict that lane to deleted pending changesets plus paired package manifests and changelogs
- replay the pinned Changesets CLI from the immutable base and require an exact Git tree match
- revalidate the exact pull-request head and lane before the final protected queue gate

## Root cause

The protected merge queue required every pull request author to be `nabilfatih`. Changesets correctly authors its generated release pull request as `github-actions[bot]`, so the release PR could pass source checks but could never enter protected `main`.

## Verification

- `pnpm test:scripts`
- `pnpm lint`
- `pnpm security:audit`
- `pnpm test`
- direct Codex review after independently reproducing and fixing its first finding
- exact replay of the current 25-path Changesets release tree
- `git diff --check origin/main...HEAD`

No runtime package changes are included, so no changeset is required.
