### PR TITLE
Restore curriculum body spacing

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/page.tsx
@@ -237,7 +237,7 @@ function CurriculumRouteBody({
   const { childRoutes, locale, materialCards } = model;
   if (materialCards.length > 0) {
     return (
-      <ContainerList className="sm:grid-cols-1">
+      <ContainerList className="pt-6 sm:grid-cols-1">
         {materialCards.map((material) => (
           <CardMaterial key={material.href} material={material} />
         ))}


### PR DESCRIPTION
## Summary

- restore the established top gutter on curriculum material-card grids
- keep curriculum parent cards, breadcrumb composition, and dropdown behavior unchanged

## Root cause

The material-card route renders the generic ContainerList directly, but it omitted the pt-6 used by the curriculum catalog, curriculum child cards, and try-out card grids. After the leaf header moved to the compact breadcrumb header, that missing body-owned gutter became visible.

## Verification

- pnpm format
- pnpm lint
- pnpm boundaries
- pnpm --filter www typecheck
- focused curriculum runtime tests, 6 passed
- full www suite, 1,497 passed with 100% coverage
- React Doctor changed scope, 100/100
- browser measurement at 1440px and 390px, 24px header-to-card gap with no horizontal overflow
- breadcrumb dropdown still renders Lainnya, Mata pelajaran, and Kurikulum Merdeka