### PR TITLE
Harden checkout revenue boundaries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,7 +64,12 @@ This glossary records stable domain terms used by Nakafa code and PR review. It 
 - **Account consent decision**: A signed-in account's Analytics consent decision for one category, with a server-owned decision time. It never inherits an anonymous browser decision.
 - **Anonymous consent decision**: A browser-local Analytics consent decision used only while no account is authenticated. Account sign-out preserves it without treating it as account state.
 - **Analytics eligibility**: The current consent and account-lifecycle proof required before a browser or backend analytics event may be admitted. Queued backend delivery rechecks eligibility around external IO.
+- **Product analytics capture**: The consent-aware admission of one optional backend product event. Failure to admit or queue it never changes the business operation that produced the event.
 - **Operational exception report**: A minimized service-reliability report with a fixed error name and message, code stack frames, and bounded technical context. It carries no account or user identifier and no raw error message, cause, request payload, or user content. It is separate from optional product analytics.
+
+## Billing
+
+- **Checkout admission**: The account-lifecycle revalidation performed after a checkout is created and before its link is released. Its result is Admitted or Unavailable; integration failures remain distinct.
 
 ## Forum Conversation
 

--- a/packages/backend/convex/analytics/capture.test.ts
+++ b/packages/backend/convex/analytics/capture.test.ts
@@ -73,6 +73,44 @@ describe("analytics/capture", () => {
       })
   );
 
+  it.effect("contains optional analytics scheduling failures", () =>
+    Effect.gen(function* () {
+      const t = convexTest(schema, convexModules);
+      const scheduledJobs = yield* Effect.promise(() =>
+        t.mutation(async (ctx) => {
+          const userId = await ctx.db.insert("users", {
+            authId: "analytics-scheduling-failure-auth",
+            credits: 10,
+            creditsResetAt: NOW,
+            email: "analytics-scheduling-failure@example.com",
+            name: "Analytics Scheduling Failure",
+            plan: "free",
+          });
+          await seedAnalyticsConsent(ctx, { decidedAt: NOW, userId });
+          const runAfter = vi
+            .spyOn(ctx.scheduler, "runAfter")
+            .mockRejectedValueOnce(new Error("scheduler unavailable"));
+
+          await runConvexProgram(
+            captureProductEvent(ctx, {
+              distinctId: userId,
+              event: {
+                name: "content viewed",
+                properties: contentViewProperties,
+              },
+              timestamp: new Date(NOW),
+            })
+          );
+
+          expect(runAfter).toHaveBeenCalledOnce();
+          return await ctx.db.system.query("_scheduled_functions").collect();
+        })
+      );
+
+      expect(scheduledJobs).toEqual([]);
+    })
+  );
+
   it.effect("drops a queued event when deletion starts before delivery", () =>
     Effect.gen(function* () {
       const capture = vi.fn(() => Promise.resolve(undefined));

--- a/packages/backend/convex/analytics/capture.ts
+++ b/packages/backend/convex/analytics/capture.ts
@@ -82,27 +82,33 @@ const hasProductAnalyticsConsent = Effect.fn(
 /** Queues one backend event behind deletion-aware PostHog delivery. */
 export const captureProductEvent = Effect.fn(
   "analytics.capture.captureProductEvent"
-)(function* (
-  ctx: ProductAnalyticsCtx,
-  { distinctId, event, timestamp }: ProductAnalyticsCaptureArgs
-) {
-  if (!(yield* hasProductAnalyticsConsent(ctx, distinctId))) {
-    return false;
-  }
+)(
+  function* (
+    ctx: ProductAnalyticsCtx,
+    { distinctId, event, timestamp }: ProductAnalyticsCaptureArgs
+  ) {
+    if (!(yield* hasProductAnalyticsConsent(ctx, distinctId))) {
+      return;
+    }
 
-  yield* Effect.tryPromise({
-    catch: toProductAnalyticsCaptureError,
-    try: () =>
-      ctx.scheduler.runAfter(0, deliverProductEventReference, {
-        disableGeoip: true,
-        distinctId,
-        event: event.name,
-        properties: JSON.stringify(event.properties),
-        timestamp: timestamp?.getTime(),
-      }),
-  });
-  return true;
-});
+    yield* Effect.tryPromise({
+      catch: toProductAnalyticsCaptureError,
+      try: () =>
+        ctx.scheduler.runAfter(0, deliverProductEventReference, {
+          disableGeoip: true,
+          distinctId,
+          event: event.name,
+          properties: JSON.stringify(event.properties),
+          timestamp: timestamp?.getTime(),
+        }),
+    });
+  },
+  Effect.catchTag("ProductAnalyticsCaptureError", (error) =>
+    Effect.logWarning("Optional product analytics capture failed.").pipe(
+      Effect.annotateLogs({ code: error.code })
+    )
+  )
+);
 /** Delivers only for eligible users and erases writes overlapping withdrawal. */
 export const deliverProductAnalyticsProgram = Effect.fn(
   "analytics.capture.deliverProductAnalytics"

--- a/packages/backend/convex/customers/actions/public.ts
+++ b/packages/backend/convex/customers/actions/public.ts
@@ -3,16 +3,14 @@ import { validateCheckoutRequest } from "@repo/backend/convex/customers/checkout
 import { checkoutLocaleValidator } from "@repo/backend/convex/customers/checkout/localization";
 import { createAdmittedCheckoutSession } from "@repo/backend/convex/customers/checkout/session";
 import {
+  type CheckoutAdmission,
   type CheckoutAdmissionArgs,
   checkoutSessionIoError,
 } from "@repo/backend/convex/customers/checkout/spec";
 import { polarGateway } from "@repo/backend/convex/customers/polar/live";
 import { requireCustomer } from "@repo/backend/convex/customers/sync/impl";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
-import {
-  accountUnavailableError,
-  requireAuthForAction,
-} from "@repo/backend/convex/lib/helpers/auth";
+import { requireAuthForAction } from "@repo/backend/convex/lib/helpers/auth";
 import { makeFunctionReference } from "convex/server";
 import { v } from "convex/values";
 import { Effect } from "effect";
@@ -20,7 +18,7 @@ import { Effect } from "effect";
 const admitCheckoutSessionReference = makeFunctionReference<
   "mutation",
   CheckoutAdmissionArgs,
-  boolean
+  CheckoutAdmission
 >("customers/checkout/admission:admitCheckoutSession");
 
 /**
@@ -42,7 +40,7 @@ export const generateCheckoutLink = action({
   handler: async (ctx, args) => {
     const { appUser } = await requireAuthForAction(ctx);
     const appUserId = appUser._id;
-    const checkout = await runConvexProgram(
+    return runConvexProgram(
       Effect.gen(function* () {
         const request = yield* validateCheckoutRequest(args);
         const requestMetadata = yield* Effect.tryPromise({
@@ -80,15 +78,9 @@ export const generateCheckoutLink = action({
             }),
         });
 
-        return checkout;
+        return { url: checkout.url };
       })
     );
-
-    if (!checkout) {
-      throw accountUnavailableError();
-    }
-
-    return { url: checkout.url };
   },
 });
 

--- a/packages/backend/convex/customers/checkout/admission.test.ts
+++ b/packages/backend/convex/customers/checkout/admission.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
-import { ProductAnalyticsCaptureError } from "@repo/backend/convex/analytics/capture";
 import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
 import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/impl";
 import { CheckoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
@@ -50,7 +49,7 @@ describe("customers/checkout/admission", () => {
         t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
       );
 
-      expect(admitted).toBe(true);
+      expect(admitted).toEqual({ kind: "admitted" });
       expect(scheduledJobs).toEqual([]);
     })
   );
@@ -87,7 +86,7 @@ describe("customers/checkout/admission", () => {
         t.query((ctx) => ctx.db.system.query("_scheduled_functions").collect())
       );
 
-      expect(admitted).toBe(true);
+      expect(admitted).toEqual({ kind: "admitted" });
       expect(scheduledJobs).toEqual([
         expect.objectContaining({
           args: [
@@ -127,30 +126,13 @@ describe("customers/checkout/admission", () => {
         })
       );
 
-      expect(admitted).toBe(false);
-    })
-  );
-
-  it.effect("does not block checkout when optional analytics fails", () =>
-    Effect.gen(function* () {
-      const admitted = yield* admitCheckoutProgram({
-        captureEvent: () =>
-          Effect.fail(
-            new ProductAnalyticsCaptureError({
-              code: "PRODUCT_ANALYTICS_CAPTURE_FAILED",
-              message: "PostHog unavailable",
-            })
-          ),
-        loadUser: () => Promise.resolve({}),
-      });
-
-      expect(admitted).toBe(true);
+      expect(admitted).toEqual({ kind: "unavailable" });
     })
   );
 
   it.effect("preserves account revalidation failures", () =>
     Effect.gen(function* () {
-      const captureEvent = vi.fn(() => Effect.succeed(true));
+      const captureEvent = vi.fn(() => Effect.void);
       const failure = yield* admitCheckoutProgram({
         captureEvent,
         loadUser: () => Promise.reject(new Error("Convex unavailable")),

--- a/packages/backend/convex/customers/checkout/admission.ts
+++ b/packages/backend/convex/customers/checkout/admission.ts
@@ -1,14 +1,16 @@
 import { internalMutation } from "@repo/backend/convex/_generated/server";
 import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import { admitCheckoutProgram } from "@repo/backend/convex/customers/checkout/impl";
-import { checkoutAdmissionArgsValidator } from "@repo/backend/convex/customers/checkout/spec";
+import {
+  checkoutAdmissionArgsValidator,
+  checkoutAdmissionValidator,
+} from "@repo/backend/convex/customers/checkout/spec";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
-import { v } from "convex/values";
 
 /** Mutation-ordered checkout admission with consent-aware optional analytics. */
 export const admitCheckoutSession = internalMutation({
   args: checkoutAdmissionArgsValidator.fields,
-  returns: v.boolean(),
+  returns: checkoutAdmissionValidator,
   handler: (ctx, args) =>
     runConvexProgram(
       admitCheckoutProgram({

--- a/packages/backend/convex/customers/checkout/impl.ts
+++ b/packages/backend/convex/customers/checkout/impl.ts
@@ -1,7 +1,7 @@
-import type { ProductAnalyticsCaptureError } from "@repo/backend/convex/analytics/capture";
 import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
 import { getPolarCheckoutLocale } from "@repo/backend/convex/customers/checkout/localization";
 import {
+  type CheckoutAdmission,
   type CheckoutRequest,
   type CheckoutRequestInput,
   checkoutSessionIoError,
@@ -15,10 +15,7 @@ import { Effect } from "effect";
 type CheckoutAdmissionUser = Parameters<typeof isAccountDeletionPending>[0];
 
 interface CheckoutAdmissionOperations {
-  readonly captureEvent: () => Effect.Effect<
-    boolean,
-    ProductAnalyticsCaptureError
-  >;
+  readonly captureEvent: () => Effect.Effect<void>;
   readonly loadUser: () => Promise<CheckoutAdmissionUser | null>;
 }
 
@@ -67,18 +64,10 @@ export const admitCheckoutProgram = Effect.fn(
   });
 
   if (!user || isAccountDeletionPending(user)) {
-    return false;
+    return { kind: "unavailable" } satisfies CheckoutAdmission;
   }
 
-  yield* operations
-    .captureEvent()
-    .pipe(
-      Effect.catchTag("ProductAnalyticsCaptureError", (error) =>
-        Effect.logWarning("Checkout analytics capture failed.").pipe(
-          Effect.annotateLogs({ code: error.code, reason: error.message })
-        )
-      )
-    );
+  yield* operations.captureEvent();
 
-  return true;
+  return { kind: "admitted" } satisfies CheckoutAdmission;
 });

--- a/packages/backend/convex/customers/checkout/session.test.ts
+++ b/packages/backend/convex/customers/checkout/session.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "@effect/vitest";
 import { createAdmittedCheckoutSession } from "@repo/backend/convex/customers/checkout/session";
 import {
+  type CheckoutAdmission,
   CheckoutSessionIoError,
+  CheckoutUnavailable,
   checkoutSessionIoErrorCode,
 } from "@repo/backend/convex/customers/checkout/spec";
+import {
+  accountUnavailableCode,
+  accountUnavailableMessage,
+} from "@repo/backend/convex/lib/helpers/auth";
 import { Effect } from "effect";
 import { vi } from "vitest";
 
@@ -12,10 +18,18 @@ describe("customers/checkout/session", () => {
   it.effect("withholds a checkout created before deletion starts", () =>
     Effect.gen(function* () {
       const createCheckout = vi.fn(() => Effect.succeed(checkout));
-      const admitCheckout = vi.fn(() => Effect.succeed(false));
-      expect(
-        yield* createAdmittedCheckoutSession({ admitCheckout, createCheckout })
-      ).toBeNull();
+      const admitCheckout = vi.fn(() =>
+        Effect.succeed({ kind: "unavailable" } satisfies CheckoutAdmission)
+      );
+      const failure = yield* createAdmittedCheckoutSession({
+        admitCheckout,
+        createCheckout,
+      }).pipe(Effect.flip);
+      expect(failure).toBeInstanceOf(CheckoutUnavailable);
+      expect(failure).toMatchObject({
+        code: accountUnavailableCode,
+        message: accountUnavailableMessage,
+      });
       expect(createCheckout).toHaveBeenCalledOnce();
       expect(admitCheckout).toHaveBeenCalledOnce();
       expect(createCheckout.mock.invocationCallOrder[0]).toBeLessThan(
@@ -26,7 +40,9 @@ describe("customers/checkout/session", () => {
   it.effect("returns a checkout admitted after Polar IO", () =>
     Effect.gen(function* () {
       const createCheckout = vi.fn(() => Effect.succeed(checkout));
-      const admitCheckout = vi.fn(() => Effect.succeed(true));
+      const admitCheckout = vi.fn(() =>
+        Effect.succeed({ kind: "admitted" } satisfies CheckoutAdmission)
+      );
       expect(
         yield* createAdmittedCheckoutSession({ admitCheckout, createCheckout })
       ).toEqual(checkout);

--- a/packages/backend/convex/customers/checkout/session.ts
+++ b/packages/backend/convex/customers/checkout/session.ts
@@ -1,12 +1,23 @@
-import type { CheckoutSessionIoError } from "@repo/backend/convex/customers/checkout/spec";
+import {
+  type CheckoutAdmission,
+  type CheckoutSessionIoError,
+  CheckoutUnavailable,
+} from "@repo/backend/convex/customers/checkout/spec";
 import type {
   CheckoutSessionResult,
   PolarCheckoutError,
 } from "@repo/backend/convex/customers/polar/spec";
+import {
+  accountUnavailableCode,
+  accountUnavailableMessage,
+} from "@repo/backend/convex/lib/helpers/auth";
 import { Effect } from "effect";
 
 interface CheckoutSessionOperations {
-  readonly admitCheckout: () => Effect.Effect<boolean, CheckoutSessionIoError>;
+  readonly admitCheckout: () => Effect.Effect<
+    CheckoutAdmission,
+    CheckoutSessionIoError
+  >;
   readonly createCheckout: () => Effect.Effect<
     CheckoutSessionResult,
     PolarCheckoutError
@@ -18,7 +29,14 @@ export const createAdmittedCheckoutSession = Effect.fn(
   "customers.checkout.createAdmittedSession"
 )(function* (operations: CheckoutSessionOperations) {
   const checkout = yield* operations.createCheckout();
-  const isActive = yield* operations.admitCheckout();
+  const admission = yield* operations.admitCheckout();
 
-  return isActive ? checkout : null;
+  if (admission.kind === "unavailable") {
+    return yield* new CheckoutUnavailable({
+      code: accountUnavailableCode,
+      message: accountUnavailableMessage,
+    });
+  }
+
+  return checkout;
 });

--- a/packages/backend/convex/customers/checkout/spec.ts
+++ b/packages/backend/convex/customers/checkout/spec.ts
@@ -5,6 +5,7 @@ import {
   type ConvexTaggedError,
   getUnknownErrorMessage,
 } from "@repo/backend/convex/lib/effect";
+import { accountUnavailableCode } from "@repo/backend/convex/lib/helpers/auth";
 import { vv } from "@repo/backend/convex/lib/validators/vv";
 import { type Infer, v } from "convex/values";
 import { Schema } from "effect";
@@ -31,9 +32,27 @@ export const checkoutAdmissionArgsValidator = v.object({
   userId: vv.id("users"),
 });
 
+export const checkoutAdmissionValidator = v.union(
+  v.object({ kind: v.literal("admitted") }),
+  v.object({ kind: v.literal("unavailable") })
+);
+
 export type CheckoutAdmissionArgs = Infer<
   typeof checkoutAdmissionArgsValidator
 >;
+export type CheckoutAdmission = Infer<typeof checkoutAdmissionValidator>;
+
+/** Raised when account revalidation withholds a newly created checkout. */
+export class CheckoutUnavailable
+  extends Schema.TaggedError<CheckoutUnavailable>()("CheckoutUnavailable", {
+    code: Schema.Literal(accountUnavailableCode),
+    message: Schema.String,
+  })
+  implements ConvexTaggedError
+{
+  declare readonly code: typeof accountUnavailableCode;
+  declare readonly message: string;
+}
 
 export class CheckoutSessionIoError
   extends Schema.TaggedError<CheckoutSessionIoError>()(

--- a/packages/backend/convex/customers/polar/webhook.test.ts
+++ b/packages/backend/convex/customers/polar/webhook.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type {
   MutationCtx,
   QueryCtx,
@@ -15,6 +16,7 @@ import {
 import schema from "@repo/backend/convex/schema";
 import type { SubscriptionRecord } from "@repo/backend/convex/subscriptions/records/spec";
 import { convexModules } from "@repo/backend/convex/test.setup";
+import { products } from "@repo/backend/convex/utils/polar/products";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -67,6 +69,36 @@ function readWebhookState(ctx: QueryCtx) {
   });
 }
 
+/** Loads the exact revenue state granted by one accepted Pro subscription. */
+function readPurchaseCompletionState(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  polarCustomerId: string,
+  subscriptionId: string
+) {
+  return Effect.all({
+    creditTransactions: Effect.promise(() =>
+      ctx.db
+        .query("creditTransactions")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .take(10)
+    ),
+    customer: Effect.promise(() =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_polarId", (q) => q.eq("id", polarCustomerId))
+        .unique()
+    ),
+    subscription: Effect.promise(() =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_subscriptionId", (q) => q.eq("id", subscriptionId))
+        .unique()
+    ),
+    user: Effect.promise(() => ctx.db.get("users", userId)),
+  });
+}
+
 /** Records one durable Polar customer deletion marker. */
 function insertCustomerTombstone(ctx: MutationCtx, polarCustomerId: string) {
   return Effect.promise(() =>
@@ -106,6 +138,79 @@ beforeEach(() => {
 });
 
 describe("customers/polar/webhook", () => {
+  it.effect("grants the complete Pro entitlement from one Polar webhook", () =>
+    Effect.gen(function* () {
+      const t = yield* createWebhookTestConvex();
+      const userId = yield* Effect.promise(() =>
+        t.mutation((ctx) => runConvexProgram(insertUser(ctx, "purchase")))
+      );
+      const subscription = {
+        ...buildSubscription("polar-purchase", "purchase"),
+        productId: products.pro.id,
+        status: "active",
+      } satisfies SubscriptionRecord;
+      polarGateway.getCustomerById.mockReturnValue(
+        Effect.succeed({
+          email: "purchase@example.com",
+          externalId: "auth-purchase",
+          id: subscription.customerId,
+          metadata: { userId },
+          name: "User purchase",
+        })
+      );
+
+      const disposition = yield* Effect.promise(() =>
+        t.action((ctx) =>
+          runConvexActionProgram(
+            upsertPolarSubscriptionWebhook(ctx, subscription, "create")
+          )
+        )
+      );
+      const state = yield* Effect.promise(() =>
+        t.query((ctx) =>
+          runConvexProgram(
+            readPurchaseCompletionState(
+              ctx,
+              userId,
+              subscription.customerId,
+              subscription.id
+            )
+          )
+        )
+      );
+
+      expect(disposition).toBe("stored");
+      expect(state.customer).toMatchObject({
+        id: subscription.customerId,
+        userId,
+      });
+      expect(state.subscription).toMatchObject({
+        customerId: subscription.customerId,
+        id: subscription.id,
+        productId: products.pro.id,
+        status: "active",
+      });
+      expect(state.user).toMatchObject({
+        credits: 3000,
+        plan: "pro",
+      });
+      expect(state.creditTransactions).toEqual([
+        expect.objectContaining({
+          amount: 3000,
+          balanceAfter: 3000,
+          metadata: {
+            "new-plan": "pro",
+            "previous-plan": "free",
+            reason: "plan-upgrade",
+            "subscription-id": subscription.id,
+          },
+          type: "purchase",
+          userId,
+        }),
+      ]);
+    })
+  );
+
   it.effect(
     "resolves the current Polar customer before storing a subscription",
     () =>

--- a/packages/backend/convex/lib/helpers/auth.ts
+++ b/packages/backend/convex/lib/helpers/auth.ts
@@ -28,11 +28,14 @@ interface AuthContext {
   readonly authUser: AuthUser;
 }
 
+export const accountUnavailableCode = "UNAUTHORIZED";
+export const accountUnavailableMessage = "User not found.";
+
 /** Keeps every rejected account state on the same public auth contract. */
 export function accountUnavailableError() {
   return new ConvexError({
-    code: "UNAUTHORIZED",
-    message: "User not found.",
+    code: accountUnavailableCode,
+    message: accountUnavailableMessage,
   });
 }
 

--- a/packages/backend/convex/triggers/contents/views.ts
+++ b/packages/backend/convex/triggers/contents/views.ts
@@ -1,32 +1,10 @@
 import type { DataModel } from "@repo/backend/convex/_generated/dataModel";
 import { captureProductEvent } from "@repo/backend/convex/analytics/capture";
 import type { ProductAnalyticsEvent } from "@repo/backend/convex/analytics/events";
-import {
-  getUnknownErrorMessage,
-  runConvexProgram,
-} from "@repo/backend/convex/lib/effect";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import type { GenericMutationCtx } from "convex/server";
 import type { Change } from "convex-helpers/server/triggers";
-import { Effect, Schema } from "effect";
-
-const contentViewEventFailedCode = "CONTENT_VIEW_EVENT_FAILED";
-
-/** Raised when the content-view analytics trigger cannot read or emit graph data. */
-class ContentViewEventError extends Schema.TaggedError<ContentViewEventError>()(
-  "ContentViewEventError",
-  {
-    code: Schema.Literal(contentViewEventFailedCode),
-    message: Schema.String,
-  }
-) {}
-
-/** Maps thrown analytics trigger failures into a typed Effect error. */
-function toContentViewEventError(error: unknown) {
-  return new ContentViewEventError({
-    code: contentViewEventFailedCode,
-    message: getUnknownErrorMessage(error),
-  });
-}
+import { Effect } from "effect";
 
 /** Converts a graph route section into the product analytics event taxonomy. */
 function getContentViewEventType(
@@ -83,7 +61,7 @@ const captureContentViewEvent = Effect.fn(
       },
     },
     timestamp: new Date(view.lastViewedAt),
-  }).pipe(Effect.mapError(toContentViewEventError));
+  });
 });
 
 /**

--- a/packages/backend/convex/triggers/subscriptions/impl.ts
+++ b/packages/backend/convex/triggers/subscriptions/impl.ts
@@ -165,7 +165,7 @@ const applyPlanChange = Effect.fn("triggers.subscriptions.applyPlanChange")(
           },
         },
         timestamp,
-      }).pipe(Effect.mapError(toSubscriptionPlanSyncIoError));
+      });
 
       yield* captureProductEvent(ctx, {
         distinctId: user._id,
@@ -177,7 +177,7 @@ const applyPlanChange = Effect.fn("triggers.subscriptions.applyPlanChange")(
           },
         },
         timestamp,
-      }).pipe(Effect.mapError(toSubscriptionPlanSyncIoError));
+      });
 
       return;
     }
@@ -230,7 +230,7 @@ const applyPlanChange = Effect.fn("triggers.subscriptions.applyPlanChange")(
           },
         },
         timestamp,
-      }).pipe(Effect.mapError(toSubscriptionPlanSyncIoError));
+      });
     }
 
     yield* captureProductEvent(ctx, {
@@ -243,7 +243,7 @@ const applyPlanChange = Effect.fn("triggers.subscriptions.applyPlanChange")(
         },
       },
       timestamp,
-    }).pipe(Effect.mapError(toSubscriptionPlanSyncIoError));
+    });
   }
 );
 

--- a/packages/backend/convex/triggers/tryouts/scores.ts
+++ b/packages/backend/convex/triggers/tryouts/scores.ts
@@ -67,7 +67,7 @@ const captureTryoutScoreEvent = Effect.fn(
       },
     },
     timestamp: new Date(score.finalizedAt),
-  }).pipe(Effect.mapError(toTryoutScoreAnalyticsError));
+  });
 });
 
 /** Runs completed-score analytics at the registered Convex trigger boundary. */

--- a/packages/backend/convex/tryouts/mutations/access.ts
+++ b/packages/backend/convex/tryouts/mutations/access.ts
@@ -31,7 +31,7 @@ export const trackPaywallView = mutation({
             properties: { source: args.source },
           },
           timestamp: new Date(now),
-        }).pipe(Effect.mapError(toTryoutStartError));
+        });
 
         return null;
       })

--- a/packages/backend/convex/tryouts/start/attempt.ts
+++ b/packages/backend/convex/tryouts/start/attempt.ts
@@ -170,7 +170,7 @@ const persistAttemptStart = Effect.fn("tryouts.start.persistAttemptStart")(
         },
       },
       timestamp: new Date(input.now),
-    }).pipe(Effect.mapError(toTryoutStartError));
+    });
   }
 );
 


### PR DESCRIPTION
## Summary

- contain optional product analytics scheduling failures behind one consent-aware interface with safe operational logging
- replace checkout admission booleans and nullable success with explicit `admitted` / `unavailable` state and a typed Effect failure
- prove the full Polar subscription path grants Pro, 3,000 credits, the customer and subscription records, and the purchase ledger entry
- document the analytics and checkout domain boundaries in the shared glossary

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm --filter @repo/backend typecheck`
- `pnpm --filter @repo/backend test` (339 files, 1,497 tests)
- isolated local Convex push with indexes and functions ready
- local Next.js production build passed compilation, TypeScript, and page-data collection; signed-content prerender remains gated by the protected CI token

No Vercel Preview was created. Production deployment remains owned by the protected merge-to-main Git integration.