### PR TITLE
Remove retired protected API aliases

### DIFF
--- a/docs/adr/0006-api.md
+++ b/docs/adr/0006-api.md
@@ -77,9 +77,9 @@ contract:
 The current release owner owns the observation gate. It starts after the
 protected-main switch and closes when every owned production alias and consumer
 points to the successor and post-switch logs contain no legitimate predecessor
-reader. The gate is evidence-based and has no fixed quiet period. It never
-requires a 24-hour wait. A predecessor exists only for deployment ordering and
-must not become a permanent compatibility surface.
+reader. The gate closes on evidence, never elapsed time. A predecessor exists
+only for deployment ordering and must not become a permanent compatibility
+surface.
 
 ## Consequences
 

--- a/packages/backend/agent/edge.test.ts
+++ b/packages/backend/agent/edge.test.ts
@@ -31,14 +31,9 @@ describe("agent edge contract", () => {
   });
 
   it.each([
-    ["", "/"],
     ["/openapi", "/openapi.json"],
-    ["/openapi.json", "/openapi.json"],
     ["/runtime", "/v1"],
     ["/runtime/content", "/v1/content"],
-    ["/v1", "/v1"],
-    ["/v1/content", "/v1/content"],
-    ["/content", "/content"],
   ])("projects the protected origin path for %s", (path, expected) => {
     expect(
       projectPublicApiPath(`${NAKAFA_API_EDGE_CONTRACT.originPath}${path}`)

--- a/packages/backend/agent/edge.ts
+++ b/packages/backend/agent/edge.ts
@@ -81,8 +81,5 @@ export function projectPublicApiPath(pathname: string) {
   if (originPath === NAKAFA_API_EDGE_CONTRACT.runtimePath) {
     return NAKAFA_API_EDGE_CONTRACT.publicPath;
   }
-  if (originPath.startsWith(`${NAKAFA_API_EDGE_CONTRACT.runtimePath}/`)) {
-    return `${NAKAFA_API_EDGE_CONTRACT.publicPath}${originPath.slice(NAKAFA_API_EDGE_CONTRACT.runtimePath.length)}`;
-  }
-  return originPath || "/";
+  return `${NAKAFA_API_EDGE_CONTRACT.publicPath}${originPath.slice(NAKAFA_API_EDGE_CONTRACT.runtimePath.length)}`;
 }

--- a/packages/backend/convex/routes/agent/api.test.ts
+++ b/packages/backend/convex/routes/agent/api.test.ts
@@ -24,18 +24,6 @@ import { TEST_RUNTIME_RELEASE } from "@repo/backend/test/runtime/values";
 
 setupApiTest();
 
-type BackendTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
-function fetchPredecessor(test: BackendTest, prefix: "" | "/v1", path: string) {
-  const headers = new Headers({
-    [NAKAFA_API_EDGE_CONTRACT.secretHeader]: API_SECRET,
-    "x-forwarded-for": "203.0.113.4",
-  });
-  return test.fetch(`${NAKAFA_API_EDGE_CONTRACT.originPath}${prefix}${path}`, {
-    headers,
-  });
-}
-
 describe("public agent API routes", () => {
   it("serves the API index, health response, and CORS preflight", async () => {
     const test = createConvexTestWithBetterAuth();
@@ -74,7 +62,6 @@ describe("public agent API routes", () => {
     const rejected = await fetchOpenApi(test, { method: "POST" });
     const rejectedBody = rejected.clone();
     const response = await fetchOpenApi(test);
-    const predecessor = await fetchPredecessor(test, "", "/openapi.json");
     const etag = response.headers.get("etag");
     const revalidated = await fetchOpenApi(test, {
       headers: { "if-none-match": etag ?? "missing" },
@@ -95,7 +82,6 @@ describe("public agent API routes", () => {
     expect(response.headers.get("cache-control")).toBe(
       "public, max-age=3600, s-maxage=3600"
     );
-    expect(predecessor.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       info: { title: "Nakafa Public API" },
       openapi: "3.1.1",
@@ -118,28 +104,30 @@ describe("public agent API routes", () => {
     }
   );
 
-  it("does not expose the predecessor origin mount", async () => {
+  it("does not expose the protected origin at the site root", async () => {
     const response = await createConvexTestWithBetterAuth().fetch("/");
 
     expect(response.status).toBe(404);
   });
 
   it.each([
-    ["", "/"],
-    ["", "/health"],
-    ["/v1", ""],
-    ["/v1", "/health"],
-    ["/v1", "/search?query=algebra"],
-  ] as const)(
-    "keeps predecessor %s%s readable during the deployment transition",
-    async (prefix, path) => {
-      const response = await fetchPredecessor(
-        createConvexTestWithBetterAuth(),
-        prefix,
-        path
+    "/",
+    NAKAFA_API_EDGE_CONTRACT.discoveryPath,
+    NAKAFA_API_EDGE_CONTRACT.publicPath,
+    `${NAKAFA_API_EDGE_CONTRACT.publicPath}/health`,
+  ])(
+    "keeps public vocabulary out of the protected origin at %s",
+    async (path) => {
+      const headers = new Headers({
+        [NAKAFA_API_EDGE_CONTRACT.secretHeader]: API_SECRET,
+        "x-forwarded-for": "203.0.113.4",
+      });
+      const response = await createConvexTestWithBetterAuth().fetch(
+        `${NAKAFA_API_EDGE_CONTRACT.originPath}${path}`,
+        { headers }
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(404);
     }
   );
 
@@ -330,16 +318,9 @@ describe("public agent API routes", () => {
 
   it("fails closed when the signed taxonomy publication is unavailable", async () => {
     const test = createConvexTestWithBetterAuth();
-    const [response, predecessor] = await Promise.all([
-      fetchApi(test, "/taxonomy?locale=en"),
-      fetchPredecessor(test, "/v1", "/taxonomy?locale=en"),
-    ]);
+    const response = await fetchApi(test, "/taxonomy?locale=en");
 
     await expectProblem(response, {
-      code: "SERVICE_UNAVAILABLE",
-      status: 503,
-    });
-    await expectProblem(predecessor, {
       code: "SERVICE_UNAVAILABLE",
       status: 503,
     });

--- a/packages/backend/convex/routes/agent/api.ts
+++ b/packages/backend/convex/routes/agent/api.ts
@@ -124,8 +124,6 @@ export function registerAgentApiRoutes(app: AgentApp) {
   );
   document.options("/", () => createOpenApiOptionsResponse());
 
-  // Keep the deployed edge destinations readable until the independently
-  // deployed public edge has switched to the capability-owned paths below.
   app.route(
     `${NAKAFA_API_EDGE_CONTRACT.originPath}${NAKAFA_API_EDGE_CONTRACT.documentPath}`,
     document
@@ -134,9 +132,6 @@ export function registerAgentApiRoutes(app: AgentApp) {
     `${NAKAFA_API_EDGE_CONTRACT.originPath}${NAKAFA_API_EDGE_CONTRACT.runtimePath}`,
     runtime
   );
-  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/openapi.json`, document);
-  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/v1`, runtime);
-  app.route(`${NAKAFA_API_EDGE_CONTRACT.originPath}/`, runtime);
 }
 
 /** Returns one exact 404 or 405 for unmatched public API routes. */


### PR DESCRIPTION
## Summary

- remove the retired protected `/v1`, `/openapi.json`, and root runtime mounts
- retain only stable unversioned protected capabilities at `/internal/agent/runtime` and `/internal/agent/openapi`
- delete rollout-only compatibility tests and simplify public-path projection to the stable runtime
- make ADR 0006 explicit that the observation gate closes on evidence, never elapsed time

## Production prerequisite

PR #547 merged through protected main at `2afa67c534f52c0c6236b93bfa537cf9a86fb767`. API, MCP, and WWW Vercel production deployments are READY at that exact SHA, and the WWW deployment successfully promoted Convex production.

Live proof after that promotion:

- `/v1`, `/v1/health`, `/v1/search`, and `/openapi.json` return the exact release SHA
- the API index and OpenAPI report public contract `1.0.0`
- OpenAPI contains only discovery plus `/v1` resource paths
- public root, health, search, content, taxonomy, Quran, and `/v2` aliases return 404
- stable protected Convex capabilities exist and reject unauthenticated direct access with 403
- repository caller scan finds no predecessor protected-path consumer
- API and MCP rollout telemetry contains no runtime errors

## Verification

- `pnpm format`: 3,032 files checked, no fixes
- focused Effect suite: 2 files, 39 tests passed
- full backend suite: 337 files, 1,487 tests passed
- backend, API, and MCP typechecks passed
- `pnpm lint`: Effect source parity, patch policy, test ownership, Ultracite, and Ruff passed
- `pnpm boundaries`: 2,928 files across 19 packages passed
- API and MCP Vercel config builds passed
- independent Codex review traced installed Hono routing, all callers, generated Vercel routes, focused tests, live production, and returned no actionable finding
- root `pnpm build` validated API and MCP, then stopped at WWW configuration because this isolated worktree has no `NEXT_PUBLIC_CONVEX_URL`; protected candidate CI supplies its anonymous backend and owns the complete production build gate

No Vercel Preview was created or used.