### PR TITLE
Compose tryout Effect test seams

### DIFF
--- a/apps/www/checks/afdocs.test.ts
+++ b/apps/www/checks/afdocs.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 
-import { beforeAll, describe, expect, it } from "@effect/vitest";
-import type { CheckResult } from "afdocs";
+import { assert, describe, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { runAfdocs } from "@/checks/afdocs";
 
@@ -31,29 +30,26 @@ function formatFailureDetails(details: Record<string, unknown> | undefined) {
 }
 
 describe("AFDocs", () => {
-  let results: readonly {
-    readonly check: { readonly id: string };
-    readonly result: CheckResult | undefined;
-  }[];
+  it.live(
+    "runs the configured site contract",
+    () =>
+      Effect.gen(function* () {
+        const results = yield* runAfdocs();
+        assert.ok(results.length > 0);
 
-  beforeAll(async () => {
-    results = await Effect.runPromise(runAfdocs());
-  }, TIMEOUT_MS);
-
-  it("runs the configured site contract", () => {
-    expect(results.length).toBeGreaterThan(0);
-
-    for (const { check, result } of results) {
-      expect(result, `${check.id} did not run`).toBeDefined();
-      if (!result || result.status === "pass") {
-        continue;
-      }
-      if (result.status === "skip" && ALLOWED_SKIPS.has(result.id)) {
-        continue;
-      }
-      expect.fail(
-        `[${result.status}] ${result.message}${formatFailureDetails(result.details)}`
-      );
-    }
-  });
+        for (const { check, result } of results) {
+          assert.ok(result, `${check.id} did not run`);
+          if (!result || result.status === "pass") {
+            continue;
+          }
+          if (result.status === "skip" && ALLOWED_SKIPS.has(result.id)) {
+            continue;
+          }
+          assert.fail(
+            `[${result.status}] ${result.message}${formatFailureDetails(result.details)}`
+          );
+        }
+      }),
+    TIMEOUT_MS
+  );
 });

--- a/apps/www/components/tryout/content/batch.test.ts
+++ b/apps/www/components/tryout/content/batch.test.ts
@@ -10,7 +10,7 @@ import {
 import { projectTryoutRuntimeContent } from "@/components/tryout/content/model";
 
 describe("try-out signed content batches", () => {
-  it.live("preserves question and answer order across the wire ceiling", () =>
+  it.effect("preserves question and answer order across the wire ceiling", () =>
     Effect.gen(function* () {
       const questions = Array.from(
         { length: MAX_PROTECTED_RUNTIME_SELECTORS - 1 },
@@ -34,7 +34,7 @@ describe("try-out signed content batches", () => {
     })
   );
 
-  it.live(
+  it.effect(
     "fails with a typed error when one rendered batch loses an item",
     () =>
       Effect.gen(function* () {
@@ -48,7 +48,7 @@ describe("try-out signed content batches", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "fails with a typed error when the rendered batch count changes",
     () =>
       Effect.gen(function* () {
@@ -66,7 +66,7 @@ describe("try-out signed content batches", () => {
       })
   );
 
-  it.live(
+  it.effect(
     "fails with a typed error when the plan count differs from its batches",
     () =>
       Effect.gen(function* () {

--- a/apps/www/lib/content/tryout/sitemap.test.ts
+++ b/apps/www/lib/content/tryout/sitemap.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it } from "@effect/vitest";
+import { assert, beforeEach, describe, it } from "@effect/vitest";
 import { Effect } from "effect";
 import {
   readPublishedTryoutSitemap,
@@ -21,31 +21,43 @@ describe("published try-out sitemap", () => {
     runtimeQueryMock.mockReset();
   });
 
-  it("reads route inventory and one exact bounded page", async () => {
-    runtimeQueryMock
-      .mockResolvedValueOnce({ pageCount: 1, routeCount: 2 })
-      .mockResolvedValueOnce({ paths: ["try-out/alpha", "try-out/zeta"] });
+  it.effect("reads route inventory and one exact bounded page", () =>
+    Effect.gen(function* () {
+      runtimeQueryMock
+        .mockResolvedValueOnce({ pageCount: 1, routeCount: 2 })
+        .mockResolvedValueOnce({ paths: ["try-out/alpha", "try-out/zeta"] });
 
-    await expect(
-      Effect.runPromise(readPublishedTryoutSitemapCount("en"))
-    ).resolves.toEqual({ pageCount: 1, routeCount: 2 });
-    await expect(
-      Effect.runPromise(readPublishedTryoutSitemap("en", 0))
-    ).resolves.toEqual({ paths: ["try-out/alpha", "try-out/zeta"] });
-    expect(runtimeQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
-      appLocale: "en",
-    });
-    expect(runtimeQueryMock).toHaveBeenNthCalledWith(2, expect.anything(), {
-      appLocale: "en",
-      page: 0,
-    });
-  });
+      assert.deepStrictEqual(yield* readPublishedTryoutSitemapCount("en"), {
+        pageCount: 1,
+        routeCount: 2,
+      });
+      assert.deepStrictEqual(yield* readPublishedTryoutSitemap("en", 0), {
+        paths: ["try-out/alpha", "try-out/zeta"],
+      });
+      assert.strictEqual(runtimeQueryMock.mock.calls.length, 2);
+      assert.deepStrictEqual(runtimeQueryMock.mock.calls[0]?.[1], {
+        appLocale: "en",
+      });
+      assert.deepStrictEqual(runtimeQueryMock.mock.calls[1]?.[1], {
+        appLocale: "en",
+        page: 0,
+      });
+    })
+  );
 
-  it("preserves runtime query failures in the Effect error channel", async () => {
-    runtimeQueryMock.mockRejectedValueOnce(new Error("sitemap unavailable"));
+  it.effect(
+    "preserves runtime query failures in the Effect error channel",
+    () =>
+      Effect.gen(function* () {
+        runtimeQueryMock.mockRejectedValueOnce(
+          new Error("sitemap unavailable")
+        );
 
-    await expect(
-      Effect.runPromise(readPublishedTryoutSitemapCount("id"))
-    ).rejects.toThrow("sitemap unavailable");
-  });
+        const failure = yield* readPublishedTryoutSitemapCount("id").pipe(
+          Effect.flip
+        );
+        assert.strictEqual(failure._tag, "TestRuntimeQueryError");
+        assert.strictEqual(failure.message, "Error: sitemap unavailable");
+      })
+  );
 });

--- a/apps/www/lib/tryout/artwork.test.ts
+++ b/apps/www/lib/tryout/artwork.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/tryout/artwork";
 
 describe("try-out artwork", () => {
-  it.live.each(["en", "id", "de"] as const)(
+  it.effect.each(["en", "id", "de"] as const)(
     "uses English-default exam artwork for %s",
     (appLocale) =>
       Effect.gen(function* () {
@@ -30,7 +30,7 @@ describe("try-out artwork", () => {
       })
   );
 
-  it.live("keeps stable source keys separate from localized slugs", () =>
+  it.effect("keeps stable source keys separate from localized slugs", () =>
     Effect.gen(function* () {
       expect(
         yield* resolveTryoutExamArtwork({
@@ -46,7 +46,7 @@ describe("try-out artwork", () => {
     })
   );
 
-  it.live("keeps unknown exams on generated social artwork", () =>
+  it.effect("keeps unknown exams on generated social artwork", () =>
     Effect.gen(function* () {
       expect(
         yield* resolveTryoutExamArtwork({
@@ -109,7 +109,7 @@ describe("try-out artwork", () => {
     ).toBeUndefined();
   });
 
-  it.live.each([
+  it.effect.each([
     { appLocale: "en", countryKey: "Indonesia", examKey: "snbt" },
     { appLocale: "en", countryKey: "indonesia", examKey: "TKA" },
   ])(
@@ -130,7 +130,7 @@ describe("try-out artwork", () => {
       })
   );
 
-  it.live.each([
+  it.effect.each([
     "try-out",
     "try-out/indonesien",
     "try-out/indonesien/snbt/2027",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start": "turbo run start",
     "test": "pnpm check:patches && pnpm check:tests && pnpm test:scripts && turbo run test",
     "test:coverage": "pnpm check:patches && pnpm check:tests && turbo run test:coverage",
-    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/dependencies/policy.test.ts scripts/github/cli.test.ts scripts/github/policy.test.ts scripts/github/provenance/bundle.test.ts scripts/github/provenance/verify.test.ts scripts/github/queue/admission.test.ts scripts/github/queue/release.test.ts scripts/github/queue/remote.test.ts scripts/github/queue/replay.test.ts scripts/github/queue/result.test.ts scripts/github/queue/tree.test.ts scripts/github/release.test.ts scripts/vercel/scope.test.ts scripts/effect/source.test.ts scripts/production/acceptance.test.ts",
+    "test:scripts": "pnpm typecheck:scripts && pnpm --filter @repo/testing exec vitest run --root ../.. scripts/check/effect.test.ts scripts/dependencies/policy.test.ts scripts/github/cli.test.ts scripts/github/policy.test.ts scripts/github/provenance/bundle.test.ts scripts/github/provenance/verify.test.ts scripts/github/queue/admission.test.ts scripts/github/queue/release.test.ts scripts/github/queue/remote.test.ts scripts/github/queue/replay.test.ts scripts/github/queue/result.test.ts scripts/github/queue/tree.test.ts scripts/github/release.test.ts scripts/vercel/scope.test.ts scripts/effect/source.test.ts scripts/production/acceptance.test.ts",
     "test:ui": "turbo run test:ui",
     "test:watch": "turbo run test:watch",
     "translate": "turbo run translate",

--- a/packages/backend/convex/contentRelease/article/order.test.ts
+++ b/packages/backend/convex/contentRelease/article/order.test.ts
@@ -5,6 +5,7 @@ import {
   PROJECTION_PAGE_LIMIT,
   PUBLICATION_SCAN_LIMIT,
 } from "@repo/backend/convex/contentRelease/paging";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -13,7 +14,6 @@ import {
 } from "@repo/backend/test/content/runtime";
 import { ARTICLE_PUBLICATION_CURSOR_PREFIX } from "@repo/contents/_types/publication";
 import { convexTest } from "convex-test";
-import { Effect } from "effect";
 
 describe("contentRelease/article/order", () => {
   it("returns one full page without a false split boundary", async () => {
@@ -26,7 +26,7 @@ describe("contentRelease/article/order", () => {
     );
 
     const first = await t.query(async (ctx) => {
-      const result = await Effect.runPromise(
+      const result = await runConvexProgram(
         paginateArticles(ctx, "blue", "en", "politics", {
           cursor: null,
           maximumBytesRead: PROJECTION_PAGE_BYTES,
@@ -50,7 +50,7 @@ describe("contentRelease/article/order", () => {
     );
 
     const second = await t.query(async (ctx) => {
-      const result = await Effect.runPromise(
+      const result = await runConvexProgram(
         paginateArticles(ctx, "blue", "en", "politics", {
           cursor: first.result.continueCursor,
           maximumBytesRead: PROJECTION_PAGE_BYTES,
@@ -80,7 +80,7 @@ describe("contentRelease/article/order", () => {
     await t.mutation((ctx) => insertRuntimeArticles(ctx, 3));
 
     const rowBound = await t.query(async (ctx) => {
-      const result = await Effect.runPromise(
+      const result = await runConvexProgram(
         paginateArticles(ctx, "blue", "en", "politics", {
           cursor: null,
           maximumBytesRead: PROJECTION_PAGE_BYTES,
@@ -102,7 +102,7 @@ describe("contentRelease/article/order", () => {
     expect(rowBound.metrics.documentsRead.used).toBeLessThanOrEqual(4);
 
     const byteBound = await t.query(async (ctx) => {
-      const result = await Effect.runPromise(
+      const result = await runConvexProgram(
         paginateArticles(ctx, "blue", "en", "politics", {
           cursor: null,
           maximumBytesRead: 1,

--- a/packages/backend/convex/contentRelease/batch.test.ts
+++ b/packages/backend/convex/contentRelease/batch.test.ts
@@ -6,7 +6,7 @@ import {
 import { Effect, Exit } from "effect";
 
 describe("contentRelease/batch", () => {
-  it.live(
+  it.effect(
     "binds batch identity to kind, release, index, order, and exact bytes",
     () =>
       Effect.gen(function* () {
@@ -32,7 +32,7 @@ describe("contentRelease/batch", () => {
       })
   );
 
-  it.live("accepts only a complete immutable retry identity", () =>
+  it.effect("accepts only a complete immutable retry identity", () =>
     Effect.gen(function* () {
       expect(
         yield* validateStoredBatch(

--- a/packages/backend/convex/contentRelease/rollback.test.ts
+++ b/packages/backend/convex/contentRelease/rollback.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, it } from "@effect/vitest";
 import {
   type RoutePage,
   RoutePageSchema,
@@ -191,39 +191,46 @@ describe("contentRelease/rollback", () => {
     );
   });
 
-  it("replays an immutable predecessor publication-date projection", async () => {
-    const t = convexTest(schema, convexModules);
-    const current = JSON.parse(testProjectionJson());
-    const { dateModified: _, datePublished, ...metadata } = current.metadata;
-    const priorProjectionJson = canonicalizeContentProjection(
-      Schema.decodeUnknownSync(PredecessorProjectionSchema)({
-        ...current,
-        metadata: { ...metadata, date: datePublished },
+  it.effect(
+    "replays an immutable predecessor publication-date projection",
+    () =>
+      Effect.gen(function* () {
+        const t = convexTest(schema, convexModules);
+        const current = JSON.parse(testProjectionJson());
+        const {
+          dateModified: _,
+          datePublished,
+          ...metadata
+        } = current.metadata;
+        const predecessor = yield* Schema.decodeUnknownEffect(
+          PredecessorProjectionSchema
+        )({
+          ...current,
+          metadata: { ...metadata, date: datePublished },
+        });
+        const priorProjectionJson = canonicalizeContentProjection(predecessor);
+        const activeFailure = yield* decodeProjectionJson(
+          priorProjectionJson
+        ).pipe(Effect.flip);
+        assert.strictEqual(activeFailure.code, "CONTENT_RELEASE_INTEGRITY");
+        yield* Effect.promise(() =>
+          t.mutation(async (ctx) => {
+            await activateRollbackFixture(ctx, 1);
+            await insertRollbackItem(ctx, 0, true, "return {};", {
+              priorProjectionJson,
+            });
+          })
+        );
+
+        const page = yield* Effect.promise(() => readPage(t, -1, 1));
+
+        const prior = page.records[0]?.prior;
+        assert.ok(prior && "projection" in prior);
+        assert.ok("date" in prior.projection.metadata);
+        assert.strictEqual(prior.projection.metadata.date, datePublished);
+        assert.ok(!("datePublished" in prior.projection.metadata));
       })
-    );
-    const activeFailure = await Effect.runPromise(
-      decodeProjectionJson(priorProjectionJson).pipe(Effect.flip)
-    );
-    expect(activeFailure).toMatchObject({
-      code: "CONTENT_RELEASE_INTEGRITY",
-    });
-    await t.mutation(async (ctx) => {
-      await activateRollbackFixture(ctx, 1);
-      await insertRollbackItem(ctx, 0, true, "return {};", {
-        priorProjectionJson,
-      });
-    });
-
-    const page = await readPage(t, -1, 1);
-
-    expect(page.records[0]?.prior).toHaveProperty(
-      "projection.metadata.date",
-      datePublished
-    );
-    expect(page.records[0]?.prior).not.toHaveProperty(
-      "projection.metadata.datePublished"
-    );
-  });
+  );
 
   it("rejects invalid identity, unreadable state, and cursor drift", async () => {
     const invalid = convexTest(schema, convexModules);

--- a/packages/backend/convex/tryouts/mutations/expiry.test.ts
+++ b/packages/backend/convex/tryouts/mutations/expiry.test.ts
@@ -350,4 +350,32 @@ describe("tryouts/mutations/expiry", () => {
       },
     });
   });
+
+  it("rejects an expired section whose parent attempt is missing", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const sectionAttemptId = await t.mutation(async (ctx) => {
+      const fixture = await seedTryoutContentAccessState(ctx, {
+        attemptStatus: "in-progress",
+        sectionStatus: "in-progress",
+        suffix: "expiry-missing-parent",
+      });
+      await ctx.db.patch(fixture.sectionAttemptId, {
+        expiresAt: EXPIRED_AT,
+      });
+      await ctx.db.delete(fixture.attemptId);
+      return fixture.sectionAttemptId;
+    });
+
+    await expect(
+      t.mutation(internal.tryouts.mutations.expiry.section, {
+        expiresAt: EXPIRED_AT,
+        sectionAttemptId,
+      })
+    ).rejects.toMatchObject({
+      data: {
+        code: "TRYOUT_ATTEMPT_NOT_FOUND",
+        message: "Try-out attempt not found.",
+      },
+    });
+  });
 });

--- a/packages/backend/convex/tryouts/mutations/expiry.ts
+++ b/packages/backend/convex/tryouts/mutations/expiry.ts
@@ -2,14 +2,17 @@ import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/functions";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
-import { tryRuntimePromise } from "@repo/backend/convex/tryouts/runtime/error";
+import {
+  TryoutRuntimeError,
+  tryRuntimePromise,
+} from "@repo/backend/convex/tryouts/runtime/error";
 import {
   expireAttempt,
   finalizeSectionAttempt,
 } from "@repo/backend/convex/tryouts/runtime/finish";
 import { makeFunctionReference } from "convex/server";
-import { ConvexError, v } from "convex/values";
-import { Effect } from "effect";
+import { v } from "convex/values";
+import { Clock, Effect } from "effect";
 
 const EXPIRY_SWEEP_LIMIT = 50;
 const EXPIRY_SWEEP_ATTEMPT_BYTES = 6 * 1024 * 1024;
@@ -39,6 +42,64 @@ const sectionReconciliationReference = makeFunctionReference<
   null
 >("tryouts/mutations/expiry:reconcileSections");
 
+/** Expires one still-matching attempt through the typed runtime program. */
+const expireScheduledAttempt = Effect.fn("tryouts.expiry.attempt")(function* (
+  ctx: MutationCtx,
+  args: { attemptId: Id<"tryoutAttempts">; expiresAt: number }
+) {
+  const attemptRow = yield* tryRuntimePromise(() => ctx.db.get(args.attemptId));
+  const now = yield* Clock.currentTimeMillis;
+
+  if (!shouldExpire(attemptRow, args.expiresAt, now)) {
+    return null;
+  }
+
+  yield* expireAttempt(ctx, { attempt: attemptRow, now });
+  return null;
+});
+
+/** Expires one still-matching section through the typed runtime program. */
+const expireScheduledSection = Effect.fn("tryouts.expiry.section")(function* (
+  ctx: MutationCtx,
+  args: { expiresAt: number; sectionAttemptId: Id<"tryoutSectionAttempts"> }
+) {
+  const sectionRow = yield* tryRuntimePromise(() =>
+    ctx.db.get(args.sectionAttemptId)
+  );
+  const now = yield* Clock.currentTimeMillis;
+
+  if (!shouldExpire(sectionRow, args.expiresAt, now)) {
+    return null;
+  }
+
+  const attemptRow = yield* tryRuntimePromise(() =>
+    ctx.db.get(sectionRow.tryoutAttemptId)
+  );
+  if (!attemptRow) {
+    return yield* new TryoutRuntimeError({
+      code: "TRYOUT_ATTEMPT_NOT_FOUND",
+      message: "Try-out attempt not found.",
+    });
+  }
+
+  if (attemptRow.status !== "in-progress") {
+    return null;
+  }
+
+  if (now >= attemptRow.expiresAt) {
+    yield* expireAttempt(ctx, { attempt: attemptRow, now });
+    return null;
+  }
+
+  yield* finalizeSectionAttempt(ctx, {
+    attempt: attemptRow,
+    endReason: "time-expired",
+    now,
+    section: sectionRow,
+  });
+  return null;
+});
+
 /** Expires one overall try-out attempt at its scheduled deadline. */
 export const attempt = internalMutation({
   args: {
@@ -46,17 +107,7 @@ export const attempt = internalMutation({
     expiresAt: v.number(),
   },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    const attemptRow = await ctx.db.get(args.attemptId);
-    const now = Date.now();
-
-    if (!shouldExpire(attemptRow, args.expiresAt, now)) {
-      return null;
-    }
-
-    await runConvexProgram(expireAttempt(ctx, { attempt: attemptRow, now }));
-    return null;
-  },
+  handler: (ctx, args) => runConvexProgram(expireScheduledAttempt(ctx, args)),
 });
 
 /** Expires one section attempt at its scheduled section deadline. */
@@ -66,53 +117,7 @@ export const section = internalMutation({
     sectionAttemptId: v.id("tryoutSectionAttempts"),
   },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    const sectionRow = await ctx.db.get(args.sectionAttemptId);
-    const now = Date.now();
-
-    if (!shouldExpire(sectionRow, args.expiresAt, now)) {
-      return null;
-    }
-
-    const attemptRow = await ctx.db.get(sectionRow.tryoutAttemptId);
-
-    if (!attemptRow) {
-      throw new ConvexError({
-        code: "TRYOUT_ATTEMPT_NOT_FOUND",
-        message: "Try-out attempt not found.",
-      });
-    }
-
-    if (attemptRow.status !== "in-progress") {
-      return null;
-    }
-
-    if (now >= attemptRow.expiresAt) {
-      await runConvexProgram(expireAttempt(ctx, { attempt: attemptRow, now }));
-      return null;
-    }
-
-    await runConvexProgram(
-      finalizeSectionAttempt(ctx, {
-        attempt: attemptRow,
-        endReason: "time-expired",
-        now,
-        section: sectionRow,
-      })
-    );
-
-    return null;
-  },
-});
-
-/** Reconciles missed try-out expiry jobs in bounded pages. */
-export const sweep = internalMutation({
-  args: {},
-  returns: v.null(),
-  handler: async (ctx) => {
-    await runConvexProgram(startExpiryReconciliation(ctx, Date.now()));
-    return null;
-  },
+  handler: (ctx, args) => runConvexProgram(expireScheduledSection(ctx, args)),
 });
 
 /** Starts one sequential, byte-bounded missed-expiry reconciliation. */
@@ -124,14 +129,27 @@ const startExpiryReconciliation = Effect.fn(
   );
 });
 
+/** Starts one current-time expiry sweep through the typed runtime program. */
+const startExpirySweep = Effect.fn("tryouts.expiry.sweep")(function* (
+  ctx: MutationCtx
+) {
+  yield* startExpiryReconciliation(ctx, yield* Clock.currentTimeMillis);
+  return null;
+});
+
+/** Reconciles missed try-out expiry jobs in bounded pages. */
+export const sweep = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: (ctx) => runConvexProgram(startExpirySweep(ctx)),
+});
+
 /** Queues missed attempt expiries before handing off section reconciliation. */
 export const reconcileAttempts = internalMutation({
   args: { before: v.number() },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    await runConvexProgram(reconcileMissedAttemptExpiries(ctx, args.before));
-    return null;
-  },
+  handler: (ctx, args) =>
+    runConvexProgram(reconcileMissedAttemptExpiries(ctx, args.before)),
 });
 
 const reconcileMissedAttemptExpiries = Effect.fn(
@@ -171,6 +189,7 @@ const reconcileMissedAttemptExpiries = Effect.fn(
       scheduledAttemptIds,
     })
   );
+  return null;
 });
 
 /** Queues section expiries whose parent was not handled by the attempt phase. */
@@ -180,15 +199,13 @@ export const reconcileSections = internalMutation({
     scheduledAttemptIds: v.array(v.id("tryoutAttempts")),
   },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    await runConvexProgram(
+  handler: (ctx, args) =>
+    runConvexProgram(
       reconcileMissedSectionExpiries(ctx, {
         before: args.before,
         scheduledAttemptIds: args.scheduledAttemptIds,
       })
-    );
-    return null;
-  },
+    ),
 });
 
 const reconcileMissedSectionExpiries = Effect.fn(
@@ -227,6 +244,7 @@ const reconcileMissedSectionExpiries = Effect.fn(
       ),
     { concurrency: "unbounded", discard: true }
   );
+  return null;
 });
 
 /** Returns true when a scheduled expiry job still matches an active row. */

--- a/packages/backend/convex/tryouts/runtime/finish.ts
+++ b/packages/backend/convex/tryouts/runtime/finish.ts
@@ -91,6 +91,7 @@ const createExpiredSectionAttempt = Effect.fn(
     source: args.scoreSource,
     totalQuestions: args.snapshot.questionCount,
   });
+  const sectionScore = yield* getSectionScoreSnapshot(score);
 
   yield* tryRuntimePromise(() =>
     ctx.db.insert("tryoutSectionAttempts", {
@@ -103,7 +104,7 @@ const createExpiredSectionAttempt = Effect.fn(
       sectionIdentity: args.snapshot.sectionIdentity,
       sectionKey: args.snapshot.sectionKey,
       sectionOrder: args.snapshot.sectionOrder,
-      score: getSectionScoreSnapshot(score),
+      score: sectionScore,
       startedAt: args.attempt.expiresAt,
       status: "expired",
       totalQuestions: args.snapshot.questionCount,
@@ -360,10 +361,11 @@ const readSectionFinalization = Effect.fn(
     source: args.scoreSource,
     totalQuestions: args.section.totalQuestions,
   });
+  const sectionScore = yield* getSectionScoreSnapshot(score);
 
   return {
     ...summary,
-    score: getSectionScoreSnapshot(score),
+    score: sectionScore,
   };
 });
 

--- a/packages/backend/convex/tryouts/runtime/result.test.ts
+++ b/packages/backend/convex/tryouts/runtime/result.test.ts
@@ -1,0 +1,63 @@
+import { assert, describe, it } from "@effect/vitest";
+import { TryoutRuntimeError } from "@repo/backend/convex/tryouts/runtime/error";
+import {
+  type AttemptScore,
+  getSectionScoreSnapshot,
+} from "@repo/backend/convex/tryouts/runtime/result";
+import { Effect } from "effect";
+
+const completeScore: AttemptScore = {
+  publishedScore: 72,
+  rawScore: 70,
+  scoreStatus: "provisional",
+  scoringStrategy: "irt",
+  theta: 0.55,
+  thetaSE: 0.18,
+  totalCorrect: 7,
+  totalQuestions: 10,
+};
+
+describe("tryouts/runtime/result", () => {
+  it.effect("projects complete and estimate-free section scores", () =>
+    Effect.gen(function* () {
+      assert.deepStrictEqual(yield* getSectionScoreSnapshot(completeScore), {
+        publishedScore: 72,
+        rawScore: 70,
+        scoreStatus: "provisional",
+        scoringStrategy: "irt",
+        theta: 0.55,
+        thetaSE: 0.18,
+      });
+      assert.deepStrictEqual(
+        yield* getSectionScoreSnapshot({
+          ...completeScore,
+          scoringStrategy: "raw",
+          theta: undefined,
+          thetaSE: undefined,
+        }),
+        {
+          publishedScore: 72,
+          rawScore: 70,
+          scoreStatus: "provisional",
+          scoringStrategy: "raw",
+        }
+      );
+    })
+  );
+
+  it.effect("rejects a partial score estimate in the typed error channel", () =>
+    Effect.gen(function* () {
+      const failure = yield* getSectionScoreSnapshot({
+        ...completeScore,
+        thetaSE: undefined,
+      }).pipe(Effect.flip);
+
+      assert.ok(failure instanceof TryoutRuntimeError);
+      assert.strictEqual(failure.code, "TRYOUT_SCORE_ESTIMATE_INCOMPLETE");
+      assert.strictEqual(
+        failure.message,
+        "Try-out score estimate is missing theta or standard error."
+      );
+    })
+  );
+});

--- a/packages/backend/convex/tryouts/runtime/result.ts
+++ b/packages/backend/convex/tryouts/runtime/result.ts
@@ -1,10 +1,11 @@
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import { TryoutRuntimeError } from "@repo/backend/convex/tryouts/runtime/error";
 import type {
   TryoutScoreResult,
   TryoutScoringStrategy,
   TryoutSectionScore,
 } from "@repo/backend/convex/tryouts/score";
-import { ConvexError } from "convex/values";
+import { Effect } from "effect";
 
 /** Stores the complete score snapshot produced before finalizing an attempt. */
 export interface AttemptScore extends TryoutScoreResult {
@@ -34,9 +35,9 @@ export function scoreRawAnswers({
 }
 
 /** Stores the immutable section-owned subset of one calculated score. */
-export function getSectionScoreSnapshot(
-  score: AttemptScore
-): TryoutSectionScore {
+export const getSectionScoreSnapshot = Effect.fn(
+  "tryouts.runtime.getSectionScoreSnapshot"
+)(function* (score: AttemptScore) {
   const snapshot: TryoutSectionScore = {
     publishedScore: score.publishedScore,
     rawScore: score.rawScore,
@@ -49,7 +50,7 @@ export function getSectionScoreSnapshot(
   }
 
   if (score.theta === undefined || score.thetaSE === undefined) {
-    throw new ConvexError({
+    return yield* new TryoutRuntimeError({
       code: "TRYOUT_SCORE_ESTIMATE_INCOMPLETE",
       message: "Try-out score estimate is missing theta or standard error.",
     });
@@ -60,7 +61,7 @@ export function getSectionScoreSnapshot(
     theta: score.theta,
     thetaSE: score.thetaSE,
   };
-}
+});
 
 /** Converts raw correctness into a bounded public percentage score. */
 export function getRawPercentage(

--- a/scripts/check/effect.test.ts
+++ b/scripts/check/effect.test.ts
@@ -1,0 +1,56 @@
+import { assert, describe, it } from "@effect/vitest";
+import { effectTestViolations } from "#scripts/check/effect";
+
+const FILE = "packages/example/src/program.test.ts";
+const VIOLATION =
+  "packages/example/src/program.test.ts: return the Effect to @effect/vitest instead of running it.";
+
+describe("Effect test policy", () => {
+  it("rejects imported Effect and ManagedRuntime runners", () => {
+    for (const source of [
+      'import { Effect } from "effect";\nEffect.runPromise(program);',
+      'import { Effect } from "effect";\nEffect["runSync"](program);',
+      'import * as Runtime from "effect";\nRuntime.Effect.runFork(program);',
+      'import { Effect } from "effect";\nconst Runtime = Effect;\nRuntime[key](program);',
+      'import { runPromise as execute } from "effect/Effect";\nexecute(program);',
+      'import { ManagedRuntime } from "effect";\nconst runtime = ManagedRuntime.make(layer);\nruntime.runSync(program);',
+      'const Runtime = await import("effect");\nRuntime.Effect.runFork(program);',
+    ]) {
+      assert.deepStrictEqual(effectTestViolations(FILE, source), [VIOLATION]);
+    }
+  });
+
+  it("rejects runners exposed through runtime destructuring", () => {
+    for (const source of [
+      'import { Effect } from "effect";\nconst { runPromise } = Effect;',
+      'import { ManagedRuntime } from "effect";\nconst runtime = ManagedRuntime.make(layer);\nconst { runFork } = runtime;',
+    ]) {
+      assert.deepStrictEqual(effectTestViolations(FILE, source), [VIOLATION]);
+    }
+  });
+
+  it("allows native tests, types, and unrelated method names", () => {
+    for (const source of [
+      'import { Effect } from "effect";\nimport { it } from "@effect/vitest";\nit.effect("runs", () => Effect.succeed(1));',
+      'import { it } from "@effect/vitest";\nit("pure", () => true);',
+      'import type { runPromise } from "effect/Effect";\ntype Runner = typeof runPromise;',
+      'import { Effect } from "effect";\ntype Runner = typeof Effect.runPromise;\nEffect.succeed(1);',
+      'import { Schema } from "effect";\nSchema.runSync(program);',
+      'import { Effect, Schema } from "effect";\nSchema.runSync(program);',
+      'import { Effect } from "effect";\nclient.runPromise(program);',
+      'import { Effect } from "effect";\nclient["runPromise"](program);',
+      'import { Effect } from "effect";\nconst { runPromise } = client;',
+      'import { Effect } from "effect";\nEffect["succeed"](1);',
+      'const { Effect } = await import("effect");\nEffect.void;',
+    ]) {
+      assert.deepStrictEqual(effectTestViolations(FILE, source), []);
+    }
+    assert.deepStrictEqual(
+      effectTestViolations(
+        "packages/example/src/program.ts",
+        'import { Effect } from "effect";\nEffect.runSync(program);'
+      ),
+      []
+    );
+  });
+});

--- a/scripts/check/effect.test.ts
+++ b/scripts/check/effect.test.ts
@@ -14,7 +14,10 @@ describe("Effect test policy", () => {
       'import { Effect } from "effect";\nconst Runtime = Effect;\nRuntime[key](program);',
       'import { runPromise as execute } from "effect/Effect";\nexecute(program);',
       'import { ManagedRuntime } from "effect";\nconst runtime = ManagedRuntime.make(layer);\nruntime.runSync(program);',
+      'import { make } from "effect/ManagedRuntime";\nconst runtime = make(layer);\nruntime.runPromise(program);',
+      'import { make as buildRuntime } from "effect/ManagedRuntime";\nconst runtime = buildRuntime(layer);\nruntime.runPromise(program);',
       'const Runtime = await import("effect");\nRuntime.Effect.runFork(program);',
+      'const { make: buildRuntime } = await import("effect/ManagedRuntime");\nconst runtime = buildRuntime(layer);\nruntime.runPromise(program);',
     ]) {
       assert.deepStrictEqual(effectTestViolations(FILE, source), [VIOLATION]);
     }

--- a/scripts/check/effect.test.ts
+++ b/scripts/check/effect.test.ts
@@ -29,6 +29,23 @@ describe("Effect test policy", () => {
     }
   });
 
+  it("resolves runtime aliases by lexical binding", () => {
+    assert.deepStrictEqual(
+      effectTestViolations(
+        FILE,
+        'import { Effect } from "effect";\nconst runtime = client;\n{\n  const runtime = Effect;\n  runtime.runPromise(program);\n}'
+      ),
+      [VIOLATION]
+    );
+    assert.deepStrictEqual(
+      effectTestViolations(
+        FILE,
+        'import { Effect } from "effect";\nconst runtime = Effect;\n{\n  const runtime = client;\n  runtime.runPromise(program);\n}'
+      ),
+      []
+    );
+  });
+
   it("allows native tests, types, and unrelated method names", () => {
     for (const source of [
       'import { Effect } from "effect";\nimport { it } from "@effect/vitest";\nit.effect("runs", () => Effect.succeed(1));',

--- a/scripts/check/effect.ts
+++ b/scripts/check/effect.ts
@@ -1,0 +1,300 @@
+import ts from "typescript";
+
+const TEST_MODULE_PATTERN = /\.test\.ts$/u;
+const EFFECT_RUNNERS = new Set(
+  "runCallback runCallbackWith runFork runForkWith runPromise runPromiseExit runPromiseExitWith runPromiseWith runSync runSyncExit runSyncExitWith runSyncWith".split(
+    " "
+  )
+);
+const MANAGED_RUNTIME_RUNNERS = new Set(
+  "runCallback runFork runPromise runPromiseExit runSync runSyncExit".split(" ")
+);
+
+type RuntimeKind = "effect" | "managed-factory" | "managed-runtime" | "root";
+
+interface RuntimeImports {
+  readonly bindings: Map<string, RuntimeKind>;
+  readonly directRunner: boolean;
+}
+
+/** Returns value-position descendants while excluding type-only subtrees. */
+function descendants(sourceFile: ts.SourceFile) {
+  const nodes: ts.Node[] = [sourceFile];
+  for (const node of nodes) {
+    if (ts.isTypeNode(node)) {
+      continue;
+    }
+    ts.forEachChild(node, (child) => {
+      nodes.push(child);
+    });
+  }
+  return nodes;
+}
+
+function importedModule(node: ts.Node) {
+  if (
+    ts.isImportDeclaration(node) &&
+    ts.isStringLiteral(node.moduleSpecifier)
+  ) {
+    return node.moduleSpecifier.text;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    node.expression.kind === ts.SyntaxKind.ImportKeyword
+  ) {
+    const [specifier] = node.arguments;
+    return specifier !== undefined && ts.isStringLiteralLike(specifier)
+      ? specifier.text
+      : undefined;
+  }
+}
+
+function staticProperty(node: ts.Node | undefined) {
+  return node !== undefined &&
+    (ts.isIdentifier(node) || ts.isStringLiteralLike(node))
+    ? node.text
+    : undefined;
+}
+
+function staticElement(node: ts.Expression) {
+  return ts.isStringLiteralLike(node) || ts.isNumericLiteral(node)
+    ? node.text
+    : undefined;
+}
+
+/** Collects local bindings that expose Effect runtime modules. */
+function runtimeImports(nodes: readonly ts.Node[]): RuntimeImports {
+  const bindings = new Map<string, RuntimeKind>();
+  let directRunner = false;
+
+  for (const node of nodes) {
+    const moduleName = importedModule(node);
+    if (
+      moduleName !== "effect" &&
+      moduleName !== "effect/Effect" &&
+      moduleName !== "effect/ManagedRuntime"
+    ) {
+      continue;
+    }
+    if (!ts.isImportDeclaration(node)) {
+      continue;
+    }
+
+    const clause = node.importClause;
+    const namedBindings = clause?.namedBindings;
+    if (clause?.isTypeOnly !== false || namedBindings === undefined) {
+      continue;
+    }
+    if (ts.isNamespaceImport(namedBindings)) {
+      if (moduleName === "effect") {
+        bindings.set(namedBindings.name.text, "root");
+      } else {
+        bindings.set(
+          namedBindings.name.text,
+          moduleName === "effect/Effect" ? "effect" : "managed-factory"
+        );
+      }
+      continue;
+    }
+
+    for (const binding of namedBindings.elements) {
+      if (binding.isTypeOnly) {
+        continue;
+      }
+      const importedName = binding.propertyName?.text ?? binding.name.text;
+      if (moduleName === "effect") {
+        if (importedName === "Effect") {
+          bindings.set(binding.name.text, "effect");
+        } else if (importedName === "ManagedRuntime") {
+          bindings.set(binding.name.text, "managed-factory");
+        }
+      } else if (moduleName === "effect/Effect") {
+        directRunner ||= EFFECT_RUNNERS.has(importedName);
+      }
+    }
+  }
+
+  return { bindings, directRunner };
+}
+
+/** Resolves an imported Effect module, factory, or runtime expression. */
+function runtimeKind(
+  node: ts.Node,
+  imports: RuntimeImports
+): RuntimeKind | undefined {
+  if (ts.isAwaitExpression(node)) {
+    return runtimeKind(node.expression, imports);
+  }
+  if (ts.isIdentifier(node)) {
+    return imports.bindings.get(node.text);
+  }
+  if (
+    ts.isPropertyAccessExpression(node) ||
+    ts.isElementAccessExpression(node)
+  ) {
+    const member = ts.isPropertyAccessExpression(node)
+      ? node.name.text
+      : staticElement(node.argumentExpression);
+    if (runtimeKind(node.expression, imports) === "root") {
+      if (member === "Effect") {
+        return "effect";
+      }
+      if (member === "ManagedRuntime") {
+        return "managed-factory";
+      }
+    }
+    return undefined;
+  }
+  if (!ts.isCallExpression(node)) {
+    return undefined;
+  }
+  if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+    const moduleName = importedModule(node);
+    if (moduleName === "effect") {
+      return "root";
+    }
+    if (moduleName === "effect/Effect") {
+      return "effect";
+    }
+    return moduleName === "effect/ManagedRuntime"
+      ? "managed-factory"
+      : undefined;
+  }
+  const callee = node.expression;
+  if (
+    (ts.isPropertyAccessExpression(callee) ||
+      ts.isElementAccessExpression(callee)) &&
+    runtimeKind(callee.expression, imports) === "managed-factory"
+  ) {
+    const member = ts.isPropertyAccessExpression(callee)
+      ? callee.name.text
+      : staticElement(callee.argumentExpression);
+    return member === "make" ? "managed-runtime" : undefined;
+  }
+}
+
+function rootMemberKind(member: string | undefined): RuntimeKind | undefined {
+  if (member === "Effect") {
+    return "effect";
+  }
+  return member === "ManagedRuntime" ? "managed-factory" : undefined;
+}
+
+function collectRootBindings(
+  pattern: ts.ObjectBindingPattern,
+  imports: RuntimeImports
+) {
+  let changed = false;
+  for (const element of pattern.elements) {
+    if (!ts.isIdentifier(element.name)) {
+      continue;
+    }
+    const member = staticProperty(element.propertyName ?? element.name);
+    const kind = rootMemberKind(member);
+    if (kind !== undefined && !imports.bindings.has(element.name.text)) {
+      imports.bindings.set(element.name.text, kind);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function collectVariableAlias(
+  declaration: ts.VariableDeclaration,
+  imports: RuntimeImports
+) {
+  if (declaration.initializer === undefined) {
+    return false;
+  }
+  const kind = runtimeKind(declaration.initializer, imports);
+  if (ts.isObjectBindingPattern(declaration.name)) {
+    return kind === "root" && collectRootBindings(declaration.name, imports);
+  }
+  if (
+    kind === undefined ||
+    !ts.isIdentifier(declaration.name) ||
+    imports.bindings.has(declaration.name.text)
+  ) {
+    return false;
+  }
+  imports.bindings.set(declaration.name.text, kind);
+  return true;
+}
+
+/** Extends imported runtime bindings through direct local aliases. */
+function collectAliases(nodes: readonly ts.Node[], imports: RuntimeImports) {
+  let changed = true;
+  while (changed) {
+    changed = nodes.some(
+      (node) =>
+        ts.isVariableDeclaration(node) && collectVariableAlias(node, imports)
+    );
+  }
+}
+
+function runtimeRunners(node: ts.Node, imports: RuntimeImports) {
+  const kind = runtimeKind(node, imports);
+  if (kind === "effect") {
+    return EFFECT_RUNNERS;
+  }
+  return kind === "managed-runtime" ? MANAGED_RUNTIME_RUNNERS : undefined;
+}
+
+function isRunnerMember(node: ts.Node, imports: RuntimeImports) {
+  if (
+    !(ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node))
+  ) {
+    return false;
+  }
+  const runners = runtimeRunners(node.expression, imports);
+  if (runners === undefined) {
+    return false;
+  }
+  const member = ts.isPropertyAccessExpression(node)
+    ? node.name.text
+    : staticElement(node.argumentExpression);
+  return member === undefined || runners.has(member);
+}
+
+/** Tests whether one destructuring pattern extracts a runtime runner. */
+function destructuresRunner(node: ts.Node, imports: RuntimeImports) {
+  if (
+    !(ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name)) ||
+    node.initializer === undefined
+  ) {
+    return false;
+  }
+  const runners = runtimeRunners(node.initializer, imports);
+  return (
+    runners !== undefined &&
+    node.name.elements.some((element) =>
+      runners.has(staticProperty(element.propertyName ?? element.name) ?? "")
+    )
+  );
+}
+
+/** Reports authored tests that manually run an Effect runtime. */
+export function effectTestViolations(file: string, sourceText: string) {
+  if (!TEST_MODULE_PATTERN.test(file)) {
+    return [];
+  }
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const nodes = descendants(sourceFile);
+  const imports = runtimeImports(nodes);
+  collectAliases(nodes, imports);
+  const hasRunner =
+    imports.directRunner ||
+    nodes.some(
+      (node) =>
+        isRunnerMember(node, imports) || destructuresRunner(node, imports)
+    );
+
+  return hasRunner
+    ? [`${file}: return the Effect to @effect/vitest instead of running it.`]
+    : [];
+}

--- a/scripts/check/effect.ts
+++ b/scripts/check/effect.ts
@@ -13,8 +13,41 @@ const MANAGED_RUNTIME_RUNNERS = new Set(
 type RuntimeKind = "effect" | "managed-factory" | "managed-runtime" | "root";
 
 interface RuntimeImports {
-  readonly bindings: Map<string, RuntimeKind>;
+  readonly bindings: Map<ts.Symbol, RuntimeKind>;
+  readonly checker: ts.TypeChecker;
   readonly directRunner: boolean;
+}
+
+interface ParsedTestModule {
+  readonly checker: ts.TypeChecker;
+  readonly sourceFile: ts.SourceFile;
+}
+
+/** Parses one test with enough binding information to resolve lexical scope. */
+function parseTestModule(file: string, sourceText: string): ParsedTestModule {
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const host: ts.CompilerHost = {
+    fileExists: (candidate) => candidate === file,
+    getCanonicalFileName: (candidate) => candidate,
+    getCurrentDirectory: () => "",
+    getDefaultLibFileName: () => "",
+    getNewLine: () => "\n",
+    getSourceFile: (candidate) => (candidate === file ? sourceFile : undefined),
+    readFile: (candidate) => (candidate === file ? sourceText : undefined),
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => undefined,
+  };
+  const program = ts.createProgram({
+    host,
+    options: { noLib: true, noResolve: true },
+    rootNames: [file],
+  });
+  return { checker: program.getTypeChecker(), sourceFile };
 }
 
 /** Returns value-position descendants while excluding type-only subtrees. */
@@ -63,8 +96,11 @@ function staticElement(node: ts.Expression) {
 }
 
 /** Collects local bindings that expose Effect runtime modules. */
-function runtimeImports(nodes: readonly ts.Node[]): RuntimeImports {
-  const bindings = new Map<string, RuntimeKind>();
+function runtimeImports(
+  nodes: readonly ts.Node[],
+  checker: ts.TypeChecker
+): RuntimeImports {
+  const bindings = new Map<ts.Symbol, RuntimeKind>();
   let directRunner = false;
 
   for (const node of nodes) {
@@ -86,11 +122,15 @@ function runtimeImports(nodes: readonly ts.Node[]): RuntimeImports {
       continue;
     }
     if (ts.isNamespaceImport(namedBindings)) {
+      const symbol = checker.getSymbolAtLocation(namedBindings.name);
+      if (symbol === undefined) {
+        continue;
+      }
       if (moduleName === "effect") {
-        bindings.set(namedBindings.name.text, "root");
+        bindings.set(symbol, "root");
       } else {
         bindings.set(
-          namedBindings.name.text,
+          symbol,
           moduleName === "effect/Effect" ? "effect" : "managed-factory"
         );
       }
@@ -102,11 +142,15 @@ function runtimeImports(nodes: readonly ts.Node[]): RuntimeImports {
         continue;
       }
       const importedName = binding.propertyName?.text ?? binding.name.text;
+      const symbol = checker.getSymbolAtLocation(binding.name);
+      if (symbol === undefined) {
+        continue;
+      }
       if (moduleName === "effect") {
         if (importedName === "Effect") {
-          bindings.set(binding.name.text, "effect");
+          bindings.set(symbol, "effect");
         } else if (importedName === "ManagedRuntime") {
-          bindings.set(binding.name.text, "managed-factory");
+          bindings.set(symbol, "managed-factory");
         }
       } else if (moduleName === "effect/Effect") {
         directRunner ||= EFFECT_RUNNERS.has(importedName);
@@ -114,7 +158,7 @@ function runtimeImports(nodes: readonly ts.Node[]): RuntimeImports {
     }
   }
 
-  return { bindings, directRunner };
+  return { bindings, checker, directRunner };
 }
 
 /** Resolves an imported Effect module, factory, or runtime expression. */
@@ -126,7 +170,8 @@ function runtimeKind(
     return runtimeKind(node.expression, imports);
   }
   if (ts.isIdentifier(node)) {
-    return imports.bindings.get(node.text);
+    const symbol = imports.checker.getSymbolAtLocation(node);
+    return symbol === undefined ? undefined : imports.bindings.get(symbol);
   }
   if (
     ts.isPropertyAccessExpression(node) ||
@@ -191,8 +236,13 @@ function collectRootBindings(
     }
     const member = staticProperty(element.propertyName ?? element.name);
     const kind = rootMemberKind(member);
-    if (kind !== undefined && !imports.bindings.has(element.name.text)) {
-      imports.bindings.set(element.name.text, kind);
+    const symbol = imports.checker.getSymbolAtLocation(element.name);
+    if (
+      kind !== undefined &&
+      symbol !== undefined &&
+      !imports.bindings.has(symbol)
+    ) {
+      imports.bindings.set(symbol, kind);
       changed = true;
     }
   }
@@ -210,14 +260,17 @@ function collectVariableAlias(
   if (ts.isObjectBindingPattern(declaration.name)) {
     return kind === "root" && collectRootBindings(declaration.name, imports);
   }
+  const symbol = ts.isIdentifier(declaration.name)
+    ? imports.checker.getSymbolAtLocation(declaration.name)
+    : undefined;
   if (
     kind === undefined ||
-    !ts.isIdentifier(declaration.name) ||
-    imports.bindings.has(declaration.name.text)
+    symbol === undefined ||
+    imports.bindings.has(symbol)
   ) {
     return false;
   }
-  imports.bindings.set(declaration.name.text, kind);
+  imports.bindings.set(symbol, kind);
   return true;
 }
 
@@ -278,14 +331,9 @@ export function effectTestViolations(file: string, sourceText: string) {
   if (!TEST_MODULE_PATTERN.test(file)) {
     return [];
   }
-  const sourceFile = ts.createSourceFile(
-    file,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true
-  );
+  const { checker, sourceFile } = parseTestModule(file, sourceText);
   const nodes = descendants(sourceFile);
-  const imports = runtimeImports(nodes);
+  const imports = runtimeImports(nodes, checker);
   collectAliases(nodes, imports);
   const hasRunner =
     imports.directRunner ||

--- a/scripts/check/effect.ts
+++ b/scripts/check/effect.ts
@@ -10,7 +10,12 @@ const MANAGED_RUNTIME_RUNNERS = new Set(
   "runCallback runFork runPromise runPromiseExit runSync runSyncExit".split(" ")
 );
 
-type RuntimeKind = "effect" | "managed-factory" | "managed-runtime" | "root";
+type RuntimeKind =
+  | "effect"
+  | "managed-make"
+  | "managed-module"
+  | "managed-runtime"
+  | "root";
 
 interface RuntimeImports {
   readonly bindings: Map<ts.Symbol, RuntimeKind>;
@@ -131,7 +136,7 @@ function runtimeImports(
       } else {
         bindings.set(
           symbol,
-          moduleName === "effect/Effect" ? "effect" : "managed-factory"
+          moduleName === "effect/Effect" ? "effect" : "managed-module"
         );
       }
       continue;
@@ -150,10 +155,12 @@ function runtimeImports(
         if (importedName === "Effect") {
           bindings.set(symbol, "effect");
         } else if (importedName === "ManagedRuntime") {
-          bindings.set(symbol, "managed-factory");
+          bindings.set(symbol, "managed-module");
         }
       } else if (moduleName === "effect/Effect") {
         directRunner ||= EFFECT_RUNNERS.has(importedName);
+      } else if (importedName === "make") {
+        bindings.set(symbol, "managed-make");
       }
     }
   }
@@ -180,15 +187,7 @@ function runtimeKind(
     const member = ts.isPropertyAccessExpression(node)
       ? node.name.text
       : staticElement(node.argumentExpression);
-    if (runtimeKind(node.expression, imports) === "root") {
-      if (member === "Effect") {
-        return "effect";
-      }
-      if (member === "ManagedRuntime") {
-        return "managed-factory";
-      }
-    }
-    return undefined;
+    return runtimeMemberKind(runtimeKind(node.expression, imports), member);
   }
   if (!ts.isCallExpression(node)) {
     return undefined;
@@ -202,31 +201,32 @@ function runtimeKind(
       return "effect";
     }
     return moduleName === "effect/ManagedRuntime"
-      ? "managed-factory"
+      ? "managed-module"
       : undefined;
   }
-  const callee = node.expression;
-  if (
-    (ts.isPropertyAccessExpression(callee) ||
-      ts.isElementAccessExpression(callee)) &&
-    runtimeKind(callee.expression, imports) === "managed-factory"
-  ) {
-    const member = ts.isPropertyAccessExpression(callee)
-      ? callee.name.text
-      : staticElement(callee.argumentExpression);
-    return member === "make" ? "managed-runtime" : undefined;
-  }
+  return runtimeKind(node.expression, imports) === "managed-make"
+    ? "managed-runtime"
+    : undefined;
 }
 
-function rootMemberKind(member: string | undefined): RuntimeKind | undefined {
-  if (member === "Effect") {
+function runtimeMemberKind(
+  owner: RuntimeKind | undefined,
+  member: string | undefined
+): RuntimeKind | undefined {
+  if (owner === "root" && member === "Effect") {
     return "effect";
   }
-  return member === "ManagedRuntime" ? "managed-factory" : undefined;
+  if (owner === "root" && member === "ManagedRuntime") {
+    return "managed-module";
+  }
+  return owner === "managed-module" && member === "make"
+    ? "managed-make"
+    : undefined;
 }
 
-function collectRootBindings(
+function collectMemberBindings(
   pattern: ts.ObjectBindingPattern,
+  owner: RuntimeKind,
   imports: RuntimeImports
 ) {
   let changed = false;
@@ -235,7 +235,7 @@ function collectRootBindings(
       continue;
     }
     const member = staticProperty(element.propertyName ?? element.name);
-    const kind = rootMemberKind(member);
+    const kind = runtimeMemberKind(owner, member);
     const symbol = imports.checker.getSymbolAtLocation(element.name);
     if (
       kind !== undefined &&
@@ -258,7 +258,10 @@ function collectVariableAlias(
   }
   const kind = runtimeKind(declaration.initializer, imports);
   if (ts.isObjectBindingPattern(declaration.name)) {
-    return kind === "root" && collectRootBindings(declaration.name, imports);
+    return (
+      kind !== undefined &&
+      collectMemberBindings(declaration.name, kind, imports)
+    );
   }
   const symbol = ts.isIdentifier(declaration.name)
     ? imports.checker.getSymbolAtLocation(declaration.name)

--- a/scripts/check/tests.ts
+++ b/scripts/check/tests.ts
@@ -1,5 +1,6 @@
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Effect, FileSystem, Path, Schema } from "effect";
+import { effectTestViolations } from "#scripts/check/effect";
 import { writeError, writeOutput } from "#scripts/output";
 
 const TEST_FILE_PATTERN = /\.test\.tsx?$/u;
@@ -86,11 +87,16 @@ const hasColocatedOwner = Effect.fn("RepositoryPolicy.hasColocatedOwner")(
 /** Validates test ownership and final repository test layout. */
 export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
   function* (root: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const files = yield* Effect.forEach(["apps", "packages"], (directory) =>
       readFiles(path.join(root, directory))
     ).pipe(Effect.map((groups) => groups.flat()));
+    const scriptFiles = yield* readFiles(path.join(root, "scripts"));
     const tests = files.filter((file) => TEST_FILE_PATTERN.test(file));
+    const effectTests = [...tests, ...scriptFiles].filter((file) =>
+      TEST_FILE_PATTERN.test(file)
+    );
     const ownership = yield* Effect.forEach(tests, (test) =>
       hasColocatedOwner(test).pipe(
         Effect.map((hasOwner) => ({ hasOwner, test }))
@@ -105,11 +111,24 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
     const nestedTestFiles = files.filter((file) =>
       file.split(path.sep).some((segment) => TEST_DIRECTORIES.has(segment))
     );
+    const effectViolations = (yield* Effect.forEach(effectTests, (test) =>
+      fileSystem.readFileString(test).pipe(
+        Effect.map(effectTestViolations.bind(undefined, test)),
+        Effect.mapError(
+          (cause) =>
+            new TestPolicyReadError({
+              cause,
+              message: `Unable to read ${test}.`,
+            })
+        )
+      )
+    )).flat();
 
     if (
       orphanTests.length === 0 &&
       tsxTestFiles.length === 0 &&
-      nestedTestFiles.length === 0
+      nestedTestFiles.length === 0 &&
+      effectViolations.length === 0
     ) {
       yield* writeOutput("Test ownership checks passed.\n");
       return 0;
@@ -135,6 +154,9 @@ export const checkTestPolicy = Effect.fn("RepositoryPolicy.checkTests")(
           .map((file) => `  - ${path.relative(root, file)}`)
           .join("\n")}\n`
       );
+    }
+    if (effectViolations.length > 0) {
+      yield* writeError(`${effectViolations.join("\n")}\n`);
     }
 
     return 1;


### PR DESCRIPTION
## Summary

- compose Effect-returning tests through `it.effect` and reserve `it.live` for intentional live-service tests
- prohibit manual Effect and ManagedRuntime runners across authored app, package, and script tests with a receiver-aware AST policy
- make score extraction, scheduled expiry reads, current time, and expected failures native Effect v4 programs
- keep `runConvexProgram` only at Convex handler boundaries

## Verification

- `pnpm lint`
- `pnpm test:scripts`: 16 files, 60 tests passed
- focused WWW: 2 files, 17 tests passed
- focused backend: 3 files, 7 tests passed
- WWW and backend typechecks
- `git diff --check`