### PR TITLE
Use breadcrumbs for curriculum subject pages

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/nested/header.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/nested/header.tsx
@@ -3,7 +3,7 @@ import type { CurriculumViewRoute } from "@/app/[locale]/(app)/(shared)/(main)/(
 import { BreadcrumbHeader } from "@/components/shared/breadcrumb/header";
 import { getCurriculumIndexHref } from "@/lib/curriculum/routes";
 
-/** Renders a nested curriculum chooser with breadcrumb context only. */
+/** Renders one nested curriculum route with breadcrumb context only. */
 export default function CurriculumNestedHeader({
   ancestors,
   currentRoute,

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
@@ -4,7 +4,6 @@ import dynamic from "next/dynamic";
 import { getTranslations } from "next-intl/server";
 import { type ReactNode, Suspense } from "react";
 import { readMaterialCardChapters } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data";
-import { readCurriculumRouteIcon } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/icons";
 import {
   CurriculumChildCards,
   CurriculumRootHeader,
@@ -14,7 +13,6 @@ import {
   listRuntimeCurriculumStaticParams,
   readRuntimeCurriculumBreadcrumbs,
   readRuntimeCurriculumCatalog,
-  readRuntimeCurriculumHeader,
   readRuntimeCurriculumOptions,
   readRuntimeCurriculumToc,
   resolveRuntimeCurriculumRoute,
@@ -24,7 +22,6 @@ import { CardMaterial } from "@/components/shared/card-material";
 import { ComingSoon } from "@/components/shared/coming-soon";
 import { ContainerList } from "@/components/shared/container-list";
 import { FooterContent } from "@/components/shared/footer-content";
-import { HeaderContent } from "@/components/shared/header-content";
 import { LayoutContent } from "@/components/shared/layout-content";
 import { LayoutMaterialContent } from "@/components/shared/material/content";
 import { LayoutMaterial } from "@/components/shared/material/layout";
@@ -171,22 +168,14 @@ async function CurriculumNestedRoute({
       breadcrumbs={breadcrumbs}
       model={model}
     >
-      {model.childRoutes.length > 0 ? (
-        <CurriculumNestedHeader
-          ancestors={model.ancestors}
-          currentRoute={route}
-          homeLabel={homeLabel}
-          locale={locale}
-          menuLabel={tCommon("more")}
-          subjectLabel={subjectLabel}
-        />
-      ) : (
-        <HeaderContent
-          icon={readCurriculumRouteIcon(route)}
-          link={readRuntimeCurriculumHeader(model)}
-          title={route.title}
-        />
-      )}
+      <CurriculumNestedHeader
+        ancestors={model.ancestors}
+        currentRoute={route}
+        homeLabel={homeLabel}
+        locale={locale}
+        menuLabel={tCommon("more")}
+        subjectLabel={subjectLabel}
+      />
     </CurriculumRouteFrame>
   );
 }

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.test.ts
@@ -8,7 +8,6 @@ import {
   listRuntimeCurriculumStaticParams,
   readRuntimeCurriculumBreadcrumbs,
   readRuntimeCurriculumCatalog,
-  readRuntimeCurriculumHeader,
   readRuntimeCurriculumOptions,
   readRuntimeCurriculumToc,
   resolveRuntimeCurriculumRoute,
@@ -157,10 +156,6 @@ describe("signed curriculum runtime", () => {
       })
     );
 
-    expect(readRuntimeCurriculumHeader(model)).toEqual({
-      href: "/en/curriculum/merdeka/class-11",
-      label: "Class 11",
-    });
     expect(readRuntimeCurriculumBreadcrumbs("Home", "Subjects", model)).toEqual(
       [
         { name: "Home", path: "" },
@@ -197,7 +192,6 @@ describe("signed curriculum runtime", () => {
     expect(
       isRenderableCurriculumView({ ...testProgramRoot, sitemap: false })
     ).toBe(false);
-    expect(readRuntimeCurriculumHeader(model)).toBeUndefined();
     expect(readRuntimeCurriculumToc(model)).toEqual({
       href: "/en/curriculum/merdeka",
       title: "Kurikulum Merdeka",

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.ts
@@ -143,18 +143,6 @@ export function readRuntimeCurriculumOptions(
   }));
 }
 
-/** Builds the immediate parent link for one resolved curriculum route. */
-export function readRuntimeCurriculumHeader(model: CurriculumRouteModel) {
-  const parent = model.ancestors.at(-1);
-  if (!parent) {
-    return;
-  }
-  return {
-    href: `/${model.locale}/${parent.publicPath}`,
-    label: parent.title,
-  };
-}
-
 /** Builds visible and structured breadcrumb entries from resolved ancestors. */
 export function readRuntimeCurriculumBreadcrumbs(
   homeLabel: string,


### PR DESCRIPTION
## Summary

- use the shared breadcrumb header for every nested curriculum route, including subject pages with lesson cards
- preserve the existing curriculum card body, references, and right-side table of contents
- remove the obsolete parent-header projection and its tests

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm --filter www typecheck`
- `pnpm --filter www test` (210 files, 1,497 tests, 100% coverage)
- `pnpm run doctor --verbose --scope changed --base main --include-untracked` (100/100)
- local browser QA for ID, EN, and DE subject routes, including the collapsed shadcn breadcrumb menu
- desktop and 390px mobile checks with no horizontal overflow
- regression QA for the class card route and curriculum root route

No Vercel Preview was created.