### PR TITLE
Switch the public API to stable routes

### DIFF
--- a/.changeset/api.md
+++ b/.changeset/api.md
@@ -1,0 +1,5 @@
+---
+"@nakafa/cli": minor
+---
+
+Use the stable unversioned Nakafa REST API paths.

--- a/packages/backend/agent/openapi/document.test.ts
+++ b/packages/backend/agent/openapi/document.test.ts
@@ -177,13 +177,13 @@ describe("Nakafa OpenAPI document", () => {
       )
     ).toBe(true);
     expect(OPENAPI_RESPONSE_EXAMPLES.QuranReference.pre_bismillah).toBeNull();
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).not.toHaveProperty("/quran/{surah}");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1/content");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1/health");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1/quran/{surah}");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1/search");
-    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/v1/taxonomy");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/content");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/health");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/quran/{surah}");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/search");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).toHaveProperty("/taxonomy");
+    expect(NAKAFA_OPENAPI_DOCUMENT.paths).not.toHaveProperty("/v1");
     expect(NAKAFA_OPENAPI_DOCUMENT.paths).not.toHaveProperty(
       "/v2/quran/{surah}"
     );

--- a/packages/backend/agent/openapi/document.ts
+++ b/packages/backend/agent/openapi/document.ts
@@ -26,14 +26,15 @@ export const NAKAFA_OPENAPI_DOCUMENT = {
       url: `${NAKAFA_BASE_URL}/contact`,
     },
     description:
-      "Read-only public access to Nakafa's signed educational content through one supported V1 contract.",
+      "Read-only public access to Nakafa's signed educational content through one stable contract.",
     license: {
       name: "Nakafa terms",
       url: `${NAKAFA_BASE_URL}/en/terms-of-service`,
     },
     title: "Nakafa Public API",
     version: NAKAFA_PUBLIC_API_VERSION,
-    "x-version-policy": "V1 is the only supported public API contract.",
+    "x-version-policy":
+      "Stable unversioned paths expose the current public API contract.",
   },
   jsonSchemaDialect: "https://json-schema.org/draft/2020-12/schema",
   openapi: "3.1.1",

--- a/packages/backend/agent/openapi/paths.ts
+++ b/packages/backend/agent/openapi/paths.ts
@@ -120,7 +120,7 @@ export const OPENAPI_PATHS = {
       summary: "Read the OpenAPI contract",
     }),
   },
-  "/v1/quran/{surah}": {
+  "/quran/{surah}": {
     get: readOperation({
       description:
         "Returns a bounded Quran verse range with semantic translation notes, signed Arabic and translation sources, and explicit locale-specific tafsir access.",
@@ -137,7 +137,7 @@ export const OPENAPI_PATHS = {
       summary: "Read a source-grounded Quran reference",
     }),
   },
-  "/v1": {
+  "/": {
     get: readOperation({
       description:
         "Returns stable service identity and links for developers and agents.",
@@ -149,7 +149,7 @@ export const OPENAPI_PATHS = {
       summary: "Read the API index",
     }),
   },
-  "/v1/content": {
+  "/content": {
     get: readOperation({
       description:
         "Resolves a readable content ID, resource URI, or canonical URL to agent-readable Markdown.",
@@ -163,7 +163,7 @@ export const OPENAPI_PATHS = {
       summary: "Read public content",
     }),
   },
-  "/v1/health": {
+  "/health": {
     get: readOperation({
       description:
         "Returns process health and an observation timestamp without reading content data.",
@@ -175,7 +175,7 @@ export const OPENAPI_PATHS = {
       summary: "Check API health",
     }),
   },
-  "/v1/search": {
+  "/search": {
     get: readOperation({
       description:
         "Searches the current signed Nakafa publication with stable pagination.",
@@ -188,7 +188,7 @@ export const OPENAPI_PATHS = {
       summary: "Search public content",
     }),
   },
-  "/v1/taxonomy": {
+  "/taxonomy": {
     get: readOperation({
       description:
         "Returns current public sections, locales, categories, counts, and agent tools.",

--- a/packages/backend/convex/routes/agent/content.test.ts
+++ b/packages/backend/convex/routes/agent/content.test.ts
@@ -81,7 +81,7 @@ describe("public agent content", () => {
 
     const response = await fetchApi(
       test,
-      `/v1/content?ref=${encodeURIComponent(topic.graph.assetId)}`
+      `/content?ref=${encodeURIComponent(topic.graph.assetId)}`
     );
     const body = response.clone();
 
@@ -90,7 +90,7 @@ describe("public agent content", () => {
       status: 404,
     });
     await expect(body.json()).resolves.toMatchObject({
-      resolution: expect.stringContaining("/v1/search"),
+      resolution: expect.stringContaining("/search"),
     });
   });
 

--- a/packages/backend/convex/routes/agent/content.ts
+++ b/packages/backend/convex/routes/agent/content.ts
@@ -54,7 +54,7 @@ function contentNotFoundResponse(request: Request, requestId: string) {
     instance: projectPublicApiPath(new URL(request.url).pathname),
     requestId,
     resolution:
-      "Use a content_id from /v1/search with markdown_url, or a canonical readable Nakafa URL.",
+      "Use a content_id from /search with markdown_url, or a canonical readable Nakafa URL.",
     status: 404,
     title: "Content not found",
     type: "content-not-found",

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -11,7 +11,7 @@ import { requestNakafaApi } from "#cli/client";
 const problem = {
   code: "NOT_FOUND",
   detail: "The requested content does not exist.",
-  instance: "/v1/content",
+  instance: "/content",
   request_id: "request-123",
   resolution: "Use a content ID returned by search.",
   status: 404,
@@ -30,7 +30,7 @@ function makeClient(
 }
 
 function execute(client: HttpClient.HttpClient, apiBase: string) {
-  return requestNakafaApi({ apiBase, path: "/v1/health" }).pipe(
+  return requestNakafaApi({ apiBase, path: "/health" }).pipe(
     Effect.provideService(HttpClient.HttpClient, client)
   );
 }
@@ -61,7 +61,7 @@ describe("Nakafa API client", () => {
       });
       const [request] = yield* Ref.get(requests);
       expect(request?.method).toBe("GET");
-      expect(request?.url).toBe("https://api.nakafa.com/v1/health");
+      expect(request?.url).toBe("https://api.nakafa.com/health");
       expect(request?.headers.accept).toBe(
         "application/json, application/problem+json"
       );

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -24,7 +24,7 @@ import { runCli } from "#cli/program";
 const problem = {
   code: "NOT_FOUND",
   detail: "The requested content does not exist.",
-  instance: "/v1/content",
+  instance: "/content",
   request_id: "request-123",
   resolution: "Use a content ID returned by search.",
   status: 404,
@@ -167,20 +167,20 @@ describe("Nakafa CLI execution", () => {
     {
       argv: ["search", "linear", "equations", "--locale", "de", "--limit", "5"],
       expectedUrl:
-        "https://api.nakafa.com/v1/search?query=linear+equations&locale=de&limit=5",
+        "https://api.nakafa.com/search?query=linear+equations&locale=de&limit=5",
     },
     {
       argv: ["get", "https://nakafa.com/en/content?id=1"],
       expectedUrl:
-        "https://api.nakafa.com/v1/content?ref=https%3A%2F%2Fnakafa.com%2Fen%2Fcontent%3Fid%3D1",
+        "https://api.nakafa.com/content?ref=https%3A%2F%2Fnakafa.com%2Fen%2Fcontent%3Fid%3D1",
     },
     {
       argv: ["taxonomy", "--locale", "id"],
-      expectedUrl: "https://api.nakafa.com/v1/taxonomy?locale=id",
+      expectedUrl: "https://api.nakafa.com/taxonomy?locale=id",
     },
     {
       argv: ["taxonomy"],
-      expectedUrl: "https://api.nakafa.com/v1/taxonomy",
+      expectedUrl: "https://api.nakafa.com/taxonomy",
     },
     {
       argv: [
@@ -195,11 +195,11 @@ describe("Nakafa CLI execution", () => {
         "--tafsir",
       ],
       expectedUrl:
-        "https://api.nakafa.com/v1/quran/1?from_verse=1&to_verse=7&locale=en&include_tafsir=true",
+        "https://api.nakafa.com/quran/1?from_verse=1&to_verse=7&locale=en&include_tafsir=true",
     },
     {
       argv: ["quran", "114"],
-      expectedUrl: "https://api.nakafa.com/v1/quran/114",
+      expectedUrl: "https://api.nakafa.com/quran/114",
     },
   ])("calls the public endpoint for $argv", ({ argv, expectedUrl }) =>
     Effect.gen(function* () {
@@ -259,7 +259,7 @@ describe("Nakafa CLI execution", () => {
           '{\n  "nested": {\n    "ok": true\n  }\n}\n'
         );
         const [request] = yield* Ref.get(requests);
-        expect(request?.url).toBe("https://isolated.example.com/v1/taxonomy");
+        expect(request?.url).toBe("https://isolated.example.com/taxonomy");
         expect(request?.headers.accept).toBe(
           "application/json, application/problem+json"
         );

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -145,12 +145,12 @@ function executeCommand(request: CliRequest) {
 function buildApiPath(command: Exclude<CliCommand, { kind: "mcp" }>) {
   if (command.kind === "get") {
     const query = new URLSearchParams({ ref: command.ref });
-    return `/v1/content?${query}`;
+    return `/content?${query}`;
   }
   if (command.kind === "taxonomy") {
     const query = new URLSearchParams();
     appendOptional(query, "locale", command.locale);
-    return withQuery("/v1/taxonomy", query);
+    return withQuery("/taxonomy", query);
   }
   if (command.kind === "quran") {
     const query = new URLSearchParams();
@@ -160,14 +160,14 @@ function buildApiPath(command: Exclude<CliCommand, { kind: "mcp" }>) {
     if (command.includeTafsir) {
       query.set("include_tafsir", "true");
     }
-    return withQuery(`/v1/quran/${command.surah}`, query);
+    return withQuery(`/quran/${command.surah}`, query);
   }
   const query = new URLSearchParams({ query: command.query });
   appendOptional(query, "section", command.section);
   appendOptional(query, "locale", command.locale);
   appendOptional(query, "limit", command.limit);
   appendOptional(query, "offset", command.offset);
-  return `/v1/search?${query}`;
+  return `/search?${query}`;
 }
 
 const plainFormatter = CliOutput.defaultFormatter({ colors: false });

--- a/packages/contents/_lib/agent/schema/api.test.ts
+++ b/packages/contents/_lib/agent/schema/api.test.ts
@@ -47,7 +47,7 @@ describe("Nakafa public API schemas", () => {
       Schema.is(NakafaProblemDetailsSchema)({
         code: "INVALID_REQUEST",
         detail: "Invalid input.",
-        instance: "/v1/search",
+        instance: "/search",
         request_id: "request-1",
         resolution: "Correct the input.",
         status: 200,


### PR DESCRIPTION
## Summary

- publish canonical unversioned paths in the OpenAPI contract
- switch every scoped Nakafa CLI command to the canonical paths
- update content recovery guidance and schema fixtures
- add a minor changeset for `@nakafa/cli@0.2.0`

## Rollout position

Protected main already exposes both canonical and `/v1` routes at production SHA `60287eee4de8c897f1a20c131853dc3111c3d20f`. This PR switches documentation and the scoped CLI while preserving `/v1` temporarily for the explicit observation phase. A later terminal cleanup removes the predecessor after production proof.

## Verification

- production canonical routes verified at exact main SHA
- backend 4 files, 54 tests
- CLI 5 files, 58 tests, 100% coverage
- contents schema 2 tests, 100% coverage
- backend, CLI, and contents native TypeScript typechecks
- API config validation
- CLI build and pinned-runtime package dry run
- format, lint, boundaries, Effect source parity, security audit, and diff check
- direct Codex review completed with no findings, then independently verified
- no Vercel Preview created