### PR TITLE
Cut public API over to V1-only routes

### DIFF
--- a/apps/api/vercel.ts
+++ b/apps/api/vercel.ts
@@ -1,7 +1,7 @@
 import { NAKAFA_API_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import {
-  createAgentEdgeRoute,
-  NAKAFA_API_ROUTE_SOURCE,
+  createAgentEdgeRoutes,
+  NAKAFA_API_EDGE_PATHS,
 } from "@repo/backend/agent/route";
 import type { VercelConfig } from "@vercel/config/v1";
 
@@ -17,10 +17,9 @@ export const config: VercelConfig = {
       main: true,
     },
   },
-  ...createAgentEdgeRoute({
+  ...createAgentEdgeRoutes({
     contract: NAKAFA_API_EDGE_CONTRACT,
-    source: NAKAFA_API_ROUTE_SOURCE,
-    suffix: "/$1",
+    paths: NAKAFA_API_EDGE_PATHS,
   }),
 };
 

--- a/apps/mcp/vercel.ts
+++ b/apps/mcp/vercel.ts
@@ -1,5 +1,5 @@
 import { NAKAFA_MCP_EDGE_CONTRACT } from "@repo/backend/agent/edge";
-import { createAgentEdgeRoute } from "@repo/backend/agent/route";
+import { createAgentEdgeRoutes } from "@repo/backend/agent/route";
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
@@ -14,10 +14,9 @@ export const config: VercelConfig = {
       main: true,
     },
   },
-  ...createAgentEdgeRoute({
+  ...createAgentEdgeRoutes({
     contract: NAKAFA_MCP_EDGE_CONTRACT,
-    source: "^/mcp$",
-    suffix: "",
+    paths: [{ source: "^/mcp$", suffix: "" }],
   }),
 };
 

--- a/packages/backend/agent/route.test.ts
+++ b/packages/backend/agent/route.test.ts
@@ -1,87 +1,106 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
+  type AgentEdgeContract,
   NAKAFA_API_EDGE_CONTRACT,
   NAKAFA_EDGE_RELEASE_SHA_HEADER,
   NAKAFA_MCP_EDGE_CONTRACT,
   VERCEL_GIT_COMMIT_SHA_ENVIRONMENT,
 } from "@repo/backend/agent/edge";
 import {
-  createAgentEdgeRoute,
-  NAKAFA_API_ROUTE_SOURCE,
+  createAgentEdgeRoutes,
+  NAKAFA_API_EDGE_PATHS,
 } from "@repo/backend/agent/route";
 
-describe("agent Vercel route", () => {
-  it.each([
-    {
-      contract: NAKAFA_API_EDGE_CONTRACT,
-      destination: "$NAKAFA_CONVEX_SITE_URL/internal/agent/$1",
-      source: NAKAFA_API_ROUTE_SOURCE,
-      suffix: "/$1",
-    },
-    {
-      contract: NAKAFA_MCP_EDGE_CONTRACT,
-      destination: "$NAKAFA_CONVEX_SITE_URL/internal/mcp",
-      source: "^/mcp$",
-      suffix: "",
-    },
-  ])("protects $source before rewriting to Convex", (input) => {
+function expectedRoute(
+  contract: AgentEdgeContract,
+  source: string,
+  destination: string
+) {
+  return {
+    src: source,
+    dest: destination,
+    env: [contract.originEnvironment],
+    respectOriginCacheControl: false,
+    transforms: [
+      {
+        type: "request.headers",
+        op: "delete",
+        target: { key: "authorization" },
+      },
+      {
+        type: "request.headers",
+        op: "delete",
+        target: { key: "cookie" },
+      },
+      {
+        type: "request.headers",
+        op: "delete",
+        target: { key: contract.secretHeader },
+      },
+      {
+        type: "request.headers",
+        op: "set",
+        target: { key: contract.secretHeader },
+        args: `$${contract.secretEnvironment}`,
+        env: [contract.secretEnvironment],
+      },
+      {
+        type: "response.headers",
+        op: "set",
+        target: { key: NAKAFA_EDGE_RELEASE_SHA_HEADER },
+        args: `$${VERCEL_GIT_COMMIT_SHA_ENVIRONMENT}`,
+        env: [VERCEL_GIT_COMMIT_SHA_ENVIRONMENT],
+      },
+    ],
+  };
+}
+
+describe("agent Vercel routes", () => {
+  it("maps the versioned public API to separated protected capabilities", () => {
     expect(
-      createAgentEdgeRoute({
-        contract: input.contract,
-        source: input.source,
-        suffix: input.suffix,
+      createAgentEdgeRoutes({
+        contract: NAKAFA_API_EDGE_CONTRACT,
+        paths: NAKAFA_API_EDGE_PATHS,
       })
     ).toEqual({
       routes: [
-        {
-          src: input.source,
-          dest: input.destination,
-          env: [input.contract.originEnvironment],
-          respectOriginCacheControl: false,
-          transforms: [
-            {
-              type: "request.headers",
-              op: "delete",
-              target: { key: "authorization" },
-            },
-            {
-              type: "request.headers",
-              op: "delete",
-              target: { key: "cookie" },
-            },
-            {
-              type: "request.headers",
-              op: "delete",
-              target: { key: input.contract.secretHeader },
-            },
-            {
-              type: "request.headers",
-              op: "set",
-              target: { key: input.contract.secretHeader },
-              args: `$${input.contract.secretEnvironment}`,
-              env: [input.contract.secretEnvironment],
-            },
-            {
-              type: "response.headers",
-              op: "set",
-              target: { key: NAKAFA_EDGE_RELEASE_SHA_HEADER },
-              args: `$${VERCEL_GIT_COMMIT_SHA_ENVIRONMENT}`,
-              env: [VERCEL_GIT_COMMIT_SHA_ENVIRONMENT],
-            },
-          ],
-        },
+        expectedRoute(
+          NAKAFA_API_EDGE_CONTRACT,
+          "^/openapi\\.json$",
+          "$NAKAFA_CONVEX_SITE_URL/internal/agent/openapi"
+        ),
+        expectedRoute(
+          NAKAFA_API_EDGE_CONTRACT,
+          "^/v1$",
+          "$NAKAFA_CONVEX_SITE_URL/internal/agent/runtime"
+        ),
+        expectedRoute(
+          NAKAFA_API_EDGE_CONTRACT,
+          "^/v1/(.*)$",
+          "$NAKAFA_CONVEX_SITE_URL/internal/agent/runtime/$1"
+        ),
+      ],
+    });
+  });
+
+  it("maps the MCP endpoint to its protected transport", () => {
+    const paths = [{ source: "^/mcp$", suffix: "" }] as const;
+
+    expect(
+      createAgentEdgeRoutes({ contract: NAKAFA_MCP_EDGE_CONTRACT, paths })
+    ).toEqual({
+      routes: [
+        expectedRoute(
+          NAKAFA_MCP_EDGE_CONTRACT,
+          "^/mcp$",
+          "$NAKAFA_CONVEX_SITE_URL/internal/mcp"
+        ),
       ],
     });
   });
 
   it.each([
-    "/",
     "/openapi.json",
-    "/health",
-    "/search",
-    "/content",
-    "/taxonomy",
-    "/quran/1",
     "/v1",
     "/v1/health",
     "/v1/search",
@@ -91,17 +110,28 @@ describe("agent Vercel route", () => {
     "/v1/taxonomy",
     "/v1/quran/1",
   ])("forwards declared API route %s", (path) => {
-    const source = new RegExp(NAKAFA_API_ROUTE_SOURCE, "u");
-
-    expect(source.test(path)).toBe(true);
+    expect(
+      NAKAFA_API_EDGE_PATHS.some(({ source }) =>
+        new RegExp(source, "u").test(path)
+      )
+    ).toBe(true);
   });
 
-  it.each(["/robots.txt", "/missing"])(
-    "leaves undeclared route %s outside the API bridge",
-    (path) => {
-      const source = new RegExp(NAKAFA_API_ROUTE_SOURCE, "u");
-
-      expect(source.test(path)).toBe(false);
-    }
-  );
+  it.each([
+    "/",
+    "/health",
+    "/search",
+    "/content",
+    "/taxonomy",
+    "/quran/1",
+    "/robots.txt",
+    "/missing",
+    "/v2",
+  ])("leaves non-contract route %s outside the API bridge", (path) => {
+    expect(
+      NAKAFA_API_EDGE_PATHS.some(({ source }) =>
+        new RegExp(source, "u").test(path)
+      )
+    ).toBe(false);
+  });
 });

--- a/packages/backend/agent/route.ts
+++ b/packages/backend/agent/route.ts
@@ -19,7 +19,7 @@ interface AgentEdgeRouteOptions {
 /** Versioned public API paths and their stable protected-runtime destinations. */
 export const NAKAFA_API_EDGE_PATHS = [
   {
-    source: "^/openapi\\.json$",
+    source: `^${NAKAFA_API_EDGE_CONTRACT.discoveryPath.replaceAll(".", "\\.")}$`,
     suffix: NAKAFA_API_EDGE_CONTRACT.documentPath,
   },
   {

--- a/packages/backend/agent/route.ts
+++ b/packages/backend/agent/route.ts
@@ -1,65 +1,83 @@
-import type { AgentEdgeContract } from "@repo/backend/agent/edge";
 import {
+  type AgentEdgeContract,
+  NAKAFA_API_EDGE_CONTRACT,
   NAKAFA_EDGE_RELEASE_SHA_HEADER,
   VERCEL_GIT_COMMIT_SHA_ENVIRONMENT,
 } from "@repo/backend/agent/edge";
 import { createRoutes, deploymentEnv } from "@vercel/config/v1";
 
-interface AgentEdgeRouteOptions {
-  readonly contract: AgentEdgeContract;
+interface AgentEdgePath {
   readonly source: string;
   readonly suffix: string;
 }
 
-/** Public API paths forwarded by Vercel while the versioned predecessor retires. */
-export const NAKAFA_API_ROUTE_SOURCE =
-  "^/(openapi\\.json|v1(?:/.*)?|health|search|content|taxonomy|quran(?:/.*)?|)$";
+interface AgentEdgeRouteOptions {
+  readonly contract: AgentEdgeContract;
+  readonly paths: readonly AgentEdgePath[];
+}
 
-/** Builds one credential-stripping Vercel route into a protected Convex runtime. */
-export function createAgentEdgeRoute({
+/** Versioned public API paths and their stable protected-runtime destinations. */
+export const NAKAFA_API_EDGE_PATHS = [
+  {
+    source: "^/openapi\\.json$",
+    suffix: NAKAFA_API_EDGE_CONTRACT.documentPath,
+  },
+  {
+    source: `^${NAKAFA_API_EDGE_CONTRACT.publicPath}$`,
+    suffix: NAKAFA_API_EDGE_CONTRACT.runtimePath,
+  },
+  {
+    source: `^${NAKAFA_API_EDGE_CONTRACT.publicPath}/(.*)$`,
+    suffix: `${NAKAFA_API_EDGE_CONTRACT.runtimePath}/$1`,
+  },
+] as const;
+
+/** Builds credential-stripping Vercel routes into one protected Convex runtime. */
+export function createAgentEdgeRoutes({
   contract,
-  source,
-  suffix,
+  paths,
 }: AgentEdgeRouteOptions) {
   const routes = createRoutes();
 
-  routes.route({
-    src: source,
-    dest: `${deploymentEnv(contract.originEnvironment)}${contract.originPath}${suffix}`,
-    env: [contract.originEnvironment],
-    respectOriginCacheControl: false,
-    transforms: [
-      {
-        type: "request.headers",
-        op: "delete",
-        target: { key: "authorization" },
-      },
-      {
-        type: "request.headers",
-        op: "delete",
-        target: { key: "cookie" },
-      },
-      {
-        type: "request.headers",
-        op: "delete",
-        target: { key: contract.secretHeader },
-      },
-      {
-        type: "request.headers",
-        op: "set",
-        target: { key: contract.secretHeader },
-        args: deploymentEnv(contract.secretEnvironment),
-        env: [contract.secretEnvironment],
-      },
-      {
-        type: "response.headers",
-        op: "set",
-        target: { key: NAKAFA_EDGE_RELEASE_SHA_HEADER },
-        args: deploymentEnv(VERCEL_GIT_COMMIT_SHA_ENVIRONMENT),
-        env: [VERCEL_GIT_COMMIT_SHA_ENVIRONMENT],
-      },
-    ],
-  });
+  for (const path of paths) {
+    routes.route({
+      src: path.source,
+      dest: `${deploymentEnv(contract.originEnvironment)}${contract.originPath}${path.suffix}`,
+      env: [contract.originEnvironment],
+      respectOriginCacheControl: false,
+      transforms: [
+        {
+          type: "request.headers",
+          op: "delete",
+          target: { key: "authorization" },
+        },
+        {
+          type: "request.headers",
+          op: "delete",
+          target: { key: "cookie" },
+        },
+        {
+          type: "request.headers",
+          op: "delete",
+          target: { key: contract.secretHeader },
+        },
+        {
+          type: "request.headers",
+          op: "set",
+          target: { key: contract.secretHeader },
+          args: deploymentEnv(contract.secretEnvironment),
+          env: [contract.secretEnvironment],
+        },
+        {
+          type: "response.headers",
+          op: "set",
+          target: { key: NAKAFA_EDGE_RELEASE_SHA_HEADER },
+          args: deploymentEnv(VERCEL_GIT_COMMIT_SHA_ENVIRONMENT),
+          env: [VERCEL_GIT_COMMIT_SHA_ENVIRONMENT],
+        },
+      ],
+    });
+  }
 
   return routes.getConfig();
 }


### PR DESCRIPTION
## Root cause

The public API edge still used one broad capture route. It forwarded both `/v1` and unversioned resource aliases to protected paths that retained public URL vocabulary. That left duplicate public contracts even after the canonical V1 identity was restored.

## Change

- expose public resources only through `/v1` and `/v1/*`
- keep `/openapi.json` as the single unversioned public discovery document
- route discovery to stable protected `/internal/agent/openapi`
- route V1 resources to stable protected `/internal/agent/runtime`
- keep MCP behavior and its protected destination unchanged
- preserve credential stripping, edge-secret replacement, release SHA headers, and cache policy
- reject `/`, `/health`, `/search`, `/content`, `/taxonomy`, `/quran/*`, and `/v2` at the public edge

## Rollout proof

The protected capability expansion is already on protected `main` at `5d3759c44e967ba85b9e152fb62f8f55316540e6`.

- API, MCP, and WWW production deployments are READY at that exact SHA
- the WWW build deployed Convex successfully with schema validation
- `/v1` and `/v1/health` report contract version `1.0.0`
- `/v2` returns 404
- OpenAPI reports `1.0.0` and contains only `/v1/*` public resources plus `/openapi.json`
- protected `/internal/agent/runtime` and `/internal/agent/openapi` exist and reject direct unauthenticated access with 403
- API, MCP, and WWW production error telemetry is clean for the release window
- there is no fixed observation delay and no 24-hour wait

After this protected merge is live-verified, the next terminal change removes the temporary predecessor protected mounts and rollout-only tests immediately.

## Exact-head verification

Head: `bda7491b2cc34ba299ccdd8e667b1914a1aa0f52`

- `pnpm format`
- 20 focused route tests
- backend full suite: 336 files, 1,492 tests
- backend, API, and MCP typechecks
- API and MCP Vercel config validation
- `pnpm lint`
- `pnpm boundaries`: 2,930 files across 19 packages
- Effect source parity at `effect@4.0.0-rc.110`
- direct Codex review, independently traced: no actionable defects
- no Vercel Preview created
