### PR TITLE
Fix checkout admission and error handling

### DIFF
--- a/apps/www/components/ai/chat-error.tsx
+++ b/apps/www/components/ai/chat-error.tsx
@@ -17,12 +17,11 @@ import {
 } from "@repo/design-system/components/ui/empty";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
-import { useAction } from "convex/react";
-import { Effect } from "effect";
 import { useLocale, useTranslations } from "next-intl";
-import { Activity, useTransition } from "react";
+import { Activity } from "react";
 import { CHAT_ERRORS } from "@/app/api/chat/constants";
 import { useChat } from "@/components/ai/context/use-chat";
+import { useBillingNavigation } from "@/lib/billing/use-navigation.client";
 import { isActiveLocale } from "@/lib/i18n/active";
 
 interface AiChatErrorSurfaceProps {
@@ -83,35 +82,21 @@ function ButtonCheckout() {
   const locale = useLocale();
   const t = useTranslations("Auth");
 
-  const [isPending, startTransition] = useTransition();
+  const billing = useBillingNavigation();
 
   const { data: hasSubscription } = useQueryWithStatus(
     api.subscriptions.queries.hasActiveSubscription,
     { productId: products.pro.id }
   );
-  const generateCustomerPortalUrl = useAction(
-    api.customers.actions.public.generateCustomerPortalUrl
-  );
-  const generateCheckoutLink = useAction(
-    api.customers.actions.public.generateCheckoutLink
-  );
-
   const handleCheckout = () => {
     if (!isActiveLocale(locale)) {
       return;
     }
 
-    const program = Effect.tryPromise(() =>
-      generateCheckoutLink({ locale, successUrl: window.location.href })
-    ).pipe(
-      Effect.tap(({ url }) =>
-        Effect.sync(() => {
-          window.location.href = url;
-        })
-      ),
-      Effect.asVoid
-    );
-    startTransition(() => Effect.runPromise(program));
+    billing.openCheckout({
+      locale,
+      source: "chat-checkout",
+    });
   };
 
   const handleManageSubscription = () => {
@@ -119,36 +104,30 @@ function ButtonCheckout() {
       return;
     }
 
-    const program = Effect.tryPromise(() => generateCustomerPortalUrl({})).pipe(
-      Effect.tap(({ url }) =>
-        Effect.sync(() => {
-          window.location.href = url;
-        })
-      ),
-      Effect.asVoid
-    );
-    startTransition(() => Effect.runPromise(program));
+    billing.openPortal({
+      source: "chat-portal",
+    });
   };
 
   return (
     <div className="flex items-center gap-4">
       <Activity mode={hasSubscription ? "visible" : "hidden"}>
         <Button
-          disabled={isPending || !isActiveLocale(locale)}
+          disabled={billing.isPending || !isActiveLocale(locale)}
           onClick={handleManageSubscription}
           variant="secondary"
         >
-          <Spinner icon={Settings01Icon} isLoading={isPending} />
+          <Spinner icon={Settings01Icon} isLoading={billing.isPending} />
           {t("manage")}
         </Button>
       </Activity>
       <Activity mode={hasSubscription ? "hidden" : "visible"}>
         <Button
-          disabled={isPending || !isActiveLocale(locale)}
+          disabled={billing.isPending || !isActiveLocale(locale)}
           onClick={handleCheckout}
           variant="secondary"
         >
-          <Spinner icon={PartyIcon} isLoading={isPending} />
+          <Spinner icon={PartyIcon} isLoading={billing.isPending} />
           {t("get-pro")}
         </Button>
       </Activity>

--- a/apps/www/components/marketing/about/pricing/billing.client.tsx
+++ b/apps/www/components/marketing/about/pricing/billing.client.tsx
@@ -6,11 +6,10 @@ import { products } from "@repo/backend/convex/utils/polar/products";
 import { useQueryWithStatus } from "@repo/backend/helpers/react";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
-import { useAction } from "convex/react";
-import { Effect } from "effect";
 import { useLocale, useTranslations } from "next-intl";
 import { useTransition } from "react";
 import { authClient } from "@/lib/auth/client";
+import { useBillingNavigation } from "@/lib/billing/use-navigation.client";
 import { useUser } from "@/lib/context/use-user";
 import { isActiveLocale } from "@/lib/i18n/active";
 
@@ -19,20 +18,15 @@ export function BillingButton() {
   const locale = useLocale();
   const t = useTranslations("Pricing");
   const callbackURL = `/${locale}/pricing`;
-  const [isPending, startTransition] = useTransition();
   const currentUser = useUser((state) => state.user);
+  const billing = useBillingNavigation();
+  const [isAuthPending, startAuthTransition] = useTransition();
 
   const { data: hasSubscription, isSuccess: subscriptionResolved } =
     useQueryWithStatus(
       api.subscriptions.queries.hasActiveSubscription,
       currentUser ? { productId: products.pro.id } : "skip"
     );
-  const createPortal = useAction(
-    api.customers.actions.public.generateCustomerPortalUrl
-  );
-  const createCheckout = useAction(
-    api.customers.actions.public.generateCheckoutLink
-  );
   const billingReady = !currentUser || subscriptionResolved;
 
   const handleBilling = () => {
@@ -40,28 +34,28 @@ export function BillingButton() {
       return;
     }
 
-    const program = currentUser
-      ? Effect.tryPromise(() =>
-          hasSubscription
-            ? createPortal({})
-            : createCheckout({ locale, successUrl: window.location.href })
-        ).pipe(
-          Effect.tap(({ url }) =>
-            Effect.sync(() => {
-              window.location.href = url;
-            })
-          ),
-          Effect.asVoid
-        )
-      : Effect.tryPromise(() =>
-          authClient.signIn.social({
-            callbackURL,
-            provider: "google",
-          })
-        ).pipe(Effect.asVoid);
+    if (!currentUser) {
+      startAuthTransition(() =>
+        authClient.signIn
+          .social({ callbackURL, provider: "google" })
+          .then(() => undefined)
+      );
+      return;
+    }
 
-    startTransition(() => Effect.runPromise(program));
+    if (hasSubscription) {
+      billing.openPortal({
+        source: "pricing-portal",
+      });
+      return;
+    }
+
+    billing.openCheckout({
+      locale,
+      source: "pricing-checkout",
+    });
   };
+  const isPending = billing.isPending || isAuthPending;
 
   return (
     <Button

--- a/apps/www/components/tryout/set/start-program.ts
+++ b/apps/www/components/tryout/set/start-program.ts
@@ -10,6 +10,7 @@ import type { PublicAppLocale } from "@repo/internationalization/src/routing";
 import { Effect } from "effect";
 import { toast } from "sonner";
 import { reportClientException } from "@/lib/analytics/client";
+import { billingNavigationProgram } from "@/lib/billing/navigation";
 import {
   isTryoutAccessRequired,
   toTryoutClientRequestError,
@@ -77,24 +78,18 @@ export function checkoutProgram(input: {
   readonly failureMessage: string;
   readonly locale: PublicAppLocale;
 }) {
-  return Effect.tryPromise({
-    try: () =>
+  return billingNavigationProgram({
+    navigate: (url) => {
+      window.location.href = url;
+    },
+    onFailure: (error) =>
+      reportRequestFailure(error, "tryout-checkout", input.failureMessage),
+    request: () =>
       input.action({
         locale: input.locale,
         successUrl: window.location.href,
       }),
-    catch: toTryoutClientRequestError,
-  }).pipe(
-    Effect.tap(({ url }) =>
-      Effect.sync(() => {
-        window.location.href = url;
-      })
-    ),
-    Effect.catch((error) =>
-      reportRequestFailure(error, "tryout-checkout", input.failureMessage)
-    ),
-    Effect.asVoid
-  );
+  });
 }
 
 /** Records one non-blocking paywall impression and reports capture failures. */

--- a/apps/www/components/user/settings/subscriptions.tsx
+++ b/apps/www/components/user/settings/subscriptions.tsx
@@ -6,46 +6,31 @@ import { products } from "@repo/backend/convex/utils/polar/products";
 import { useQueryWithStatus } from "@repo/backend/helpers/react";
 import { Button } from "@repo/design-system/components/ui/button";
 import { Spinner } from "@repo/design-system/components/ui/spinner";
-import { useAction } from "convex/react";
-import { Effect } from "effect";
 import { useLocale, useTranslations } from "next-intl";
-import { Activity, useTransition } from "react";
+import { Activity } from "react";
 import { FormBlock } from "@/components/shared/form-block";
+import { useBillingNavigation } from "@/lib/billing/use-navigation.client";
 import { isActiveLocale } from "@/lib/i18n/active";
 
 export function UserSettingsSubscriptions() {
   const locale = useLocale();
   const t = useTranslations("Auth");
 
-  const [isPending, startTransition] = useTransition();
+  const billing = useBillingNavigation();
 
   const { data: hasSubscription } = useQueryWithStatus(
     api.subscriptions.queries.hasActiveSubscription,
     { productId: products.pro.id }
   );
-  const generateCustomerPortalUrl = useAction(
-    api.customers.actions.public.generateCustomerPortalUrl
-  );
-  const generateCheckoutLink = useAction(
-    api.customers.actions.public.generateCheckoutLink
-  );
-
   const handleCheckout = () => {
     if (!isActiveLocale(locale)) {
       return;
     }
 
-    const program = Effect.tryPromise(() =>
-      generateCheckoutLink({ locale, successUrl: window.location.href })
-    ).pipe(
-      Effect.tap(({ url }) =>
-        Effect.sync(() => {
-          window.location.href = url;
-        })
-      ),
-      Effect.asVoid
-    );
-    startTransition(() => Effect.runPromise(program));
+    billing.openCheckout({
+      locale,
+      source: "settings-checkout",
+    });
   };
 
   const handleManageSubscription = () => {
@@ -53,15 +38,9 @@ export function UserSettingsSubscriptions() {
       return;
     }
 
-    const program = Effect.tryPromise(() => generateCustomerPortalUrl({})).pipe(
-      Effect.tap(({ url }) =>
-        Effect.sync(() => {
-          window.location.href = url;
-        })
-      ),
-      Effect.asVoid
-    );
-    startTransition(() => Effect.runPromise(program));
+    billing.openPortal({
+      source: "settings-portal",
+    });
   };
 
   return (
@@ -72,19 +51,19 @@ export function UserSettingsSubscriptions() {
       <div className="flex items-center gap-4">
         <Activity mode={hasSubscription ? "visible" : "hidden"}>
           <Button
-            disabled={isPending || !isActiveLocale(locale)}
+            disabled={billing.isPending || !isActiveLocale(locale)}
             onClick={handleManageSubscription}
           >
-            <Spinner icon={Settings01Icon} isLoading={isPending} />
+            <Spinner icon={Settings01Icon} isLoading={billing.isPending} />
             {t("manage")}
           </Button>
         </Activity>
         <Activity mode={hasSubscription ? "hidden" : "visible"}>
           <Button
-            disabled={isPending || !isActiveLocale(locale)}
+            disabled={billing.isPending || !isActiveLocale(locale)}
             onClick={handleCheckout}
           >
-            <Spinner icon={PartyIcon} isLoading={isPending} />
+            <Spinner icon={PartyIcon} isLoading={billing.isPending} />
             {t("get-pro")}
           </Button>
         </Activity>

--- a/apps/www/e2e/support/pricing.ts
+++ b/apps/www/e2e/support/pricing.ts
@@ -212,9 +212,11 @@ export function expectStablePricingTransition(
   }
 
   expect(observation.after).not.toBeNull();
-  expect(observation.before).not.toBeNull();
   expect(observation.layoutShift).toBe(0);
 
+  // A fast streamed response can replace both fallbacks before either receives
+  // a painted layout box. The HTML-shell assertion still proves the fallbacks
+  // exist, while the layout-shift observer covers the rendered transition.
   if (!(observation.after && observation.before)) {
     return;
   }

--- a/apps/www/lib/billing/navigation.test.ts
+++ b/apps/www/lib/billing/navigation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { vi } from "vitest";
+import { billingNavigationProgram } from "@/lib/billing/navigation";
+
+describe("billing navigation", () => {
+  it.effect("opens the destination returned by the billing action", () =>
+    Effect.gen(function* () {
+      const navigate = vi.fn();
+      const onFailure = vi.fn(() => Effect.void);
+
+      yield* billingNavigationProgram({
+        navigate,
+        onFailure,
+        request: () =>
+          Promise.resolve({ url: "https://checkout.polar.sh/test" }),
+      });
+
+      expect(navigate).toHaveBeenCalledWith("https://checkout.polar.sh/test");
+      expect(onFailure).not.toHaveBeenCalled();
+    })
+  );
+
+  it.effect(
+    "reports a rejected action without escaping to the error boundary",
+    () =>
+      Effect.gen(function* () {
+        const failure = new Error("Checkout unavailable");
+        const navigate = vi.fn();
+        const onFailure = vi.fn(() => Effect.void);
+
+        yield* billingNavigationProgram({
+          navigate,
+          onFailure,
+          request: () => Promise.reject(failure),
+        });
+
+        expect(onFailure).toHaveBeenCalledWith(failure);
+        expect(navigate).not.toHaveBeenCalled();
+      })
+  );
+});

--- a/apps/www/lib/billing/navigation.ts
+++ b/apps/www/lib/billing/navigation.ts
@@ -20,19 +20,16 @@ class BillingNavigationError extends Data.TaggedError(
 /** Opens a billing destination while containing recoverable request failures. */
 export const billingNavigationProgram = Effect.fn("www.billing.navigate")(
   function* (input: BillingNavigationInput) {
-    const destination = yield* Effect.tryPromise({
+    yield* Effect.tryPromise({
       try: input.request,
       catch: (cause) => new BillingNavigationError({ cause }),
     }).pipe(
+      Effect.tap((destination) =>
+        Effect.sync(() => input.navigate(destination.url))
+      ),
       Effect.catchTag("BillingNavigationError", (error) =>
-        input.onFailure(error.cause).pipe(Effect.as(null))
+        input.onFailure(error.cause)
       )
     );
-
-    if (!destination) {
-      return;
-    }
-
-    yield* Effect.sync(() => input.navigate(destination.url));
   }
 );

--- a/apps/www/lib/billing/navigation.ts
+++ b/apps/www/lib/billing/navigation.ts
@@ -1,0 +1,38 @@
+import { Data, Effect } from "effect";
+
+interface BillingDestination {
+  readonly url: string;
+}
+
+interface BillingNavigationInput {
+  readonly navigate: (url: string) => void;
+  readonly onFailure: (cause: unknown) => Effect.Effect<void>;
+  readonly request: () => Promise<BillingDestination>;
+}
+
+/** Typed rejection from a checkout or customer-portal request. */
+class BillingNavigationError extends Data.TaggedError(
+  "BillingNavigationError"
+)<{
+  readonly cause: unknown;
+}> {}
+
+/** Opens a billing destination while containing recoverable request failures. */
+export const billingNavigationProgram = Effect.fn("www.billing.navigate")(
+  function* (input: BillingNavigationInput) {
+    const destination = yield* Effect.tryPromise({
+      try: input.request,
+      catch: (cause) => new BillingNavigationError({ cause }),
+    }).pipe(
+      Effect.catchTag("BillingNavigationError", (error) =>
+        input.onFailure(error.cause).pipe(Effect.as(null))
+      )
+    );
+
+    if (!destination) {
+      return;
+    }
+
+    yield* Effect.sync(() => input.navigate(destination.url));
+  }
+);

--- a/apps/www/lib/billing/use-navigation.client.ts
+++ b/apps/www/lib/billing/use-navigation.client.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { api } from "@repo/backend/convex/_generated/api";
+import type { PublicAppLocale } from "@repo/internationalization/src/routing";
+import { useAction } from "convex/react";
+import { Effect } from "effect";
+import { useTranslations } from "next-intl";
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { reportClientException } from "@/lib/analytics/client";
+import { billingNavigationProgram } from "@/lib/billing/navigation";
+
+interface BillingSource {
+  readonly source: string;
+}
+
+interface CheckoutNavigation extends BillingSource {
+  readonly locale: PublicAppLocale;
+}
+
+/** Owns checkout and customer-portal requests for every client purchase CTA. */
+export function useBillingNavigation() {
+  const t = useTranslations("Auth");
+  const [isPending, startTransition] = useTransition();
+  const createCheckout = useAction(
+    api.customers.actions.public.generateCheckoutLink
+  );
+  const createPortal = useAction(
+    api.customers.actions.public.generateCustomerPortalUrl
+  );
+
+  function runBillingRequest(
+    request: () => Promise<{ url: string }>,
+    failure: BillingSource & { readonly message: string }
+  ) {
+    startTransition(() =>
+      Effect.runPromise(
+        billingNavigationProgram({
+          navigate: (url) => {
+            window.location.href = url;
+          },
+          onFailure: (cause) =>
+            reportClientException(cause, { source: failure.source }).pipe(
+              Effect.tap(() =>
+                Effect.sync(() => {
+                  toast.error(failure.message, { position: "bottom-center" });
+                })
+              )
+            ),
+          request,
+        })
+      )
+    );
+  }
+
+  return {
+    isPending,
+    openCheckout: ({ locale, ...failure }: CheckoutNavigation) =>
+      runBillingRequest(
+        () => createCheckout({ locale, successUrl: window.location.href }),
+        { ...failure, message: t("checkout-error") }
+      ),
+    openPortal: (source: BillingSource) =>
+      runBillingRequest(() => createPortal({}), {
+        ...source,
+        message: t("portal-error"),
+      }),
+  };
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -378,6 +378,7 @@ import type * as credits_mutations from "../credits/mutations.js";
 import type * as crons from "../crons.js";
 import type * as customers_actions_internal from "../customers/actions/internal.js";
 import type * as customers_actions_public from "../customers/actions/public.js";
+import type * as customers_checkout_admission from "../customers/checkout/admission.js";
 import type * as customers_checkout_impl from "../customers/checkout/impl.js";
 import type * as customers_checkout_localization from "../customers/checkout/localization.js";
 import type * as customers_checkout_session from "../customers/checkout/session.js";
@@ -953,6 +954,7 @@ declare const fullApi: ApiFromModules<{
   crons: typeof crons;
   "customers/actions/internal": typeof customers_actions_internal;
   "customers/actions/public": typeof customers_actions_public;
+  "customers/checkout/admission": typeof customers_checkout_admission;
   "customers/checkout/impl": typeof customers_checkout_impl;
   "customers/checkout/localization": typeof customers_checkout_localization;
   "customers/checkout/session": typeof customers_checkout_session;

--- a/packages/backend/convex/analytics/capture.test.ts
+++ b/packages/backend/convex/analytics/capture.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
-import { internal } from "@repo/backend/convex/_generated/api";
 import {
-  captureActionProductEventProgram,
   captureProductEvent,
   deliverProductAnalyticsProgram,
-  ProductAnalyticsCaptureError,
 } from "@repo/backend/convex/analytics/capture";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -26,16 +23,6 @@ const contentViewProperties = {
   lens_id: "lens:id:articles:example",
   locale: "id",
   route: "articles/example",
-} as const;
-const checkoutStartedEvent = {
-  name: "checkout started",
-  properties: {
-    checkout_locale: "en",
-    customer_ip_available: true,
-    locale: "en",
-    product_count: 1,
-    product_id: "product-pro",
-  },
 } as const;
 
 describe("analytics/capture", () => {
@@ -183,175 +170,6 @@ describe("analytics/capture", () => {
           _tag: "ProductAnalyticsCaptureError",
           message: "eligibility unavailable",
         });
-      })
-  );
-
-  it.effect("admits an action event while its app user remains active", () =>
-    Effect.gen(function* () {
-      const t = convexTest(schema, convexModules);
-      const userId = yield* Effect.promise(() =>
-        t.mutation(async (ctx) => {
-          const insertedUserId = await ctx.db.insert("users", {
-            authId: "active-analytics-user-auth",
-            credits: 10,
-            creditsResetAt: NOW,
-            email: "active-analytics@example.com",
-            name: "Active Analytics User",
-            plan: "free",
-          });
-          await seedAnalyticsConsent(ctx, {
-            decidedAt: NOW,
-            userId: insertedUserId,
-          });
-          return insertedUserId;
-        })
-      );
-
-      const admitted = yield* Effect.promise(() =>
-        t.mutation(internal.analytics.capture.captureActionProductEvent, {
-          distinctId: userId,
-          event: checkoutStartedEvent,
-          timestamp: NOW,
-        })
-      );
-      const scheduledJobs = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-      );
-
-      expect(admitted).toBe(true);
-      expect(scheduledJobs).toEqual([
-        expect.objectContaining({
-          args: [
-            expect.objectContaining({
-              event: checkoutStartedEvent.name,
-              properties: JSON.stringify(checkoutStartedEvent.properties),
-              timestamp: NOW,
-            }),
-          ],
-          name: expect.stringContaining("deliverProductEvent"),
-        }),
-      ]);
-    })
-  );
-
-  it.effect("drops an action event while account deletion is prepared", () =>
-    Effect.gen(function* () {
-      const t = convexTest(schema, convexModules);
-      const userId = yield* Effect.promise(() =>
-        t.mutation(async (ctx) => {
-          const insertedUserId = await ctx.db.insert("users", {
-            authId: "deleting-analytics-user-auth",
-            credits: 10,
-            creditsResetAt: NOW,
-            deletionPreparedAt: NOW,
-            email: "deleting-analytics@example.com",
-            name: "Deleting Analytics User",
-            plan: "free",
-          });
-          await seedAnalyticsConsent(ctx, {
-            decidedAt: NOW,
-            userId: insertedUserId,
-          });
-          return insertedUserId;
-        })
-      );
-
-      const admitted = yield* Effect.promise(() =>
-        t.mutation(internal.analytics.capture.captureActionProductEvent, {
-          distinctId: userId,
-          event: checkoutStartedEvent,
-          timestamp: NOW,
-        })
-      );
-      const scheduledJobs = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-      );
-
-      expect(admitted).toBe(false);
-      expect(scheduledJobs).toEqual([]);
-    })
-  );
-
-  it.effect("drops an action event without current analytics consent", () =>
-    Effect.gen(function* () {
-      const t = convexTest(schema, convexModules);
-      const userId = yield* Effect.promise(() =>
-        t.mutation((ctx) =>
-          ctx.db.insert("users", {
-            authId: "removed-analytics-user-auth",
-            credits: 10,
-            creditsResetAt: NOW,
-            email: "removed-analytics@example.com",
-            name: "Removed Analytics User",
-            plan: "free",
-          })
-        )
-      );
-
-      const admitted = yield* Effect.promise(() =>
-        t.mutation(internal.analytics.capture.captureActionProductEvent, {
-          distinctId: userId,
-          event: checkoutStartedEvent,
-        })
-      );
-      const scheduledJobs = yield* Effect.promise(() =>
-        t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
-      );
-
-      expect(admitted).toBe(false);
-      expect(scheduledJobs).toEqual([]);
-    })
-  );
-
-  it.effect(
-    "surfaces action event failures through the typed capture channel",
-    () =>
-      Effect.gen(function* () {
-        const t = convexTest(schema, convexModules);
-        const userId = yield* Effect.promise(() =>
-          t.mutation((ctx) =>
-            ctx.db.insert("users", {
-              authId: "failing-analytics-user-auth",
-              credits: 10,
-              creditsResetAt: NOW,
-              email: "failing-analytics@example.com",
-              name: "Failing Analytics User",
-              plan: "free",
-            })
-          )
-        );
-
-        yield* Effect.promise(() =>
-          expect(
-            t.mutation((ctx) =>
-              runConvexProgram(
-                captureActionProductEventProgram(
-                  ctx,
-                  {
-                    distinctId: userId,
-                    event: checkoutStartedEvent,
-                    timestamp: new Date(NOW),
-                  },
-                  {
-                    capture: () =>
-                      Effect.fail(
-                        new ProductAnalyticsCaptureError({
-                          code: "PRODUCT_ANALYTICS_CAPTURE_FAILED",
-                          message: "PostHog unavailable",
-                        })
-                      ),
-                    loadUser: () => ctx.db.get("users", userId),
-                  }
-                )
-              )
-            )
-          ).rejects.toMatchObject({
-            data: {
-              code: "PRODUCT_ANALYTICS_CAPTURE_FAILED",
-              message: "PostHog unavailable",
-            },
-          })
-        );
       })
   );
 });

--- a/packages/backend/convex/analytics/capture.ts
+++ b/packages/backend/convex/analytics/capture.ts
@@ -1,18 +1,14 @@
 import { ANALYTICS_CONSENT_CATEGORY } from "@repo/analytics/consent";
 import { components } from "@repo/backend/convex/_generated/api";
-import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import {
   internalAction,
-  internalMutation,
   internalQuery,
   type MutationCtx,
   type QueryCtx,
 } from "@repo/backend/convex/_generated/server";
 import { requestAnalyticsErasure } from "@repo/backend/convex/analytics/erasure/request";
-import {
-  type ProductAnalyticsEvent,
-  productAnalyticsEventValidator,
-} from "@repo/backend/convex/analytics/events";
+import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
 import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
 import { hasCurrentConsent } from "@repo/backend/convex/consents/impl";
 import {
@@ -30,10 +26,6 @@ interface ProductAnalyticsCaptureArgs {
   readonly distinctId: Id<"users">;
   readonly event: ProductAnalyticsEvent;
   readonly timestamp?: Date;
-}
-interface ProductAnalyticsCaptureOperations {
-  readonly capture: () => Effect.Effect<boolean, ProductAnalyticsCaptureError>;
-  readonly loadUser: () => Promise<Doc<"users"> | null>;
 }
 interface ProductAnalyticsDeliveryOperations {
   readonly capture: () => Promise<void>;
@@ -199,42 +191,4 @@ export const deliverProductEvent = internalAction({
     );
     return null;
   },
-});
-/** Re-enters mutation ordering before admitting an action-owned event. */
-export const captureActionProductEventProgram = Effect.fn(
-  "analytics.capture.captureActionProductEvent"
-)(function* (
-  ctx: MutationCtx,
-  args: ProductAnalyticsCaptureArgs,
-  operations: ProductAnalyticsCaptureOperations = {
-    capture: () => captureProductEvent(ctx, args),
-    loadUser: () => ctx.db.get("users", args.distinctId),
-  }
-) {
-  const user = yield* Effect.tryPromise({
-    catch: toProductAnalyticsCaptureError,
-    try: operations.loadUser,
-  });
-  if (!user || isAccountDeletionPending(user)) {
-    return false;
-  }
-  return yield* operations.capture();
-});
-/** Mutation boundary for action-owned analytics events. */
-export const captureActionProductEvent = internalMutation({
-  args: {
-    distinctId: vv.id("users"),
-    event: productAnalyticsEventValidator,
-    timestamp: v.optional(v.number()),
-  },
-  returns: v.boolean(),
-  handler: (ctx, args) =>
-    runConvexProgram(
-      captureActionProductEventProgram(ctx, {
-        distinctId: args.distinctId,
-        event: args.event,
-        timestamp:
-          args.timestamp === undefined ? undefined : new Date(args.timestamp),
-      })
-    ),
 });

--- a/packages/backend/convex/customers/actions/public.ts
+++ b/packages/backend/convex/customers/actions/public.ts
@@ -1,6 +1,5 @@
-import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { action } from "@repo/backend/convex/_generated/server";
-import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
+import type { CheckoutAdmissionArgs } from "@repo/backend/convex/customers/checkout/admission";
 import { validateCheckoutRequest } from "@repo/backend/convex/customers/checkout/impl";
 import { checkoutLocaleValidator } from "@repo/backend/convex/customers/checkout/localization";
 import { createAdmittedCheckoutSession } from "@repo/backend/convex/customers/checkout/session";
@@ -16,15 +15,11 @@ import { makeFunctionReference } from "convex/server";
 import { v } from "convex/values";
 import { Effect } from "effect";
 
-const captureActionProductEventReference = makeFunctionReference<
+const admitCheckoutSessionReference = makeFunctionReference<
   "mutation",
-  {
-    distinctId: Id<"users">;
-    event: ProductAnalyticsEvent;
-    timestamp?: number;
-  },
+  CheckoutAdmissionArgs,
   boolean
->("analytics/capture:captureActionProductEvent");
+>("customers/checkout/admission:admitCheckoutSession");
 
 /**
  * Create one authenticated Polar checkout session after validating the selected
@@ -65,8 +60,7 @@ export const generateCheckoutLink = action({
           admitCheckout: () =>
             Effect.tryPromise({
               try: () =>
-                ctx.runMutation(captureActionProductEventReference, {
-                  distinctId: appUserId,
+                ctx.runMutation(admitCheckoutSessionReference, {
                   event: {
                     name: "checkout started",
                     properties: {
@@ -78,6 +72,7 @@ export const generateCheckoutLink = action({
                     },
                   },
                   timestamp: Date.now(),
+                  userId: appUserId,
                 }),
               catch: checkoutSessionIoError,
             }),

--- a/packages/backend/convex/customers/actions/public.ts
+++ b/packages/backend/convex/customers/actions/public.ts
@@ -1,9 +1,11 @@
 import { action } from "@repo/backend/convex/_generated/server";
-import type { CheckoutAdmissionArgs } from "@repo/backend/convex/customers/checkout/admission";
 import { validateCheckoutRequest } from "@repo/backend/convex/customers/checkout/impl";
 import { checkoutLocaleValidator } from "@repo/backend/convex/customers/checkout/localization";
 import { createAdmittedCheckoutSession } from "@repo/backend/convex/customers/checkout/session";
-import { checkoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
+import {
+  type CheckoutAdmissionArgs,
+  checkoutSessionIoError,
+} from "@repo/backend/convex/customers/checkout/spec";
 import { polarGateway } from "@repo/backend/convex/customers/polar/live";
 import { requireCustomer } from "@repo/backend/convex/customers/sync/impl";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";

--- a/packages/backend/convex/customers/checkout/admission.test.ts
+++ b/packages/backend/convex/customers/checkout/admission.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "@effect/vitest";
+import { internal } from "@repo/backend/convex/_generated/api";
+import { ProductAnalyticsCaptureError } from "@repo/backend/convex/analytics/capture";
+import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
+import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/admission";
+import { CheckoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
+import schema from "@repo/backend/convex/schema";
+import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { convexTest } from "convex-test";
+import { Effect } from "effect";
+import { vi } from "vitest";
+
+const NOW = Date.UTC(2026, 7, 31, 5, 0, 0);
+const checkoutStartedEvent = {
+  name: "checkout started",
+  properties: {
+    checkout_locale: "en",
+    customer_ip_available: true,
+    locale: "en",
+    product_count: 1,
+    product_id: "product-pro",
+  },
+} as const satisfies ProductAnalyticsEvent;
+describe("customers/checkout/admission", () => {
+  it.effect("admits an active account without analytics consent", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "checkout-without-consent-auth",
+            credits: 10,
+            creditsResetAt: NOW,
+            email: "checkout-without-consent@example.com",
+            name: "Checkout Without Consent",
+            plan: "free",
+          })
+        )
+      );
+
+      const admitted = yield* Effect.promise(() =>
+        t.mutation(internal.customers.checkout.admission.admitCheckoutSession, {
+          event: checkoutStartedEvent,
+          timestamp: NOW,
+          userId,
+        })
+      );
+      const scheduledJobs = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+      );
+
+      expect(admitted).toBe(true);
+      expect(scheduledJobs).toEqual([]);
+    })
+  );
+
+  it.effect("captures analytics when an active account has consent", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const insertedUserId = await ctx.db.insert("users", {
+            authId: "checkout-with-consent-auth",
+            credits: 10,
+            creditsResetAt: NOW,
+            email: "checkout-with-consent@example.com",
+            name: "Checkout With Consent",
+            plan: "free",
+          });
+          await seedAnalyticsConsent(ctx, {
+            decidedAt: NOW,
+            userId: insertedUserId,
+          });
+          return insertedUserId;
+        })
+      );
+
+      const admitted = yield* Effect.promise(() =>
+        t.mutation(internal.customers.checkout.admission.admitCheckoutSession, {
+          event: checkoutStartedEvent,
+          timestamp: NOW,
+          userId,
+        })
+      );
+      const scheduledJobs = yield* Effect.promise(() =>
+        t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
+      );
+
+      expect(admitted).toBe(true);
+      expect(scheduledJobs).toEqual([
+        expect.objectContaining({
+          args: [
+            expect.objectContaining({
+              event: checkoutStartedEvent.name,
+              properties: JSON.stringify(checkoutStartedEvent.properties),
+              timestamp: NOW,
+            }),
+          ],
+          name: expect.stringContaining("deliverProductEvent"),
+        }),
+      ]);
+    })
+  );
+
+  it.effect("withholds checkout while account deletion is prepared", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) =>
+          ctx.db.insert("users", {
+            authId: "deleting-checkout-auth",
+            credits: 10,
+            creditsResetAt: NOW,
+            deletionPreparedAt: NOW,
+            email: "deleting-checkout@example.com",
+            name: "Deleting Checkout",
+            plan: "free",
+          })
+        )
+      );
+
+      const admitted = yield* Effect.promise(() =>
+        t.mutation(internal.customers.checkout.admission.admitCheckoutSession, {
+          event: checkoutStartedEvent,
+          userId,
+        })
+      );
+
+      expect(admitted).toBe(false);
+    })
+  );
+
+  it.effect("does not block checkout when optional analytics fails", () =>
+    Effect.gen(function* () {
+      const admitted = yield* admitCheckoutProgram({
+        captureEvent: () =>
+          Effect.fail(
+            new ProductAnalyticsCaptureError({
+              code: "PRODUCT_ANALYTICS_CAPTURE_FAILED",
+              message: "PostHog unavailable",
+            })
+          ),
+        loadUser: () => Promise.resolve({}),
+      });
+
+      expect(admitted).toBe(true);
+    })
+  );
+
+  it.effect("preserves account revalidation failures", () =>
+    Effect.gen(function* () {
+      const captureEvent = vi.fn(() => Effect.succeed(true));
+      const failure = yield* admitCheckoutProgram({
+        captureEvent,
+        loadUser: () => Promise.reject(new Error("Convex unavailable")),
+      }).pipe(Effect.flip);
+
+      expect(failure).toBeInstanceOf(CheckoutSessionIoError);
+      expect(captureEvent).not.toHaveBeenCalled();
+    })
+  );
+});

--- a/packages/backend/convex/customers/checkout/admission.test.ts
+++ b/packages/backend/convex/customers/checkout/admission.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { ProductAnalyticsCaptureError } from "@repo/backend/convex/analytics/capture";
 import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
-import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/admission";
+import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/impl";
 import { CheckoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
 import schema from "@repo/backend/convex/schema";
 import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";

--- a/packages/backend/convex/customers/checkout/admission.ts
+++ b/packages/backend/convex/customers/checkout/admission.ts
@@ -1,0 +1,79 @@
+import { internalMutation } from "@repo/backend/convex/_generated/server";
+import {
+  captureProductEvent,
+  type ProductAnalyticsCaptureError,
+} from "@repo/backend/convex/analytics/capture";
+import { productAnalyticsEventValidator } from "@repo/backend/convex/analytics/events";
+import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
+import { checkoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { vv } from "@repo/backend/convex/lib/validators/vv";
+import { type Infer, v } from "convex/values";
+import { Effect } from "effect";
+
+type CheckoutAdmissionUser = Parameters<typeof isAccountDeletionPending>[0];
+
+interface CheckoutAdmissionOperations {
+  readonly captureEvent: () => Effect.Effect<
+    boolean,
+    ProductAnalyticsCaptureError
+  >;
+  readonly loadUser: () => Promise<CheckoutAdmissionUser | null>;
+}
+
+const checkoutAdmissionArgsValidator = v.object({
+  event: productAnalyticsEventValidator,
+  timestamp: v.optional(v.number()),
+  userId: vv.id("users"),
+});
+
+export type CheckoutAdmissionArgs = Infer<
+  typeof checkoutAdmissionArgsValidator
+>;
+
+/** Revalidates account access after Polar IO without gating sales on analytics. */
+export const admitCheckoutProgram = Effect.fn(
+  "customers.checkout.admitCheckout"
+)(function* (operations: CheckoutAdmissionOperations) {
+  const user = yield* Effect.tryPromise({
+    try: operations.loadUser,
+    catch: checkoutSessionIoError,
+  });
+
+  if (!user || isAccountDeletionPending(user)) {
+    return false;
+  }
+
+  yield* operations
+    .captureEvent()
+    .pipe(
+      Effect.catchTag("ProductAnalyticsCaptureError", (error) =>
+        Effect.logWarning("Checkout analytics capture failed.").pipe(
+          Effect.annotateLogs({ code: error.code, reason: error.message })
+        )
+      )
+    );
+
+  return true;
+});
+
+/** Mutation-ordered checkout admission with consent-aware optional analytics. */
+export const admitCheckoutSession = internalMutation({
+  args: checkoutAdmissionArgsValidator.fields,
+  returns: v.boolean(),
+  handler: (ctx, args) =>
+    runConvexProgram(
+      admitCheckoutProgram({
+        captureEvent: () =>
+          captureProductEvent(ctx, {
+            distinctId: args.userId,
+            event: args.event,
+            timestamp:
+              args.timestamp === undefined
+                ? undefined
+                : new Date(args.timestamp),
+          }),
+        loadUser: () => ctx.db.get("users", args.userId),
+      })
+    ),
+});

--- a/packages/backend/convex/customers/checkout/admission.ts
+++ b/packages/backend/convex/customers/checkout/admission.ts
@@ -1,61 +1,9 @@
 import { internalMutation } from "@repo/backend/convex/_generated/server";
-import {
-  captureProductEvent,
-  type ProductAnalyticsCaptureError,
-} from "@repo/backend/convex/analytics/capture";
-import { productAnalyticsEventValidator } from "@repo/backend/convex/analytics/events";
-import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
-import { checkoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
+import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
+import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/impl";
+import { checkoutAdmissionArgsValidator } from "@repo/backend/convex/customers/checkout/spec";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
-import { vv } from "@repo/backend/convex/lib/validators/vv";
-import { type Infer, v } from "convex/values";
-import { Effect } from "effect";
-
-type CheckoutAdmissionUser = Parameters<typeof isAccountDeletionPending>[0];
-
-interface CheckoutAdmissionOperations {
-  readonly captureEvent: () => Effect.Effect<
-    boolean,
-    ProductAnalyticsCaptureError
-  >;
-  readonly loadUser: () => Promise<CheckoutAdmissionUser | null>;
-}
-
-const checkoutAdmissionArgsValidator = v.object({
-  event: productAnalyticsEventValidator,
-  timestamp: v.optional(v.number()),
-  userId: vv.id("users"),
-});
-
-export type CheckoutAdmissionArgs = Infer<
-  typeof checkoutAdmissionArgsValidator
->;
-
-/** Revalidates account access after Polar IO without gating sales on analytics. */
-export const admitCheckoutProgram = Effect.fn(
-  "customers.checkout.admitCheckout"
-)(function* (operations: CheckoutAdmissionOperations) {
-  const user = yield* Effect.tryPromise({
-    try: operations.loadUser,
-    catch: checkoutSessionIoError,
-  });
-
-  if (!user || isAccountDeletionPending(user)) {
-    return false;
-  }
-
-  yield* operations
-    .captureEvent()
-    .pipe(
-      Effect.catchTag("ProductAnalyticsCaptureError", (error) =>
-        Effect.logWarning("Checkout analytics capture failed.").pipe(
-          Effect.annotateLogs({ code: error.code, reason: error.message })
-        )
-      )
-    );
-
-  return true;
-});
+import { v } from "convex/values";
 
 /** Mutation-ordered checkout admission with consent-aware optional analytics. */
 export const admitCheckoutSession = internalMutation({

--- a/packages/backend/convex/customers/checkout/impl.ts
+++ b/packages/backend/convex/customers/checkout/impl.ts
@@ -1,13 +1,26 @@
+import type { ProductAnalyticsCaptureError } from "@repo/backend/convex/analytics/capture";
+import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
 import { getPolarCheckoutLocale } from "@repo/backend/convex/customers/checkout/localization";
 import {
   type CheckoutRequest,
   type CheckoutRequestInput,
+  checkoutSessionIoError,
   InvalidCheckoutSuccessUrl,
   invalidCheckoutSuccessUrlCode,
 } from "@repo/backend/convex/customers/checkout/spec";
 import { products } from "@repo/backend/convex/utils/polar/products";
 import { siteOrigin } from "@repo/backend/convex/utils/site";
 import { Effect } from "effect";
+
+type CheckoutAdmissionUser = Parameters<typeof isAccountDeletionPending>[0];
+
+interface CheckoutAdmissionOperations {
+  readonly captureEvent: () => Effect.Effect<
+    boolean,
+    ProductAnalyticsCaptureError
+  >;
+  readonly loadUser: () => Promise<CheckoutAdmissionUser | null>;
+}
 
 const checkoutProductIds = [products.pro.id] as const;
 
@@ -42,4 +55,30 @@ export const validateCheckoutRequest = Effect.fn(
     productIds: checkoutProductIds,
     successUrl: input.successUrl,
   } satisfies CheckoutRequest;
+});
+
+/** Revalidates account access after Polar IO without gating sales on analytics. */
+export const admitCheckoutProgram = Effect.fn(
+  "customers.checkout.admitCheckout"
+)(function* (operations: CheckoutAdmissionOperations) {
+  const user = yield* Effect.tryPromise({
+    try: operations.loadUser,
+    catch: checkoutSessionIoError,
+  });
+
+  if (!user || isAccountDeletionPending(user)) {
+    return false;
+  }
+
+  yield* operations
+    .captureEvent()
+    .pipe(
+      Effect.catchTag("ProductAnalyticsCaptureError", (error) =>
+        Effect.logWarning("Checkout analytics capture failed.").pipe(
+          Effect.annotateLogs({ code: error.code, reason: error.message })
+        )
+      )
+    );
+
+  return true;
 });

--- a/packages/backend/convex/customers/checkout/spec.ts
+++ b/packages/backend/convex/customers/checkout/spec.ts
@@ -1,9 +1,12 @@
 import type { ActiveAppLocaleCode as Locale } from "@nakafa/aksara-contracts/locale";
+import { productAnalyticsEventValidator } from "@repo/backend/convex/analytics/events";
 import type { PolarCheckoutLocale } from "@repo/backend/convex/customers/checkout/localization";
 import {
   type ConvexTaggedError,
   getUnknownErrorMessage,
 } from "@repo/backend/convex/lib/effect";
+import { vv } from "@repo/backend/convex/lib/validators/vv";
+import { type Infer, v } from "convex/values";
 import { Schema } from "effect";
 
 export const invalidCheckoutSuccessUrlCode = "INVALID_CHECKOUT_SUCCESS_URL";
@@ -21,6 +24,16 @@ export interface CheckoutRequest {
   readonly productIds: readonly string[];
   readonly successUrl: string;
 }
+
+export const checkoutAdmissionArgsValidator = v.object({
+  event: productAnalyticsEventValidator,
+  timestamp: v.optional(v.number()),
+  userId: vv.id("users"),
+});
+
+export type CheckoutAdmissionArgs = Infer<
+  typeof checkoutAdmissionArgsValidator
+>;
 
 export class CheckoutSessionIoError
   extends Schema.TaggedError<CheckoutSessionIoError>()(

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -538,6 +538,8 @@
     "subscriptions-description": "Verwalte Nakafa Pro, 3.000 monatliche KI-Credits und dein Zahlungsportal.",
     "get-pro": "Pro holen",
     "manage": "Verwalten",
+    "checkout-error": "Der Pro-Checkout konnte nicht geöffnet werden. Versuche es erneut.",
+    "portal-error": "Das Abo-Portal konnte nicht geöffnet werden. Versuche es erneut.",
     "plan-free": "Kostenlos",
     "plan-pro": "Pro",
     "name": "Name",

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -538,6 +538,8 @@
     "subscriptions-description": "Manage Nakafa Pro, 3,000 monthly AI credits, and your payment portal.",
     "get-pro": "Get Pro",
     "manage": "Manage",
+    "checkout-error": "We could not open Pro checkout. Please try again.",
+    "portal-error": "We could not open the subscription portal. Please try again.",
     "plan-free": "Free",
     "plan-pro": "Pro",
     "name": "Name",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -538,6 +538,8 @@
     "subscriptions-description": "Kelola Nakafa Pro, 3.000 kredit AI bulanan, dan portal pembayaranmu.",
     "get-pro": "Dapatkan Pro",
     "manage": "Kelola",
+    "checkout-error": "Checkout Pro belum bisa dibuka. Coba lagi.",
+    "portal-error": "Portal langganan belum bisa dibuka. Coba lagi.",
     "plan-free": "Free",
     "plan-pro": "Pro",
     "name": "Nama",


### PR DESCRIPTION
## Summary

- separate active-account checkout admission from optional consent-aware analytics
- preserve checkout when analytics consent is absent or analytics delivery fails
- contain checkout and portal action failures in one billing navigation boundary with localized feedback
- cover checkout admission, provider navigation, and failure behavior with focused tests

## Root cause

The Polar checkout session was created successfully, then the post-checkout analytics mutation returned `false` when the user had not granted analytics consent. Checkout admission interpreted that result as an unavailable user and emitted the misleading `UNAUTHORIZED: User not found` error. No Convex user or Polar customer backfill is required.

## Verification

- `pnpm --filter @repo/backend test` (337 files, 1,485 tests)
- `pnpm --filter www test` (212 files, 1,501 tests, 100% coverage)
- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm run doctor --verbose --scope changed --base origin/main --include-untracked` (100)
- local Next.js production compile and TypeScript completed; page-data collection requires the CI signed-content environment

## Release

No Vercel Preview is requested. Production deployment must occur only through protected merge to `main`.