### PR TITLE
fix(ci): restore Vercel production builds

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,6 +7,7 @@
     "./*": "./*.ts"
   },
   "scripts": {
+    "build": "pnpm typecheck",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "customers:verify": "tsx scripts/customers/verify.ts",
     "customers:verify:prod": "tsx scripts/customers/verify.ts --prod",

--- a/packages/backend/scripts/content/runtime/ci/command.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/command.test.ts
@@ -2,9 +2,12 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { afterEach, describe, expect, it } from "@effect/vitest";
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
 import {
   runRuntimeCommand,
   sanitizeRuntimeCommandError,
+  setConvexAdminAuth,
 } from "@repo/backend/scripts/content/runtime/ci/command";
 import { Effect, FileSystem } from "effect";
 
@@ -12,6 +15,55 @@ describe("content runtime command diagnostics", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
+
+  it.effect("authenticates and clears Convex system-query requests", () =>
+    Effect.gen(function* () {
+      const authorizations: Array<null | string> = [];
+      const client = new ConvexHttpClient(
+        "https://happy-animal-123.convex.cloud",
+        {
+          fetch: async (_input, init) => {
+            authorizations.push(
+              new Headers(init?.headers).get("Authorization")
+            );
+            return new Response(
+              JSON.stringify({ status: "success", value: null }),
+              {
+                headers: { "Content-Type": "application/json" },
+                status: 200,
+              }
+            );
+          },
+          logger: false,
+        }
+      );
+      const query = makeFunctionReference<
+        "query",
+        Record<string, never>,
+        null
+      >("test:query");
+
+      yield* setConvexAdminAuth(client, "test-admin-key");
+      yield* Effect.promise(() => client.query(query, {}));
+      client.clearAuth();
+      yield* Effect.promise(() => client.query(query, {}));
+
+      expect(authorizations).toEqual(["Convex test-admin-key", null]);
+    })
+  );
+
+  it.effect("fails closed when Convex removes runtime admin auth", () =>
+    Effect.gen(function* () {
+      const failure = yield* setConvexAdminAuth({}, "test-admin-key").pipe(
+        Effect.flip
+      );
+
+      expect(failure).toMatchObject({
+        _tag: "ContentRuntimeCiError",
+        message: "Convex HTTP client does not expose admin authentication.",
+      });
+    })
+  );
 
   it("keeps a bounded single-line diagnostic and redacts secrets", () => {
     const deployKey = "sensitive-deploy-key";

--- a/packages/backend/scripts/content/runtime/ci/command.ts
+++ b/packages/backend/scripts/content/runtime/ci/command.ts
@@ -45,17 +45,17 @@ interface RuntimeCommand {
  * Convex strips internal methods from its public declarations, so this runtime
  * capability is validated before any production read is attempted.
  */
-const setConvexAdminAuth = Effect.fn("contentRuntime.setConvexAdminAuth")(
-  function* (client: ConvexHttpClient, deployKey: string) {
-    const authenticate: unknown = Reflect.get(client, "setAdminAuth");
-    if (typeof authenticate !== "function") {
-      return yield* contentRuntimeCiError(
-        "Convex HTTP client does not expose admin authentication."
-      );
-    }
-    yield* Effect.sync(() => Reflect.apply(authenticate, client, [deployKey]));
+export const setConvexAdminAuth = Effect.fn(
+  "contentRuntime.setConvexAdminAuth"
+)(function* (client: object, deployKey: string) {
+  const authenticate: unknown = Reflect.get(client, "setAdminAuth");
+  if (typeof authenticate !== "function") {
+    return yield* contentRuntimeCiError(
+      "Convex HTTP client does not expose admin authentication."
+    );
   }
-);
+  yield* Effect.sync(() => Reflect.apply(authenticate, client, [deployKey]));
+});
 
 /**
  * Runs one runtime command with mode-600 output captured at process startup.

--- a/packages/backend/scripts/content/runtime/ci/command.ts
+++ b/packages/backend/scripts/content/runtime/ci/command.ts
@@ -41,6 +41,23 @@ interface RuntimeCommand {
 }
 
 /**
+ * Authenticates the HTTP client for Convex's CLI-only system query.
+ * Convex strips internal methods from its public declarations, so this runtime
+ * capability is validated before any production read is attempted.
+ */
+const setConvexAdminAuth = Effect.fn("contentRuntime.setConvexAdminAuth")(
+  function* (client: ConvexHttpClient, deployKey: string) {
+    const authenticate: unknown = Reflect.get(client, "setAdminAuth");
+    if (typeof authenticate !== "function") {
+      return yield* contentRuntimeCiError(
+        "Convex HTTP client does not expose admin authentication."
+      );
+    }
+    yield* Effect.sync(() => Reflect.apply(authenticate, client, [deployKey]));
+  }
+);
+
+/**
  * Runs one runtime command with mode-600 output captured at process startup.
  * Paths and arguments stay positional so the shell never reparses them.
  * @see https://github.com/Effect-TS/effect/blob/66114151c2b4640bf773f2b3456ce70d679422f6/packages/effect/src/unstable/process/ChildProcess.ts
@@ -132,8 +149,7 @@ export const runConvexData = Effect.fn("contentRuntime.readProductionTable")(
       `https://${CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT}.convex.cloud`,
       { logger: false }
     );
-    client.setDebug(false);
-    client.setAdminAuth(options.deployKey);
+    yield* setConvexAdminAuth(client, options.deployKey);
 
     const rows = yield* collectConvexTableRows({
       limit: options.limit,


### PR DESCRIPTION
## Summary

- Restore the Vercel `www` production build after #562 by avoiding direct TypeScript access to Convex methods that are deliberately stripped from the package's public declarations.
- Retain the existing authenticated, paginated production snapshot read and fail closed if Convex no longer exposes its CLI admin-auth capability at runtime.
- Add a backend `build` task so the root production build typechecks the same backend scripts that Vercel typechecks before deployment.

## Production incident

The merge-group acceptance for #562 passed, but its Git-linked Vercel production deployment failed during `packages/backend` typechecking:

```text
scripts/content/runtime/ci/command.ts(135,12): error TS2339: Property 'setDebug' does not exist on type 'ConvexHttpClient'.
scripts/content/runtime/ci/command.ts(136,12): error TS2339: Property 'setAdminAuth' does not exist on type 'ConvexHttpClient'.
```

Convex uses these methods in its own CLI implementation, but marks them internal and strips them from published declarations. The runtime capability therefore remains available while direct public TypeScript access is rejected.

## Safety

- `logger: false` already suppresses query logging, so the internal `setDebug` call is removed.
- Admin authentication is resolved with `Reflect.get`, checked to be callable, and invoked only with the production deploy key.
- Missing runtime capability produces a typed, fail-closed content-runtime error before a table read.
- Authentication is still cleared in the existing finalizer.
- No deployment key, content snapshot, schema, authored content, or public application behavior changes.

## Verification

- Exact-head CI must pass dependency audit, repository tests, backend typecheck through the root build, production snapshot export/import, production build, browser checks, site checks, and final runtime-generation verification.
- After merge, the Git-linked Vercel deployment for the resulting `main` SHA must reach `READY` before #563 or #564 enters the queue.