### PR TITLE
Expand the stable API origin

### DIFF
--- a/packages/backend/convex/routes/agent/api.test.ts
+++ b/packages/backend/convex/routes/agent/api.test.ts
@@ -27,9 +27,9 @@ describe("public agent API routes", () => {
   it("serves the API index, health response, and CORS preflight", async () => {
     const test = createConvexTestWithBetterAuth();
     const [index, health, options] = await Promise.all([
-      fetchApi(test, "/v1"),
-      fetchApi(test, "/v1/health"),
-      fetchApi(test, "/v1/search", { method: "OPTIONS" }),
+      fetchApi(test, "/"),
+      fetchApi(test, "/health"),
+      fetchApi(test, "/search", { method: "OPTIONS" }),
     ]);
 
     expect(index.status).toBe(200);
@@ -80,7 +80,7 @@ describe("public agent API routes", () => {
     expect(revalidated.headers.get("etag")).toBe(etag);
   });
 
-  it.each(["/v1/health", "/v1/quran/1?locale=en"])(
+  it.each(["/", "/health", "/quran/1?locale=en"])(
     "rejects direct origin access to %s before dispatching a route",
     async (path) => {
       const response = await createConvexTestWithBetterAuth().fetch(
@@ -95,31 +95,53 @@ describe("public agent API routes", () => {
   );
 
   it("does not expose the predecessor origin mount", async () => {
-    const response = await createConvexTestWithBetterAuth().fetch("/v1");
+    const response = await createConvexTestWithBetterAuth().fetch("/");
 
     expect(response.status).toBe(404);
   });
 
+  it.each(["/v1", "/v1/health", "/v1/search?query=algebra"])(
+    "keeps predecessor route %s readable during the deployment transition",
+    async (path) => {
+      const response = await fetchApi(createConvexTestWithBetterAuth(), path);
+
+      expect(response.status).toBe(200);
+    }
+  );
+
+  it.each(["/v1/openapi.json", "/v2", "/v2/search"])(
+    "does not expose retired versioned path %s",
+    async (path) => {
+      const response = await fetchApi(createConvexTestWithBetterAuth(), path);
+
+      await expectProblem(response, {
+        code: "ENDPOINT_NOT_FOUND",
+        status: 404,
+      });
+    }
+  );
+
   it.each([
-    ["/v1/search?unknown=value", {}, "INVALID_REQUEST", 400],
+    ["/search?unknown=value", {}, "INVALID_REQUEST", 400],
+    ["/content", {}, "INVALID_REQUEST", 400],
     ["/v1/content", {}, "INVALID_REQUEST", 400],
-    ["/v1/search", { headers: { accept: "text/html" } }, "NOT_ACCEPTABLE", 406],
+    ["/search", { headers: { accept: "text/html" } }, "NOT_ACCEPTABLE", 406],
     [
-      "/v1/health",
+      "/health",
       { body: "{}", method: "OPTIONS" },
       "UNSUPPORTED_MEDIA_TYPE",
       415,
     ],
-    ["/v1/search?limit=11", {}, "UNPROCESSABLE_REQUEST", 422],
-    ["/v1/content?ref=", {}, "UNPROCESSABLE_REQUEST", 422],
+    ["/search?limit=11", {}, "UNPROCESSABLE_REQUEST", 422],
+    ["/content?ref=", {}, "UNPROCESSABLE_REQUEST", 422],
     [
-      "/v1/content?ref=https%3A%2F%2Fexample.com%2Fen%2Fquran%2F1",
+      "/content?ref=https%3A%2F%2Fexample.com%2Fen%2Fquran%2F1",
       {},
       "UNPROCESSABLE_REQUEST",
       422,
     ],
-    ["/v1/missing", {}, "ENDPOINT_NOT_FOUND", 404],
-    ["/v1/health", { method: "POST" }, "METHOD_NOT_ALLOWED", 405],
+    ["/missing", {}, "ENDPOINT_NOT_FOUND", 404],
+    ["/health", { method: "POST" }, "METHOD_NOT_ALLOWED", 405],
   ] as const)(
     "returns a structured problem for %s",
     async (path, init, code, status) => {
@@ -135,7 +157,7 @@ describe("public agent API routes", () => {
   it("returns stable empty search pagination from an empty deployment", async () => {
     const response = await fetchApi(
       createConvexTestWithBetterAuth(),
-      "/v1/search?query=algebra&locale=en&limit=10&offset=0"
+      "/search?query=algebra&locale=en&limit=10&offset=0"
     );
 
     expect(response.status).toBe(200);
@@ -169,7 +191,7 @@ describe("public agent API routes", () => {
     });
     const response = await fetchApi(
       test,
-      "/v1/search?query=rational%20function&locale=en&section=articles"
+      "/search?query=rational%20function&locale=en&section=articles"
     );
 
     expect(response.status).toBe(200);
@@ -195,7 +217,7 @@ describe("public agent API routes", () => {
     const reference = encodeURIComponent(
       `https://nakafa.com/en/${article.publicPath}`
     );
-    const response = await fetchApi(test, `/v1/content?ref=${reference}`);
+    const response = await fetchApi(test, `/content?ref=${reference}`);
 
     expect(response.status).toBe(200);
     expectPublicJson(response);
@@ -215,7 +237,7 @@ describe("public agent API routes", () => {
     await activateMaterialCatalog(test, [material], ["en"]);
     const response = await fetchApi(
       test,
-      `/v1/content?ref=${encodeURIComponent(material.graph.assetId)}`
+      `/content?ref=${encodeURIComponent(material.graph.assetId)}`
     );
 
     expect(response.status).toBe(200);
@@ -240,7 +262,7 @@ describe("public agent API routes", () => {
 
     const response = await fetchApi(
       test,
-      `/v1/content?ref=${encodeURIComponent(topic.graph.assetId)}`
+      `/content?ref=${encodeURIComponent(topic.graph.assetId)}`
     );
 
     await expectProblem(response, {
@@ -265,7 +287,7 @@ describe("public agent API routes", () => {
     const reference = encodeURIComponent(
       `https://nakafa.com/en/${article.publicPath}`
     );
-    const response = await fetchApi(test, `/v1/content?ref=${reference}`);
+    const response = await fetchApi(test, `/content?ref=${reference}`);
 
     await expectProblem(response, {
       code: "SERVICE_UNAVAILABLE",
@@ -274,12 +296,17 @@ describe("public agent API routes", () => {
   });
 
   it("fails closed when the signed taxonomy publication is unavailable", async () => {
-    const response = await fetchApi(
-      createConvexTestWithBetterAuth(),
-      "/v1/taxonomy?locale=en"
-    );
+    const test = createConvexTestWithBetterAuth();
+    const [response, predecessor] = await Promise.all([
+      fetchApi(test, "/taxonomy?locale=en"),
+      fetchApi(test, "/v1/taxonomy?locale=en"),
+    ]);
 
     await expectProblem(response, {
+      code: "SERVICE_UNAVAILABLE",
+      status: 503,
+    });
+    await expectProblem(predecessor, {
       code: "SERVICE_UNAVAILABLE",
       status: 503,
     });
@@ -291,7 +318,7 @@ describe("public agent API routes", () => {
       [NAKAFA_API_EDGE_CONTRACT.secretHeader]: API_SECRET,
     });
     const response = await test.fetch(
-      `${NAKAFA_API_EDGE_CONTRACT.originPath}/v1/search`,
+      `${NAKAFA_API_EDGE_CONTRACT.originPath}/search`,
       { headers }
     );
 
@@ -304,10 +331,10 @@ describe("public agent API routes", () => {
   it("limits metered reads without limiting health checks", async () => {
     const test = createConvexTestWithBetterAuth();
     for (let index = 0; index < 30; index += 1) {
-      expect((await fetchApi(test, "/v1/search")).status).toBe(200);
-      expect((await fetchApi(test, "/v1/health")).status).toBe(200);
+      expect((await fetchApi(test, "/search")).status).toBe(200);
+      expect((await fetchApi(test, "/health")).status).toBe(200);
     }
-    const limited = await fetchApi(test, "/v1/search");
+    const limited = await fetchApi(test, "/search");
 
     await expectProblem(limited, { code: "RATE_LIMITED", status: 429 });
     expect(Number(limited.headers.get("retry-after"))).toBeGreaterThan(0);

--- a/packages/backend/convex/routes/agent/api.ts
+++ b/packages/backend/convex/routes/agent/api.ts
@@ -42,18 +42,11 @@ import { Hono } from "hono";
 
 /** Registers the protected read-only API and its machine-readable contract. */
 export function registerAgentApiRoutes(app: AgentApp) {
-  const api: AgentApp = new Hono();
+  const runtime: AgentApp = new Hono();
 
-  api.use("/openapi.json", guardAgentApi);
-  api.use("/v1", guardAgentApi);
-  api.use("/v1/*", guardAgentApi);
+  runtime.use("*", guardAgentApi);
 
-  api.get("/openapi.json", (context) =>
-    createOpenApiResponse(context.req.header("if-none-match"))
-  );
-  api.options("/openapi.json", () => createOpenApiOptionsResponse());
-
-  api.get("/v1", (context) =>
+  runtime.get("/", (context) =>
     runAgentRequest(
       context.req.raw,
       context.get("requestId"),
@@ -75,7 +68,7 @@ export function registerAgentApiRoutes(app: AgentApp) {
     )
   );
 
-  api.get("/v1/health", (context) =>
+  runtime.get("/health", (context) =>
     runAgentRequest(
       context.req.raw,
       context.get("requestId"),
@@ -92,10 +85,10 @@ export function registerAgentApiRoutes(app: AgentApp) {
     )
   );
 
-  registerAgentSearchRoute(api);
-  registerAgentContentRoute(api);
+  registerAgentSearchRoute(runtime);
+  registerAgentContentRoute(runtime);
 
-  api.get("/v1/taxonomy", (context) =>
+  runtime.get("/taxonomy", (context) =>
     runMeteredRequest(
       context.env,
       context.req.raw,
@@ -114,17 +107,28 @@ export function registerAgentApiRoutes(app: AgentApp) {
     )
   );
 
-  registerAgentQuranRoutes(api);
+  registerAgentQuranRoutes(runtime);
 
-  for (const path of ["/v1", "/v1/health", "/v1/taxonomy"]) {
-    api.options(path, () => agentOptionsResponse());
+  for (const path of ["/", "/health", "/taxonomy"]) {
+    runtime.options(path, () => agentOptionsResponse());
   }
 
-  api.all("/v1/*", (context) =>
+  runtime.all("*", (context) =>
     missingRouteResponse(context.req.raw, context.get("requestId"))
   );
 
-  app.route(NAKAFA_API_EDGE_CONTRACT.originPath, api);
+  const document: AgentApp = new Hono();
+  document.use("*", guardAgentApi);
+  document.get("/", (context) =>
+    createOpenApiResponse(context.req.header("if-none-match"))
+  );
+  document.options("/", () => createOpenApiOptionsResponse());
+
+  // Expand the protected origin before the independently deployed edge switches.
+  // The contract phase removes the predecessor after public consumers migrate.
+  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/openapi.json`, document);
+  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/v1`, runtime);
+  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/`, runtime);
 }
 
 /** Returns one exact 404 or 405 for unmatched public API routes. */

--- a/packages/backend/convex/routes/agent/content.test.ts
+++ b/packages/backend/convex/routes/agent/content.test.ts
@@ -36,7 +36,7 @@ describe("public agent content", () => {
     const reference = encodeURIComponent(
       `https://nakafa.com/en/${article.publicPath}`
     );
-    const response = await fetchApi(test, `/v1/content?ref=${reference}`);
+    const response = await fetchApi(test, `/content?ref=${reference}`);
 
     expect(response.status).toBe(200);
     expectPublicJson(response);
@@ -56,7 +56,7 @@ describe("public agent content", () => {
     await activateMaterialCatalog(test, [material], ["en"]);
     const response = await fetchApi(
       test,
-      `/v1/content?ref=${encodeURIComponent(material.graph.assetId)}`
+      `/content?ref=${encodeURIComponent(material.graph.assetId)}`
     );
 
     expect(response.status).toBe(200);
@@ -83,10 +83,14 @@ describe("public agent content", () => {
       test,
       `/v1/content?ref=${encodeURIComponent(topic.graph.assetId)}`
     );
+    const body = response.clone();
 
     await expectProblem(response, {
       code: "CONTENT_NOT_FOUND",
       status: 404,
+    });
+    await expect(body.json()).resolves.toMatchObject({
+      resolution: expect.stringContaining("/v1/search"),
     });
   });
 
@@ -113,7 +117,7 @@ describe("public agent content", () => {
     );
     const response = await fetchApi(
       test,
-      "/v1/content?ref=asset%3Aen%3Aquran%3Aquran-surah%3A1"
+      "/content?ref=asset%3Aen%3Aquran%3Aquran-surah%3A1"
     );
 
     expect(response.status).toBe(200);
@@ -156,7 +160,7 @@ describe("public agent content", () => {
     const reference = encodeURIComponent(
       `https://nakafa.com/en/${article.publicPath}`
     );
-    const response = await fetchApi(test, `/v1/content?ref=${reference}`);
+    const response = await fetchApi(test, `/content?ref=${reference}`);
 
     await expectProblem(response, {
       code: "SERVICE_UNAVAILABLE",

--- a/packages/backend/convex/routes/agent/content.ts
+++ b/packages/backend/convex/routes/agent/content.ts
@@ -16,7 +16,7 @@ import { Effect, Option } from "effect";
 
 /** Registers the canonical content read and its matching preflight. */
 export function registerAgentContentRoute(api: AgentApp) {
-  api.get("/v1/content", (context) =>
+  api.get("/content", (context) =>
     runMeteredRequest(
       context.env,
       context.req.raw,
@@ -43,7 +43,7 @@ export function registerAgentContentRoute(api: AgentApp) {
       )
     )
   );
-  api.options("/v1/content", () => agentOptionsResponse());
+  api.options("/content", () => agentOptionsResponse());
 }
 
 /** Returns a stable missing-content problem. */

--- a/packages/backend/convex/routes/agent/input.test.ts
+++ b/packages/backend/convex/routes/agent/input.test.ts
@@ -20,7 +20,7 @@ describe("agent HTTP input", () => {
       expect(
         yield* readSearchInput(
           url(
-            "/v1/search?query=linear&query=equation&locale=id&section=material&limit=5&offset=1"
+            "/search?query=linear&query=equation&locale=id&section=material&limit=5&offset=1"
           )
         )
       ).toEqual({
@@ -30,11 +30,11 @@ describe("agent HTTP input", () => {
         queries: ["linear", "equation"],
         section: "material",
       });
-      expect(yield* readSearchInput(url("/v1/search"))).toEqual({});
-      expect(yield* readTaxonomyInput(url("/v1/taxonomy?locale=de"))).toEqual({
+      expect(yield* readSearchInput(url("/search"))).toEqual({});
+      expect(yield* readTaxonomyInput(url("/taxonomy?locale=de"))).toEqual({
         locale: "de",
       });
-      expect(yield* readTaxonomyInput(url("/v1/taxonomy"))).toEqual({});
+      expect(yield* readTaxonomyInput(url("/taxonomy"))).toEqual({});
     })
   );
 
@@ -42,14 +42,12 @@ describe("agent HTTP input", () => {
     Effect.gen(function* () {
       expect(
         yield* readContentInput(
-          url("/v1/content?ref=asset%3Aexample%3Amaterial%3Aalgebra")
+          url("/content?ref=asset%3Aexample%3Amaterial%3Aalgebra")
         )
       ).toBe("asset:example:material:algebra");
       expect(
         yield* readQuranInput(
-          url(
-            "/v1/quran/2?from_verse=1&to_verse=3&locale=id&include_tafsir=true"
-          ),
+          url("/quran/2?from_verse=1&to_verse=3&locale=id&include_tafsir=true"),
           "2"
         )
       ).toEqual({
@@ -59,7 +57,7 @@ describe("agent HTTP input", () => {
         surah: 2,
         to_verse: 3,
       });
-      expect(yield* readQuranInput(url("/v1/quran/1"), "1")).toEqual({
+      expect(yield* readQuranInput(url("/quran/1"), "1")).toEqual({
         surah: 1,
       });
     })
@@ -68,22 +66,22 @@ describe("agent HTTP input", () => {
   it.effect("rejects missing, repeated, unknown, and malformed values", () =>
     Effect.gen(function* () {
       const failures = yield* Effect.all({
-        duplicate: readSearchInput(url("/v1/search?locale=en&locale=id")).pipe(
+        duplicate: readSearchInput(url("/search?locale=en&locale=id")).pipe(
           Effect.flip
         ),
         invalidBoolean: readQuranInput(
-          url("/v1/quran/1?include_tafsir=yes"),
+          url("/quran/1?include_tafsir=yes"),
           "1"
         ).pipe(Effect.flip),
-        invalidInteger: readSearchInput(url("/v1/search?limit=1.5")).pipe(
+        invalidInteger: readSearchInput(url("/search?limit=1.5")).pipe(
           Effect.flip
         ),
         invalidPath: readQuranInput(
-          url("/v1/quran/not-a-number"),
+          url("/quran/not-a-number"),
           "not-a-number"
         ).pipe(Effect.flip),
-        missing: readContentInput(url("/v1/content")).pipe(Effect.flip),
-        unknown: readSearchInput(url("/v1/search?unknown=value")).pipe(
+        missing: readContentInput(url("/content")).pipe(Effect.flip),
+        unknown: readSearchInput(url("/search?unknown=value")).pipe(
           Effect.flip
         ),
       });
@@ -96,26 +94,24 @@ describe("agent HTTP input", () => {
   );
 
   it("recognizes only requests with a body or invalid declared length", () => {
-    expect(hasRequestBody(new Request("https://api.nakafa.com/v1"))).toBe(
-      false
-    );
+    expect(hasRequestBody(new Request("https://api.nakafa.com"))).toBe(false);
     expect(
       hasRequestBody(
-        new Request("https://api.nakafa.com/v1", {
+        new Request("https://api.nakafa.com", {
           headers: { "content-length": "1" },
         })
       )
     ).toBe(true);
     expect(
       hasRequestBody(
-        new Request("https://api.nakafa.com/v1", {
+        new Request("https://api.nakafa.com", {
           headers: { "content-length": "invalid" },
         })
       )
     ).toBe(true);
     expect(
       hasRequestBody(
-        new Request("https://api.nakafa.com/v1", {
+        new Request("https://api.nakafa.com", {
           body: "{}",
           method: "POST",
         })

--- a/packages/backend/convex/routes/agent/quran.test.ts
+++ b/packages/backend/convex/routes/agent/quran.test.ts
@@ -19,21 +19,19 @@ import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 setupApiTest();
 
 describe("public Quran API routes", () => {
-  it.each([
-    "/quran/1",
-    "/quran/1?locale=en",
-    "/v2/quran/1",
-    "/v2/quran/1?locale=en",
-  ])("does not expose the retired Quran path %s", async (path) => {
-    const response = await fetchApi(createConvexTestWithBetterAuth(), path);
+  it.each(["/v2/quran/1", "/v2/quran/1?locale=en"])(
+    "does not expose the retired Quran path %s",
+    async (path) => {
+      const response = await fetchApi(createConvexTestWithBetterAuth(), path);
 
-    expect(response.status).toBe(404);
-  });
+      expect(response.status).toBe(404);
+    }
+  );
 
   it("rejects an out-of-range canonical surah", async () => {
     const response = await fetchApi(
       createConvexTestWithBetterAuth(),
-      "/v1/quran/115"
+      "/quran/115"
     );
 
     await expectProblem(response, {
@@ -65,7 +63,7 @@ describe("public Quran API routes", () => {
     );
     const response = await fetchApi(
       test,
-      "/v1/content?ref=asset%3Aen%3Aquran%3Aquran-surah%3A1"
+      "/content?ref=asset%3Aen%3Aquran%3Aquran-surah%3A1"
     );
 
     expect(response.status).toBe(200);
@@ -114,14 +112,17 @@ describe("public Quran API routes", () => {
         makeQuranSearch("id", 1),
       ])
     );
-    const response = await fetchApi(
-      test,
-      "/v1/quran/1?locale=id&from_verse=1&include_tafsir=true"
-    );
+    const [response, predecessor] = await Promise.all([
+      fetchApi(test, "/quran/1?locale=id&from_verse=1&include_tafsir=true"),
+      fetchApi(test, "/v1/quran/1?locale=id&from_verse=1&include_tafsir=true"),
+    ]);
 
     expect(response.status).toBe(200);
+    expect(predecessor.status).toBe(200);
     expectPublicJson(response);
-    expect(await response.json()).toMatchObject({
+    const body = await response.json();
+    await expect(predecessor.json()).resolves.toEqual(body);
+    expect(body).toMatchObject({
       alignmentId: "alignment:quran:quran-surah:1",
       assetId: "asset:id:quran:quran-surah:1",
       conceptId: "concept:quran:surah:1",

--- a/packages/backend/convex/routes/agent/quran.ts
+++ b/packages/backend/convex/routes/agent/quran.ts
@@ -27,7 +27,7 @@ type ReadQuranReference = (
 
 /** Registers the canonical Quran route in the stable public API namespace. */
 export function registerAgentQuranRoutes(api: AgentApp) {
-  registerQuranRoute(api, "/v1/quran/:surah", (ctx, input) =>
+  registerQuranRoute(api, "/quran/:surah", (ctx, input) =>
     getNakafaQuranReference(ctx, input)
   );
 }
@@ -35,7 +35,7 @@ export function registerAgentQuranRoutes(api: AgentApp) {
 /** Registers one Quran GET and its matching preflight. */
 function registerQuranRoute(
   api: AgentApp,
-  path: "/v1/quran/:surah",
+  path: "/quran/:surah",
   readReference: ReadQuranReference
 ) {
   api.get(path, (context) =>

--- a/packages/backend/convex/routes/agent/response.test.ts
+++ b/packages/backend/convex/routes/agent/response.test.ts
@@ -16,7 +16,7 @@ describe("agent responses", () => {
       );
       const response = yield* logInternalFailure(
         Cause.die(new Error("private defect detail")),
-        "/v1/content",
+        "/content",
         "request-123"
       ).pipe(Effect.provide(Logger.layer([logger])));
       const body = yield* Effect.promise(() => response.json());
@@ -24,7 +24,7 @@ describe("agent responses", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]).toMatchObject({
         annotations: {
-          instance: "/v1/content",
+          instance: "/content",
           requestId: "request-123",
         },
         level: "ERROR",
@@ -33,7 +33,7 @@ describe("agent responses", () => {
       expect(entries[0]?.cause).toContain("private defect detail");
       expect(body).toMatchObject({
         code: "INTERNAL_ERROR",
-        instance: "/v1/content",
+        instance: "/content",
         request_id: "request-123",
         status: 500,
       });

--- a/packages/backend/convex/routes/agent/search.test.ts
+++ b/packages/backend/convex/routes/agent/search.test.ts
@@ -22,7 +22,7 @@ describe("public agent search", () => {
   it("returns stable empty pagination from an empty deployment", async () => {
     const response = await fetchApi(
       createConvexTestWithBetterAuth(),
-      "/v1/search?query=algebra&locale=en&limit=10&offset=0"
+      "/search?query=algebra&locale=en&limit=10&offset=0"
     );
 
     expect(response.status).toBe(200);
@@ -56,7 +56,7 @@ describe("public agent search", () => {
     });
     const response = await fetchApi(
       test,
-      "/v1/search?query=rational%20function&locale=en&section=articles"
+      "/search?query=rational%20function&locale=en&section=articles"
     );
 
     expect(response.status).toBe(200);

--- a/packages/backend/convex/routes/agent/search.ts
+++ b/packages/backend/convex/routes/agent/search.ts
@@ -12,7 +12,7 @@ import { Effect } from "effect";
 
 /** Registers the canonical search read and its matching preflight. */
 export function registerAgentSearchRoute(api: AgentApp) {
-  api.get("/v1/search", (context) =>
+  api.get("/search", (context) =>
     runMeteredRequest(
       context.env,
       context.req.raw,
@@ -23,5 +23,5 @@ export function registerAgentSearchRoute(api: AgentApp) {
       )
     )
   );
-  api.options("/v1/search", () => agentOptionsResponse());
+  api.options("/search", () => agentOptionsResponse());
 }

--- a/packages/backend/convex/routes/agent/security.test.ts
+++ b/packages/backend/convex/routes/agent/security.test.ts
@@ -17,7 +17,7 @@ function requestWithSecret(secret?: string) {
   if (secret !== undefined) {
     headers.set(NAKAFA_API_EDGE_CONTRACT.secretHeader, secret);
   }
-  return new Request("https://api.nakafa.com/v1/health", { headers });
+  return new Request("https://api.nakafa.com/health", { headers });
 }
 
 describe("agent edge security", () => {


### PR DESCRIPTION
## Summary

- expand the protected Convex API origin with the stable unversioned route set
- keep the current `/v1` public edge and OpenAPI contract unchanged in this release
- isolate OpenAPI at its canonical origin path so `/v1/openapi.json` stays absent

## Rollout boundary

This is the expand phase of the public API migration. The Vercel edge and CLI switch only after this exact backend expansion is merged, deployed, and live-verified. No Vercel Preview was created.

## Verification

- `pnpm format`
- `pnpm --filter @repo/backend test` (336 files, 1,466 tests)
- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter api build`
- `pnpm --filter api typecheck`
- `pnpm lint`
- `pnpm boundaries` (2,921 files)
- `git diff --check`
