### PR TITLE
test: enforce Effect Vitest APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Build for longevity. Favor readable, skimmable, well-verified code over speed or
 ## Testing And Content
 
 - Vitest is the standard test runner. Keep `*.test.ts` beside the real owning `.ts` module. Do not add orphan concept tests, `*.test.tsx`, renamed React tests, or nested test folders.
+- Import test APIs from `@effect/vitest`. Use the shared configured `vi` global for mocks because Vitest hoists mock calls before re-export bindings initialize. Do not import `vi`. Keep `vitest` installed only because `@effect/vitest`, the CLI runner, coverage, and `vitest/config` require it. Raw `vitest` imports are forbidden in authored TypeScript.
 - Do not add React component tests that mock children to verify static markup. Move testable behavior into an owning `.ts` domain seam and verify rendered behavior through production-mode Browser or E2E acceptance.
 - Keep tests behavior-oriented, focused, and free of `.only` or `.skip`. Run the nearest test first, then the relevant workspace suite when risk warrants it. Some workspaces require per-file 100% coverage.
 - Use `pnpm run doctor --verbose --scope changed --base main --include-untracked` for changed React code and `pnpm run doctor --verbose --scope full` for a whole-codebase audit. Do not use the deprecated `--diff` alias or plain `npx react-doctor@latest`.

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { readMaterialCardChapters } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/data";
 
 describe("curriculum presentation data", () => {

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/runtime.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { GitCommitShaSchema } from "@nakafa/aksara-contracts/ids";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type CurriculumRouteModel,
   isRenderableCurriculumView,

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { readCurriculumSeoContext } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/seo";
 import {
   testProgramClass,

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/data.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/data.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   listMaterialStaticParams,
   parseMaterialParams,

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/metadata.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/metadata.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { toMaterialMetadataCopy } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/metadata";
 import { previewMetadata } from "@/test/content-preview";
 

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/navigation.test.ts
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/navigation.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   PublicPathSchema,
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MaterialPageContent } from "@/app/[locale]/(app)/(shared)/(main)/(learn)/materials/[subject]/[topic]/[[...lesson]]/content";
 import {
   readMaterialNavigation,

--- a/apps/www/app/api/chat/content.test.ts
+++ b/apps/www/app/api/chat/content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getCanonicalCurrentPageContentUrl,
   isVerifiableContentPath,

--- a/apps/www/app/api/chat/context.test.ts
+++ b/apps/www/app/api/chat/context.test.ts
@@ -5,7 +5,6 @@ import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import type { NinaContextSnapshot } from "@repo/ai/nina/memory/pack";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { resolveNinaLearningSession } from "@/app/api/chat/context";
 import { previewProjection, previewSourcePath } from "@/test/content-preview";
 

--- a/apps/www/app/api/chat/observability.test.ts
+++ b/apps/www/app/api/chat/observability.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ModelIdSchema } from "@repo/ai/config/model";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createChatErrorReporter } from "@/app/api/chat/observability";
 
 const observabilityMocks = vi.hoisted(() => ({

--- a/apps/www/app/api/chat/persistence.test.ts
+++ b/apps/www/app/api/chat/persistence.test.ts
@@ -7,7 +7,6 @@ import type {
 } from "@repo/ai/nina/memory/pack";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import {
   createChatWithMessage,

--- a/apps/www/app/api/chat/published.test.ts
+++ b/apps/www/app/api/chat/published.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   isPublishedMaterialPath,
   readPublishedNinaMaterial,

--- a/apps/www/app/api/chat/utils.test.ts
+++ b/apps/www/app/api/chat/utils.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { api as convexApi } from "@repo/backend/convex/_generated/api";
 import { fetchMutation, fetchQuery } from "convex/nextjs";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { ChatMutationError, ChatQueryError } from "@/app/api/chat/errors";
 import {
   getCurriculumPreference,

--- a/apps/www/app/api/internal/content/cache/route.test.ts
+++ b/apps/www/app/api/internal/content/cache/route.test.ts
@@ -11,7 +11,6 @@ import {
 } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
 import { NextRequest } from "next/server";
-import { vi } from "vitest";
 import {
   ContentCacheInvalidationError,
   type invalidateContentCache,

--- a/apps/www/app/api/internal/content/preview/route.test.ts
+++ b/apps/www/app/api/internal/content/preview/route.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/internal/content/preview/route";
 import {
   PreviewRequestError,

--- a/apps/www/app/api/internal/content/renderer/route.test.ts
+++ b/apps/www/app/api/internal/content/renderer/route.test.ts
@@ -10,7 +10,6 @@ import {
 import { RENDERER_DOMAINS } from "@nakafa/aksara-contracts/renderer/domain";
 import { Effect, Schema } from "effect";
 import { NextRequest } from "next/server";
-import { vi } from "vitest";
 
 const nonce = PreviewRendererNonceSchema.make("n".repeat(43));
 const secret = PreviewRendererSecretSchema.make("s".repeat(43));

--- a/apps/www/app/llms.mdx/[...slug]/route.test.ts
+++ b/apps/www/app/llms.mdx/[...slug]/route.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/llms.mdx/[...slug]/route";
 import { BASE_URL } from "@/lib/llms/constants";
 

--- a/apps/www/app/manifest.test.ts
+++ b/apps/www/app/manifest.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { THEME_COMPATIBILITY_COLORS } from "@repo/design-system/lib/theme/compatibility";
-import { describe, expect, it, vi } from "vitest";
 import manifest from "@/app/manifest";
 
 const HEX_COLOR_PATTERN = /#[\da-f]{3,8}\b/i;

--- a/apps/www/app/og/article.test.ts
+++ b/apps/www/app/og/article.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { readArticleOgMetadata } from "@/app/og/article";
 
 const mocks = vi.hoisted(() => ({

--- a/apps/www/app/og/content.test.ts
+++ b/apps/www/app/og/content.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { readOgMetadata } from "@/app/og/content";
 
 const mocks = vi.hoisted(() => ({

--- a/apps/www/app/robots.test.ts
+++ b/apps/www/app/robots.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import robots from "@/app/robots";
 
 describe("robots metadata", () => {

--- a/apps/www/app/rss.xml/route.test.ts
+++ b/apps/www/app/rss.xml/route.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/rss.xml/route";
 
 const mockReadActiveContentIdentity = vi.hoisted(() => vi.fn());

--- a/apps/www/app/sitemap.xml/route.test.ts
+++ b/apps/www/app/sitemap.xml/route.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/sitemap.xml/route";
 
 const mockReadSitemapPageDescriptors = vi.hoisted(() => vi.fn());

--- a/apps/www/app/sitemap/[id]/route.test.ts
+++ b/apps/www/app/sitemap/[id]/route.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/sitemap/[id]/route";
 
 const mockGetSitemapEntries = vi.hoisted(() => vi.fn());

--- a/apps/www/components/ai/chat/state.test.ts
+++ b/apps/www/components/ai/chat/state.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import {
   patchChatPage,
   removeChatFromPage,

--- a/apps/www/components/ai/store/draft.test.ts
+++ b/apps/www/components/ai/store/draft.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   clearAiDraftText,
   readAiDraftText,

--- a/apps/www/components/articles/category.test.ts
+++ b/apps/www/components/articles/category.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { BookOpen02Icon, EvilIcon } from "@hugeicons/core-free-icons";
 import { ArticleCategorySchema } from "@nakafa/aksara-contracts/projection/article";
-import { describe, expect, it } from "vitest";
 import { getArticleCategoryIcon } from "@/components/articles/category";
 
 describe("article category presentation", () => {

--- a/apps/www/components/comments/state.test.ts
+++ b/apps/www/components/comments/state.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import {
   deleteCommentFromPage,
   updateCommentVote,

--- a/apps/www/components/marketing/about/pricing/display.test.ts
+++ b/apps/www/components/marketing/about/pricing/display.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getProPricingDisplay,
   pricingCountryHeaderName,

--- a/apps/www/components/marketing/about/projectile/loader.test.ts
+++ b/apps/www/components/marketing/about/projectile/loader.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { Duration, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
 import { createElement } from "react";

--- a/apps/www/components/marketing/about/trust/source.test.ts
+++ b/apps/www/components/marketing/about/trust/source.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 import {
   buildTrustSourceExcerpt,

--- a/apps/www/components/programs/onboarding/destination.test.ts
+++ b/apps/www/components/programs/onboarding/destination.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getOnboardingDestinationHref } from "@/components/programs/onboarding/destination";
 
 describe("onboarding destination", () => {

--- a/apps/www/components/programs/onboarding/state.test.ts
+++ b/apps/www/components/programs/onboarding/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   applyOnboardingAnswer,
   getCompleteOnboardingAnswers,

--- a/apps/www/components/programs/onboarding/submit.test.ts
+++ b/apps/www/components/programs/onboarding/submit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import {
   finishOnboarding,

--- a/apps/www/components/school/classes/forum/conversation/data/scroll/metrics.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/scroll/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   type ConversationGeometryHandle,
   getConversationBottomDistance,

--- a/apps/www/components/school/classes/forum/conversation/data/scroll/snapshot.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/scroll/snapshot.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import { createConversationScrollSnapshot } from "@/components/school/classes/forum/conversation/data/scroll/snapshot";
 
 const postId = "post_1" as Id<"schoolClassForumPosts">;

--- a/apps/www/components/school/classes/forum/conversation/data/transcript/active.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/transcript/active.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { ForumPost } from "@/components/school/classes/forum/conversation/data/entities";
 import { createActiveTranscriptModel } from "@/components/school/classes/forum/conversation/data/transcript/active";
 import {

--- a/apps/www/components/school/classes/forum/conversation/data/transcript/pages.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/transcript/pages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { ForumPost } from "@/components/school/classes/forum/conversation/data/entities";
 import {
   createConversationRows,

--- a/apps/www/components/school/classes/forum/conversation/data/transcript/unread.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/transcript/unread.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getInitialConversationUnreadCue } from "@/components/school/classes/forum/conversation/data/transcript/unread";
 import { createConversationTestPost } from "@/components/school/classes/forum/conversation/fixtures/data";
 

--- a/apps/www/components/school/classes/forum/conversation/data/view/model.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/view/model.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import {
   areConversationViewsEqual,
   isConversationViewAtPost,

--- a/apps/www/components/school/classes/forum/conversation/data/view/position.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/view/position.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   captureConversationView,
   hasConversationViewReached,

--- a/apps/www/components/school/classes/forum/conversation/data/view/visible.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/data/view/visible.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { ForumPost } from "@/components/school/classes/forum/conversation/data/entities";
 import type { ConversationRow } from "@/components/school/classes/forum/conversation/data/transcript/pages";
 import {

--- a/apps/www/components/school/classes/forum/conversation/fixtures/data.ts
+++ b/apps/www/components/school/classes/forum/conversation/fixtures/data.ts
@@ -1,5 +1,4 @@
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { vi } from "vitest";
 import type {
   Forum,
   ForumPost,

--- a/apps/www/components/school/classes/forum/conversation/input/draft.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/draft.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { restoreForumPostInputDraft } from "@/components/school/classes/forum/conversation/input/draft";
 
 const replyTarget = {

--- a/apps/www/components/school/classes/forum/conversation/input/optimistic.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/optimistic.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import {
   createConversationTestForum,
   createConversationTestPost,

--- a/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/input/submit.test.ts
@@ -6,7 +6,6 @@ import type { FileWithPreview } from "@repo/design-system/hooks/use-file-upload"
 import { Effect, Layer, Result } from "effect";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import type { HttpClientRequest } from "effect/unstable/http/HttpClientRequest";
-import { vi } from "vitest";
 import { submitForumPost } from "@/components/school/classes/forum/conversation/input/submit";
 
 const mocks = vi.hoisted(() => ({

--- a/apps/www/components/school/classes/forum/conversation/viewport/events.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/events.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   createAdapters,
   createViewport,

--- a/apps/www/components/school/classes/forum/conversation/viewport/fixture.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/fixture.ts
@@ -1,6 +1,5 @@
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { Effect, Queue, Ref, SubscriptionRef } from "effect";
-import { vi } from "vitest";
 import type { ActiveTranscriptModel } from "@/components/school/classes/forum/conversation/data/transcript/active";
 import { areConversationViewsEqual } from "@/components/school/classes/forum/conversation/data/view/model";
 import {

--- a/apps/www/components/school/classes/forum/conversation/viewport/frame.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/frame.test.ts
@@ -1,6 +1,6 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Stream } from "effect";
 import type { RefObject } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BrowserViewportScroller } from "@/components/school/classes/forum/conversation/viewport/browser";
 import { viewportTestTranscript } from "@/components/school/classes/forum/conversation/viewport/fixture";
 import {

--- a/apps/www/components/school/classes/forum/conversation/viewport/intent.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/intent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   conversationTestFirstPost as firstPost,
   conversationTestSecondPost as secondPost,

--- a/apps/www/components/school/classes/forum/conversation/viewport/model.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/model.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import type { ActiveTranscriptModel } from "@/components/school/classes/forum/conversation/data/transcript/active";
 import {
   conversationTestFirstPost as firstPost,

--- a/apps/www/components/school/classes/forum/conversation/viewport/navigate/back.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/navigate/back.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import {
   conversationTestFirstPost as firstPost,
   conversationTestSecondPost as secondPost,

--- a/apps/www/components/school/classes/forum/conversation/viewport/navigate/post.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/navigate/post.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   conversationTestFirstPost as firstPost,
   conversationTestSecondPost as secondPost,

--- a/apps/www/components/school/classes/forum/conversation/viewport/placement.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/placement.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   conversationTestFirstPost as firstPost,
   conversationTestSecondPost as secondPost,

--- a/apps/www/components/school/classes/forum/conversation/viewport/scroller.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/scroller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { ActiveTranscriptModel } from "@/components/school/classes/forum/conversation/data/transcript/active";
 import {
   createConversationTestRowsHandle,

--- a/apps/www/components/school/classes/forum/conversation/viewport/service.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   conversationTestFirstPost as firstPost,
   conversationTestRows as rows,

--- a/apps/www/components/school/classes/forum/conversation/viewport/transcript.test.ts
+++ b/apps/www/components/school/classes/forum/conversation/viewport/transcript.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { createActiveTranscriptModel } from "@/components/school/classes/forum/conversation/data/transcript/active";
 import {
   createConversationTestForum,

--- a/apps/www/components/school/classes/forum/helpers/routes.test.ts
+++ b/apps/www/components/school/classes/forum/helpers/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getSchoolClassesForumHref } from "@/components/school/classes/forum/helpers/routes";
 
 describe("school/classes/forum/helpers/routes", () => {

--- a/apps/www/components/school/classes/forum/reaction/state.test.ts
+++ b/apps/www/components/school/classes/forum/reaction/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { toggleReactionState } from "@/components/school/classes/forum/reaction/state";
 
 const state = {

--- a/apps/www/components/school/classes/forum/read/state.test.ts
+++ b/apps/www/components/school/classes/forum/read/state.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { describe, expect, it } from "vitest";
 import { markTranscriptRead } from "@/components/school/classes/forum/read/state";
 
 /** Create a typed post id for pure state fixtures. */

--- a/apps/www/components/school/classes/forum/store/session.test.ts
+++ b/apps/www/components/school/classes/forum/store/session.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import { beforeEach, describe, expect, it } from "vitest";
 import { createForumSessionStore } from "@/components/school/classes/forum/store/session";
 
 const forumId = "forum_1" as Id<"schoolClassForums">;

--- a/apps/www/components/school/classes/image/state.test.ts
+++ b/apps/www/components/school/classes/image/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { updateClassImageState } from "@/components/school/classes/image/state";
 
 describe("updateClassImageState", () => {

--- a/apps/www/components/school/classes/materials/state.test.ts
+++ b/apps/www/components/school/classes/materials/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { updateMaterialGroupState } from "@/components/school/classes/materials/state";
 
 const group = {

--- a/apps/www/components/school/classes/order.test.ts
+++ b/apps/www/components/school/classes/order.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { reorderPage } from "@/components/school/classes/order";
 
 const page = [

--- a/apps/www/components/school/classes/schedule.test.ts
+++ b/apps/www/components/school/classes/schedule.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   formatScheduledAt,
   getDefaultScheduledAt,

--- a/apps/www/components/shared/open-content/copy.test.ts
+++ b/apps/www/components/shared/open-content/copy.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 import {
   copyOpenContent,
   OpenContentCopyError,

--- a/apps/www/components/sidebar/data/navigation.test.ts
+++ b/apps/www/components/sidebar/data/navigation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getAppNavigationViewer,
   getForYouNavigationHref,

--- a/apps/www/components/tryout/catalog/icons.test.ts
+++ b/apps/www/components/tryout/catalog/icons.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getTryoutExamIcon,
   getTryoutTrackIcon,

--- a/apps/www/components/tryout/catalog/metadata.test.ts
+++ b/apps/www/components/tryout/catalog/metadata.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   createRetainedTryoutMetadata,
   generateTryoutRouteMetadata,

--- a/apps/www/components/tryout/catalog/options.test.ts
+++ b/apps/www/components/tryout/catalog/options.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { PublicPathSchema } from "@nakafa/aksara-contracts/ids";
-import { describe, expect, it } from "vitest";
 import {
   buildTryoutCountryOptions,
   buildTryoutExamOptions,

--- a/apps/www/components/tryout/catalog/table/filter.test.ts
+++ b/apps/www/components/tryout/catalog/table/filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   isTryoutSetStatusFilter,
   readTryoutSetAttemptStatus,

--- a/apps/www/components/tryout/catalog/table/sort.test.ts
+++ b/apps/www/components/tryout/catalog/table/sort.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { readTryoutSetSort } from "@/components/tryout/catalog/table/sort";
 
 describe("readTryoutSetSort", () => {

--- a/apps/www/components/tryout/navigation/intent.test.ts
+++ b/apps/www/components/tryout/navigation/intent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getTryoutDataIntentKey,
   isTryoutQueryLeaseActive,

--- a/apps/www/components/tryout/route/owner.test.ts
+++ b/apps/www/components/tryout/route/owner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   createTryoutSetRestartTarget,
   selectTryoutFrozenPage,

--- a/apps/www/components/tryout/route/path.test.ts
+++ b/apps/www/components/tryout/route/path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getTryoutAttemptAuthHref,
   getTryoutAttemptHref,

--- a/apps/www/components/tryout/runtime/state.test.ts
+++ b/apps/www/components/tryout/runtime/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getActiveTryoutAttempt,
   getTryoutRuntimeState,

--- a/apps/www/components/tryout/section/finished.test.ts
+++ b/apps/www/components/tryout/section/finished.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getTryoutFinishedSectionDescription,
   getTryoutFinishedSectionStatus,

--- a/apps/www/components/user/state.test.ts
+++ b/apps/www/components/user/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { updateUserName, updateUserRole } from "@/components/user/state";
 
 describe("current user optimistic state", () => {

--- a/apps/www/instrumentation.test.ts
+++ b/apps/www/instrumentation.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const instrumentationMocks = vi.hoisted(() => ({
   captureServerException: vi.fn(),

--- a/apps/www/lib/analytics/consent/preferences.test.ts
+++ b/apps/www/lib/analytics/consent/preferences.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   initialConsentPreferences,
   updateConsentPreferences,

--- a/apps/www/lib/analytics/consent/session.test.ts
+++ b/apps/www/lib/analytics/consent/session.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_CONSENT_CATEGORY,
   ANALYTICS_CONSENT_MECHANISM,
   ANALYTICS_CONSENT_NOTICE_VERSION,
 } from "@repo/analytics/consent";
-import { describe, expect, it } from "vitest";
 import {
   type AnalyticsConsentSessionOverrides,
   canCommitAnalyticsConsentRevocation,

--- a/apps/www/lib/analytics/consent/signal.test.ts
+++ b/apps/www/lib/analytics/consent/signal.test.ts
@@ -13,7 +13,6 @@ import type { FunctionReturnType } from "convex/server";
 import { ConvexError } from "convex/values";
 import { Duration, Effect, Fiber, Option } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 import {
   AccountConsentPersistenceError,
   AccountConsentRejectedError,

--- a/apps/www/lib/analytics/consent/state.test.ts
+++ b/apps/www/lib/analytics/consent/state.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_CONSENT_CATEGORY,
   ANALYTICS_CONSENT_MECHANISM,
@@ -5,7 +6,6 @@ import {
   createAnonymousAnalyticsConsent,
 } from "@repo/analytics/consent";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 import {
   type BrowserAnalyticsUser,
   createBrowserAnalyticsIdentity,

--- a/apps/www/lib/analytics/server.test.ts
+++ b/apps/www/lib/analytics/server.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   scheduleCurrentServerExceptionCapture,
   scheduleServerExceptionCapture,

--- a/apps/www/lib/auth/deletion/delete.test.ts
+++ b/apps/www/lib/auth/deletion/delete.test.ts
@@ -11,7 +11,6 @@ import {
   accountDeletionRequestPhase,
 } from "@repo/backend/convex/auth/deletion/spec";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { authClient } from "@/lib/auth/client";
 import { deleteCurrentAccount } from "@/lib/auth/deletion/delete";
 import {

--- a/apps/www/lib/auth/deletion/prepare.test.ts
+++ b/apps/www/lib/auth/deletion/prepare.test.ts
@@ -5,7 +5,6 @@ import {
   accountDeletionRequestPhase,
 } from "@repo/backend/convex/auth/deletion/spec";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { AccountDeletionAttemptStorageFailed } from "@/lib/auth/deletion/attempt";
 import {
   AccountDeletionFailed,

--- a/apps/www/lib/auth/identity/browser.test.ts
+++ b/apps/www/lib/auth/identity/browser.test.ts
@@ -5,7 +5,6 @@ import {
   resetBrowserAnalyticsIdentity,
 } from "@repo/analytics/posthog/browser";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { authClient } from "@/lib/auth/client";
 import {
   AccountSignOutFailed,

--- a/apps/www/lib/auth/server.test.ts
+++ b/apps/www/lib/auth/server.test.ts
@@ -9,7 +9,6 @@ import {
   describe,
   expect,
   it,
-  vi,
 } from "@effect/vitest";
 import { Effect } from "effect";
 import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external";

--- a/apps/www/lib/auth/utils.test.ts
+++ b/apps/www/lib/auth/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getAuthCallbackPath } from "@/lib/auth/utils";
 
 describe("lib/auth/utils", () => {

--- a/apps/www/lib/billing/navigation.test.ts
+++ b/apps/www/lib/billing/navigation.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { billingNavigationProgram } from "@/lib/billing/navigation";
 
 describe("billing navigation", () => {

--- a/apps/www/lib/content/article/catalog.test.ts
+++ b/apps/www/lib/content/article/catalog.test.ts
@@ -14,7 +14,6 @@ import type { api } from "@repo/backend/convex/_generated/api";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
 import type { FunctionReturnType } from "convex/server";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedArticlePage,
   getPublishedCategories,

--- a/apps/www/lib/content/article/category.test.ts
+++ b/apps/www/lib/content/article/category.test.ts
@@ -12,7 +12,6 @@ import {
 } from "@nakafa/aksara-contracts/projection/article";
 import { RendererDomainSchema } from "@nakafa/aksara-contracts/renderer/domain";
 import { Data, Effect, Schema } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedArticleCategory,
   getPublishedCategoryAlternates,

--- a/apps/www/lib/content/article/discovery.test.ts
+++ b/apps/www/lib/content/article/discovery.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   readPublishedArticleBucket,
   readPublishedCategoryArticles,

--- a/apps/www/lib/content/article/navigation.test.ts
+++ b/apps/www/lib/content/article/navigation.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@nakafa/aksara-contracts/projection/article";
 import { RendererDomainSchema } from "@nakafa/aksara-contracts/renderer/domain";
 import { Effect, Schema } from "effect";
-import { vi } from "vitest";
 import {
   getShellArticleNavigation,
   readArticleNavigation,

--- a/apps/www/lib/content/article/publication.test.ts
+++ b/apps/www/lib/content/article/publication.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getArticlePublication } from "@/lib/content/article/publication";
 import {
   testArticleArtifact,

--- a/apps/www/lib/content/article/route.test.ts
+++ b/apps/www/lib/content/article/route.test.ts
@@ -5,7 +5,6 @@ import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { canonicalizeArticleProjection } from "@nakafa/aksara-contracts/projection/article";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedArticleRoute,
   readPublishedArticleRoute,

--- a/apps/www/lib/content/article/sitemap.test.ts
+++ b/apps/www/lib/content/article/sitemap.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   readPublishedArticleBuckets,
   readPublishedArticleSitemap,

--- a/apps/www/lib/content/cache.test.ts
+++ b/apps/www/lib/content/cache.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@nakafa/aksara-contracts/cache/content";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { Data, Effect, Schema } from "effect";
-import { vi } from "vitest";
 import {
   applyContentRuntimeCache,
   applyPublishedCatalogCache,

--- a/apps/www/lib/content/internal/authorization.test.ts
+++ b/apps/www/lib/content/internal/authorization.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { isInternalContentAuthorized } from "@/lib/content/internal/authorization";
 
 describe("internal content authorization", () => {

--- a/apps/www/lib/content/material/catalog.test.ts
+++ b/apps/www/lib/content/material/catalog.test.ts
@@ -7,7 +7,6 @@ import {
 } from "@nakafa/aksara-contracts/projection/material";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedMaterialRoutes,
   readPublishedMaterialPage,

--- a/apps/www/lib/content/material/context.test.ts
+++ b/apps/www/lib/content/material/context.test.ts
@@ -10,7 +10,6 @@ import {
   CurriculumRouteSchema,
 } from "@nakafa/aksara-contracts/program/curriculum";
 import { Effect, Schema } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedMaterialContext,
   readPublishedMaterialContext,

--- a/apps/www/lib/content/material/discovery.test.ts
+++ b/apps/www/lib/content/material/discovery.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Data, Effect } from "effect";
-import { vi } from "vitest";
 import {
   readPublishedLatestMaterials,
   readPublishedMaterialBucket,

--- a/apps/www/lib/content/material/publication.test.ts
+++ b/apps/www/lib/content/material/publication.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@nakafa/aksara-contracts/ids";
 import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { getMaterialPublication } from "@/lib/content/material/publication";
 import { PublishedProjectionError } from "@/lib/content/published/errors";
 import {

--- a/apps/www/lib/content/material/route.test.ts
+++ b/apps/www/lib/content/material/route.test.ts
@@ -5,7 +5,6 @@ import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedMaterialRoute,
   readPublishedMaterialRoute,

--- a/apps/www/lib/content/material/sitemap.test.ts
+++ b/apps/www/lib/content/material/sitemap.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   readPublishedMaterialBuckets,
   readPublishedMaterialSitemap,

--- a/apps/www/lib/content/material/trust.test.ts
+++ b/apps/www/lib/content/material/trust.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedTrustLesson,
   readPublishedTrustLesson,

--- a/apps/www/lib/content/page/catalog.test.ts
+++ b/apps/www/lib/content/page/catalog.test.ts
@@ -10,7 +10,6 @@ import {
   ArtifactLocaleSchema,
 } from "@nakafa/aksara-contracts/locale";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedPageCatalog,
   readPublishedPageCatalog,

--- a/apps/www/lib/content/page/navigation.test.ts
+++ b/apps/www/lib/content/page/navigation.test.ts
@@ -15,7 +15,6 @@ import {
   PublicPageProjectionSchema,
 } from "@nakafa/aksara-contracts/projection/page";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getShellPageNavigation,
   PageNavigationMissingError,

--- a/apps/www/lib/content/preview/config.test.ts
+++ b/apps/www/lib/content/preview/config.test.ts
@@ -2,7 +2,6 @@
 
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option, Redacted } from "effect";
-import { vi } from "vitest";
 import {
   hasPreviewConfig,
   previewUrl,

--- a/apps/www/lib/content/preview/events.test.ts
+++ b/apps/www/lib/content/preview/events.test.ts
@@ -2,7 +2,6 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect, Option } from "effect";
-import { vi } from "vitest";
 import {
   PreviewConfigError,
   readPreviewConfig,

--- a/apps/www/lib/content/preview/manifest.test.ts
+++ b/apps/www/lib/content/preview/manifest.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { readPreviewManifestForPrerender } from "@/lib/content/preview/manifest";
 import { makePendingManifest } from "@/test/content-preview";
 

--- a/apps/www/lib/content/preview/material.test.ts
+++ b/apps/www/lib/content/preview/material.test.ts
@@ -15,7 +15,6 @@ import {
   SigningKeyNotFoundError,
 } from "@nakafa/aksara-contracts/signature/spec";
 import { Context, Effect, Layer, Option, Schema } from "effect";
-import { vi } from "vitest";
 import { readPreviewConfig } from "@/lib/content/preview/config";
 import {
   type MaterialPreviewInput,

--- a/apps/www/lib/content/preview/question.test.ts
+++ b/apps/www/lib/content/preview/question.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import { executePreviewArtifact } from "@/lib/content/preview/artifact";
 import { readPreviewSnapshot } from "@/lib/content/preview/manifest";
 import {

--- a/apps/www/lib/content/preview/request.test.ts
+++ b/apps/www/lib/content/preview/request.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from "@effect/vitest";
 import { SigningKeyIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Deferred, Effect, Fiber, Redacted } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 import type { PreviewConfig } from "@/lib/content/preview/config";
 import {
   fetchPreviewJson,

--- a/apps/www/lib/content/preview/route.test.ts
+++ b/apps/www/lib/content/preview/route.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@nakafa/aksara-contracts/preview/spec";
 import type { RendererDomain } from "@nakafa/aksara-contracts/renderer/domain";
 import { Data, Effect, Option, Schema } from "effect";
-import { vi } from "vitest";
 import { PreviewIntegrityError } from "@/lib/content/preview/errors";
 import {
   readPreviewManifestForPrerender,

--- a/apps/www/lib/content/program/catalog.test.ts
+++ b/apps/www/lib/content/program/catalog.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { PROJECTION_PAGE_LIMIT } from "@repo/backend/convex/contentRelease/paging";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedProgramCatalog,
   getPublishedProgramRoutes,

--- a/apps/www/lib/content/program/route.test.ts
+++ b/apps/www/lib/content/program/route.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedProgramRoute,
   readPublishedProgramRoute,

--- a/apps/www/lib/content/published/active.test.ts
+++ b/apps/www/lib/content/published/active.test.ts
@@ -6,7 +6,6 @@ import {
   Sha256HashSchema,
 } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readActiveContentIdentity } from "@/lib/content/published/active";
 import { createTestRuntimeQuery } from "@/test/runtime-query";
 

--- a/apps/www/lib/content/published/exchange.test.ts
+++ b/apps/www/lib/content/published/exchange.test.ts
@@ -9,7 +9,6 @@ import { ContentRuntimeMissingError } from "@repo/backend/client/content/errors"
 import { readPublicContent } from "@repo/backend/client/content/public";
 import { contentRuntimeKeys } from "@repo/next-config/keys";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import type { PublishedContentInput } from "@/lib/content/published/exchange";
 import {
   readCurrentPublishedContent,

--- a/apps/www/lib/content/published/release.test.ts
+++ b/apps/www/lib/content/published/release.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import type { PublishedProjectionIdentity } from "@/lib/content/published/errors";
 import {
   decodeContentReleasePin,

--- a/apps/www/lib/content/published/route.test.ts
+++ b/apps/www/lib/content/published/route.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readActiveContentRoute } from "@/lib/content/published/route";
 import { testArticleProjection } from "@/test/content-article";
 import { previewProjection } from "@/test/content-preview";

--- a/apps/www/lib/content/quran/publication.test.ts
+++ b/apps/www/lib/content/quran/publication.test.ts
@@ -9,7 +9,6 @@ import {
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getPublishedQuranCatalog,
   getPublishedQuranView,

--- a/apps/www/lib/content/quran/recovery.test.ts
+++ b/apps/www/lib/content/quran/recovery.test.ts
@@ -2,7 +2,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Sha256HashSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Result } from "effect";
-import { vi } from "vitest";
 import {
   QuranSnapshotRecoveryError,
   recoverStalePublishedQuranSnapshot,

--- a/apps/www/lib/content/quran/references.test.ts
+++ b/apps/www/lib/content/quran/references.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   makeQuranLocaleSources,
   makeQuranTafsirProjection,
 } from "@repo/backend/test/quran/rows";
-import { describe, expect, it } from "vitest";
 import { getQuranReferences } from "@/lib/content/quran/references";
 
 const expectedSourceIds = {

--- a/apps/www/lib/content/renderer/capability.test.ts
+++ b/apps/www/lib/content/renderer/capability.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   createComponentCapability,
   createComponentRequirements,

--- a/apps/www/lib/content/renderer/components.test.ts
+++ b/apps/www/lib/content/renderer/components.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from "@effect/vitest";
 import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import { semanticMdxComponents } from "@repo/design-system/lib/markdown/semantic";
 import { Data, Effect } from "effect";
-import { vi } from "vitest";
 
 vi.mock("@repo/internationalization/src/navigation", () => ({
   getPathname: vi.fn(),

--- a/apps/www/lib/content/renderer/manifest.test.ts
+++ b/apps/www/lib/content/renderer/manifest.test.ts
@@ -12,7 +12,6 @@ import {
 } from "@nakafa/aksara-contracts/renderer/manifest";
 import { semanticComponentNames } from "@repo/design-system/lib/markdown/names";
 import { Effect, Exit, Schema } from "effect";
-import { vi } from "vitest";
 import { baseComponentLoaders } from "@/lib/content/renderer/domain/base";
 import { loadRendererDomainModule } from "@/lib/content/renderer/selection";
 

--- a/apps/www/lib/content/runtime/query.test.ts
+++ b/apps/www/lib/content/runtime/query.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "@effect/vitest";
 import { ConvexRuntimeQueryError } from "@repo/backend/client/runtime";
 import { api } from "@repo/backend/convex/_generated/api";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readRuntimeQuery } from "@/lib/content/runtime/query";
 
 const { readMock, runtimeUrl } = vi.hoisted(() => ({

--- a/apps/www/lib/content/search-highlight.test.ts
+++ b/apps/www/lib/content/search-highlight.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getSearchExcerptParts,
   hasSearchExcerpt,

--- a/apps/www/lib/content/tryout/sitemap.test.ts
+++ b/apps/www/lib/content/tryout/sitemap.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   readPublishedTryoutSitemap,
   readPublishedTryoutSitemapCount,

--- a/apps/www/lib/content/views/key.test.ts
+++ b/apps/www/lib/content/views/key.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { createContentViewKey } from "@/lib/content/views/key";
 
 describe("createContentViewKey", () => {

--- a/apps/www/lib/curriculum/artwork.test.ts
+++ b/apps/www/lib/curriculum/artwork.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import { PublicPathSchema } from "@nakafa/aksara-contracts/ids";
 import { MaterialDomainSchema } from "@nakafa/aksara-contracts/material/domain";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
-import { describe, expect, it } from "vitest";
 import {
   getCurriculumIndexSocialImage,
   getCurriculumRouteSocialImage,

--- a/apps/www/lib/curriculum/routes.test.ts
+++ b/apps/www/lib/curriculum/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getCurriculumIndexHref,
   getCurriculumProgramHref,

--- a/apps/www/lib/i18n/active.test.ts
+++ b/apps/www/lib/i18n/active.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { isActiveLocale } from "@/lib/i18n/active";
 
 describe("active locale", () => {

--- a/apps/www/lib/i18n/params.test.ts
+++ b/apps/www/lib/i18n/params.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { getActiveLocaleOrThrow, getLocaleOrThrow } from "@/lib/i18n/params";
 
 const hasPreviewConfigMock = vi.hoisted(() => vi.fn(() => false));

--- a/apps/www/lib/llms/constants.test.ts
+++ b/apps/www/lib/llms/constants.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 
 describe("llms constants", () => {
   afterEach(() => {

--- a/apps/www/lib/llms/content/entries.test.ts
+++ b/apps/www/lib/llms/content/entries.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { MaterialLessonProjection } from "@nakafa/aksara-contracts/projection/material";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import { getContentPageLlmsEntries } from "@/lib/llms/content/entries";
 import type { LlmsEntry } from "@/lib/llms/entries";

--- a/apps/www/lib/llms/content/listing.test.ts
+++ b/apps/www/lib/llms/content/listing.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import { getContentListingLlmsEntries } from "@/lib/llms/content/listing";
 
 const mockReadPublishedCategoryArticles = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/llms/content/markdown.test.ts
+++ b/apps/www/lib/llms/content/markdown.test.ts
@@ -2,7 +2,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
 import type { Locale } from "next-intl";
-import { vi } from "vitest";
 import {
   getLlmsMarkdownText,
   hasLlmsMarkdownSource,

--- a/apps/www/lib/llms/content/material.test.ts
+++ b/apps/www/lib/llms/content/material.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readMaterialLlmsInventory } from "@/lib/llms/content/material";
 
 const mockReadPublishedBuckets = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/llms/entries.test.ts
+++ b/apps/www/lib/llms/entries.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   ContentKeySchema,
   CorpusSourcePathSchema,
@@ -12,7 +14,6 @@ import {
   PageKeySchema,
   PublicPageProjectionSchema,
 } from "@nakafa/aksara-contracts/projection/page";
-import { describe, expect, it } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import {
   buildPublishedContentLlmsEntries,

--- a/apps/www/lib/llms/format.test.ts
+++ b/apps/www/lib/llms/format.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { ENGLISH_LANGUAGE_NAMES } from "@/lib/llms/constants";
 import {
   AGENT_MARKDOWN_DIRECTIVE,

--- a/apps/www/lib/llms/index/cache.test.ts
+++ b/apps/www/lib/llms/index/cache.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { getCachedLlmsSectionIndexText } from "@/lib/llms/index/cache";
 
 const mockApplyContentRuntimeCache = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/llms/index/generate.test.ts
+++ b/apps/www/lib/llms/index/generate.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import type { LlmsEntry } from "@/lib/llms/entries";
 import { getLlmsSectionIndexText } from "@/lib/llms/index/generate";

--- a/apps/www/lib/llms/published.test.ts
+++ b/apps/www/lib/llms/published.test.ts
@@ -6,7 +6,6 @@ import {
   ReleaseIdSchema,
 } from "@nakafa/aksara-contracts/ids";
 import { Data, Effect } from "effect";
-import { vi } from "vitest";
 import { readPublishedPage } from "@/lib/content/page/published";
 import { readPublishedArticle } from "@/lib/content/published/article";
 import { readPublishedMaterial } from "@/lib/content/published/material";

--- a/apps/www/lib/llms/quran.test.ts
+++ b/apps/www/lib/llms/quran.test.ts
@@ -5,7 +5,6 @@ import type { QuranTranslationDocument } from "@nakafa/aksara-contracts/quran/no
 import { loadLocaleMessages } from "@repo/internationalization/src/messages";
 import { Effect, Option } from "effect";
 import { createTranslator, type Locale } from "next-intl";
-import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import {
   classifyQuranLlmsRoute,

--- a/apps/www/lib/llms/routes.test.ts
+++ b/apps/www/lib/llms/routes.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import {
   type LlmsProxyRouteDecision,
   type LlmsProxyRouteRequest,

--- a/apps/www/lib/llms/section.test.ts
+++ b/apps/www/lib/llms/section.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { BASE_URL } from "@/lib/llms/constants";
 import type { LlmsEntry } from "@/lib/llms/entries";
 import {

--- a/apps/www/lib/llms/site.test.ts
+++ b/apps/www/lib/llms/site.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { buildSiteLlmsEntries } from "@/lib/llms/entries";
 import { readSiteLlmsEntries } from "@/lib/llms/site";
 import { testPageProjection } from "@/test/content-page";

--- a/apps/www/lib/og/artwork.test.ts
+++ b/apps/www/lib/og/artwork.test.ts
@@ -2,7 +2,7 @@
 
 import { glob, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getAppSocialArtwork } from "@/lib/og/app-artwork";
 import {
   listStaticArtworkPaths,

--- a/apps/www/lib/og/route.test.ts
+++ b/apps/www/lib/og/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   createOgRouteAliasRewrites,
   isOgRouteAliasPathname,

--- a/apps/www/lib/routing/locale/published.test.ts
+++ b/apps/www/lib/routing/locale/published.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import { readPublishedLocalizedHref } from "@/lib/routing/locale/published";
 import {
   testArticleDeProjection,

--- a/apps/www/lib/routing/locale/resolve.test.ts
+++ b/apps/www/lib/routing/locale/resolve.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@nakafa/aksara-contracts/ids";
 import type { ActiveAppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import { resolveLocalizedNavigationHref } from "@/lib/routing/locale/resolve";
 import {
   testArticleDeProjection,

--- a/apps/www/lib/routing/material/query.test.ts
+++ b/apps/www/lib/routing/material/query.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   readMaterialContextQuery,
   toMaterialContextQueryString,

--- a/apps/www/lib/routing/prerender.test.ts
+++ b/apps/www/lib/routing/prerender.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { selectLearningStaticParams } from "@/lib/routing/prerender";
 
 const EXPECTED_STATIC_PARAM_LIMIT = 512;

--- a/apps/www/lib/routing/public/document.test.ts
+++ b/apps/www/lib/routing/public/document.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 import { resolvePublicDocumentRoute } from "@/lib/routing/public/document";
 
 const routeMocks = vi.hoisted(() => ({

--- a/apps/www/lib/routing/public/migration.test.ts
+++ b/apps/www/lib/routing/public/migration.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readPublicUrlMigrationRedirect } from "@/lib/routing/public/migration";
 
 const readRuntimeQueryMock = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/routing/public/ownership.test.ts
+++ b/apps/www/lib/routing/public/ownership.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   isApplicationRoutePath,
   isApplicationRouteRoot,

--- a/apps/www/lib/routing/public/pathnames.test.ts
+++ b/apps/www/lib/routing/public/pathnames.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 import {
   getLocalizedMappedRoutePathname,
   projectLocalizedMappedRoutePathname,

--- a/apps/www/lib/routing/public/projected.test.ts
+++ b/apps/www/lib/routing/public/projected.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readProjectedHtmlRouteRejection } from "@/lib/routing/public/projected";
 
 const mockReadRuntimeContentReference = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/routing/public/source.test.ts
+++ b/apps/www/lib/routing/public/source.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Data, Effect } from "effect";
-import { vi } from "vitest";
 import { readSourceBackedHtmlRouteRejection } from "@/lib/routing/public/source";
 
 const publishedMocks = vi.hoisted(() => ({

--- a/apps/www/lib/seo/cache.test.ts
+++ b/apps/www/lib/seo/cache.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { getCachedSEOMetadata } from "@/lib/seo/cache";
 
 const mocks = vi.hoisted(() => ({

--- a/apps/www/lib/seo/generator.test.ts
+++ b/apps/www/lib/seo/generator.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { generateSEOMetadata } from "@/lib/seo/generator";
 
 const { mockGetTranslations } = vi.hoisted(() => ({

--- a/apps/www/lib/seo/quran.test.ts
+++ b/apps/www/lib/seo/quran.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { generateQuranMetadata } from "@/lib/seo/quran";
 
 const { mockGetTranslations } = vi.hoisted(() => ({

--- a/apps/www/lib/seo/translations.test.ts
+++ b/apps/www/lib/seo/translations.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   fetchSEOTranslationsNamespace,
   SEOTranslationLoadError,

--- a/apps/www/lib/sitemap/catalog.test.ts
+++ b/apps/www/lib/sitemap/catalog.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
-import { vi } from "vitest";
 import { readSitemapPageDescriptors } from "@/lib/sitemap/catalog";
 
 class MissingSignedMaterialInventory extends Schema.TaggedError<MissingSignedMaterialInventory>()(

--- a/apps/www/lib/sitemap/entries.test.ts
+++ b/apps/www/lib/sitemap/entries.test.ts
@@ -2,7 +2,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import type { getPathname } from "@repo/internationalization/src/navigation";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { getSitemapEntries } from "@/lib/sitemap/entries";
 
 const mockReadSitemapRoutePage = vi.hoisted(() => vi.fn());

--- a/apps/www/lib/sitemap/identity.test.ts
+++ b/apps/www/lib/sitemap/identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getSitemapPageDescriptor } from "@/lib/sitemap/identity";
 
 describe("sitemap page identity", () => {

--- a/apps/www/lib/sitemap/routes.test.ts
+++ b/apps/www/lib/sitemap/routes.test.ts
@@ -2,7 +2,6 @@
 
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import { readSitemapRoutePage } from "@/lib/sitemap/routes";
 
 const articleMocks = vi.hoisted(() => ({

--- a/apps/www/lib/sitemap/xml.test.ts
+++ b/apps/www/lib/sitemap/xml.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { buildSitemapIndexXml, buildSitemapUrlSetXml } from "@/lib/sitemap/xml";
 
 describe("sitemap XML serialization", () => {

--- a/apps/www/lib/store/search.test.ts
+++ b/apps/www/lib/store/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 import { createSearchStore } from "@/lib/store/search";
 

--- a/apps/www/lib/theme/viewport.test.ts
+++ b/apps/www/lib/theme/viewport.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { THEME_COMPATIBILITY_COLORS } from "@repo/design-system/lib/theme/compatibility";
-import { describe, expect, it } from "vitest";
 import { appViewport } from "@/lib/theme/viewport";
 
 describe("appViewport", () => {

--- a/apps/www/lib/tryout/access.test.ts
+++ b/apps/www/lib/tryout/access.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { ConvexError } from "convex/values";
-import { describe, expect, it } from "vitest";
 import {
   getTryoutStartDialogKind,
   isTryoutAccessRequired,

--- a/apps/www/lib/tryout/choice-variant.test.ts
+++ b/apps/www/lib/tryout/choice-variant.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   getTryoutPreviewChoiceVariant,
   getTryoutReviewedChoiceVariant,

--- a/apps/www/lib/utils/browser.test.ts
+++ b/apps/www/lib/utils/browser.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   getLocale,
   getMaterialContextHint,

--- a/apps/www/lib/utils/date.test.ts
+++ b/apps/www/lib/utils/date.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getLocale } from "@/lib/utils/date";
 
 describe("getLocale", () => {

--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import { GitCommitShaSchema } from "@nakafa/aksara-contracts/ids";
-import { describe, expect, it } from "vitest";
 import {
   getAksaraTreeUrl,
   getAksaraUrl,

--- a/apps/www/lib/utils/helper.test.ts
+++ b/apps/www/lib/utils/helper.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getInitialName } from "@/lib/utils/helper";
 
 describe("getInitialName", () => {

--- a/apps/www/lib/utils/metadata.test.ts
+++ b/apps/www/lib/utils/metadata.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { getOgUrl, getSocialMetadata } from "@/lib/utils/metadata";
 
 describe("getOgUrl", () => {

--- a/apps/www/lib/utils/pages/quran.test.ts
+++ b/apps/www/lib/utils/pages/quran.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import type { QuranSurahRow } from "@nakafa/aksara-contracts/quran/spec";
-import { describe, expect, it } from "vitest";
 import { getQuranPagination, getQuranSurahName } from "@/lib/utils/pages/quran";
 
 describe("quran page helpers", () => {

--- a/apps/www/lib/utils/system.test.ts
+++ b/apps/www/lib/utils/system.test.ts
@@ -3,7 +3,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { Effect } from "effect";
-import { vi } from "vitest";
 import {
   getCachedMetadataFromSlug,
   getMetadataFromSlug,

--- a/apps/www/proxy.test.ts
+++ b/apps/www/proxy.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server.js";
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { hasLlmsMarkdownSource } from "@/lib/llms/content/markdown";
 import { config, proxy } from "@/proxy";
 

--- a/apps/www/scripts/indexing/google/structured.test.ts
+++ b/apps/www/scripts/indexing/google/structured.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { hasGoogleIndexingApiEligibleStructuredData } from "@/scripts/indexing/google/structured";
 
 describe("hasGoogleIndexingApiEligibleStructuredData", () => {

--- a/apps/www/scripts/indexing/manifest.test.ts
+++ b/apps/www/scripts/indexing/manifest.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const sitemapMocks = vi.hoisted(() => ({
   getSitemapEntries: vi.fn(),

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
-    "types": ["@repo/internationalization/i18n.d.ts"],
+    "types": ["@repo/internationalization/i18n.d.ts", "vitest/globals"],
     "paths": {
       "@/*": ["./*"],
       "@repo/*": ["../../packages/*"]

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,7 +34,17 @@
             "noRestrictedImports": {
               "level": "error",
               "options": {
+                "paths": {
+                  "@effect/vitest": {
+                    "importNames": ["vi"],
+                    "message": "Use the configured global vi for mocks. Import the remaining test APIs from @effect/vitest."
+                  }
+                },
                 "patterns": [
+                  {
+                    "group": ["vitest", "vitest/*", "!vitest/config"],
+                    "message": "Import test APIs from @effect/vitest. Keep vitest only as the required runner and config package."
+                  },
                   {
                     "group": ["./**", "../**"],
                     "message": "Use the owning @/, @repo/*, or #scripts/* alias instead."
@@ -59,6 +69,44 @@
             }
           }
         }
+      }
+    },
+    {
+      "includes": ["*.{ts,tsx,mts,cts}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@effect/vitest": {
+                    "importNames": ["vi"],
+                    "message": "Use the configured global vi for mocks. Import the remaining test APIs from @effect/vitest."
+                  }
+                },
+                "patterns": [
+                  {
+                    "group": ["vitest", "vitest/*", "!vitest/config"],
+                    "message": "Import test APIs from @effect/vitest. Keep vitest only as the required runner and config package."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "**/*.test.{ts,tsx,mts,cts}",
+        "**/test/**/*.{ts,tsx,mts,cts}",
+        "**/vitest.setup.{ts,mts,cts}",
+        "apps/www/components/school/classes/forum/conversation/fixtures/data.ts",
+        "apps/www/components/school/classes/forum/conversation/viewport/fixture.ts"
+      ],
+      "javascript": {
+        "globals": ["vi"]
       }
     }
   ],

--- a/packages/ai/agents/math/descriptions.test.ts
+++ b/packages/ai/agents/math/descriptions.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   mathAlgebra,
   mathArithmetic,
@@ -11,7 +12,6 @@ import {
   mathStatistics,
 } from "@repo/ai/agents/math/descriptions";
 import { mathOperations } from "@repo/math/schema/operations";
-import { describe, expect, it } from "vitest";
 
 const mathToolDescriptions = [
   mathAlgebra,

--- a/packages/ai/agents/math/format.test.ts
+++ b/packages/ai/agents/math/format.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import { formatMathData } from "@repo/ai/agents/math/format";
 import type { MathData } from "@repo/math/schema/data";
 import type { MathRequest } from "@repo/math/schema/request";
 import type { MathResult } from "@repo/math/schema/result";
-import { describe, expect, it } from "vitest";
 
 const input = {
   expression: "6 * 7",

--- a/packages/ai/agents/math/prompt.test.ts
+++ b/packages/ai/agents/math/prompt.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { mathPrompt } from "@repo/ai/agents/math/prompt";
 import { mathOperations } from "@repo/math/schema/operations";
-import { describe, expect, it } from "vitest";
 
 const base = {
   context: {

--- a/packages/ai/agents/math/repair.test.ts
+++ b/packages/ai/agents/math/repair.test.ts
@@ -8,7 +8,6 @@ import { ModelIdSchema } from "@repo/ai/config/model";
 import type { JSONSchema7, ToolCallRepairFunction, ToolSet } from "ai";
 import { generateText, InvalidToolInputError, NoSuchToolError, tool } from "ai";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const generateTextMock = vi.hoisted(() => vi.fn());
 

--- a/packages/ai/agents/math/step.test.ts
+++ b/packages/ai/agents/math/step.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { prepareMathStep } from "@repo/ai/agents/math/step";
-import { describe, expect, it } from "vitest";
 
 describe("prepareMathStep", () => {
   it("requires one deterministic math tool on the first step", () => {

--- a/packages/ai/agents/math/tools/compute.test.ts
+++ b/packages/ai/agents/math/tools/compute.test.ts
@@ -7,7 +7,6 @@ import type { MathToolInput } from "@repo/math/schema/tool-input";
 import { MathService } from "@repo/math/service";
 import type { UIMessageStreamWriter } from "ai";
 import { ConfigProvider, Effect } from "effect";
-import { vi } from "vitest";
 
 type WrittenPart = Parameters<UIMessageStreamWriter<MyUIMessage>["write"]>[0];
 const input = {

--- a/packages/ai/agents/nakafa/preview.test.ts
+++ b/packages/ai/agents/nakafa/preview.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { previewQuran, previewRead } from "@repo/ai/agents/nakafa/preview";
 import { makeQuranFixture } from "@repo/ai/agents/nakafa/tools/fixture";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
-import { describe, expect, it } from "vitest";
 
 describe("nakafa previews", () => {
   it("omits an unavailable content description", () => {

--- a/packages/ai/agents/nakafa/prompt.test.ts
+++ b/packages/ai/agents/nakafa/prompt.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import { nakafaAgentPrompt } from "@repo/ai/agents/nakafa/prompt";
-import { describe, expect, it } from "vitest";
 
 const context = {
   currentDate: "May 15, 2026",

--- a/packages/ai/agents/nakafa/step.test.ts
+++ b/packages/ai/agents/nakafa/step.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   prepareAnswerFromNakafaEvidenceStep,
   prepareReadStep,
@@ -8,7 +9,6 @@ import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import type { NakafaAgentSection } from "@repo/contents/_lib/agent/schema/ref";
 import type { NakafaAgentSearchResult } from "@repo/contents/_lib/agent/schema/search";
 import type { Locale } from "@repo/contents/_types/content";
-import { describe, expect, it } from "vitest";
 
 /** Builds a typed Nakafa search item fixture from canonical route parts. */
 function contentSummary({

--- a/packages/ai/agents/nakafa/tools/fixture.test.ts
+++ b/packages/ai/agents/nakafa/tools/fixture.test.ts
@@ -1,8 +1,7 @@
-import { it as effectIt } from "@effect/vitest";
+import { describe, it as effectIt, expect, it } from "@effect/vitest";
 import { makeQuranFixture } from "@repo/ai/agents/nakafa/tools/fixture";
 import { createNakafaTestService } from "@repo/ai/agents/nakafa/tools/test";
 import { Effect, Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("Nakafa Quran AI fixtures", () => {
   const meaningByLocale = {

--- a/packages/ai/agents/nakafa/tools/search-result.test.ts
+++ b/packages/ai/agents/nakafa/tools/search-result.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   formatSearchGroup,
   getSearchTokens,
@@ -9,7 +10,6 @@ import {
   NakafaAgentSearchResultSchema,
 } from "@repo/contents/_lib/agent/schema/search";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 /** Builds one schema-decoded search result for ranking tests. */
 function searchResult(

--- a/packages/ai/agents/research/grounding.test.ts
+++ b/packages/ai/agents/research/grounding.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   addEligibleSourceUrls,
   filterResearchOutputCitations,
@@ -7,7 +8,6 @@ import {
   createGroundingWebSearchData,
   hasSingleGroundingQuery,
 } from "@repo/ai/agents/research/grounding";
-import { describe, expect, it } from "vitest";
 
 describe("research Google Search grounding", () => {
   it("drops query-only Google grounding when redirect sources are unusable", () => {

--- a/packages/ai/agents/research/messages.test.ts
+++ b/packages/ai/agents/research/messages.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createResearchMessages,
   createResearchSynthesisMessages,
 } from "@repo/ai/agents/research/messages";
-import { describe, expect, it } from "vitest";
 
 describe("research agent messages", () => {
   it("keeps search tools usable after source evidence is prefetched", () => {

--- a/packages/ai/agents/research/output.test.ts
+++ b/packages/ai/agents/research/output.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   addEligibleCitationUrl,
   addEligibleSourceUrls,
@@ -5,7 +6,6 @@ import {
   normalizeResearchCitationUrl,
 } from "@repo/ai/agents/research/citations";
 import { formatResearchOutput } from "@repo/ai/agents/research/output";
-import { describe, expect, it } from "vitest";
 
 describe("formatResearchOutput", () => {
   it("renders citations inline from structured research output", () => {

--- a/packages/ai/agents/research/prompt.test.ts
+++ b/packages/ai/agents/research/prompt.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   nakafaScrape,
   nakafaWebSearch,
@@ -6,7 +7,6 @@ import {
   researchEvidencePrompt,
   researchPrompt,
 } from "@repo/ai/agents/research/prompt";
-import { describe, expect, it } from "vitest";
 
 const context = {
   currentDate: "May 15, 2026",

--- a/packages/ai/agents/research/schema.test.ts
+++ b/packages/ai/agents/research/schema.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ResearchOutputSchema,
   ScrapeInputSchema,
   WebSearchInputSchema,
 } from "@repo/ai/agents/research/schema";
 import { Result, Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("research schema", () => {
   it("validates scrape URLs with Effect schema", () => {

--- a/packages/ai/agents/research/search/scope.test.ts
+++ b/packages/ai/agents/research/search/scope.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { scopeSources } from "@repo/ai/agents/research/search/scope";
-import { describe, expect, it } from "vitest";
 
 function makeSearchSource(title: string, url: string) {
   return {

--- a/packages/ai/agents/research/step.test.ts
+++ b/packages/ai/agents/research/step.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   prepareGoogleGroundingStep,
   prepareResearchEvidenceStep,
 } from "@repo/ai/agents/research/step";
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
 
 const messages = [
   { role: "user", content: "research latest climate data" },

--- a/packages/ai/agents/research/tools/markdown.test.ts
+++ b/packages/ai/agents/research/tools/markdown.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { fetchSourceMarkdown } from "@repo/ai/agents/research/tools/markdown";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 describe("source markdown fetcher", () => {
   afterEach(() => {

--- a/packages/ai/agents/research/tools/safety.test.ts
+++ b/packages/ai/agents/research/tools/safety.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { assertPublicResearchUrl } from "@repo/ai/agents/research/tools/safety";
 import { Effect, Result } from "effect";
-import { vi } from "vitest";
 
 const lookup = vi.hoisted(() => vi.fn());
 vi.mock("node:dns/promises", () => ({

--- a/packages/ai/agents/research/tools/scrape.test.ts
+++ b/packages/ai/agents/research/tools/scrape.test.ts
@@ -7,7 +7,6 @@ import {
 import type { MyUIMessage } from "@repo/ai/types/message";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const firecrawlApp = vi.hoisted(() => ({
   scrape: vi.fn(),

--- a/packages/ai/agents/research/tools/search.test.ts
+++ b/packages/ai/agents/research/tools/search.test.ts
@@ -3,7 +3,6 @@ import { searchWeb } from "@repo/ai/agents/research/tools/search";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import type { UIMessageStreamWriter } from "ai";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const firecrawlApp = vi.hoisted(() => ({
   search: vi.fn(),

--- a/packages/ai/agents/research/url.test.ts
+++ b/packages/ai/agents/research/url.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   isBlockedIpAddress,
   isIpAddress,
   isPublicHttpUrlSyntax,
   normalizeHostname,
 } from "@repo/ai/agents/research/url";
-import { describe, expect, it } from "vitest";
 
 describe("research URL policy", () => {
   it("accepts only public http(s) URL syntax", () => {

--- a/packages/ai/clients/weather/client.test.ts
+++ b/packages/ai/clients/weather/client.test.ts
@@ -6,7 +6,6 @@ import {
   type HttpClientRequest,
   HttpClientResponse,
 } from "effect/unstable/http";
-import { vi } from "vitest";
 
 const latitude = "-6.2088";
 const longitude = "106.8456";

--- a/packages/ai/clients/weather/schema.test.ts
+++ b/packages/ai/clients/weather/schema.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   CurrentWeatherSummarySchema,
   OpenWeatherCurrentResponseSchema,
 } from "@repo/ai/clients/weather/schema";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("OpenWeatherCurrentResponseSchema", () => {
   it("keeps only the provider fields needed by the weather summary", () => {

--- a/packages/ai/clients/weather/transport.test.ts
+++ b/packages/ai/clients/weather/transport.test.ts
@@ -7,7 +7,6 @@ import {
   type HttpClientRequest,
   HttpClientResponse,
 } from "effect/unstable/http";
-import { vi } from "vitest";
 
 interface TestClientInput {
   makeResponse: (request: HttpClientRequest.HttpClientRequest) => Response;

--- a/packages/ai/config/devtools-runtime.test.ts
+++ b/packages/ai/config/devtools-runtime.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { isAiSdkDevToolsTelemetryEnabled } from "@repo/ai/config/devtools-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("AI SDK DevTools runtime gate", () => {
   afterEach(() => {

--- a/packages/ai/config/devtools.test.ts
+++ b/packages/ai/config/devtools.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { registerTelemetry } from "ai";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const originalAiSdkDevTools = process.env.AI_SDK_DEVTOOLS;
 const originalNodeEnv = process.env.NODE_ENV;

--- a/packages/ai/config/gateway-error.test.ts
+++ b/packages/ai/config/gateway-error.test.ts
@@ -1,6 +1,6 @@
 import { GatewayInternalServerError } from "@ai-sdk/gateway";
+import { describe, expect, it } from "@effect/vitest";
 import { getGatewayErrorContext } from "@repo/ai/config/gateway-error";
-import { describe, expect, it } from "vitest";
 
 describe("Gateway error context", () => {
   it("extracts Gateway metadata for production log correlation", () => {

--- a/packages/ai/config/model.test.ts
+++ b/packages/ai/config/model.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   defaultModel,
   getFastModelProviderOptions,
@@ -13,7 +14,6 @@ import {
 } from "@repo/ai/config/model";
 import { gatewayProviderOptions } from "@repo/ai/config/routing";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("Nakafa model registry", () => {
   const liteModel = ModelIdSchema.make("nakafa-lite");

--- a/packages/ai/features/title.test.ts
+++ b/packages/ai/features/title.test.ts
@@ -4,7 +4,6 @@ import { DEFAULT_TITLE, MAX_TITLE_LENGTH } from "@repo/ai/features/constants";
 import { generateTitle } from "@repo/ai/features/title";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const generateText = vi.hoisted(() => vi.fn());
 const modelId = ModelIdSchema.make("nakafa-lite");

--- a/packages/ai/keys.test.ts
+++ b/packages/ai/keys.test.ts
@@ -1,10 +1,10 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   devtoolsKeys,
   firecrawlKeys,
   gatewayKeys,
   weatherKeys,
 } from "@repo/ai/keys";
-import { afterEach, describe, expect, it } from "vitest";
 
 const originalAiGatewayApiKey = process.env.AI_GATEWAY_API_KEY;
 const originalAiSdkDevTools = process.env.AI_SDK_DEVTOOLS;

--- a/packages/ai/lib/domain.test.ts
+++ b/packages/ai/lib/domain.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { extractDomain } from "@repo/ai/lib/domain";
-import { describe, expect, it } from "vitest";
 
 describe("extractDomain", () => {
   it("extracts the registrable domain label from full and partial URLs", () => {

--- a/packages/ai/lib/search-query.test.ts
+++ b/packages/ai/lib/search-query.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getDistinctiveSearchTerms,
   hasSearchableTerms,
@@ -5,7 +6,6 @@ import {
   normalizeSearchTerm,
   planSearchQueries,
 } from "@repo/ai/lib/search-query";
-import { describe, expect, it } from "vitest";
 
 describe("search query planning", () => {
   it("keeps generated queries as executable search text", () => {

--- a/packages/ai/lib/selection.test.ts
+++ b/packages/ai/lib/selection.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { selectRelevantContent } from "@repo/ai/lib/selection";
-import { describe, expect, it } from "vitest";
 
 describe("selectRelevantContent", () => {
   it("returns empty content unchanged", () => {

--- a/packages/ai/lib/source.test.ts
+++ b/packages/ai/lib/source.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getSourceReferences,
   getSourceReferencesFromMessages,
 } from "@repo/ai/lib/source";
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
 
 const sourceMessages = [
   {

--- a/packages/ai/nina/capability/spec.test.ts
+++ b/packages/ai/nina/capability/spec.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   CapabilityTrace,
   EvidenceEnvelope,
   encodeCapabilityTrace,
 } from "@repo/ai/nina/capability/spec";
-import { describe, expect, it } from "vitest";
 
 describe("nina/capability/spec", () => {
   it("encodes schema class traces into plain operational values", () => {

--- a/packages/ai/nina/harness/stream.test.ts
+++ b/packages/ai/nina/harness/stream.test.ts
@@ -12,7 +12,6 @@ import {
 import { NinaReporter } from "@repo/ai/nina/runtime/report";
 import { NinaStore } from "@repo/ai/nina/runtime/store";
 import { Cause, Effect, Exit, Option } from "effect";
-import { vi } from "vitest";
 
 const createNinaStreamResponseMock = vi.hoisted(() => vi.fn());
 vi.mock("@repo/ai/nina/runtime/stream", () => ({

--- a/packages/ai/nina/prompt/prompt.test.ts
+++ b/packages/ai/nina/prompt/prompt.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import type { NinaContextPack } from "@repo/ai/nina/memory/pack";
 import { createNinaPrompt } from "@repo/ai/nina/prompt/prompt";
-import { describe, expect, it } from "vitest";
 
 const nina = {
   learning: {

--- a/packages/ai/nina/prompt/system.test.ts
+++ b/packages/ai/nina/prompt/system.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import type { NinaContextPack } from "@repo/ai/nina/memory/pack";
 import { formatNinaContextPackPrompt } from "@repo/ai/nina/prompt/system";
-import { describe, expect, it } from "vitest";
 
 const placementProgramKey = LearningProgramKeySchema.make(
   "cambridge-lower-secondary"

--- a/packages/ai/nina/runtime/agent.test.ts
+++ b/packages/ai/nina/runtime/agent.test.ts
@@ -24,7 +24,6 @@ import type {
 } from "ai";
 import { ToolLoopAgent, tool, toUIMessageStream } from "ai";
 import { Cause, Effect, Exit, Option } from "effect";
-import { vi } from "vitest";
 
 interface CapturedAgentSettings {
   readonly id?: string;

--- a/packages/ai/nina/runtime/finish.test.ts
+++ b/packages/ai/nina/runtime/finish.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   getNinaResponseFailure,
   IncompleteNinaResponseError,
 } from "@repo/ai/nina/runtime/finish";
 import type { MyUIMessage } from "@repo/ai/types/message";
-import { describe, expect, it } from "vitest";
 
 const completeAssistantMessage = {
   id: "assistant-complete",

--- a/packages/ai/nina/runtime/page.test.ts
+++ b/packages/ai/nina/runtime/page.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createPageFetchState,
   determinePageFetchNeed,
@@ -14,7 +15,6 @@ import {
   type NakafaAgentSection,
 } from "@repo/contents/_lib/agent/schema/ref";
 import type { Locale } from "@repo/contents/_types/content";
-import { describe, expect, it } from "vitest";
 
 const englishLocale = "en" satisfies Locale;
 const materialSection = "material" satisfies NakafaAgentSection;

--- a/packages/ai/nina/runtime/step.test.ts
+++ b/packages/ai/nina/runtime/step.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createNinaPrepareStep,
   type NinaPrepareStep,
 } from "@repo/ai/nina/runtime/step";
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
 
 const emptyMessages = [] satisfies ModelMessage[];
 const instructions = "Base system prompt";

--- a/packages/ai/nina/runtime/suggest.test.ts
+++ b/packages/ai/nina/runtime/suggest.test.ts
@@ -6,7 +6,6 @@ import type { MyUIMessage } from "@repo/ai/types/message";
 import type { ModelMessage, UIMessageStreamWriter } from "ai";
 import { streamText } from "ai";
 import { Effect, Result, Stream } from "effect";
-import { vi } from "vitest";
 
 const streamTextMock = vi.hoisted(() => vi.fn());
 

--- a/packages/ai/prompt/curriculum-preference.test.ts
+++ b/packages/ai/prompt/curriculum-preference.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import { formatCurriculumPreferencePromptContext } from "@repo/ai/prompt/curriculum-preference";
 import type { AgentCurriculumPreference } from "@repo/ai/types/agents";
-import { describe, expect, it } from "vitest";
 
 const preference: AgentCurriculumPreference = {
   program: {

--- a/packages/ai/prompt/suggestions.test.ts
+++ b/packages/ai/prompt/suggestions.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { nakafaSuggestions } from "@repo/ai/prompt/suggestions";
-import { describe, expect, it } from "vitest";
 
 describe("nakafaSuggestions", () => {
   it("keeps Indonesian output instructions without mixed-language examples", () => {

--- a/packages/ai/schema/data.test.ts
+++ b/packages/ai/schema/data.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { NakafaDataSchema } from "@repo/ai/schema/data";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const ref = readNakafaContentRefFixture("en", "quran/1", "quran");
 const common = {

--- a/packages/ai/schema/tools.test.ts
+++ b/packages/ai/schema/tools.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   formatSpecialistToolTask,
   mathToolInputSchema,
@@ -7,7 +8,6 @@ import {
 import { asSchema } from "ai";
 import dedent from "dedent";
 import { Predicate } from "effect";
-import { describe, expect, it } from "vitest";
 
 function readJsonSchema(schema: ReturnType<typeof asSchema>) {
   const jsonSchema = schema.jsonSchema;

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
+    "types": ["vitest/globals"],
     "paths": {
       "@repo/*": ["../*"],
       "@repo/ai/*": ["./*"]

--- a/packages/analytics/consent.test.ts
+++ b/packages/analytics/consent.test.ts
@@ -1,4 +1,4 @@
-import { it as effectIt } from "@effect/vitest";
+import { describe, it as effectIt, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_CONSENT_NOTICE_VERSION,
   AnonymousAnalyticsConsentRecordSchema,
@@ -11,7 +11,6 @@ import {
   resolveAnalyticsConsentState,
 } from "@repo/analytics/consent";
 import { Effect, Option, Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const grantedAnonymousConsent = Schema.decodeSync(
   AnonymousAnalyticsConsentRecordSchema

--- a/packages/analytics/keys.test.ts
+++ b/packages/analytics/keys.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   keys,
   postHogProxyKeys,
   postHogPublicKeys,
 } from "@repo/analytics/keys";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 /** Installs one complete analytics environment for each assertion. */
 function stubAnalyticsEnvironment() {

--- a/packages/analytics/posthog/browser.test.ts
+++ b/packages/analytics/posthog/browser.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Fiber, Ref } from "effect";
-import { vi } from "vitest";
 
 const client = {
   captureException: vi.fn(),

--- a/packages/analytics/posthog/config.test.ts
+++ b/packages/analytics/posthog/config.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createPostHogProxyRewrites,
   isPostHogProxyPathname,
 } from "@repo/analytics/posthog/config";
-import { describe, expect, it } from "vitest";
 
 describe("PostHog proxy config", () => {
   it("builds the documented PostHog rewrite order", () => {

--- a/packages/analytics/posthog/exception.test.ts
+++ b/packages/analytics/posthog/exception.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createOperationalException,
   decodeOperationalExceptionProperties,
 } from "@repo/analytics/posthog/exception";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("operational exception privacy", () => {
   it("removes messages and retains stack frames", () => {

--- a/packages/analytics/posthog/identity.test.ts
+++ b/packages/analytics/posthog/identity.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   authorizeAnalyticsIdentity,
   authorizeAnonymousAnalyticsIdentity,
@@ -7,7 +8,6 @@ import {
   revokeAnalyticsIdentity,
 } from "@repo/analytics/posthog/identity";
 import type { CaptureResult } from "posthog-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const USER_ID = "user-1";
 

--- a/packages/analytics/posthog/server.test.ts
+++ b/packages/analytics/posthog/server.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const postHogMocks = vi.hoisted(() => ({
   captureExceptionImmediate: vi.fn(),

--- a/packages/analytics/server-reporting.test.ts
+++ b/packages/analytics/server-reporting.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { isServerExceptionReportingEnabled } from "@repo/analytics/server-reporting";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@repo/typescript-config/library.json",
   "compilerOptions": {
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "paths": {
       "@repo/*": ["../*"],
       "@repo/analytics/*": ["./*"]

--- a/packages/backend/agent/mcp/schema.test.ts
+++ b/packages/backend/agent/mcp/schema.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { toMcpObjectSchema } from "@repo/backend/agent/mcp/schema";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MCP object schemas", () => {
   it("keeps input and output schemas object-rooted", () => {

--- a/packages/backend/agent/openapi/response.test.ts
+++ b/packages/backend/agent/openapi/response.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   NAKAFA_OPENAPI_ETAG,
   NAKAFA_OPENAPI_JSON,
@@ -6,7 +7,6 @@ import {
   createOpenApiOptionsResponse,
   createOpenApiResponse,
 } from "@repo/backend/agent/openapi/response";
-import { describe, expect, it } from "vitest";
 
 const WEAK_ETAG_PREFIX = /^W\//;
 

--- a/packages/backend/client/content/protected.test.ts
+++ b/packages/backend/client/content/protected.test.ts
@@ -41,7 +41,6 @@ import {
 } from "@repo/backend/test/content/proof";
 import { testPublicationScope } from "@repo/backend/test/content/release";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const endpoint = `https://example.convex.site${PROTECTED_CONTENT_RUNTIME_PATH}`;
 const target = {

--- a/packages/backend/client/content/public.test.ts
+++ b/packages/backend/client/content/public.test.ts
@@ -32,7 +32,6 @@ import {
   testRendererJson,
 } from "@repo/backend/test/content/release";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const endpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_PATH}`;
 const batchEndpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_BATCH_PATH}`;

--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -17,7 +17,6 @@ import {
 } from "@repo/backend/content/endpoint";
 import { Duration, Effect, Fiber, Logger } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 
 const endpoint = `https://example.convex.site${PUBLIC_CONTENT_RUNTIME_PATH}`;
 const target = {

--- a/packages/backend/client/nakafa/markdown.test.ts
+++ b/packages/backend/client/nakafa/markdown.test.ts
@@ -7,7 +7,6 @@ import {
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import type { NakafaAgentContentRef } from "@repo/contents/_lib/agent/schema/ref";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   readPublishedMarkdown: vi.fn(),

--- a/packages/backend/client/nakafa/published.test.ts
+++ b/packages/backend/client/nakafa/published.test.ts
@@ -7,7 +7,6 @@ import { makeMaterialProjection } from "@repo/backend/test/content/material";
 import { TEST_ARTICLE_PROJECTION } from "@repo/backend/test/content/runtime";
 import { createNakafaContentRefFromGraphProjection } from "@repo/contents/_lib/agent/refs";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 
 const readMock = vi.hoisted(() => vi.fn());
 const material = makeMaterialProjection("en", 1);

--- a/packages/backend/client/nakafa/query.test.ts
+++ b/packages/backend/client/nakafa/query.test.ts
@@ -6,7 +6,6 @@ import { toRuntimeQueryError } from "@repo/backend/test/runtime/query";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import type { FunctionArgs } from "convex/server";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   runtimeQuery: vi.fn(),

--- a/packages/backend/client/nakafa/quran.test.ts
+++ b/packages/backend/client/nakafa/quran.test.ts
@@ -22,7 +22,6 @@ import { NakafaAgentInputError } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect, Option, Schema } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   runtimeQuery: vi.fn(),

--- a/packages/backend/client/nakafa/ref.test.ts
+++ b/packages/backend/client/nakafa/ref.test.ts
@@ -9,7 +9,6 @@ import { toRuntimeQueryError } from "@repo/backend/test/runtime/query";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect, Option } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   runtimeQuery: vi.fn(),

--- a/packages/backend/client/nakafa/release.test.ts
+++ b/packages/backend/client/nakafa/release.test.ts
@@ -5,7 +5,6 @@ import {
   verifyNakafaReleasePin,
 } from "@repo/backend/client/nakafa/release";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const queryMock = vi.hoisted(() => vi.fn());
 

--- a/packages/backend/client/nakafa/taxonomy.test.ts
+++ b/packages/backend/client/nakafa/taxonomy.test.ts
@@ -10,7 +10,6 @@ import {
 import { toRuntimeQueryError } from "@repo/backend/test/runtime/query";
 import { type FunctionReference, getFunctionName } from "convex/server";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   runtimeQuery: vi.fn(),

--- a/packages/backend/client/nakafa/verify.test.ts
+++ b/packages/backend/client/nakafa/verify.test.ts
@@ -5,7 +5,6 @@ import { toRuntimeQueryError } from "@repo/backend/test/runtime/query";
 import { NakafaAgentDataReadError } from "@repo/contents/_lib/agent/errors";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
   runtimeQuery: vi.fn(),

--- a/packages/backend/client/network.test.ts
+++ b/packages/backend/client/network.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   createNetworkRequestError,
   isRetryableNetworkError,
   NetworkRequestError,
 } from "@repo/backend/client/network";
-import { describe, expect, it } from "vitest";
 
 describe("network request classification", () => {
   it("classifies nested Undici and Node retry codes", () => {

--- a/packages/backend/client/quran/integrity.test.ts
+++ b/packages/backend/client/quran/integrity.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   hasExactQuranVerseRange,
   hasExpectedQuranNeighbors,
 } from "@repo/backend/client/quran/integrity";
-import { describe, expect, it } from "vitest";
 
 /** Builds the minimal validator-independent verse identity used by integrity checks. */
 function verses(...numbers: number[]) {

--- a/packages/backend/client/quran/route.test.ts
+++ b/packages/backend/client/quran/route.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { parseQuranSurahNumber } from "@repo/backend/client/quran/route";
-import { describe, expect, it } from "vitest";
 
 describe("parseQuranSurahNumber", () => {
   it.each(["1", "114"])("accepts canonical surah segment %s", (value) => {

--- a/packages/backend/client/response.test.ts
+++ b/packages/backend/client/response.test.ts
@@ -10,7 +10,6 @@ import type { FunctionArgs } from "convex/server";
 import { ConvexError } from "convex/values";
 import { Duration, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 
 const clientState = vi.hoisted(() => ({ query: vi.fn() }));
 

--- a/packages/backend/client/runtime.test.ts
+++ b/packages/backend/client/runtime.test.ts
@@ -10,7 +10,6 @@ import type { FunctionArgs } from "convex/server";
 import { ConvexError } from "convex/values";
 import { Duration, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
-import { vi } from "vitest";
 
 const clientState = vi.hoisted(() => {
   const constructorFailure: { error: Error | undefined } = {

--- a/packages/backend/content/quran/bismillah.test.ts
+++ b/packages/backend/content/quran/bismillah.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   separateQuranBismillah,
   splitQuranBismillahPrefix,
 } from "@repo/backend/content/quran/bismillah";
-import { describe, expect, it } from "vitest";
 
 const bismillah = {
   arabic: "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ",

--- a/packages/backend/content/quran/contract.test.ts
+++ b/packages/backend/content/quran/contract.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   formatQuranMeaning,
   selectQuranMeaning,
 } from "@repo/backend/content/quran/contract";
-import { describe, expect, it } from "vitest";
 
 describe("published Quran meaning selection", () => {
   it("selects every localized meaning from the current signed contract", () => {

--- a/packages/backend/content/trust.test.ts
+++ b/packages/backend/content/trust.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@nakafa/aksara-contracts/signature/trusted";
 import { contentKeyResolver } from "@repo/backend/content/trust";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const unknownKeyId = SigningKeyIdSchema.make("unknown-key");
 const agentKeyId = SigningKeyIdSchema.make("agent-test-key");

--- a/packages/backend/convex/analytics/capture.test.ts
+++ b/packages/backend/convex/analytics/capture.test.ts
@@ -9,7 +9,6 @@ import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
 const contentViewProperties = {

--- a/packages/backend/convex/analytics/erasure/action.test.ts
+++ b/packages/backend/convex/analytics/erasure/action.test.ts
@@ -6,7 +6,6 @@ import {
   PostHogErasureRequestError,
 } from "@repo/backend/convex/analytics/erasure/action";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const config = {
   deletionApiKey: "phx_test",

--- a/packages/backend/convex/analytics/erasure/request.test.ts
+++ b/packages/backend/convex/analytics/erasure/request.test.ts
@@ -1,5 +1,5 @@
 import workflowTest from "@convex-dev/workflow/test";
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { requestAnalyticsErasure } from "@repo/backend/convex/analytics/erasure/request";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";

--- a/packages/backend/convex/analytics/events.test.ts
+++ b/packages/backend/convex/analytics/events.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import { chatResponseFailureCode } from "@repo/ai/config/generation";
 import { getModelCreditCost, ModelIdSchema } from "@repo/ai/config/model";
 import { productAnalyticsEventValidator } from "@repo/backend/convex/analytics/events";
 import { validate } from "convex-helpers/validators";
-import { describe, expect, it } from "vitest";
 
 const contentViewProperties = {
   alignment_id: "alignment:id:articles:example",

--- a/packages/backend/convex/auth/cleanup.test.ts
+++ b/packages/backend/convex/auth/cleanup.test.ts
@@ -9,7 +9,6 @@ import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 22, 8, 0, 0);
 const deletedAuthIdPattern = /^deleted:/;

--- a/packages/backend/convex/auth/cleanup/schools.test.ts
+++ b/packages/backend/convex/auth/cleanup/schools.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { cleanupUserSchoolData } from "@repo/backend/convex/auth/cleanup/schools";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 8, 0, 0);
 

--- a/packages/backend/convex/auth/deletion.test.ts
+++ b/packages/backend/convex/auth/deletion.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import {
   ACCOUNT_DELETION_CANCELLATION_UNPROVEN_CODE,
@@ -11,7 +12,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/auth/deletion/attemptCancellation.test.ts
+++ b/packages/backend/convex/auth/deletion/attemptCancellation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   cancelAccountDeletionAttempt,
   cancelAccountDeletionAttemptByToken,
@@ -12,7 +13,6 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 9, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/auth/deletion/cancel.test.ts
+++ b/packages/backend/convex/auth/deletion/cancel.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { cancelAccountDeletionAttemptByToken } from "@repo/backend/convex/auth/deletion/attemptCancellation";
 import {
@@ -14,7 +15,6 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 9, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/auth/deletion/claim.test.ts
+++ b/packages/backend/convex/auth/deletion/claim.test.ts
@@ -1,6 +1,6 @@
 import { Resend } from "@convex-dev/resend";
 import resendTest from "@convex-dev/resend/test";
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { components } from "@repo/backend/convex/_generated/api";
 import { claimAccountDeletion } from "@repo/backend/convex/auth/deletion/claim";
 import { ACCOUNT_DELETION_RECOVERY_DELAY_MS } from "@repo/backend/convex/auth/deletion/constants";

--- a/packages/backend/convex/auth/deletion/commit.test.ts
+++ b/packages/backend/convex/auth/deletion/commit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { continueAccountDeletionCommitProgram } from "@repo/backend/convex/auth/deletion/commit";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";

--- a/packages/backend/convex/auth/deletion/finalize.test.ts
+++ b/packages/backend/convex/auth/deletion/finalize.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {
   ACCOUNT_DELETION_SUCCESSOR_PAGE_SIZE,
@@ -8,7 +9,6 @@ import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 10, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/auth/deletion/prepare.test.ts
+++ b/packages/backend/convex/auth/deletion/prepare.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {

--- a/packages/backend/convex/auth/deletion/receipt.test.ts
+++ b/packages/backend/convex/auth/deletion/receipt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE } from "@repo/backend/convex/auth/deletion/constants";
 import {

--- a/packages/backend/convex/auth/deletion/recovery.test.ts
+++ b/packages/backend/convex/auth/deletion/recovery.test.ts
@@ -12,7 +12,6 @@ import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 11, 0, 0);
 const ATTEMPT_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/auth/deletion/state.test.ts
+++ b/packages/backend/convex/auth/deletion/state.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { isAccountDeletionPending } from "@repo/backend/convex/auth/deletion/state";
-import { describe, expect, it } from "vitest";
 
 describe("auth/deletion/state", () => {
   it.each([

--- a/packages/backend/convex/auth/deletion/verification.test.ts
+++ b/packages/backend/convex/auth/deletion/verification.test.ts
@@ -5,7 +5,6 @@ import { createDeletedUserTombstone } from "@repo/backend/convex/auth/deletion/t
 import { drainDeletedUserVerificationsProgram } from "@repo/backend/convex/auth/deletion/verification";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { Effect, Schema } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 21, 0, 0);
 const decodeVerificationPage = Schema.decodeUnknownSync(

--- a/packages/backend/convex/auth/runtime.test.ts
+++ b/packages/backend/convex/auth/runtime.test.ts
@@ -7,7 +7,6 @@ import {
 import { accountDeletionPreparationOutcome } from "@repo/backend/convex/auth/deletion/spec";
 import { verifyAccountDeletionPreparation } from "@repo/backend/convex/auth/runtime";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 describe("auth/runtime", () => {
   it.effect("accepts one ready preparation step", () =>

--- a/packages/backend/convex/auth/username/policy.test.ts
+++ b/packages/backend/convex/auth/username/policy.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createGoogleUsernameFields,
   usernameOptions,
 } from "@repo/backend/convex/auth/username/policy";
-import { describe, expect, it } from "vitest";
 
 describe("auth/username policy", () => {
   it("creates a valid Better Auth username from a Google profile", () => {

--- a/packages/backend/convex/chats/assistantResponses.test.ts
+++ b/packages/backend/convex/chats/assistantResponses.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import { chatResponseFailureCode } from "@repo/ai/config/generation";
 import { getModelCreditCost, ModelIdSchema } from "@repo/ai/config/model";
@@ -6,7 +7,6 @@ import schema from "@repo/backend/convex/schema";
 import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
 const liteModel = ModelIdSchema.make("nakafa-lite");

--- a/packages/backend/convex/chats/messageParts/dbToUi.test.ts
+++ b/packages/backend/convex/chats/messageParts/dbToUi.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { mapDBPartToUIMessagePart } from "@repo/backend/convex/chats/messageParts/dbToUi";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { NakafaAgentContentRefInputSchema } from "@repo/contents/_lib/agent/schema/read";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const now = Date.UTC(2026, 4, 8, 0, 0, 0);
 const ref = readNakafaContentRefFixture(

--- a/packages/backend/convex/chats/messageParts/uiToDb.test.ts
+++ b/packages/backend/convex/chats/messageParts/uiToDb.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { MyUIMessage } from "@repo/ai/types/message";
 import { mapUIMessagePartsToDBParts } from "@repo/backend/convex/chats/messageParts/uiToDb";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { NakafaAgentContentRefInputSchema } from "@repo/contents/_lib/agent/schema/read";
 import type { ProviderMetadata } from "ai";
-import { describe, expect, it } from "vitest";
 
 const ref = readNakafaContentRefFixture(
   "en",

--- a/packages/backend/convex/chats/mutations.test.ts
+++ b/packages/backend/convex/chats/mutations.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
@@ -11,7 +12,6 @@ import {
 } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
 

--- a/packages/backend/convex/chats/nakafa.test.ts
+++ b/packages/backend/convex/chats/nakafa.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { nakafaDataValidator } from "@repo/backend/convex/chats/nakafa";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import { validate } from "convex-helpers/validators";
-import { describe, expect, it } from "vitest";
 
 const quranRef = readNakafaContentRefFixture("en", "quran/1", "quran");
 const input = {

--- a/packages/backend/convex/chats/queries.test.ts
+++ b/packages/backend/convex/chats/queries.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { ninaContextSnapshotValidator } from "@repo/backend/convex/chats/context";
 import {
@@ -5,7 +6,6 @@ import {
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
 import type { Infer } from "convex/values";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 13, 12, 0, 0);
 

--- a/packages/backend/convex/chats/read.test.ts
+++ b/packages/backend/convex/chats/read.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import { MAX_CHAT_MESSAGE_PARTS } from "@repo/backend/convex/chats/constants";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 12, 0, 0);
 

--- a/packages/backend/convex/chats/traces/queries.test.ts
+++ b/packages/backend/convex/chats/traces/queries.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import { CAPABILITY_TRACE_BATCH_SIZE } from "@repo/backend/convex/chats/traces/spec";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
 

--- a/packages/backend/convex/chats/utils.test.ts
+++ b/packages/backend/convex/chats/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { chatResponseFailureCode } from "@repo/ai/config/generation";
 import type {
   NinaContextSnapshot,
@@ -7,7 +8,6 @@ import { mapDBMessagesToUIMessages } from "@repo/backend/convex/chats/utils";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const now = Date.UTC(2026, 5, 6, 0, 0, 0);
 const ninaContextSnapshot = {

--- a/packages/backend/convex/classes/forums/attachments/impl.test.ts
+++ b/packages/backend/convex/classes/forums/attachments/impl.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { FORUM_PENDING_UPLOAD_EXPIRATION_MS } from "@repo/backend/convex/classes/forums/attachments/constants";
@@ -20,7 +21,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 15, 0, 0);
 const UPLOAD_TOKEN = "forum-upload-token";

--- a/packages/backend/convex/classes/forums/attachments/route.test.ts
+++ b/packages/backend/convex/classes/forums/attachments/route.test.ts
@@ -19,7 +19,6 @@ import {
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
 import { Effect, Schema } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 15, 0, 0);
 const LEASE_ID = "019fa44c-02be-7cd0-a4ed-61a7af8e0620";

--- a/packages/backend/convex/classes/forums/queries/forums.test.ts
+++ b/packages/backend/convex/classes/forums/queries/forums.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -15,7 +16,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const FORUM_CREATED_AT = Date.UTC(2026, 3, 18, 8, 0, 0);
 const READ_AT = Date.UTC(2026, 3, 18, 8, 5, 0);

--- a/packages/backend/convex/classes/forums/queries/pages.test.ts
+++ b/packages/backend/convex/classes/forums/queries/pages.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -12,7 +13,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const FORUM_CREATED_AT = Date.UTC(2026, 3, 18, 8, 0, 0);
 

--- a/packages/backend/convex/classes/forums/utils/readStateWrite.test.ts
+++ b/packages/backend/convex/classes/forums/utils/readStateWrite.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { updateForumReadState } from "@repo/backend/convex/classes/forums/utils/readStateWrite";
@@ -9,7 +10,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 9, 0, 0);
 

--- a/packages/backend/convex/classes/materials/mutations.test.ts
+++ b/packages/backend/convex/classes/materials/mutations.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import {
   insertClass,
@@ -7,7 +8,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 16, 14, 0, 0);
 

--- a/packages/backend/convex/classes/queries.test.ts
+++ b/packages/backend/convex/classes/queries.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   insertClass,
@@ -9,7 +10,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 14, 12, 0, 0);
 

--- a/packages/backend/convex/consents/current.test.ts
+++ b/packages/backend/convex/consents/current.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_BROWSER_SIGNAL_MECHANISM,
   ANALYTICS_CONSENT_CATEGORY,
@@ -11,7 +12,6 @@ import {
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
 import type { FunctionArgs } from "convex/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 20, 16, 0, 0);
 const analyticsCategory = ANALYTICS_CONSENT_CATEGORY;

--- a/packages/backend/convex/consents/schema.test.ts
+++ b/packages/backend/convex/consents/schema.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ANALYTICS_BROWSER_SIGNAL_MECHANISM,
   ANALYTICS_CONSENT_CATEGORY,
@@ -6,7 +7,6 @@ import {
 } from "@repo/analytics/consent";
 import { consentWriteValidator } from "@repo/backend/convex/consents/schema";
 import { validate } from "convex-helpers/validators";
-import { describe, expect, it } from "vitest";
 
 describe("consent schema", () => {
   it("rejects stale notice versions", () => {

--- a/packages/backend/convex/contentRelease/abort/budget.test.ts
+++ b/packages/backend/convex/contentRelease/abort/budget.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   ABORT_DOCUMENT_HEADROOM,
   ABORT_QUERY_HEADROOM,
@@ -6,7 +7,6 @@ import {
 } from "@repo/backend/convex/contentRelease/abort/budget";
 import { TRANSACTION_READ_HEADROOM } from "@repo/backend/convex/contentRelease/spec";
 import type { TransactionMetrics } from "convex/server";
-import { describe, expect, it } from "vitest";
 
 /** Builds deterministic remaining capacity for one abort budget assertion. */
 function transactionMetrics(

--- a/packages/backend/convex/contentRelease/activate.test.ts
+++ b/packages/backend/convex/contentRelease/activate.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { ContentFamilySchema } from "@nakafa/aksara-contracts/content";
 import { internal } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";

--- a/packages/backend/convex/contentRelease/bucket.test.ts
+++ b/packages/backend/convex/contentRelease/bucket.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getHashBucket,
   isProjectionBucket,
 } from "@repo/backend/convex/contentRelease/bucket";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/bucket", () => {
   it("derives only canonical SHA-256 hash buckets", () => {

--- a/packages/backend/convex/contentRelease/digest.test.ts
+++ b/packages/backend/convex/contentRelease/digest.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";
 import { Effect } from "effect";
 

--- a/packages/backend/convex/contentRelease/http/secret.test.ts
+++ b/packages/backend/convex/contentRelease/http/secret.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   bearerToken,
   matchesHttpSecret,

--- a/packages/backend/convex/contentRelease/ingress/dispatch.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/dispatch.test.ts
@@ -29,7 +29,6 @@ import {
 } from "@repo/backend/test/content/state";
 import { convexTest } from "convex-test";
 import { Schema } from "effect";
-import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_ID, TEST_KEY_RESOLVER } = await import(

--- a/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/lifecycle.test.ts
@@ -41,7 +41,6 @@ import {
 import { completeContentProof } from "@repo/backend/test/content/verify";
 import { convexTest, type TestConvex } from "convex-test";
 import { Data, Effect, Schema } from "effect";
-import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_RESOLVER } = await import(

--- a/packages/backend/convex/contentRelease/ingress/runtime/bundle.test.ts
+++ b/packages/backend/convex/contentRelease/ingress/runtime/bundle.test.ts
@@ -21,7 +21,6 @@ import {
 } from "@repo/backend/test/runtime/ingress";
 import { convexTest } from "convex-test";
 import { type Cause, Effect } from "effect";
-import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_ID: keyId, TEST_KEY_RESOLVER: resolver } = await import(

--- a/packages/backend/convex/contentRelease/models.test.ts
+++ b/packages/backend/convex/contentRelease/models.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import type { ContentFamily } from "@nakafa/aksara-contracts/content";
 import { PublicationScopeSchema } from "@nakafa/aksara-contracts/release/snapshot/scope";
 import { internal } from "@repo/backend/convex/_generated/api";

--- a/packages/backend/convex/contentRelease/proof/budget.test.ts
+++ b/packages/backend/convex/contentRelease/proof/budget.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { hasProofTransactionHeadroom } from "@repo/backend/convex/contentRelease/proof/budget";
 import {
   PROOF_QUERY_HEADROOM,
   TRANSACTION_READ_HEADROOM,
 } from "@repo/backend/convex/contentRelease/spec";
-import { describe, expect, it } from "vitest";
 
 /** Builds measured transaction capacity for one deterministic budget test. */
 function transactionMetrics(bytesRemaining: number, queryRemaining: number) {

--- a/packages/backend/convex/contentRelease/proof/coordinator.test.ts
+++ b/packages/backend/convex/contentRelease/proof/coordinator.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import workflowTest from "@convex-dev/workflow/test";
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { cleanupProofWorkflow } from "@repo/backend/convex/contentRelease/proof/coordinator";

--- a/packages/backend/convex/contentRelease/proof/poll.test.ts
+++ b/packages/backend/convex/contentRelease/proof/poll.test.ts
@@ -23,7 +23,6 @@ import {
   recomputeContentProof,
 } from "@repo/backend/test/content/verify";
 import { convexTest, type TestConvex } from "convex-test";
-import { vi } from "vitest";
 
 vi.mock("@repo/backend/content/trust", async () => {
   const { TEST_KEY_RESOLVER } = await import(

--- a/packages/backend/convex/contentRelease/quran/chunks.test.ts
+++ b/packages/backend/convex/contentRelease/quran/chunks.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranChunks } from "@repo/backend/convex/contentRelease/quran/chunks";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -5,7 +6,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeQuranChunk } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const firstChunk = makeQuranChunk({
   firstQuranNumber: 1,

--- a/packages/backend/convex/contentRelease/quran/document.test.ts
+++ b/packages/backend/convex/contentRelease/quran/document.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranDocument } from "@repo/backend/convex/contentRelease/quran/document";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -12,7 +13,6 @@ import {
 } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 /** Builds every signed row needed by one two-chunk technical document. */
 function documentRows() {

--- a/packages/backend/convex/contentRelease/quran/interpretation.test.ts
+++ b/packages/backend/convex/contentRelease/quran/interpretation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranInterpretation } from "@repo/backend/convex/contentRelease/quran/interpretation";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -13,7 +14,6 @@ import {
   restoreAbsentQuranSnapshot,
 } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 /** Creates only the signed rows required to read verse seven. */
 function interpretationRows() {

--- a/packages/backend/convex/contentRelease/quran/limits.test.ts
+++ b/packages/backend/convex/contentRelease/quran/limits.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { QURAN_SURAH_COUNT } from "@nakafa/aksara-contracts/quran/spec";
 import { CONTENT_DOCUMENT_LIMIT } from "@repo/backend/convex/contentRelease/document";
 import {
@@ -12,7 +13,6 @@ import {
   TRANSACTION_READ_HEADROOM,
   TRANSACTION_READ_LIMIT,
 } from "@repo/backend/convex/contentRelease/spec";
-import { describe, expect, it } from "vitest";
 
 const readBudget = TRANSACTION_READ_LIMIT - TRANSACTION_READ_HEADROOM;
 

--- a/packages/backend/convex/contentRelease/quran/markdown.test.ts
+++ b/packages/backend/convex/contentRelease/quran/markdown.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranMarkdown } from "@repo/backend/convex/contentRelease/quran/markdown";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -12,7 +13,6 @@ import {
 } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/quran/markdown", () => {
   it("returns a normalized unmanaged markdown projection", async () => {

--- a/packages/backend/convex/contentRelease/quran/reference.test.ts
+++ b/packages/backend/convex/contentRelease/quran/reference.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranPassage } from "@repo/backend/convex/contentRelease/quran/reference";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -10,7 +11,6 @@ import {
 } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 /** Creates two chunks and their signed metadata for one seven-verse surah. */
 function referenceRows() {

--- a/packages/backend/convex/contentRelease/quran/row.test.ts
+++ b/packages/backend/convex/contentRelease/quran/row.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
 import { readQuranRow } from "@repo/backend/convex/contentRelease/quran/row";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -6,7 +7,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeQuranSurah } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/quran/row", () => {
   it("reads one exact verified row and rejects a missing identity", async () => {

--- a/packages/backend/convex/contentRelease/quran/verify.test.ts
+++ b/packages/backend/convex/contentRelease/quran/verify.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { QuranSearchRowSchema } from "@nakafa/aksara-contracts/quran/snapshot/row";
 import { QuranSurahRowSchema } from "@nakafa/aksara-contracts/quran/spec";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
@@ -9,7 +10,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeQuranSearch } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 /** Loads the only technical Quran row inside one test transaction. */
 async function loadRow(ctx: Pick<QueryCtx, "db">) {

--- a/packages/backend/convex/contentRelease/quran/view.test.ts
+++ b/packages/backend/convex/contentRelease/quran/view.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readQuranView } from "@repo/backend/convex/contentRelease/quran/view";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -13,7 +14,6 @@ import {
 } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 /** Builds every verified source row needed by the first Quran page. */
 function viewRows() {

--- a/packages/backend/convex/contentRelease/recovery.test.ts
+++ b/packages/backend/convex/contentRelease/recovery.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  assert,
-  beforeEach,
-  describe,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 import { ContentFamilySchema } from "@nakafa/aksara-contracts/content";
 import { invertContentSnapshots } from "@nakafa/aksara-contracts/release/snapshot/spec";
 import { internal } from "@repo/backend/convex/_generated/api";

--- a/packages/backend/convex/contentRelease/reference/agent.test.ts
+++ b/packages/backend/convex/contentRelease/reference/agent.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readAgentContentSource } from "@repo/backend/convex/contentRelease/reference/agent";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
@@ -10,7 +11,6 @@ import {
 } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/reference/agent", () => {
   it("returns no source when the signed reference is absent", async () => {

--- a/packages/backend/convex/contentRelease/search/spec.test.ts
+++ b/packages/backend/convex/contentRelease/search/spec.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { ContentFamilySchema } from "@nakafa/aksara-contracts/content";
 import {
   isSearchFamily,
   SEARCH_FAMILIES,
 } from "@repo/backend/convex/contentRelease/search/spec";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/search/spec", () => {
   it("keeps only learning families in canonical release order", () => {

--- a/packages/backend/convex/contentRelease/sitemap.test.ts
+++ b/packages/backend/convex/contentRelease/sitemap.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { compareSitemapPaths } from "@repo/backend/convex/contentRelease/sitemap";
-import { describe, expect, it } from "vitest";
 
 describe("current content sitemap", () => {
   it("matches Convex UTF-8 index order for punctuation and umlauts", () => {

--- a/packages/backend/convex/contentRelease/spec.test.ts
+++ b/packages/backend/convex/contentRelease/spec.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MAX_SIGNED_ARTIFACT_BYTES } from "@nakafa/aksara-contracts/limits";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import {
@@ -37,7 +38,6 @@ import {
   TRANSACTION_READ_HEADROOM,
   TRANSACTION_READ_LIMIT,
 } from "@repo/backend/convex/contentRelease/spec";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/spec", () => {
   it("preserves four MiB around worst-case lifecycle pages", () => {

--- a/packages/backend/convex/contentRelease/tryout/limits.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/limits.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { CONTENT_DOCUMENT_LIMIT } from "@repo/backend/convex/contentRelease/document";
 import {
   TRANSACTION_READ_HEADROOM,
@@ -12,7 +13,6 @@ import {
   TRYOUT_SECTION_LIMIT,
   TRYOUT_SET_QUESTION_LIMIT,
 } from "@repo/backend/convex/contentRelease/tryout/limits";
-import { describe, expect, it } from "vitest";
 
 describe("contentRelease/tryout/limits", () => {
   const ownerBytes = 3 * CONTENT_DOCUMENT_LIMIT;

--- a/packages/backend/convex/contentRelease/tryout/runtime.test.ts
+++ b/packages/backend/convex/contentRelease/tryout/runtime.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   inheritContentSnapshot,
   inheritContentSnapshots,

--- a/packages/backend/convex/contents/analytics/impl.test.ts
+++ b/packages/backend/convex/contents/analytics/impl.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {

--- a/packages/backend/convex/contents/helpers/search/quran/candidates.test.ts
+++ b/packages/backend/convex/contents/helpers/search/quran/candidates.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { QURAN_SEARCH_RESULT_LIMIT } from "@repo/backend/convex/contentRelease/quran/limits";
 import { readTextCandidates } from "@repo/backend/convex/contents/helpers/search/quran/candidates";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -6,7 +7,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeQuranSearch } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("contents/helpers/search/quran/candidates", () => {
   it("preserves prefix matching for every alternate text variant", async () => {

--- a/packages/backend/convex/contents/helpers/search/quran/read.test.ts
+++ b/packages/backend/convex/contents/helpers/search/quran/read.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { QURAN_SEARCH_DOCUMENT_LIMIT } from "@repo/backend/convex/contentRelease/quran/limits";
 import { readSignedQuranSearchDocuments } from "@repo/backend/convex/contents/helpers/search/quran/read";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -6,7 +7,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { makeQuranSearch } from "@repo/backend/test/quran/rows";
 import { activateQuranSnapshot } from "@repo/backend/test/quran/snapshot";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("contents/helpers/search/quran/read", () => {
   it("returns no source fallback before signed Quran activation", async () => {

--- a/packages/backend/convex/contents/helpers/search/rank.test.ts
+++ b/packages/backend/convex/contents/helpers/search/rank.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   type ContentSearchRankDocument,
   matchesContentSearchQuery,
   rankContentSearchDocuments,
 } from "@repo/backend/convex/contents/helpers/search/rank";
-import { describe, expect, it } from "vitest";
 
 /** Builds a persisted search row slice for rank tests without Convex IDs. */
 function createSearchRow(

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import {

--- a/packages/backend/convex/contents/views/impl.test.ts
+++ b/packages/backend/convex/contents/views/impl.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";
 import {

--- a/packages/backend/convex/credits/helpers/state.test.ts
+++ b/packages/backend/convex/credits/helpers/state.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getCreditResetGrantTransaction,
   getCurrentCreditResetTimestamp,
@@ -10,7 +11,6 @@ import {
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("credits/helpers/state", () => {
   it("resolves the current UTC day boundary for free users", () => {

--- a/packages/backend/convex/credits/mutations.test.ts
+++ b/packages/backend/convex/credits/mutations.test.ts
@@ -1,8 +1,8 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("credits/mutations", () => {
   beforeEach(() => {

--- a/packages/backend/convex/customers/checkout/admission.test.ts
+++ b/packages/backend/convex/customers/checkout/admission.test.ts
@@ -8,7 +8,6 @@ import { seedAnalyticsConsent } from "@repo/backend/convex/test.helpers";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 31, 5, 0, 0);
 const checkoutStartedEvent = {

--- a/packages/backend/convex/customers/checkout/session.test.ts
+++ b/packages/backend/convex/customers/checkout/session.test.ts
@@ -11,7 +11,6 @@ import {
   accountUnavailableMessage,
 } from "@repo/backend/convex/lib/helpers/auth";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const checkout = { url: "https://polar.sh/checkout/test" };
 describe("customers/checkout/session", () => {

--- a/packages/backend/convex/customers/deletion/billing.test.ts
+++ b/packages/backend/convex/customers/deletion/billing.test.ts
@@ -11,7 +11,6 @@ import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const polarGateway = vi.hoisted(() => ({
   deleteCustomer: vi.fn(),

--- a/packages/backend/convex/customers/deletion/workflow.test.ts
+++ b/packages/backend/convex/customers/deletion/workflow.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it, vi } from "@effect/vitest";
+import { assert, describe, expect, it } from "@effect/vitest";
 import { launchDeletedUserCleanupProgram } from "@repo/backend/convex/customers/deletion/workflow";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";

--- a/packages/backend/convex/customers/polar/webhook.test.ts
+++ b/packages/backend/convex/customers/polar/webhook.test.ts
@@ -19,7 +19,6 @@ import { convexModules } from "@repo/backend/convex/test.setup";
 import { products } from "@repo/backend/convex/utils/polar/products";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const polarGateway = vi.hoisted(() => ({
   getCustomerById: vi.fn(),

--- a/packages/backend/convex/customers/sync/settlement.test.ts
+++ b/packages/backend/convex/customers/sync/settlement.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { settleCustomerSync } from "@repo/backend/convex/customers/sync/settlement";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";

--- a/packages/backend/convex/emails/deletion.test.ts
+++ b/packages/backend/convex/emails/deletion.test.ts
@@ -11,7 +11,6 @@ import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const testResend = new Resend(components.resend, {
   apiKey: "re_test_account_deletion",

--- a/packages/backend/convex/emails/welcome.test.ts
+++ b/packages/backend/convex/emails/welcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { canonicalizePublicPageProjection } from "@nakafa/aksara-contracts/projection/page";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";

--- a/packages/backend/convex/learningPreferences/mutations.test.ts
+++ b/packages/backend/convex/learningPreferences/mutations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   ActiveAppLocaleListSchema,
   ActiveAppLocaleSchema,

--- a/packages/backend/convex/lib/attempts.test.ts
+++ b/packages/backend/convex/lib/attempts.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getAttemptStatusFromEndReason } from "@repo/backend/convex/lib/attempts";
-import { describe, expect, it } from "vitest";
 
 describe("lib/attempts", () => {
   it("maps persisted end reasons to finalized attempt statuses", () => {

--- a/packages/backend/convex/lib/effect.test.ts
+++ b/packages/backend/convex/lib/effect.test.ts
@@ -7,7 +7,6 @@ import {
 } from "@repo/backend/convex/lib/effect";
 import { ConvexError } from "convex/values";
 import { Cause, Clock, Effect, Schema } from "effect";
-import { vi } from "vitest";
 
 const boundaryFailureCode = "BOUNDARY_FAILURE";
 

--- a/packages/backend/convex/lib/helpers/auth.test.ts
+++ b/packages/backend/convex/lib/helpers/auth.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getOptionalActiveAppUser,
   getOptionalAppUserForRead,
@@ -8,7 +9,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 28, 11, 0, 0);
 

--- a/packages/backend/convex/onboarding/mutations.test.ts
+++ b/packages/backend/convex/onboarding/mutations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import {

--- a/packages/backend/convex/onboarding/spec.test.ts
+++ b/packages/backend/convex/onboarding/spec.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getOnboardingDestination,
   getOnboardingRegionDefaults,
 } from "@repo/backend/convex/onboarding/spec";
-import { describe, expect, it } from "vitest";
 
 describe("onboarding product defaults", () => {
   it.each([

--- a/packages/backend/convex/privacy/recovery.test.ts
+++ b/packages/backend/convex/privacy/recovery.test.ts
@@ -1,4 +1,5 @@
 import type { WorkflowId } from "@convex-dev/workflow";
+import { describe, expect, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   cleanupWorkflowStorageProgram,
@@ -8,7 +9,6 @@ import { cleanupSource } from "@repo/backend/convex/privacy/spec";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it, vi } from "vitest";
 
 describe("privacy workflow recovery", () => {
   it("restarts a retained failed cleanup asynchronously", async () => {

--- a/packages/backend/convex/routes/agent/mcp/guard.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/guard.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { NAKAFA_MCP_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const MCP_SECRET = "technical-mcp-edge-secret";
 const ORIGINS_ENVIRONMENT = "NAKAFA_MCP_ALLOWED_ORIGINS";

--- a/packages/backend/convex/routes/agent/mcp/route.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/route.test.ts
@@ -11,7 +11,6 @@ import { NAKAFA_MCP_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { NAKAFA_MCP_PROTOCOL_VERSION } from "@repo/contents/_lib/agent/constants";
 import { Effect } from "effect";
-import { vi } from "vitest";
 
 const MCP_SECRET = "technical-mcp-edge-secret";
 const MCP_PATH = NAKAFA_MCP_EDGE_CONTRACT.originPath;

--- a/packages/backend/convex/routes/agent/security.test.ts
+++ b/packages/backend/convex/routes/agent/security.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from "@effect/vitest";
 import { NAKAFA_API_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import { hasValidEdgeSecret } from "@repo/backend/convex/routes/agent/security";
 import { Effect, Result } from "effect";
-import { vi } from "vitest";
 
 const SECRET_NAME = NAKAFA_API_EDGE_CONTRACT.secretEnvironment;
 

--- a/packages/backend/convex/routes/polar.test.ts
+++ b/packages/backend/convex/routes/polar.test.ts
@@ -8,7 +8,6 @@ import { registerPolarRoutes } from "@repo/backend/convex/routes/polar";
 import type { HonoWithConvex } from "convex-helpers/server/hono";
 import { Effect, Schema } from "effect";
 import { Hono } from "hono";
-import { vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   processEvent: vi.fn(),

--- a/packages/backend/convex/schools/mutations.test.ts
+++ b/packages/backend/convex/schools/mutations.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 7, 22, 5, 0, 0);
 

--- a/packages/backend/convex/schools/queries.test.ts
+++ b/packages/backend/convex/schools/queries.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -5,7 +6,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 15, 9, 0, 0);
 

--- a/packages/backend/convex/schools/slug.test.ts
+++ b/packages/backend/convex/schools/slug.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   isReservedSchoolSlug,
   SCHOOL_ROUTE_SLUGS,
 } from "@repo/backend/convex/schools/slug";
-import { describe, expect, it } from "vitest";
 
 describe("schools/slug", () => {
   it("owns the static School route tokens", () => {

--- a/packages/backend/convex/subscriptions/mutations.test.ts
+++ b/packages/backend/convex/subscriptions/mutations.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type {
@@ -9,7 +10,6 @@ import type { SubscriptionRecord } from "@repo/backend/convex/subscriptions/reco
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { products } from "@repo/backend/convex/utils/polar/products";
 import { convexTest } from "convex-test";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 18, 0, 0);
 

--- a/packages/backend/convex/triggers/comments/commentVotes.test.ts
+++ b/packages/backend/convex/triggers/comments/commentVotes.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 18, 0, 0);
 

--- a/packages/backend/convex/triggers/comments/comments.test.ts
+++ b/packages/backend/convex/triggers/comments/comments.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 18, 0, 0);
 

--- a/packages/backend/convex/triggers/contents/views.test.ts
+++ b/packages/backend/convex/triggers/contents/views.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/triggers/forums/posts.test.ts
+++ b/packages/backend/convex/triggers/forums/posts.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type {
@@ -15,7 +16,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 14, 0, 0);
 

--- a/packages/backend/convex/triggers/helpers/notifications.test.ts
+++ b/packages/backend/convex/triggers/helpers/notifications.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { createNotification } from "@repo/backend/convex/triggers/helpers/notifications";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("triggers/helpers/notifications", () => {
   it("does not recreate notification data for a deletion-pending recipient", async () => {

--- a/packages/backend/convex/triggers/materials/groups.test.ts
+++ b/packages/backend/convex/triggers/materials/groups.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   insertClass,
@@ -9,7 +10,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 16, 14, 0, 0);
 

--- a/packages/backend/convex/triggers/materials/materials.test.ts
+++ b/packages/backend/convex/triggers/materials/materials.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   insertClass,
@@ -9,7 +10,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 16, 14, 0, 0);
 

--- a/packages/backend/convex/triggers/schools/classMembers.test.ts
+++ b/packages/backend/convex/triggers/schools/classMembers.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 21, 0, 0);
 

--- a/packages/backend/convex/triggers/schools/cleanup.test.ts
+++ b/packages/backend/convex/triggers/schools/cleanup.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -6,7 +7,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 16, 9, 0, 0);
 

--- a/packages/backend/convex/triggers/schools/members.test.ts
+++ b/packages/backend/convex/triggers/schools/members.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 4, 29, 20, 30, 0);
 

--- a/packages/backend/convex/triggers/subscriptions/impl.test.ts
+++ b/packages/backend/convex/triggers/subscriptions/impl.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
@@ -11,7 +12,6 @@ import type { UserPlan } from "@repo/backend/convex/users/schema";
 import { logger } from "@repo/backend/convex/utils/logger";
 import { products } from "@repo/backend/convex/utils/polar/products";
 import { convexTest } from "convex-test";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 18, 0, 0);
 

--- a/packages/backend/convex/tryouts/access/impl.test.ts
+++ b/packages/backend/convex/tryouts/access/impl.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
@@ -10,7 +11,6 @@ import {
 import { getIncludedAttemptAccess } from "@repo/backend/convex/tryouts/access/impl";
 import { products } from "@repo/backend/convex/utils/polar/products";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 7, 12, 0, 0);
 const PERIOD_END = Date.UTC(2026, 6, 21, 12, 0, 0);

--- a/packages/backend/convex/tryouts/mutations/access.test.ts
+++ b/packages/backend/convex/tryouts/mutations/access.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import posthogTest from "@posthog/convex/test";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
@@ -5,7 +6,6 @@ import {
   seedAnalyticsConsent,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 6, 22, 9, 0, 0);
 

--- a/packages/backend/convex/tryouts/mutations/attempts.test.ts
+++ b/packages/backend/convex/tryouts/mutations/attempts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/tryouts/mutations/expiry.test.ts
+++ b/packages/backend/convex/tryouts/mutations/expiry.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import {

--- a/packages/backend/convex/tryouts/queries/access.test.ts
+++ b/packages/backend/convex/tryouts/queries/access.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,
@@ -5,7 +6,6 @@ import {
 } from "@repo/backend/convex/test.helpers";
 import { TRYOUT_TEST_NOW } from "@repo/backend/test/tryouts";
 import type { FunctionArgs } from "convex/server";
-import { describe, expect, it } from "vitest";
 
 const startAccessArgs: FunctionArgs<
   typeof api.tryouts.queries.access.getStartAccess

--- a/packages/backend/convex/tryouts/queries/attempt.test.ts
+++ b/packages/backend/convex/tryouts/queries/attempt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/tryouts/queries/attemptPage.test.ts
+++ b/packages/backend/convex/tryouts/queries/attemptPage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/tryouts/queries/history.test.ts
+++ b/packages/backend/convex/tryouts/queries/history.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";

--- a/packages/backend/convex/tryouts/queries/runtime.test.ts
+++ b/packages/backend/convex/tryouts/queries/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/tryouts/response/impl.test.ts
+++ b/packages/backend/convex/tryouts/response/impl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {

--- a/packages/backend/convex/tryouts/response/spec.test.ts
+++ b/packages/backend/convex/tryouts/response/spec.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { toTryoutResponseError } from "@repo/backend/convex/tryouts/response/spec";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("tryouts/response/spec", () => {
   it("hides unexpected storage details while retaining the internal cause", async () => {

--- a/packages/backend/convex/tryouts/runtime/access.test.ts
+++ b/packages/backend/convex/tryouts/runtime/access.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { readOwnedTryoutSectionContent } from "@repo/backend/convex/tryouts/runtime/access";

--- a/packages/backend/convex/tryouts/runtime/finish.test.ts
+++ b/packages/backend/convex/tryouts/runtime/finish.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";

--- a/packages/backend/convex/tryouts/runtime/irt/items.test.ts
+++ b/packages/backend/convex/tryouts/runtime/irt/items.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";

--- a/packages/backend/convex/tryouts/runtime/ownership.test.ts
+++ b/packages/backend/convex/tryouts/runtime/ownership.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, describe, it, vi } from "@effect/vitest";
+import { assert, beforeEach, describe, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { loadTryoutSignedContent } from "@repo/backend/convex/tryouts/runtime/selectors";

--- a/packages/backend/convex/tryouts/runtime/score.test.ts
+++ b/packages/backend/convex/tryouts/runtime/score.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";

--- a/packages/backend/convex/tryouts/runtime/selectors.test.ts
+++ b/packages/backend/convex/tryouts/runtime/selectors.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, describe, it, vi } from "@effect/vitest";
+import { assert, beforeEach, describe, it } from "@effect/vitest";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { loadTryoutSignedContent } from "@repo/backend/convex/tryouts/runtime/selectors";

--- a/packages/backend/convex/tryouts/sets/published.test.ts
+++ b/packages/backend/convex/tryouts/sets/published.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
 import { tryoutCatalogNodeIdentity } from "@nakafa/aksara-contracts/tryout/identity";
 import { api } from "@repo/backend/convex/_generated/api";

--- a/packages/backend/convex/tryouts/start/impl.test.ts
+++ b/packages/backend/convex/tryouts/start/impl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { api } from "@repo/backend/convex/_generated/api";
 import {
   createConvexTestWithBetterAuth,

--- a/packages/backend/convex/tryouts/start/scale.test.ts
+++ b/packages/backend/convex/tryouts/start/scale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { ACTIVE_APP_LOCALE_CODES } from "@nakafa/aksara-contracts/locale";
 import { api } from "@repo/backend/convex/_generated/api";
 import {

--- a/packages/backend/convex/tryouts/start/source.test.ts
+++ b/packages/backend/convex/tryouts/start/source.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import { ReleaseIdSchema } from "@nakafa/aksara-contracts/ids";
 import { SignedContentReleaseSchema } from "@nakafa/aksara-contracts/release";
 import { api } from "@repo/backend/convex/_generated/api";

--- a/packages/backend/convex/users/mutations.test.ts
+++ b/packages/backend/convex/users/mutations.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { api, components } from "@repo/backend/convex/_generated/api";
 import {
   DEFAULT_USER_CREDITS,
@@ -8,7 +9,6 @@ import {
   createConvexTestWithBetterAuth,
   seedAuthenticatedUser,
 } from "@repo/backend/convex/test.helpers";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOW = Date.UTC(2026, 3, 2, 12, 0, 0);
 

--- a/packages/backend/convex/users/queries.test.ts
+++ b/packages/backend/convex/users/queries.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "@effect/vitest";
 import { internal } from "@repo/backend/convex/_generated/api";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
 
 describe("users/queries", () => {
   it("loads users by id and auth id", async () => {

--- a/packages/backend/convex/users/roles.test.ts
+++ b/packages/backend/convex/users/roles.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import { userRoles } from "@repo/ai/types/roles";
 import {
   isSelfSelectableUserRole,
   selfSelectableUserRoles,
 } from "@repo/backend/convex/users/roles";
-import { describe, expect, it } from "vitest";
 
 describe("users/roles", () => {
   it("keeps self-selectable roles within persisted roles", () => {

--- a/packages/backend/convex/utils/error.test.ts
+++ b/packages/backend/convex/utils/error.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getErrorMessage } from "@repo/backend/convex/utils/error";
 import { ConvexError } from "convex/values";
-import { describe, expect, it } from "vitest";
 
 describe("utils/error", () => {
   it("extracts readable messages from known thrown values", () => {

--- a/packages/backend/convex/utils/polar/products.test.ts
+++ b/packages/backend/convex/utils/polar/products.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 
 async function loadProducts() {
   vi.resetModules();

--- a/packages/backend/convex/utils/text.test.ts
+++ b/packages/backend/convex/utils/text.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { slugify, truncateText } from "@repo/backend/convex/utils/text";
-import { describe, expect, it } from "vitest";
 
 describe("utils/text", () => {
   it("turns display text into a stable slug", () => {

--- a/packages/backend/scripts/content/runtime/ci/command.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/command.test.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   runRuntimeCommand,
   sanitizeRuntimeCommandError,

--- a/packages/backend/scripts/content/runtime/ci/config.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT,
   clearContentRuntimeSecrets,

--- a/packages/backend/test/agent/http.ts
+++ b/packages/backend/test/agent/http.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, vi } from "@effect/vitest";
+import { afterEach, beforeEach, expect } from "@effect/vitest";
 import { NAKAFA_API_EDGE_CONTRACT } from "@repo/backend/agent/edge";
 import type { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 

--- a/packages/backend/test/content/view.ts
+++ b/packages/backend/test/content/view.ts
@@ -1,3 +1,4 @@
+import { expect } from "@effect/vitest";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import type { LearningContextStorage } from "@repo/backend/convex/contents/context";
 import { getContentAnalyticsPartition } from "@repo/backend/convex/contents/helpers/partitions";
@@ -11,7 +12,6 @@ import {
   insertRuntimeArticles,
   testArticleProjection,
 } from "@repo/backend/test/content/runtime";
-import { expect } from "vitest";
 
 const ARTICLE_VIEW_PROJECTION = testArticleProjection(0);
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -18,7 +18,7 @@
         "allowedDuplicatedPackages": ["@nakafa/aksara-contracts"]
       }
     ],
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "paths": {
       "@/*": ["./*"],
       "@repo/*": ["../../packages/*"]

--- a/packages/backend/vitest.setup.ts
+++ b/packages/backend/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, vi } from "vitest";
+import { afterEach } from "@effect/vitest";
 
 // @posthog/convex reads component env from process.env under convex-test.
 // Override shell env so tests never send real analytics events.

--- a/packages/contents/_lib/agent/errors.test.ts
+++ b/packages/contents/_lib/agent/errors.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getUnknownErrorMessage } from "@repo/contents/_lib/agent/errors";
-import { describe, expect, it } from "vitest";
 
 describe("Nakafa agent errors", () => {
   it("normalizes Error and non-Error failure values", () => {

--- a/packages/contents/_lib/agent/fixture.test.ts
+++ b/packages/contents/_lib/agent/fixture.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
-import { describe, expect, it } from "vitest";
 
 describe("Nakafa content reference fixtures", () => {
   it("rejects runtime section values outside the agent contract", () => {

--- a/packages/contents/_lib/agent/refs.test.ts
+++ b/packages/contents/_lib/agent/refs.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   createNakafaContentRefFromGraphProjection,
   createNakafaContentRefFromSummary,
@@ -5,7 +6,6 @@ import {
   parseNakafaUrlRoute,
 } from "@repo/contents/_lib/agent/refs";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 const graphProjection = {
   alignmentId: "alignment:catalog:article:example",

--- a/packages/contents/_lib/agent/schema/quran/input.test.ts
+++ b/packages/contents/_lib/agent/schema/quran/input.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { NakafaAgentQuranReferenceOptionsSchema } from "@repo/contents/_lib/agent/schema/quran/input";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("NakafaAgentQuranReferenceOptionsSchema", () => {
   it("applies default Quran options", () => {

--- a/packages/contents/_lib/agent/schema/quran/reference.test.ts
+++ b/packages/contents/_lib/agent/schema/quran/reference.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import {
   type QuranEmbeddedSourceId,
@@ -6,7 +7,6 @@ import {
 } from "@nakafa/aksara-contracts/quran/identity";
 import { NakafaAgentQuranReferenceSchema } from "@repo/contents/_lib/agent/schema/quran/reference";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const ARTIFACT = {
   byte_count: 1,

--- a/packages/contents/_lib/agent/schema/read.test.ts
+++ b/packages/contents/_lib/agent/schema/read.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import {
   NakafaAgentContentRefInputSchema,
   NakafaAgentMarkdownSchema,
 } from "@repo/contents/_lib/agent/schema/read";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const quranAssetId = "asset:en:quran:quran-surah:1";
 

--- a/packages/contents/_lib/agent/schema/ref.test.ts
+++ b/packages/contents/_lib/agent/schema/ref.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { readNakafaContentRefFixture } from "@repo/contents/_lib/agent/fixture";
 import {
   NakafaAgentContentIdSchema,
@@ -8,7 +9,6 @@ import {
   NakafaAgentMarkdownUrlSchema,
 } from "@repo/contents/_lib/agent/schema/ref";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const quranRef = readNakafaContentRefFixture("en", "quran/1", "quran");
 

--- a/packages/contents/_lib/agent/schema/search.test.ts
+++ b/packages/contents/_lib/agent/schema/search.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { NakafaAgentSearchOptionsSchema } from "@repo/contents/_lib/agent/schema/search";
 import { NAKAFA_AGENT_SEARCH_WINDOW } from "@repo/contents/_types/agent/search";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("NakafaAgentSearchOptionsSchema", () => {
   it("applies the documented search defaults", () => {

--- a/packages/contents/_lib/curriculum/grade.test.ts
+++ b/packages/contents/_lib/curriculum/grade.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getGradeNonNumeric } from "@repo/contents/_lib/curriculum/grade";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("subject grade helpers", () => {
   it("resolves grade labels", () => {

--- a/packages/contents/_lib/curriculum/material.test.ts
+++ b/packages/contents/_lib/curriculum/material.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@effect/vitest";
 import { BulbIcon, PiIcon } from "@hugeicons/core-free-icons";
 import { getMaterialIcon } from "@repo/contents/_lib/curriculum/material";
 import { PRESENTED_MATERIAL_DOMAINS } from "@repo/contents/_types/taxonomy";
-import { describe, expect, it } from "vitest";
 
 describe("getMaterialIcon", () => {
   it("resolves mathematics to the pi icon", () => {

--- a/packages/contents/_lib/toc.test.ts
+++ b/packages/contents/_lib/toc.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { extractAllHeadingIds, getHeadings } from "@repo/contents/_lib/toc";
 import type { ParsedHeading } from "@repo/contents/_types/toc";
-import { describe, expect, it } from "vitest";
 
 const MAIN_HEADING_REGEX = /^#main-heading$/;
 const TEST_HEADING_WITH_SPACES_REGEX = /^#test-heading-with-spaces$/;

--- a/packages/contents/_shared/date.test.ts
+++ b/packages/contents/_shared/date.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { formatContentDateISO } from "@repo/contents/_shared/date";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("content date helpers", () => {
   it("rejects invalid or non-canonical date strings", () => {

--- a/packages/contents/_types/llms/code.test.ts
+++ b/packages/contents/_types/llms/code.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { formatCodeBlockData } from "@repo/contents/_types/llms/code";
-import { describe, expect, it } from "vitest";
 
 describe("CodeBlock data formatting", () => {
   it("ignores missing and blank code", () => {

--- a/packages/contents/_types/llms/mdx.test.ts
+++ b/packages/contents/_types/llms/mdx.test.ts
@@ -1,10 +1,9 @@
-import { it } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   MdxAgentProjectionError,
   projectMdxForAgentMarkdown,
 } from "@repo/contents/_types/llms/mdx";
 import { Effect } from "effect";
-import { describe, expect } from "vitest";
 
 describe("MDX agent markdown projection", () => {
   it.effect(

--- a/packages/contents/_types/route/material/context.test.ts
+++ b/packages/contents/_types/route/material/context.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MaterialKeySchema } from "@nakafa/aksara-contracts/projection/material";
 import {
   projectMaterialContextToLocale,
@@ -9,7 +10,6 @@ import type {
   MaterialContextRef,
   MaterialRouteIdentity,
 } from "@repo/contents/_types/route/material/reference";
-import { describe, expect, it } from "vitest";
 
 const SOURCE_PATH =
   "material/lesson/mathematics/linear-equation-inequality/system-linear-equation";

--- a/packages/contents/_types/route/material/reference.test.ts
+++ b/packages/contents/_types/route/material/reference.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MaterialKeySchema } from "@nakafa/aksara-contracts/projection/material";
 import {
   type MaterialContextRef,
   type MaterialRouteIdentity,
   readMaterialContextRef,
 } from "@repo/contents/_types/route/material/reference";
-import { describe, expect, it } from "vitest";
 
 const route = {
   locale: "id",

--- a/packages/contents/_types/route/surface.test.ts
+++ b/packages/contents/_types/route/surface.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   PUBLIC_ROUTE_SURFACES,
   readNamespaceSegment,
 } from "@repo/contents/_types/route/surface";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/packages/contents/tsconfig.json
+++ b/packages/contents/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@repo/typescript-config/library.json",
   "compilerOptions": {
+    "types": ["vitest/globals"],
     "paths": {
       "@repo/*": ["../*"],
       "@repo/contents/*": ["./*"]

--- a/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
+++ b/packages/design-system/components/contents/mathematics/bacterial-growth.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   BacterialGrowthFrameInputSchema,
   getBacterialGrowthFrame,
 } from "@repo/design-system/components/contents/mathematics/bacterial-growth";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("bacterial growth frames", () => {
   it("keeps every exponential division visible for a large initial culture", () => {

--- a/packages/design-system/components/contents/mathematics/circle.test.ts
+++ b/packages/design-system/components/contents/mathematics/circle.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   createCircleArcLine,
   createCircleArcPoints,
@@ -8,7 +10,6 @@ import {
   createCircleRadiusPoints,
   createCircleSegmentBoundaryLines,
 } from "@repo/design-system/components/contents/mathematics/circle";
-import { describe, expect, it } from "vitest";
 
 const EXPECTED_PRECISION = 12;
 

--- a/packages/design-system/components/contents/mathematics/cuboid.test.ts
+++ b/packages/design-system/components/contents/mathematics/cuboid.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import { createCuboidLines } from "@repo/design-system/components/contents/mathematics/cuboid";
-import { describe, expect, it } from "vitest";
 
 function getEdgeLength({
   points,

--- a/packages/design-system/components/contents/mathematics/line/resolve.test.ts
+++ b/packages/design-system/components/contents/mathematics/line/resolve.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import { resolveAuthoredLines } from "@repo/design-system/components/contents/mathematics/line/resolve";
-import { describe, expect, it } from "vitest";
 
 const rawLine = {
   color: "blue",

--- a/packages/design-system/components/contents/snbt/geometry.test.ts
+++ b/packages/design-system/components/contents/snbt/geometry.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
+import { describe, expect, it } from "@effect/vitest";
 import {
   getArcPoints,
   getMidpoint,
 } from "@repo/design-system/components/contents/snbt/geometry";
-import { describe, expect, it } from "vitest";
 
 describe("SNBT geometry", () => {
   it("returns the midpoint on every graph axis", () => {

--- a/packages/design-system/components/evilcharts/ui/chart-config.test.ts
+++ b/packages/design-system/components/evilcharts/ui/chart-config.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   axisValueToPercentFormatter,
   type ChartConfig,
@@ -12,7 +13,6 @@ import {
   THEMES,
   validateChartConfigColors,
 } from "@repo/design-system/components/evilcharts/ui/chart-config";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const chartConfig = {
   selected: {

--- a/packages/design-system/components/evilcharts/ui/chart-payload.test.ts
+++ b/packages/design-system/components/evilcharts/ui/chart-payload.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getChartPayloadStringValue } from "@repo/design-system/components/evilcharts/ui/chart-payload";
-import { describe, expect, it } from "vitest";
 
 describe("chart payload utilities", () => {
   it("reads string fields from unknown payload values", () => {

--- a/packages/design-system/components/three/helpers/quality.test.ts
+++ b/packages/design-system/components/three/helpers/quality.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   createArcPoints,
   getCurveDivisions,
 } from "@repo/design-system/components/three/helpers/quality";
-import { describe, expect, it } from "vitest";
 
 describe("graph quality helpers", () => {
   it("uses requested curve divisions when provided", () => {

--- a/packages/design-system/components/three/inequality-data.test.ts
+++ b/packages/design-system/components/three/inequality-data.test.ts
@@ -1,5 +1,5 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { getAdaptiveInequalityResolution } from "@repo/design-system/components/three/inequality-data";
-import { afterEach, describe, expect, it } from "vitest";
 
 const originalHardwareConcurrency = navigator.hardwareConcurrency;
 const originalUserAgent = navigator.userAgent;

--- a/packages/design-system/lib/breakpoints.test.ts
+++ b/packages/design-system/lib/breakpoints.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   createMaxWidthInclusiveMediaQuery,
   createMaxWidthMediaQuery,
   TAILWIND_MEDIA_QUERIES,
 } from "@repo/design-system/lib/breakpoints";
-import { describe, expect, it } from "vitest";
 
 describe("breakpoint media queries", () => {
   it("matches Tailwind max breakpoint semantics", () => {

--- a/packages/design-system/lib/button.test.ts
+++ b/packages/design-system/lib/button.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { buttonVariants } from "@repo/design-system/lib/button";
-import { describe, expect, it } from "vitest";
 
 const BUTTON_VARIANTS = [
   "default",

--- a/packages/design-system/lib/calendar/day-key.test.ts
+++ b/packages/design-system/lib/calendar/day-key.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import { getCalendarDayKey } from "@repo/design-system/lib/calendar/day-key";
-import { describe, expect, it } from "vitest";
 
 describe("calendar day key", () => {
   it("serializes local calendar parts as a zero-padded ISO-style key", () => {

--- a/packages/design-system/lib/charts/series-cue.test.ts
+++ b/packages/design-system/lib/charts/series-cue.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   getBarSeriesCue,
   getLineSeriesCue,
   getPointSeriesCue,
 } from "@repo/design-system/lib/charts/series-cue";
-import { describe, expect, it } from "vitest";
 
 describe("chart series cues", () => {
   it("assigns distinct line strokes and markers", () => {

--- a/packages/design-system/lib/code-block/clipboard.test.ts
+++ b/packages/design-system/lib/code-block/clipboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   CodeClipboardUnavailableError,
   CodeClipboardWriteError,

--- a/packages/design-system/lib/code-block/highlight.test.ts
+++ b/packages/design-system/lib/code-block/highlight.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@repo/design-system/lib/code-block/highlight";
 import { Effect } from "effect";
 import type { CodeOptionsMultipleThemes } from "shiki";
-import { vi } from "vitest";
 
 const { codeToHtmlMock } = vi.hoisted(() => ({
   codeToHtmlMock: vi.fn(),

--- a/packages/design-system/lib/code-block/language-extension.test.ts
+++ b/packages/design-system/lib/code-block/language-extension.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { getCodeFileExtension } from "@repo/design-system/lib/code-block/language-extension";
-import { describe, expect, it } from "vitest";
 
 describe("getCodeFileExtension", () => {
   it("uses text for missing and unsupported languages", () => {

--- a/packages/design-system/lib/code-block/lines.test.ts
+++ b/packages/design-system/lib/code-block/lines.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { preserveShikiLineBreaks } from "@repo/design-system/lib/code-block/lines";
-import { describe, expect, it } from "vitest";
 
 describe("preserveShikiLineBreaks", () => {
   it("adds text newlines between rendered Shiki line spans", () => {

--- a/packages/design-system/lib/device.test.ts
+++ b/packages/design-system/lib/device.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   getPowerPreference,
   isMobileDevice,
 } from "@repo/design-system/lib/device";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 const IPHONE_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X)";

--- a/packages/design-system/lib/files/download.test.ts
+++ b/packages/design-system/lib/files/download.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   BrowserFileDownloadError,
   downloadFile,

--- a/packages/design-system/lib/geometry/angles.test.ts
+++ b/packages/design-system/lib/geometry/angles.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   getCos,
   getRadians,
   getSin,
   getTan,
 } from "@repo/design-system/lib/geometry/angles";
-import { describe, expect, it } from "vitest";
 
 describe("math degree helpers", () => {
   it("converts degrees to radians", () => {

--- a/packages/design-system/lib/markdown/blocks.test.ts
+++ b/packages/design-system/lib/markdown/blocks.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   parseMarkdownIntoBlocks,
   readMarkdownBlocks,
 } from "@repo/design-system/lib/markdown/blocks";
 import { Lexer, type Tokens } from "marked";
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 function mockLexerBlocks(...blocks: string[]) {
   const tokens = Object.assign(

--- a/packages/design-system/lib/markdown/math.test.ts
+++ b/packages/design-system/lib/markdown/math.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import { preprocessLaTeX } from "@repo/design-system/lib/markdown/math";
 import { Lexer } from "marked";
-import { describe, expect, it } from "vitest";
 
 describe("preprocessLaTeX", () => {
   it("returns empty text unchanged", () => {

--- a/packages/design-system/lib/markdown/mermaid.test.ts
+++ b/packages/design-system/lib/markdown/mermaid.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
 import {
   normalizeMermaidChart,
   readMermaidMetadata,
 } from "@repo/design-system/lib/markdown/mermaid";
-import { describe, expect, it } from "vitest";
 
 describe("readMermaidMetadata", () => {
   it("uses distinct fallback copy when metadata is missing", () => {

--- a/packages/design-system/lib/markdown/names.test.ts
+++ b/packages/design-system/lib/markdown/names.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   aiDsComponentNames,
   biologyComponentNames,
@@ -12,7 +13,6 @@ import {
   snbtQuantComponentNames,
   tkaMathComponentNames,
 } from "@repo/design-system/lib/markdown/names";
-import { describe, expect, it } from "vitest";
 
 const domainComponentNames = {
   "ai-ds": aiDsComponentNames,

--- a/packages/design-system/lib/prompt-input/files.test.ts
+++ b/packages/design-system/lib/prompt-input/files.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   convertPromptInputFiles,
   PromptInputAttachmentConversionError,

--- a/packages/design-system/lib/prompt-input/submission.test.ts
+++ b/packages/design-system/lib/prompt-input/submission.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import type { PromptInputFile } from "@repo/design-system/lib/prompt-input/files";
 import {
   PromptInputCompletionError,

--- a/packages/design-system/lib/sidebar/boundary.test.ts
+++ b/packages/design-system/lib/sidebar/boundary.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
 import { runSidebarStateProgram } from "@repo/design-system/lib/sidebar/boundary";
 import { SidebarStatePersistenceError } from "@repo/design-system/lib/sidebar/persistence";
 import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { captureExceptionMock } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),

--- a/packages/design-system/lib/sidebar/persistence.test.ts
+++ b/packages/design-system/lib/sidebar/persistence.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   BrowserSidebarCookieWriterLive,
   persistSidebarState,

--- a/packages/design-system/lib/theme/options.test.ts
+++ b/packages/design-system/lib/theme/options.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { themeOptions } from "@repo/design-system/lib/theme/options";
 import { themes } from "@repo/design-system/lib/theme/registry";
-import { describe, expect, it } from "vitest";
 
 describe("theme picker options", () => {
   it("stays synchronized with every runtime theme definition", () => {

--- a/packages/design-system/lib/toggle/variants.test.ts
+++ b/packages/design-system/lib/toggle/variants.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { toggleVariants } from "@repo/design-system/lib/toggle/variants";
-import { describe, expect, it } from "vitest";
 
 describe("toggleVariants", () => {
   it.each(["default", "outline"] as const)(

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
-    "types": ["@repo/internationalization/i18n.d.ts"],
+    "types": ["@repo/internationalization/i18n.d.ts", "vitest/globals"],
     "plugins": [
       {
         "name": "next"

--- a/packages/internationalization/package.json
+++ b/packages/internationalization/package.json
@@ -16,6 +16,7 @@
     "next-intl": "^4.13.7"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.11",

--- a/packages/internationalization/src/href.test.ts
+++ b/packages/internationalization/src/href.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { normalizeLocalizedInternalHref } from "@repo/internationalization/src/href";
-import { describe, expect, it } from "vitest";
 
 describe("localized internal href normalization", () => {
   it.each([

--- a/packages/math/errors.test.ts
+++ b/packages/math/errors.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathCasRequestError, MathCasResponseError } from "@repo/math/errors";
-import { describe, expect, it } from "vitest";
 
 describe("math errors", () => {
   it("keeps request failures tagged", () => {

--- a/packages/math/schema/data.test.ts
+++ b/packages/math/schema/data.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathDataSchema } from "@repo/math/schema/data";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathDataSchema", () => {
   it("decodes completed math data parts", () => {

--- a/packages/math/schema/request.test.ts
+++ b/packages/math/schema/request.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathRequestSchema } from "@repo/math/schema/request";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathRequestSchema", () => {
   it("decodes a CAS request", () => {

--- a/packages/math/schema/result.test.ts
+++ b/packages/math/schema/result.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathResultSchema } from "@repo/math/schema/result";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathResultSchema", () => {
   it("decodes a CAS result", () => {

--- a/packages/math/schema/tool-input.test.ts
+++ b/packages/math/schema/tool-input.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathToolInputSchema } from "@repo/math/schema/tool-input";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathToolInputSchema", () => {
   it("routes member inputs through the combined tool schema", () => {

--- a/packages/math/schema/tool/calculus.test.ts
+++ b/packages/math/schema/tool/calculus.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathCalculusInputSchema } from "@repo/math/schema/tool/calculus";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathCalculusInputSchema", () => {
   const decodeCalculusInput = Schema.decodeUnknownSync(MathCalculusInputSchema);

--- a/packages/math/schema/tool/equation.test.ts
+++ b/packages/math/schema/tool/equation.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathEquationInputSchema } from "@repo/math/schema/tool/equation";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathEquationInputSchema", () => {
   const decodeEquationInput = Schema.decodeUnknownSync(MathEquationInputSchema);

--- a/packages/math/schema/tool/geometry.test.ts
+++ b/packages/math/schema/tool/geometry.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathGeometryInputSchema } from "@repo/math/schema/tool/geometry";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathGeometryInputSchema", () => {
   const decodeGeometryInput = Schema.decodeUnknownSync(MathGeometryInputSchema);

--- a/packages/math/schema/tool/probability.test.ts
+++ b/packages/math/schema/tool/probability.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathProbabilityInputSchema } from "@repo/math/schema/tool/probability";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathProbabilityInputSchema", () => {
   const decodeProbabilityInput = Schema.decodeUnknownSync(

--- a/packages/math/schema/tool/series.test.ts
+++ b/packages/math/schema/tool/series.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@effect/vitest";
 import { MathSeriesInputSchema } from "@repo/math/schema/tool/series";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 describe("MathSeriesInputSchema", () => {
   it("accepts zero-order series requests", () => {

--- a/packages/math/service.test.ts
+++ b/packages/math/service.test.ts
@@ -1,8 +1,7 @@
-import { it } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { MathCasRequestError } from "@repo/math/errors";
 import { MathService } from "@repo/math/service";
 import { ConfigProvider, Effect, Exit } from "effect";
-import { afterEach, describe, expect, vi } from "vitest";
 
 const provider = ConfigProvider.fromEnvRecord({
   MATH_CAS_API_KEY: "secret",

--- a/packages/math/tsconfig.json
+++ b/packages/math/tsconfig.json
@@ -5,7 +5,7 @@
       "@repo/*": ["../*"],
       "@repo/math/*": ["./*"]
     },
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "coverage"]

--- a/packages/next-config/index.test.ts
+++ b/packages/next-config/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   config,
   createLoopbackConnectSources,
@@ -6,7 +7,6 @@ import {
   withAnalyzer,
   withMDX,
 } from "@repo/next-config";
-import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@next/bundle-analyzer", () => ({
   default: () => (sourceConfig: object) => ({

--- a/packages/next-config/keys.test.ts
+++ b/packages/next-config/keys.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   analyzeKeys,
   contentRuntimeKeys,

--- a/packages/next-config/tsconfig.json
+++ b/packages/next-config/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
+    "types": ["vitest/globals"],
     "paths": {
       "@repo/*": ["../*"],
       "@repo/next-config/*": ["./*"]

--- a/packages/seo/company.test.ts
+++ b/packages/seo/company.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   COMPANY_IDENTITY,
   COMPANY_REGISTERED_ADDRESS,
@@ -5,7 +6,6 @@ import {
 } from "@repo/seo/company";
 import { COMPANY_SOCIAL_PROFILE_URLS } from "@repo/seo/company-profiles";
 import { Schema } from "effect";
-import { describe, expect, it } from "vitest";
 
 const decodeCompanyIdentity = Schema.decodeUnknownSync(CompanyIdentitySchema);
 

--- a/packages/seo/json-ld/constants.test.ts
+++ b/packages/seo/json-ld/constants.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import { COMPANY_IDENTITY } from "@repo/seo/company";
 import {
   ORGANIZATION,
   ORGANIZATION_ID,
   ORGANIZATION_REFERENCE,
 } from "@repo/seo/json-ld/constants";
-import { describe, expect, it } from "vitest";
 
 describe("organization JSON-LD", () => {
   it("preserves every registered locality component", () => {

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -18,6 +18,7 @@
     "schema-dts": "^2.0.0"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@repo/testing": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/lodash.merge": "^4.6.9",

--- a/packages/testing/base.ts
+++ b/packages/testing/base.ts
@@ -8,6 +8,7 @@ const config = defineConfig({
     },
   },
   test: {
+    globals: true,
     coverage: {
       enabled: true,
       provider: "istanbul",

--- a/packages/utilities/body.test.ts
+++ b/packages/utilities/body.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { parseContentLength, readBoundedBody } from "@repo/utilities/body";
 import { Deferred, Effect, Fiber } from "effect";
-import { vi } from "vitest";
 
 /** Builds one bounded body read for the Effect test runtime. */
 function read(body: ReadableStream<Uint8Array> | null, maxBytes = 8) {

--- a/packages/utilities/helper.test.ts
+++ b/packages/utilities/helper.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { cleanSlug, createStableId } from "@repo/utilities/helper";
-import { describe, expect, it } from "vitest";
 
 const STABLE_ID_PATTERN = /^json-ld-[a-z0-9]+$/;
 

--- a/packages/utilities/http/accept.test.ts
+++ b/packages/utilities/http/accept.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
 import {
   HttpMediaTypeSchema,
   mergeVaryHeader,
   negotiateMediaType,
 } from "@repo/utilities/http/accept";
 import { Option } from "effect";
-import { describe, expect, it } from "vitest";
 
 const HTML = HttpMediaTypeSchema.make("text/html; charset=utf-8");
 const MARKDOWN = HttpMediaTypeSchema.make("text/markdown; charset=utf-8");

--- a/packages/utilities/logging/effect.test.ts
+++ b/packages/utilities/logging/effect.test.ts
@@ -1,11 +1,10 @@
-import { it } from "@effect/vitest";
+import { describe, expect, it } from "@effect/vitest";
 import {
   logError,
   logHttpRequest,
   timeOperation,
 } from "@repo/utilities/logging/effect";
 import { Effect, Logger } from "effect";
-import { describe, expect } from "vitest";
 
 type StructuredLogEntry = ReturnType<typeof Logger.formatStructured.log>;
 

--- a/packages/utilities/mime.test.ts
+++ b/packages/utilities/mime.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { isJsonContentType } from "@repo/utilities/mime";
-import { describe, expect, it } from "vitest";
 
 describe("JSON content type", () => {
   it.each([

--- a/packages/utilities/security.test.ts
+++ b/packages/utilities/security.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "@effect/vitest";
 import { timingSafeEqual } from "@repo/utilities/security";
-import { describe, expect, it } from "vitest";
 
 describe("timingSafeEqual", () => {
   it("matches identical tokens", () => {

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -5,7 +5,7 @@
       "@repo/*": ["../*"],
       "@repo/utilities/*": ["./*"]
     },
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "coverage"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,6 +947,9 @@ importers:
         specifier: ^4.13.7
         version: 4.13.7(@swc/helpers@0.5.23)(@typescript/typescript6@6.0.2)(next@16.3.2(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1052,6 +1055,9 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@typescript/typescript6@6.0.2)
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(vitest@4.1.11)
       '@repo/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary
- migrate authored test APIs from raw Vitest imports to @effect/vitest
- keep vi as the documented global because importing it breaks vi.hoisted initialization
- encode import and test ownership policy in Biome and shared test configuration

## Verification
- pnpm format
- pnpm lint
- all workspace typechecks
- pnpm test: 13 of 13 tasks passed
- pnpm boundaries
- pnpm security:audit
- production build compiled and passed TypeScript; local data collection then stopped at the intentionally dummy Convex endpoint, so exact-head CI remains the authoritative environment-backed build gate