### PR TITLE
Fix CLI release archive path

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -62,7 +62,7 @@ jobs:
             --outfile="$RELEASE_ROOT/provenance.mjs" \
             --platform=node \
             --target=node24
-          pack=$(npm pack packages/cli --ignore-scripts --json \
+          pack=$(npm pack ./packages/cli --ignore-scripts --json \
             --pack-destination "$RELEASE_ROOT")
           archive=$(jq -er '.[0].filename' <<< "$pack")
           tarball="$RELEASE_ROOT/$archive"

--- a/scripts/github/cli.test.ts
+++ b/scripts/github/cli.test.ts
@@ -175,6 +175,14 @@ describe("CLI workflow policy", () => {
         )
       );
 
+      assert.ok(
+        validateCliWorkflow(
+          source.replace("npm pack ./packages/cli", "npm pack packages/cli")
+        ).includes(
+          "CLI build job is missing required contract: npm pack ./packages/cli"
+        )
+      );
+
       const unsafeRerun = source.replace(
         "          for attempt in {1..5}; do",
         "          for attempt in {1..1}; do"

--- a/scripts/github/cli.ts
+++ b/scripts/github/cli.ts
@@ -44,6 +44,7 @@ const REQUIRED_BUILD_SOURCE = [
   "pnpm --filter @nakafa/cli typecheck",
   "pnpm --filter @nakafa/cli test:coverage",
   "pnpm --filter @nakafa/cli build",
+  "npm pack ./packages/cli",
   "pnpm exec esbuild scripts/github/provenance/main.ts",
   "createRequire(import.meta.url)",
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",


### PR DESCRIPTION
## Problem

The first OIDC release run for `@nakafa/cli@0.1.1` failed before publication. npm interpreted `packages/cli` as GitHub shorthand and attempted to fetch `ssh://git@github.com/packages/cli.git`.

No package was published. The registry remains at `@nakafa/cli@0.1.0`.

## Fix

- Pack the workspace through the explicit local path `./packages/cli`.
- Make that exact path part of the checked workflow contract.
- Add a negative regression test that rejects the ambiguous operand.

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm test:scripts` with 15 files and 56 tests
- `pnpm typecheck:scripts`
- `pnpm --filter @nakafa/cli build`
- `pnpm security:audit`
- `git diff --check`
- Real `npm pack ./packages/cli` under the repository Node 24.19.0 runtime
- Direct Codex review, followed by independent validation of its conclusion

The verified archive is `nakafa-cli-0.1.1.tgz` and contains only `LICENSE`, `dist/main.js`, `package.json`, and `README.md`.

No Vercel Preview was created.
