### PR TITLE
Render exact LineEquation and cuboid geometry

### DIFF
--- a/apps/www/lib/content/renderer/client/snbt/math/equation.tsx
+++ b/apps/www/lib/content/renderer/client/snbt/math/equation.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const LineEquation = dynamic(() =>
+  import(
+    "@repo/design-system/components/contents/mathematics/line/equation"
+  ).then(({ LineEquation: Component }) => Component)
+);

--- a/apps/www/lib/content/renderer/domain/snbt-math.ts
+++ b/apps/www/lib/content/renderer/domain/snbt-math.ts
@@ -3,6 +3,13 @@ import type { RendererComponentLoader } from "@/lib/content/renderer/loader";
 
 export const domainComponentLoaders = [
   {
+    name: snbtMathComponentNames.lineEquation,
+    load: () =>
+      import("@/lib/content/renderer/client/snbt/math/equation").then(
+        ({ LineEquation }) => LineEquation
+      ),
+  },
+  {
     name: snbtMathComponentNames.numberLine,
     load: () =>
       import("@/lib/content/renderer/client/snbt/math/number").then(

--- a/apps/www/lib/content/renderer/manifest.test.ts
+++ b/apps/www/lib/content/renderer/manifest.test.ts
@@ -72,7 +72,7 @@ describe("renderer manifest", () => {
       });
 
       expect(historicalManifest.hash).toBe(
-        "sha256:e06c5326020aeb0c43c0c565948b18a111a4df009ff3b3fe5cd827f35f9275e7"
+        "sha256:641c6bfbd1307ab31779a68455e4111e27a61daa26c3047da2e5995b0ac17e9f"
       );
       expect(yield* validateRendererManifestHash(historicalManifest)).toEqual(
         historicalManifest

--- a/packages/design-system/components/contents/mathematics/cuboid.test.ts
+++ b/packages/design-system/components/contents/mathematics/cuboid.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { createCuboidLines } from "@repo/design-system/components/contents/mathematics/cuboid";
+import { describe, expect, it } from "vitest";
+
+function getEdgeLength({
+  points,
+}: ReturnType<typeof createCuboidLines>[number]) {
+  const [start, end] = points;
+
+  if (!(start && end)) {
+    return 0;
+  }
+
+  return Math.hypot(end.x - start.x, end.y - start.y, end.z - start.z);
+}
+
+describe("cuboid visual geometry", () => {
+  it("creates twelve straight edges with four of every declared dimension", () => {
+    const lines = createCuboidLines({
+      center: { x: 2, y: 3, z: 4 },
+      color: "slategray",
+      height: 6,
+      kind: "cuboid",
+      length: 4,
+      width: 8,
+    });
+
+    expect(lines).toHaveLength(12);
+    expect(lines.map(getEdgeLength).sort((a, b) => a - b)).toEqual([
+      4, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8,
+    ]);
+    expect(lines).toSatisfy((edges: typeof lines) =>
+      edges.every(
+        (edge) =>
+          edge.color === "slategray" &&
+          edge.points.length === 2 &&
+          edge.showPoints === false &&
+          edge.smooth === false
+      )
+    );
+  });
+
+  it("centers omitted coordinates on the exact origin extents", () => {
+    const lines = createCuboidLines({
+      height: 6,
+      kind: "cuboid",
+      length: 4,
+      width: 8,
+    });
+    const vertices = lines.flatMap((line) => line.points);
+
+    expect(new Set(vertices.map(({ x }) => x))).toEqual(new Set([-2, 2]));
+    expect(new Set(vertices.map(({ y }) => y))).toEqual(new Set([-3, 3]));
+    expect(new Set(vertices.map(({ z }) => z))).toEqual(new Set([-4, 4]));
+  });
+});

--- a/packages/design-system/components/contents/mathematics/cuboid.ts
+++ b/packages/design-system/components/contents/mathematics/cuboid.ts
@@ -1,0 +1,62 @@
+import type {
+  CuboidLine,
+  LinePoint,
+  ResolvedLine,
+} from "@repo/design-system/components/contents/mathematics/line/spec";
+
+const ORIGIN: LinePoint = { x: 0, y: 0, z: 0 };
+
+const EDGE_VERTEX_INDICES = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [3, 0],
+  [4, 5],
+  [5, 6],
+  [6, 7],
+  [7, 4],
+  [0, 4],
+  [1, 5],
+  [2, 6],
+  [3, 7],
+] as const;
+
+/**
+ * Resolves a mathematical cuboid into its twelve exact, axis-aligned edges.
+ *
+ * Length follows the x-axis, height follows the y-axis, and width follows the
+ * z-axis. Every edge is a separate two-point line so the renderer can never
+ * round a cuboid corner through curve interpolation.
+ */
+export function createCuboidLines({
+  center = ORIGIN,
+  color,
+  height,
+  length,
+  lineWidth,
+  showPoints = false,
+  width,
+}: CuboidLine): ResolvedLine[] {
+  const halfLength = length / 2;
+  const halfHeight = height / 2;
+  const halfWidth = width / 2;
+  const { x, y, z } = center;
+  const vertices: LinePoint[] = [
+    { x: x - halfLength, y: y - halfHeight, z: z - halfWidth },
+    { x: x + halfLength, y: y - halfHeight, z: z - halfWidth },
+    { x: x + halfLength, y: y + halfHeight, z: z - halfWidth },
+    { x: x - halfLength, y: y + halfHeight, z: z - halfWidth },
+    { x: x - halfLength, y: y - halfHeight, z: z + halfWidth },
+    { x: x + halfLength, y: y - halfHeight, z: z + halfWidth },
+    { x: x + halfLength, y: y + halfHeight, z: z + halfWidth },
+    { x: x - halfLength, y: y + halfHeight, z: z + halfWidth },
+  ];
+
+  return EDGE_VERTEX_INDICES.map(([startIndex, endIndex]) => ({
+    color,
+    lineWidth,
+    points: [vertices[startIndex], vertices[endIndex]],
+    showPoints,
+    smooth: false,
+  }));
+}

--- a/packages/design-system/components/contents/mathematics/line/equation.tsx
+++ b/packages/design-system/components/contents/mathematics/line/equation.tsx
@@ -16,6 +16,7 @@ const DEFAULT_CAMERA_POSITION_Z = 10;
 
 interface Props {
   cameraPosition?: [number, number, number];
+  cameraTarget?: [number, number, number];
   data: readonly AuthoredLine[];
   description: ReactNode;
   showZAxis?: boolean;
@@ -32,6 +33,7 @@ export function LineEquation({
     DEFAULT_CAMERA_POSITION_Y,
     DEFAULT_CAMERA_POSITION_Z,
   ],
+  cameraTarget,
   showZAxis = true,
 }: Props) {
   const lines = resolveAuthoredLines(data);
@@ -45,6 +47,7 @@ export function LineEquation({
       <CardContent>
         <DeferredLineScene
           cameraPosition={cameraPosition}
+          cameraTarget={cameraTarget}
           lines={lines}
           showZAxis={showZAxis}
         />

--- a/packages/design-system/components/contents/mathematics/line/resolve.test.ts
+++ b/packages/design-system/components/contents/mathematics/line/resolve.test.ts
@@ -10,7 +10,7 @@ const rawLine = {
   ],
 };
 
-describe("authored circle lines", () => {
+describe("authored mathematical lines", () => {
   it("preserves concrete line data and resolves every declarative primitive", () => {
     const lines = resolveAuthoredLines([
       rawLine,
@@ -49,16 +49,27 @@ describe("authored circle lines", () => {
         startDegrees: 30,
         sweepDegrees: 120,
       },
+      {
+        center: { x: 2, y: 3, z: 4 },
+        color: "slategray",
+        height: 6,
+        kind: "cuboid",
+        length: 4,
+        width: 8,
+      },
     ]);
 
-    expect(lines).toHaveLength(7);
+    expect(lines).toHaveLength(19);
     expect(lines[0]).toBe(rawLine);
     expect(lines[1]).toMatchObject({
       color: "cyan",
       showPoints: false,
+      smooth: true,
     });
     expect(lines[1]?.points.length).toBeGreaterThan(4);
+    expect(lines[2]).toMatchObject({ smooth: false });
     expect(lines[2]?.points).toHaveLength(2);
+    expect(lines[3]).toMatchObject({ smooth: false });
     expect(lines[3]?.points[0]).toEqual({ x: 0, y: 0, z: 0 });
     expect(lines[4]).toMatchObject({
       color: "amber",
@@ -67,5 +78,15 @@ describe("authored circle lines", () => {
     });
     expect(lines[5]).toMatchObject({ smooth: true });
     expect(lines[6]).toMatchObject({ smooth: false });
+    expect(lines.slice(7)).toHaveLength(12);
+    expect(lines.slice(7)).toSatisfy((cuboidLines: typeof lines) =>
+      cuboidLines.every(
+        (line) =>
+          line.color === "slategray" &&
+          line.points.length === 2 &&
+          line.showPoints === false &&
+          line.smooth === false
+      )
+    );
   });
 });

--- a/packages/design-system/components/contents/mathematics/line/resolve.ts
+++ b/packages/design-system/components/contents/mathematics/line/resolve.ts
@@ -5,6 +5,7 @@ import {
   createCircleRadiusPoints,
   createCircleSegmentBoundaryLines,
 } from "@repo/design-system/components/contents/mathematics/circle";
+import { createCuboidLines } from "@repo/design-system/components/contents/mathematics/cuboid";
 import type {
   AuthoredLine,
   ResolvedLine,
@@ -18,7 +19,13 @@ function resolveLine(line: AuthoredLine): ResolvedLine[] {
 
   if (line.kind === "circle-outline") {
     const { kind: _kind, radius, ...props } = line;
-    return [{ ...props, points: createCircleOutlinePoints(radius) }];
+    return [
+      {
+        ...props,
+        points: createCircleOutlinePoints(radius),
+        smooth: true,
+      },
+    ];
   }
 
   if (line.kind === "circle-chord") {
@@ -31,6 +38,7 @@ function resolveLine(line: AuthoredLine): ResolvedLine[] {
           startDegrees,
           sweepDegrees,
         }),
+        smooth: false,
       },
     ];
   }
@@ -41,6 +49,7 @@ function resolveLine(line: AuthoredLine): ResolvedLine[] {
       {
         ...props,
         points: createCircleRadiusPoints({ degrees, radius }),
+        smooth: false,
       },
     ];
   }
@@ -48,6 +57,10 @@ function resolveLine(line: AuthoredLine): ResolvedLine[] {
   if (line.kind === "circle-arc") {
     const { kind: _kind, ...arc } = line;
     return [createCircleArcLine(arc)];
+  }
+
+  if (line.kind === "cuboid") {
+    return createCuboidLines(line);
   }
 
   const { kind: _kind, ...segment } = line;

--- a/packages/design-system/components/contents/mathematics/line/scene.tsx
+++ b/packages/design-system/components/contents/mathematics/line/scene.tsx
@@ -7,12 +7,14 @@ import { LineEquation } from "@repo/design-system/components/three/line-equation
 /** Renders the client-only WebGL implementation of one line scene. */
 export function LineScene({
   cameraPosition,
+  cameraTarget,
   lines,
   showZAxis,
 }: LineSceneProps) {
   return (
     <CoordinateSystem
       cameraPosition={cameraPosition}
+      cameraTarget={cameraTarget}
       showGizmo={showZAxis}
       showZAxis={showZAxis}
     >

--- a/packages/design-system/components/contents/mathematics/line/spec.ts
+++ b/packages/design-system/components/contents/mathematics/line/spec.ts
@@ -1,7 +1,7 @@
 import type { ThreeFontSize } from "@repo/design-system/components/three/data/constants";
 import type { ReactNode } from "react";
 
-interface LinePoint {
+export interface LinePoint {
   x: number;
   y: number;
   z: number;
@@ -34,11 +34,21 @@ export interface ResolvedLine {
 /** Exact serializable payload owned by the deferred WebGL boundary. */
 export interface LineSceneProps {
   cameraPosition: [number, number, number];
+  cameraTarget?: [number, number, number];
   lines: readonly ResolvedLine[];
   showZAxis: boolean;
 }
 
-type CircleLine = Omit<ResolvedLine, "points">;
+type CircleLine = Omit<ResolvedLine, "points" | "smooth">;
+
+export interface CuboidLine
+  extends Pick<ResolvedLine, "color" | "lineWidth" | "showPoints"> {
+  readonly center?: LinePoint;
+  readonly height: number;
+  readonly kind: "cuboid";
+  readonly length: number;
+  readonly width: number;
+}
 
 interface CircleAngle {
   readonly radius: number;
@@ -83,4 +93,5 @@ export type AuthoredLine =
   | CircleOutlineLine
   | CircleRadiusLine
   | CircleSegmentLine
+  | CuboidLine
   | ResolvedLine;

--- a/packages/design-system/lib/markdown/names.ts
+++ b/packages/design-system/lib/markdown/names.ts
@@ -185,6 +185,7 @@ export const snbtGeneralComponentNames = {
 
 /** Canonical rich component names owned by SNBT mathematical-reasoning routes. */
 export const snbtMathComponentNames = {
+  lineEquation: "LineEquation",
   numberLine: "NumberLine",
   set2Question19Graph: "Set2Question19Graph",
   set2Question6Graph: "Set2Question6Graph",


### PR DESCRIPTION
## Outcome

Registers the existing declarative `LineEquation` renderer for SNBT mathematics and makes exact geometric primitives render as exact geometry. This fixes the rounded-corner balok failure without changing the tryout UI or user journey.

## Changes

- Adds `LineEquation` to the source-owned SNBT math renderer manifest
- Resolves a declarative `cuboid` into exactly eight vertices and twelve independent straight edges
- Forces circle chords, radii, segment boundaries, and cuboid edges to `smooth: false`
- Keeps true circle arcs and outlines smooth
- Supports an explicit camera target for mathematically useful framing
- Adds tests for four edges of every declared cuboid dimension, origin-centered extents, straightness, and manifest identity

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base origin/main --include-untracked` at 100/100
- Design-system tests: 35 files, 337 tests, 100% coverage
- WWW tests: 211 files, 1,499 tests, 100% coverage
- Renderer tests: 3 files, 14 tests
- `pnpm --filter @repo/design-system typecheck`
- `pnpm --filter www typecheck`

No dependency, lockfile, backend, UI shell, or route behavior changes. Vercel Preview is intentionally not used; protected exact-head CI owns the production build and browser acceptance with its isolated Convex snapshot.