### PR TITLE
fix(tryout): bridge featured response deployment

### DIFF
--- a/apps/www/components/marketing/about/features-tryout.tsx
+++ b/apps/www/components/marketing/about/features-tryout.tsx
@@ -1,17 +1,12 @@
-import type { api } from "@repo/backend/convex/_generated/api";
-import type { FunctionReturnType } from "convex/server";
+import type { QuestionResponse } from "@nakafa/aksara-contracts/question/response";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import { renderTryoutResponseLabels } from "@/components/tryout/runtime/response/labels";
 import { TryoutResponsePreview } from "@/components/tryout/runtime/response/preview.client";
 
-type FeaturedTryout = FunctionReturnType<
-  typeof api.tryouts.queries.catalog.getFeaturedQuestion
->;
-
 export interface FeaturesTryoutModel {
   readonly question: ReactNode;
-  readonly response: FeaturedTryout["response"];
+  readonly response: QuestionResponse;
 }
 
 /** Shows one signed production question with the established landing surface. */

--- a/apps/www/components/tryout/catalog/featured.test.ts
+++ b/apps/www/components/tryout/catalog/featured.test.ts
@@ -42,13 +42,23 @@ describe("featured try-out response", () => {
 
   it.effect("rejects a missing response contract", () =>
     Effect.gen(function* () {
-      const exit = yield* Effect.exit(
+      const error = yield* Effect.flip(
         decodeFeaturedResponse({
           question: { contentKey: "ignored-at-this-boundary" },
         })
       );
 
-      expect(exit._tag).toBe("Failure");
+      expect(error._tag).toBe("FeaturedTryoutResponseError");
+    })
+  );
+
+  it.effect("rejects predecessor choices that cannot form a response", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        decodeFeaturedResponse({ choices: [options[0]] })
+      );
+
+      expect(error._tag).toBe("FeaturedTryoutResponseError");
     })
   );
 });

--- a/apps/www/components/tryout/catalog/featured.test.ts
+++ b/apps/www/components/tryout/catalog/featured.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { decodeFeaturedResponse } from "@/components/tryout/catalog/featured";
+
+const options = [
+  {
+    isCorrect: true,
+    label: "Correct",
+    optionKey: "option-1",
+    order: 1,
+  },
+  {
+    isCorrect: false,
+    label: "Incorrect",
+    optionKey: "option-2",
+    order: 2,
+  },
+] as const;
+
+describe("featured try-out response", () => {
+  it.effect("keeps the canonical response", () =>
+    Effect.gen(function* () {
+      const response = yield* decodeFeaturedResponse({
+        question: { contentKey: "ignored-at-this-boundary" },
+        response: { kind: "single-choice", options },
+      });
+
+      expect(response).toEqual({ kind: "single-choice", options });
+    })
+  );
+
+  it.effect("converts predecessor choices during the deployment switch", () =>
+    Effect.gen(function* () {
+      const response = yield* decodeFeaturedResponse({
+        choices: options,
+        question: { contentKey: "ignored-at-this-boundary" },
+      });
+
+      expect(response).toEqual({ kind: "single-choice", options });
+    })
+  );
+
+  it.effect("rejects a missing response contract", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeFeaturedResponse({
+          question: { contentKey: "ignored-at-this-boundary" },
+        })
+      );
+
+      expect(exit._tag).toBe("Failure");
+    })
+  );
+});

--- a/apps/www/components/tryout/catalog/featured.ts
+++ b/apps/www/components/tryout/catalog/featured.ts
@@ -13,6 +13,12 @@ const FeaturedResponseSchema = Schema.Union([
   Schema.Struct({ choices: Schema.Array(PredecessorChoiceSchema) }),
 ]);
 
+/** Expected failure when the deployed featured response matches no contract. */
+export class FeaturedTryoutResponseError extends Schema.TaggedError<FeaturedTryoutResponseError>()(
+  "FeaturedTryoutResponseError",
+  { cause: Schema.Unknown }
+) {}
+
 /**
  * Reads the featured response across the one deployment where web and backend
  * switch from predecessor choices to the canonical response contract.
@@ -21,17 +27,20 @@ const FeaturedResponseSchema = Schema.Union([
  */
 export const decodeFeaturedResponse = Effect.fn(
   "tryouts.catalog.decodeFeaturedResponse"
-)(function* (input: unknown) {
-  const featured = yield* Schema.decodeUnknownEffect(FeaturedResponseSchema, {
-    onExcessProperty: "ignore",
-  })(input);
-  if ("response" in featured) {
-    return featured.response;
-  }
-  return yield* Schema.decodeEffect(QuestionResponseSchema, {
-    onExcessProperty: "error",
-  })({
-    kind: "single-choice",
-    options: featured.choices,
-  });
-});
+)(
+  function* (input: unknown) {
+    const featured = yield* Schema.decodeUnknownEffect(FeaturedResponseSchema, {
+      onExcessProperty: "ignore",
+    })(input);
+    if ("response" in featured) {
+      return featured.response;
+    }
+    return yield* Schema.decodeEffect(QuestionResponseSchema, {
+      onExcessProperty: "error",
+    })({
+      kind: "single-choice",
+      options: featured.choices,
+    });
+  },
+  Effect.mapError((cause) => new FeaturedTryoutResponseError({ cause }))
+);

--- a/apps/www/components/tryout/catalog/featured.ts
+++ b/apps/www/components/tryout/catalog/featured.ts
@@ -1,0 +1,37 @@
+import { QuestionResponseSchema } from "@nakafa/aksara-contracts/question/response";
+import { Effect, Schema } from "effect";
+
+const PredecessorChoiceSchema = Schema.Struct({
+  isCorrect: Schema.Boolean,
+  label: Schema.String,
+  optionKey: Schema.String,
+  order: Schema.Finite,
+});
+
+const FeaturedResponseSchema = Schema.Union([
+  Schema.Struct({ response: QuestionResponseSchema }),
+  Schema.Struct({ choices: Schema.Array(PredecessorChoiceSchema) }),
+]);
+
+/**
+ * Reads the featured response across the one deployment where web and backend
+ * switch from predecessor choices to the canonical response contract.
+ *
+ * Remove this boundary after the canonical backend and web deployment are live.
+ */
+export const decodeFeaturedResponse = Effect.fn(
+  "tryouts.catalog.decodeFeaturedResponse"
+)(function* (input: unknown) {
+  const featured = yield* Schema.decodeUnknownEffect(FeaturedResponseSchema, {
+    onExcessProperty: "ignore",
+  })(input);
+  if ("response" in featured) {
+    return featured.response;
+  }
+  return yield* Schema.decodeEffect(QuestionResponseSchema, {
+    onExcessProperty: "error",
+  })({
+    kind: "single-choice",
+    options: featured.choices,
+  });
+});

--- a/apps/www/components/tryout/catalog/server.ts
+++ b/apps/www/components/tryout/catalog/server.ts
@@ -9,6 +9,7 @@ import { fetchQuery } from "convex/nextjs";
 import type { FunctionArgs } from "convex/server";
 import { Effect, Schema } from "effect";
 import type { Locale } from "next-intl";
+import { decodeFeaturedResponse } from "@/components/tryout/catalog/featured";
 import { loadTryoutQuestion } from "@/components/tryout/content/signed";
 import { applyContentRuntimeCache } from "@/lib/content/cache";
 import { decodeSourceRevision } from "@/lib/content/published/origin";
@@ -41,11 +42,14 @@ export async function readFeaturedTryout(locale: Locale) {
 
   return await Effect.runPromise(
     Effect.gen(function* () {
-      const question = yield* loadTryoutQuestion(featured.question);
+      const [question, response] = yield* Effect.all([
+        loadTryoutQuestion(featured.question),
+        decodeFeaturedResponse(featured),
+      ]);
 
       return {
         question: question.content,
-        response: featured.response,
+        response,
       };
     })
   );


### PR DESCRIPTION
## Summary

- decode the featured try-out response at the server boundary while the production backend still returns predecessor choices
- convert that exact predecessor shape into the canonical single-choice response through Effect Schema
- keep the renderer and UI on the canonical response contract with no visual or journey change
- fail closed for any shape outside the predecessor and canonical contracts

## Root cause

Vercel production deployment `dpl_2kuRU8VZFNtP5HbUqqytpo1zWWpY` built exact merged main `c2df560ab8a11b7ddfba1353b89922d171baa0ce`, but Next.js prerender queried the still-live predecessor Convex function before `convex deploy` could publish the new function. `/en` therefore received `choices` instead of `response`, and `renderTryoutResponseLabels` dereferenced an undefined response.

This boundary exists only for that deployment switch. It must be removed in the terminal cleanup after the canonical backend and web deployment are both live.

## Verification

- production query evidence: predecessor `choices=true`, canonical `response=false`, decoded `single-choice` with 5 options
- focused Effect Vitest: 3 passed with 100% coverage
- `pnpm --filter www typecheck`
- `pnpm lint`
- `pnpm boundaries`
- React Doctor changed scope: 100/100, no findings
- local production build compiled, typechecked, collected page data, and passed the formerly failing `/en` boundary; complete static generation requires the production-only `CONTENT_RUNTIME_TOKEN` unavailable locally
- `git diff --check`
