### PR TITLE
fix(tryout): keep landing featured content stable

### DIFF
--- a/packages/backend/convex/tryouts/catalog/featured.test.ts
+++ b/packages/backend/convex/tryouts/catalog/featured.test.ts
@@ -3,190 +3,179 @@ import {
   ACTIVE_APP_LOCALE_CODES,
   type ActiveAppLocaleCode,
 } from "@nakafa/aksara-contracts/locale";
-import {
-  type TryoutCatalogRow,
-  TryoutCatalogRowSchema,
-} from "@nakafa/aksara-contracts/tryout/catalog";
+import { TryoutCatalogRowSchema } from "@nakafa/aksara-contracts/tryout/catalog";
 import { TryoutPlacementSchema } from "@nakafa/aksara-contracts/tryout/placement";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
-import { readFeaturedTryout } from "@repo/backend/convex/tryouts/catalog/featured";
+import {
+  LANDING_FEATURED_TRYOUT,
+  readFeaturedTryout,
+} from "@repo/backend/convex/tryouts/catalog/featured";
 import { TEST_RELEASE_ID } from "@repo/backend/test/content/release";
 import { insertTestTryoutRuntimeBundle } from "@repo/backend/test/runtime/bundle";
 import { activateTryoutSnapshot } from "@repo/backend/test/tryout/snapshot";
 import {
-  activateTryoutStartSource,
-  makeTryoutStartCatalog,
   makeTryoutStartHierarchy,
   makeTryoutStartPlacement,
-  TRYOUT_REUSED_SECTION,
-  TRYOUT_REUSED_SET,
   TRYOUT_START_CONTENT_HASH,
-  TRYOUT_START_COUNTRY,
-  TRYOUT_START_EXAM,
-  TRYOUT_START_SECTION,
-  TRYOUT_START_SET,
-  TRYOUT_START_TRACK,
 } from "@repo/backend/test/tryout/source";
 import { convexTest } from "convex-test";
 import { Effect, Schema } from "effect";
 
-const FIRST_SOURCE_SEGMENT = `/${TRYOUT_START_SECTION}/${TRYOUT_START_SET}`;
-const SECOND_SOURCE_SEGMENT = `/${TRYOUT_REUSED_SECTION}/${TRYOUT_REUSED_SET}`;
-const SECOND_SET_PATH = `try-out/${TRYOUT_START_COUNTRY}/${TRYOUT_START_EXAM}/${TRYOUT_START_TRACK}/${TRYOUT_REUSED_SET}`;
-const SECOND_TRACK = "second-track";
-const SECOND_TRACK_PATH = `try-out/${TRYOUT_START_COUNTRY}/${TRYOUT_START_EXAM}/${SECOND_TRACK}`;
-const SECOND_TRACK_SET_PATH = `${SECOND_TRACK_PATH}/${TRYOUT_REUSED_SET}`;
-type NestedCatalogRow = Extract<
-  TryoutCatalogRow,
-  { readonly kind: "section" | "set" | "track" }
->;
+const LANDING_SET_PATH = "try-out/indonesia/snbt/2027/set-1";
+const LANDING_CONTENT_ROOT =
+  "question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1";
+const LANDING_SOURCE_ROOT =
+  "packages/corpus/question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1";
+const LANDING_QUESTION_ROOT = `${LANDING_CONTENT_ROOT}/question-1`;
+const LANDING_QUESTION_SOURCE_ROOT = `${LANDING_SOURCE_ROOT}/question-1`;
+const DISTRACTOR_CONTENT_ROOT =
+  "question-bank/tryout/indonesia/snbt/general-reasoning/set-1";
+const DISTRACTOR_SOURCE_ROOT =
+  "packages/corpus/question-bank/tryout/indonesia/snbt/general-reasoning/set-1";
+const DISTRACTOR_QUESTION_ROOT = `${DISTRACTOR_CONTENT_ROOT}/question-1`;
+const DISTRACTOR_QUESTION_SOURCE_ROOT = `${DISTRACTOR_SOURCE_ROOT}/question-1`;
 
-/** Gives copied fixture rows distinct graph identities. */
-function makeSecondSetGraph(graph: TryoutCatalogRow["graph"]) {
-  return {
-    alignmentId: `${graph.alignmentId}:second`,
-    assetId: `${graph.assetId}:second`,
-    conceptId: `${graph.conceptId}:second`,
-    learningObjectId: `${graph.learningObjectId}:second`,
-    lensId: `${graph.lensId}:second`,
-  };
+/** Maps the technical fixture onto the stable landing question identity. */
+function makeLandingHierarchy(
+  locale: ActiveAppLocaleCode,
+  visibility: "internal-entry" | "visible",
+  scoringStrategy: "raw" | "irt" = "raw"
+) {
+  return Schema.decodeSync(Schema.Array(TryoutCatalogRowSchema))(
+    makeTryoutStartHierarchy(locale, visibility, scoringStrategy).map((row) => {
+      switch (row.kind) {
+        case "country":
+          return row;
+        case "exam":
+          return {
+            ...row,
+            examKey: LANDING_FEATURED_TRYOUT.examKey,
+            publicPath: "try-out/indonesia/snbt",
+            title: "SNBT",
+          };
+        case "track":
+          return {
+            ...row,
+            examKey: LANDING_FEATURED_TRYOUT.examKey,
+            publicPath: "try-out/indonesia/snbt/2027",
+            title: "Year 2027",
+            trackKey: LANDING_FEATURED_TRYOUT.trackKey,
+            trackKind: "year",
+          };
+        case "set":
+          return {
+            ...row,
+            examKey: LANDING_FEATURED_TRYOUT.examKey,
+            publicPath: LANDING_SET_PATH,
+            setKey: LANDING_FEATURED_TRYOUT.setKey,
+            title: "Set 1",
+            trackKey: LANDING_FEATURED_TRYOUT.trackKey,
+          };
+        case "section":
+          return {
+            ...row,
+            examKey: LANDING_FEATURED_TRYOUT.examKey,
+            publicPath:
+              visibility === "visible"
+                ? `${LANDING_SET_PATH}/${LANDING_FEATURED_TRYOUT.sectionKey}`
+                : undefined,
+            questionSourcePath: LANDING_SOURCE_ROOT,
+            sectionKey: LANDING_FEATURED_TRYOUT.sectionKey,
+            setKey: LANDING_FEATURED_TRYOUT.setKey,
+            title: "Quantitative Knowledge",
+            trackKey: LANDING_FEATURED_TRYOUT.trackKey,
+          };
+        default:
+          return row;
+      }
+    })
+  );
 }
 
-/** Builds a hierarchy whose first set is private and second set is public. */
-function makeInternalThenVisibleCatalog(locale: ActiveAppLocaleCode) {
-  const privateFirstHierarchy = makeTryoutStartHierarchy(
-    locale,
-    "internal-entry"
-  ).map((row) =>
-    row.kind === "track"
-      ? {
-          ...row,
-          questionCount: 2,
-          sectionCount: 2,
-          setCount: 2,
-          visibleSectionCount: 1,
-        }
-      : row
-  );
-  const publicSecondSet = makeTryoutStartCatalog(locale, "visible").map(
-    (row) => {
-      const graph = makeSecondSetGraph(row.graph);
-      if (row.kind === "set") {
-        return {
-          ...row,
-          graph,
-          order: 2,
-          publicPath: SECOND_SET_PATH,
-          setKey: TRYOUT_REUSED_SET,
-          title: "Set 2",
-        };
-      }
-
-      if (row.kind === "section") {
-        return {
-          ...row,
-          graph,
-          publicPath: `${SECOND_SET_PATH}/${TRYOUT_REUSED_SECTION}`,
-          questionSourcePath: row.questionSourcePath.replace(
-            FIRST_SOURCE_SEGMENT,
-            SECOND_SOURCE_SEGMENT
-          ),
-          sectionKey: TRYOUT_REUSED_SECTION,
-          setKey: TRYOUT_REUSED_SET,
-          title: "Aljabar",
-        };
-      }
-
-      return row;
-    }
-  );
-
-  return Schema.decodeSync(Schema.Array(TryoutCatalogRowSchema))([
-    ...privateFirstHierarchy,
-    ...publicSecondSet,
-  ]);
-}
-
-/** Moves the technical placement into the public second set. */
-function makeSecondSetPlacement(locale: ActiveAppLocaleCode) {
-  const placement = makeTryoutStartPlacement(locale);
-  const moveToSecondSet = (value: string) =>
-    value.replace(FIRST_SOURCE_SEGMENT, SECOND_SOURCE_SEGMENT);
-
+/** Maps the technical placement onto the stable landing question identity. */
+function makeLandingPlacement(locale: ActiveAppLocaleCode) {
   return Schema.decodeSync(TryoutPlacementSchema)({
-    ...placement,
-    answerContentKey: moveToSecondSet(placement.answerContentKey),
-    questionContentKey: moveToSecondSet(placement.questionContentKey),
-    questionSourcePath: moveToSecondSet(placement.questionSourcePath),
-    sectionKey: TRYOUT_REUSED_SECTION,
-    setKey: TRYOUT_REUSED_SET,
+    ...makeTryoutStartPlacement(locale),
+    answerContentKey: `${LANDING_QUESTION_ROOT}/answer`,
+    examKey: LANDING_FEATURED_TRYOUT.examKey,
+    questionContentKey: LANDING_FEATURED_TRYOUT.questionContentKey,
+    questionSourcePath: LANDING_QUESTION_SOURCE_ROOT,
+    rendererDomain: "snbt-quant",
+    sectionKey: LANDING_FEATURED_TRYOUT.sectionKey,
+    trackKey: LANDING_FEATURED_TRYOUT.trackKey,
   });
 }
 
-/** Builds a hierarchy whose first track is private and second track is public. */
-function makeInternalTrackThenVisibleCatalog(locale: ActiveAppLocaleCode) {
-  const privateFirstTrack = makeTryoutStartHierarchy(locale, "internal-entry");
-  const publicSecondTrack = makeTryoutStartHierarchy(locale, "visible")
-    .filter(
-      (row): row is NestedCatalogRow =>
-        row.kind === "track" || row.kind === "set" || row.kind === "section"
-    )
-    .map((row) => {
-      const graph = makeSecondSetGraph(row.graph);
-      if (row.kind === "track") {
-        return {
-          ...row,
-          graph,
-          order: 2,
-          publicPath: SECOND_TRACK_PATH,
-          title: "Second track",
-          trackKey: SECOND_TRACK,
-        };
-      }
-      if (row.kind === "set") {
-        return {
-          ...row,
-          graph,
-          publicPath: SECOND_TRACK_SET_PATH,
-          setKey: TRYOUT_REUSED_SET,
-          title: "Set 2",
-          trackKey: SECOND_TRACK,
-        };
-      }
-      return {
-        ...row,
-        graph,
-        publicPath: `${SECOND_TRACK_SET_PATH}/${TRYOUT_REUSED_SECTION}`,
-        questionSourcePath: row.questionSourcePath.replace(
-          FIRST_SOURCE_SEGMENT,
-          SECOND_SOURCE_SEGMENT
-        ),
-        sectionKey: TRYOUT_REUSED_SECTION,
-        setKey: TRYOUT_REUSED_SET,
-        title: "Aljabar",
-        trackKey: SECOND_TRACK,
-      };
-    });
+/** Activates the stable landing hierarchy for a backend test. */
+async function activateLandingSource(
+  ctx: Parameters<typeof activateTryoutSnapshot>[0],
+  visibility: "internal-entry" | "visible"
+) {
+  const snapshotId = await activateTryoutSnapshot(ctx, {
+    catalog: ACTIVE_APP_LOCALE_CODES.flatMap((locale) =>
+      makeLandingHierarchy(locale, visibility)
+    ),
+    placements: ACTIVE_APP_LOCALE_CODES.map(makeLandingPlacement),
+  });
+  await insertTestTryoutRuntimeBundle(ctx, snapshotId);
+}
+
+/** Adds an earlier signed section without changing the landing target. */
+function makeLeadingSectionHierarchy(locale: ActiveAppLocaleCode) {
+  const hierarchy = makeLandingHierarchy(locale, "visible");
+  const target = hierarchy.find(
+    (row) =>
+      row.kind === "section" &&
+      row.sectionKey === LANDING_FEATURED_TRYOUT.sectionKey
+  );
+  if (!(target && target.kind === "section")) {
+    throw new Error("Expected the stable landing section fixture.");
+  }
 
   return Schema.decodeSync(Schema.Array(TryoutCatalogRowSchema))([
-    ...privateFirstTrack,
-    ...publicSecondTrack,
+    ...hierarchy.map((row) => {
+      if (row.kind === "track" || row.kind === "set") {
+        return {
+          ...row,
+          questionCount: 2,
+          sectionCount: 2,
+          ...(row.kind === "track" ? { visibleSectionCount: 2 } : {}),
+          ...(row.kind === "set" ? { visibleSectionCount: 2 } : {}),
+        };
+      }
+      if (row.kind === "section") {
+        return { ...row, order: 2 };
+      }
+      return row;
+    }),
+    {
+      ...target,
+      order: 1,
+      publicPath: `${LANDING_SET_PATH}/general-reasoning`,
+      questionSourcePath: DISTRACTOR_SOURCE_ROOT,
+      sectionKey: "general-reasoning",
+      title: "General Reasoning",
+    },
   ]);
 }
 
-/** Moves the public technical placement into the second authored track. */
-function makeSecondTrackPlacement(locale: ActiveAppLocaleCode) {
+/** Creates the earlier signed placement used to prove order independence. */
+function makeLeadingPlacement(locale: ActiveAppLocaleCode) {
   return Schema.decodeSync(TryoutPlacementSchema)({
-    ...makeSecondSetPlacement(locale),
-    trackKey: SECOND_TRACK,
+    ...makeLandingPlacement(locale),
+    answerContentKey: `${DISTRACTOR_QUESTION_ROOT}/answer`,
+    questionContentKey: `${DISTRACTOR_QUESTION_ROOT}/question`,
+    questionSourcePath: DISTRACTOR_QUESTION_SOURCE_ROOT,
+    rendererDomain: "snbt-plain",
+    sectionKey: "general-reasoning",
   });
 }
 
 /** Makes the first authored placement exercise the full response contract. */
 function makeMultipleChoicePlacement(locale: ActiveAppLocaleCode) {
-  const placement = makeTryoutStartPlacement(locale);
+  const placement = makeLandingPlacement(locale);
   return Schema.decodeSync(TryoutPlacementSchema)({
     ...placement,
     response: {
@@ -202,7 +191,7 @@ function makeMultipleChoicePlacement(locale: ActiveAppLocaleCode) {
 
 /** Makes the first authored placement exercise category assignments. */
 function makeCategoryPlacement(locale: ActiveAppLocaleCode) {
-  const placement = makeTryoutStartPlacement(locale);
+  const placement = makeLandingPlacement(locale);
   return Schema.decodeSync(TryoutPlacementSchema)({
     ...placement,
     response: {
@@ -225,13 +214,13 @@ function makeCategoryPlacement(locale: ActiveAppLocaleCode) {
 
 describe("tryouts/catalog/featured", () => {
   it.effect(
-    "returns the first visible signed question for the public landing demo",
+    "returns the stable signed question for the public landing demo",
     () =>
       Effect.gen(function* () {
         const t = convexTest(schema, convexModules);
-        const source = makeTryoutStartPlacement("id");
+        const source = makeLandingPlacement("id");
         yield* Effect.promise(() =>
-          t.mutation((ctx) => activateTryoutStartSource(ctx, "visible"))
+          t.mutation((ctx) => activateLandingSource(ctx, "visible"))
         );
 
         const featured = yield* Effect.promise(() =>
@@ -281,7 +270,7 @@ describe("tryouts/catalog/featured", () => {
       Effect.gen(function* () {
         const t = convexTest(schema, convexModules);
         yield* Effect.promise(() =>
-          t.mutation((ctx) => activateTryoutStartSource(ctx, "internal-entry"))
+          t.mutation((ctx) => activateLandingSource(ctx, "internal-entry"))
         );
 
         const failure = yield* Effect.tryPromise(() =>
@@ -294,7 +283,7 @@ describe("tryouts/catalog/featured", () => {
   );
 
   it.effect(
-    "continues to the next set when the first set has no visible section",
+    "ignores an earlier section when selecting the landing question",
     () =>
       Effect.gen(function* () {
         const t = convexTest(schema, convexModules);
@@ -302,11 +291,11 @@ describe("tryouts/catalog/featured", () => {
           t.mutation(async (ctx) => {
             const snapshotId = await activateTryoutSnapshot(ctx, {
               catalog: ACTIVE_APP_LOCALE_CODES.flatMap(
-                makeInternalThenVisibleCatalog
+                makeLeadingSectionHierarchy
               ),
               placements: ACTIVE_APP_LOCALE_CODES.flatMap((locale) => [
-                makeTryoutStartPlacement(locale),
-                makeSecondSetPlacement(locale),
+                makeLeadingPlacement(locale),
+                makeLandingPlacement(locale),
               ]),
             });
             await insertTestTryoutRuntimeBundle(ctx, snapshotId);
@@ -317,14 +306,14 @@ describe("tryouts/catalog/featured", () => {
           t.query((ctx) => runConvexProgram(readFeaturedTryout(ctx, "id")))
         );
 
-        expect(featured.question.contentKey).toContain(
-          `/${TRYOUT_REUSED_SECTION}/${TRYOUT_REUSED_SET}/`
+        expect(featured.question.contentKey).toBe(
+          LANDING_FEATURED_TRYOUT.questionContentKey
         );
       })
   );
 
   it.effect(
-    "returns the first authored question for every response format",
+    "returns the stable authored question for every response format",
     () =>
       Effect.gen(function* () {
         const t = convexTest(schema, convexModules);
@@ -332,7 +321,7 @@ describe("tryouts/catalog/featured", () => {
           t.mutation(async (ctx) => {
             const snapshotId = await activateTryoutSnapshot(ctx, {
               catalog: ACTIVE_APP_LOCALE_CODES.flatMap((locale) =>
-                makeTryoutStartHierarchy(locale, "visible")
+                makeLandingHierarchy(locale, "visible")
               ),
               placements: ACTIVE_APP_LOCALE_CODES.map(
                 makeMultipleChoicePlacement
@@ -358,7 +347,7 @@ describe("tryouts/catalog/featured", () => {
         t.mutation(async (ctx) => {
           const snapshotId = await activateTryoutSnapshot(ctx, {
             catalog: ACTIVE_APP_LOCALE_CODES.flatMap((locale) =>
-              makeTryoutStartHierarchy(locale, "visible")
+              makeLandingHierarchy(locale, "visible")
             ),
             placements: ACTIVE_APP_LOCALE_CODES.map(makeCategoryPlacement),
           });
@@ -383,34 +372,6 @@ describe("tryouts/catalog/featured", () => {
           },
         ],
       });
-    })
-  );
-
-  it.effect("continues to the next track when the first track is private", () =>
-    Effect.gen(function* () {
-      const t = convexTest(schema, convexModules);
-      yield* Effect.promise(() =>
-        t.mutation(async (ctx) => {
-          const snapshotId = await activateTryoutSnapshot(ctx, {
-            catalog: ACTIVE_APP_LOCALE_CODES.flatMap(
-              makeInternalTrackThenVisibleCatalog
-            ),
-            placements: ACTIVE_APP_LOCALE_CODES.flatMap((locale) => [
-              makeTryoutStartPlacement(locale),
-              makeSecondTrackPlacement(locale),
-            ]),
-          });
-          await insertTestTryoutRuntimeBundle(ctx, snapshotId);
-        })
-      );
-
-      const featured = yield* Effect.promise(() =>
-        t.query((ctx) => runConvexProgram(readFeaturedTryout(ctx, "id")))
-      );
-
-      expect(featured.question.contentKey).toContain(
-        `/${TRYOUT_REUSED_SECTION}/${TRYOUT_REUSED_SET}/`
-      );
     })
   );
 

--- a/packages/backend/convex/tryouts/catalog/featured.ts
+++ b/packages/backend/convex/tryouts/catalog/featured.ts
@@ -1,5 +1,8 @@
+import { ContentKeySchema } from "@nakafa/aksara-contracts/ids";
 import type { AppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import { canonicalQuestionResponse } from "@nakafa/aksara-contracts/question/response";
+import type { TryoutSection } from "@nakafa/aksara-contracts/tryout/catalog";
+import type { TryoutPlacement } from "@nakafa/aksara-contracts/tryout/placement";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import { loadTryoutCatalog } from "@repo/backend/convex/contentRelease/tryout/catalog";
@@ -8,7 +11,6 @@ import {
   indexPublishedCatalog,
   type PublishedCatalogIndex,
   readPublishedSetSections,
-  sortCatalogRows,
 } from "@repo/backend/convex/tryouts/catalog/hierarchy";
 import { tryoutResponseSpecValidator } from "@repo/backend/convex/tryouts/response/model";
 import {
@@ -26,15 +28,30 @@ export const featuredTryoutValidator = v.object({
   response: tryoutResponseSpecValidator,
 });
 
-/** Selects the first authored question from the canonical try-out hierarchy. */
+type FeaturedTryoutTarget = Pick<
+  TryoutSection,
+  "countryKey" | "examKey" | "sectionKey" | "setKey" | "trackKey"
+> &
+  Pick<TryoutPlacement, "questionContentKey">;
+
+/** Stable authored question demonstrated by the landing page learning loop. */
+export const LANDING_FEATURED_TRYOUT = {
+  countryKey: "indonesia",
+  examKey: "snbt",
+  questionContentKey: ContentKeySchema.make(
+    "question-bank/tryout/indonesia/snbt/quantitative-knowledge/set-1/question-1/question"
+  ),
+  sectionKey: "quantitative-knowledge",
+  setKey: "set-1",
+  trackKey: "2027",
+} as const satisfies FeaturedTryoutTarget;
+
+/** Selects the stable authored question for the public landing demo. */
 export const readFeaturedTryout = Effect.fn("tryouts.catalog.readFeatured")(
   function* (ctx: QueryCtx, locale: AppLocaleCode) {
     const catalog = yield* loadTryoutCatalog(ctx, locale);
     const index = yield* indexPublishedCatalog(catalog);
-    const section = yield* readFirstVisibleSection(index);
-    if (!section) {
-      return yield* missingFeaturedTryout("section");
-    }
+    const section = yield* readLandingFeaturedSection(index, locale);
     const source = yield* readTryoutSection(ctx, {
       countryKey: section.countryKey,
       examKey: section.examKey,
@@ -43,7 +60,10 @@ export const readFeaturedTryout = Effect.fn("tryouts.catalog.readFeatured")(
       setKey: section.setKey,
       trackKey: section.trackKey,
     });
-    const placement = source.placements[0]?.row;
+    const placement = source.placements.find(
+      ({ row }) =>
+        row.questionContentKey === LANDING_FEATURED_TRYOUT.questionContentKey
+    )?.row;
     if (!(placement && catalog.activeReleaseId && catalog.bundleHash)) {
       return yield* missingFeaturedTryout("question");
     }
@@ -69,62 +89,66 @@ export const readFeaturedTryout = Effect.fn("tryouts.catalog.readFeatured")(
   }
 );
 
-/** Finds the first public section in authored hierarchy order. */
-const readFirstVisibleSection = Effect.fn(
-  "tryouts.catalog.readFirstVisibleSection"
-)(function* (index: PublishedCatalogIndex) {
-  const countries = sortCatalogRows(index.countries);
-  if (countries.length === 0) {
+/** Resolves the stable landing section without depending on catalog order. */
+const readLandingFeaturedSection = Effect.fn(
+  "tryouts.catalog.readLandingFeaturedSection"
+)(function* (index: PublishedCatalogIndex, locale: AppLocaleCode) {
+  const target = LANDING_FEATURED_TRYOUT;
+  const country = index.countries.find(
+    (row) => row.appLocale === locale && row.countryKey === target.countryKey
+  );
+  if (!country) {
     return yield* missingFeaturedTryout("country");
   }
 
-  for (const country of countries) {
-    const exams = sortCatalogRows(
-      index.exams.filter((row) => row.countryKey === country.countryKey)
-    );
-    if (exams.length === 0) {
-      return yield* missingFeaturedTryout("exam");
-    }
-
-    for (const exam of exams) {
-      const tracks = sortCatalogRows(
-        index.tracks.filter(
-          (row) =>
-            row.countryKey === country.countryKey &&
-            row.examKey === exam.examKey
-        )
-      );
-      if (tracks.length === 0) {
-        return yield* missingFeaturedTryout("track");
-      }
-
-      for (const track of tracks) {
-        const sets = sortCatalogRows(
-          index.sets.filter(
-            (row) =>
-              row.countryKey === country.countryKey &&
-              row.examKey === exam.examKey &&
-              row.trackKey === track.trackKey
-          )
-        );
-        if (sets.length !== track.setCount) {
-          return yield* missingFeaturedTryout("set");
-        }
-
-        for (const set of sets) {
-          const sections = yield* readPublishedSetSections(index, set);
-          const section = sections.find(
-            ({ visibility }) => visibility === "visible"
-          );
-          if (section) {
-            return section;
-          }
-        }
-      }
-    }
+  const exam = index.exams.find(
+    (row) =>
+      row.appLocale === locale &&
+      row.countryKey === country.countryKey &&
+      row.examKey === target.examKey
+  );
+  if (!exam) {
+    return yield* missingFeaturedTryout("exam");
   }
 
-  return null;
+  const track = index.tracks.find(
+    (row) =>
+      row.appLocale === locale &&
+      row.countryKey === exam.countryKey &&
+      row.examKey === exam.examKey &&
+      row.trackKey === target.trackKey
+  );
+  if (!track) {
+    return yield* missingFeaturedTryout("track");
+  }
+
+  const sets = index.sets.filter(
+    (row) =>
+      row.appLocale === locale &&
+      row.countryKey === track.countryKey &&
+      row.examKey === track.examKey &&
+      row.trackKey === track.trackKey
+  );
+  if (sets.length !== track.setCount) {
+    return yield* missingFeaturedTryout("set");
+  }
+
+  const set = sets.find((row) => row.setKey === target.setKey);
+  if (!set) {
+    return yield* missingFeaturedTryout("set");
+  }
+
+  const sections = yield* readPublishedSetSections(index, set);
+  const section = sections.find(
+    (row) =>
+      row.appLocale === locale &&
+      row.sectionKey === target.sectionKey &&
+      row.visibility === "visible"
+  );
+  if (!section) {
+    return yield* missingFeaturedTryout("section");
+  }
+  return section;
 });
 
 /** Creates one fail-closed integrity error for an incomplete featured path. */


### PR DESCRIPTION
## Summary

- Pin the landing-page Tryout demo to the existing signed SNBT Quantitative Knowledge Set 1 Question 1, the math example whose verified result continues into Nina.
- Stop deriving landing content from catalog order and `placements[0]`.
- Preserve the full canonical response contract, including single-choice, multiple-choice, and category responses.
- Add backend regression coverage plus a production-mode Playwright check that verifies the signed landing answer remains `19` and interactive correctness feedback still works.
- Merge current `main` so this PR is validated with the paginated production snapshot exporter and patched dependency graph from #562.

## Root cause

The landing query selected the first visible section and its first placement. The signed SNBT catalog now places General Reasoning first, so its mango question replaced the intended math demo even though the landing UI and Nina example did not change.

## Safety

- The selector uses an existing signed Aksara content key and reads through the canonical published catalog, section snapshot, artifact, and response surfaces.
- It verifies the target country, exam, track, set, section, visibility, and exact placement, then fails closed if any required signed identity is unavailable.
- No authored corpus is copied into Nakafa, and no Convex query arguments, return validator, schema, response renderer, or deployment setting changes are introduced.
- The current Aksara source keeps `19` as the single correct response across English, Indonesian, and German, matching Nina's adjacent fixed calculation.

## Verification

- Backend tests cover the stable target, hidden internal sections, earlier catalog sections, multiple-choice responses, category responses, and missing active hierarchy.
- `apps/www/e2e/featured-tryout.browser.ts` verifies the real signed homepage question exposes five options, includes `10` as an incorrect response and `19` as the correct response, and updates the live status correctly after both interactions.
- Exact-head CI is authoritative for dependency audit, tests, formatting, lint, type checks, production snapshot export and import, signed renderer verification, production build, browser checks, site checks, and final runtime-generation verification.
- No Vercel Preview is requested or permitted.