### PR TITLE
Expose stable public API routes

### DIFF
--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -1,5 +1,8 @@
 import { NAKAFA_API_EDGE_CONTRACT } from "@repo/backend/agent/edge";
-import { createAgentEdgeRoute } from "@repo/backend/agent/route";
+import {
+  createAgentEdgeRoute,
+  NAKAFA_API_ROUTE_SOURCE,
+} from "@repo/backend/agent/route";
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
@@ -16,7 +19,7 @@ export const config: VercelConfig = {
   },
   ...createAgentEdgeRoute({
     contract: NAKAFA_API_EDGE_CONTRACT,
-    source: "^/(openapi\\.json|v1(?:/.*)?)$",
+    source: NAKAFA_API_ROUTE_SOURCE,
     suffix: "/$1",
   }),
 };

--- a/packages/backend/agent/edge.test.ts
+++ b/packages/backend/agent/edge.test.ts
@@ -27,6 +27,7 @@ describe("agent edge contract", () => {
     ["/openapi.json", "/openapi.json"],
     ["/v1", "/v1"],
     ["/v1/content", "/v1/content"],
+    ["/content", "/content"],
   ])("projects the protected origin path for %s", (path, expected) => {
     expect(
       projectPublicApiPath(`${NAKAFA_API_EDGE_CONTRACT.originPath}${path}`)

--- a/packages/backend/agent/route.test.ts
+++ b/packages/backend/agent/route.test.ts
@@ -5,14 +5,17 @@ import {
   NAKAFA_MCP_EDGE_CONTRACT,
   VERCEL_GIT_COMMIT_SHA_ENVIRONMENT,
 } from "@repo/backend/agent/edge";
-import { createAgentEdgeRoute } from "@repo/backend/agent/route";
+import {
+  createAgentEdgeRoute,
+  NAKAFA_API_ROUTE_SOURCE,
+} from "@repo/backend/agent/route";
 
 describe("agent Vercel route", () => {
   it.each([
     {
       contract: NAKAFA_API_EDGE_CONTRACT,
       destination: "$NAKAFA_CONVEX_SITE_URL/internal/agent/$1",
-      source: "^/(openapi\\.json|v1(?:/.*)?)$",
+      source: NAKAFA_API_ROUTE_SOURCE,
       suffix: "/$1",
     },
     {
@@ -70,4 +73,35 @@ describe("agent Vercel route", () => {
       ],
     });
   });
+
+  it.each([
+    "/",
+    "/openapi.json",
+    "/health",
+    "/search",
+    "/content",
+    "/taxonomy",
+    "/quran/1",
+    "/v1",
+    "/v1/health",
+    "/v1/search",
+    "/v1/content",
+    "/v1/missing",
+    "/v1/openapi.json",
+    "/v1/taxonomy",
+    "/v1/quran/1",
+  ])("forwards declared API route %s", (path) => {
+    const source = new RegExp(NAKAFA_API_ROUTE_SOURCE, "u");
+
+    expect(source.test(path)).toBe(true);
+  });
+
+  it.each(["/robots.txt", "/missing"])(
+    "leaves undeclared route %s outside the API bridge",
+    (path) => {
+      const source = new RegExp(NAKAFA_API_ROUTE_SOURCE, "u");
+
+      expect(source.test(path)).toBe(false);
+    }
+  );
 });

--- a/packages/backend/agent/route.ts
+++ b/packages/backend/agent/route.ts
@@ -11,6 +11,10 @@ interface AgentEdgeRouteOptions {
   readonly suffix: string;
 }
 
+/** Public API paths forwarded by Vercel while the versioned predecessor retires. */
+export const NAKAFA_API_ROUTE_SOURCE =
+  "^/(openapi\\.json|v1(?:/.*)?|health|search|content|taxonomy|quran(?:/.*)?|)$";
+
 /** Builds one credential-stripping Vercel route into a protected Convex runtime. */
 export function createAgentEdgeRoute({
   contract,


### PR DESCRIPTION
## Summary

- expose the stable unversioned public API routes at the Vercel edge
- preserve the existing `/v1` predecessor during the controlled rollout
- centralize and verify the exact route allowlist

## Verification

- API config validation
- API and backend native TypeScript typechecks
- 26 focused Effect Vitest tests with full targeted coverage
- format, lint, boundaries, Effect source parity, and diff checks
- independent Codex review, followed by direct verification of the review conclusion

No Vercel Preview was created. Production remains restricted to protected `main`.