### PR TITLE
fix(content): skip unchanged popularity refresh writes

### DIFF
--- a/packages/backend/convex/contents/metrics/refresh.ts
+++ b/packages/backend/convex/contents/metrics/refresh.ts
@@ -20,6 +20,30 @@ import { Clock, Effect } from "effect";
 type PopularityCounter = Doc<"learningPopularityCounters">;
 type PopularitySignal = Doc<"learningPopularitySignals">;
 
+/** Rebuilt semantics; `updatedAt` advances only when one of these changes. */
+const refreshFields = [
+  "alignmentId",
+  "assetId",
+  "conceptId",
+  "contextMaterialKey",
+  "contextMode",
+  "contextNodeKey",
+  "contextParentPath",
+  "contextProgramKey",
+  "contextPublicPath",
+  "contextSourcePath",
+  "description",
+  "learningObjectId",
+  "lensId",
+  "materialDomain",
+  "route",
+  "score",
+  "sourcePath",
+  "title",
+] as const satisfies readonly (keyof PopularityCounter)[];
+
+type Refresh = Pick<PopularityCounter, (typeof refreshFields)[number]>;
+
 /** Generated internal mutation reference accepted by Convex refresh scheduling. */
 type RefreshLearningPopularityWindowPageReference = FunctionReference<
   "mutation",
@@ -91,6 +115,40 @@ const recomputePopularityCounter = Effect.fn(
   };
 });
 
+/** Projects the stored counter state produced by one authoritative rebuild. */
+function projectPopularityRefresh(
+  counter: PopularityCounter,
+  latestSignal: PopularitySignal | null,
+  score: number
+): Refresh {
+  return {
+    alignmentId: latestSignal?.alignmentId ?? counter.alignmentId,
+    assetId: latestSignal?.assetId ?? counter.assetId,
+    conceptId: latestSignal?.conceptId ?? counter.conceptId,
+    contextMaterialKey:
+      latestSignal?.contextMaterialKey ?? counter.contextMaterialKey,
+    contextMode: latestSignal?.contextMode ?? counter.contextMode,
+    contextNodeKey: latestSignal?.contextNodeKey ?? counter.contextNodeKey,
+    contextParentPath:
+      latestSignal?.contextParentPath ?? counter.contextParentPath,
+    contextProgramKey:
+      latestSignal?.contextProgramKey ?? counter.contextProgramKey,
+    contextPublicPath:
+      latestSignal?.contextPublicPath ?? counter.contextPublicPath,
+    contextSourcePath:
+      latestSignal?.contextSourcePath ?? counter.contextSourcePath,
+    description: latestSignal?.description ?? counter.description,
+    learningObjectId:
+      latestSignal?.learningObjectId ?? counter.learningObjectId,
+    lensId: latestSignal?.lensId ?? counter.lensId,
+    materialDomain: latestSignal?.materialDomain ?? counter.materialDomain,
+    route: latestSignal?.route ?? counter.route,
+    score,
+    sourcePath: latestSignal?.sourcePath ?? counter.sourcePath,
+    title: latestSignal?.title ?? counter.title,
+  };
+}
+
 /** Applies a recomputed finite-window score to one popularity counter row. */
 const refreshPopularityCounter = Effect.fn(
   "contents.metrics.refreshPopularityCounter"
@@ -109,35 +167,27 @@ const refreshPopularityCounter = Effect.fn(
     };
   }
 
-  const latestSignal = refresh.latestSignal;
+  const update = projectPopularityRefresh(
+    counter,
+    refresh.latestSignal,
+    refresh.score
+  );
+
+  const changed = refreshFields.some(
+    (field) => counter[field] !== update[field]
+  );
+
+  if (!changed) {
+    return {
+      removed: false,
+      refreshed: false,
+    };
+  }
 
   yield* Effect.tryPromise({
     try: () =>
       ctx.db.patch(counter._id, {
-        alignmentId: latestSignal?.alignmentId ?? counter.alignmentId,
-        assetId: latestSignal?.assetId ?? counter.assetId,
-        conceptId: latestSignal?.conceptId ?? counter.conceptId,
-        contextMaterialKey:
-          latestSignal?.contextMaterialKey ?? counter.contextMaterialKey,
-        contextMode: latestSignal?.contextMode ?? counter.contextMode,
-        contextNodeKey: latestSignal?.contextNodeKey ?? counter.contextNodeKey,
-        contextParentPath:
-          latestSignal?.contextParentPath ?? counter.contextParentPath,
-        contextProgramKey:
-          latestSignal?.contextProgramKey ?? counter.contextProgramKey,
-        contextPublicPath:
-          latestSignal?.contextPublicPath ?? counter.contextPublicPath,
-        contextSourcePath:
-          latestSignal?.contextSourcePath ?? counter.contextSourcePath,
-        description: latestSignal?.description ?? counter.description,
-        learningObjectId:
-          latestSignal?.learningObjectId ?? counter.learningObjectId,
-        lensId: latestSignal?.lensId ?? counter.lensId,
-        materialDomain: latestSignal?.materialDomain ?? counter.materialDomain,
-        route: latestSignal?.route ?? counter.route,
-        score: refresh.score,
-        sourcePath: latestSignal?.sourcePath ?? counter.sourcePath,
-        title: latestSignal?.title ?? counter.title,
+        ...update,
         updatedAt: timestamp,
       }),
     catch: toContentAnalyticsIoError,

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -45,16 +45,27 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   const subjectCounterId = await ctx.db.insert("learningPopularityCounters", {
     ...subject,
-    contextKey: "canonical",
+    alignmentId: "stale-alignment",
+    assetId: "stale-asset",
+    conceptId: "stale-concept",
+    contextKey: "placement:mathematics:addition",
+    contextMaterialKey: "stale-material",
     contextMode: "canonical",
+    contextNodeKey: "stale-node",
+    contextParentPath: "stale/parent",
+    contextProgramKey: "stale-program",
+    contextPublicPath: "stale/public",
+    contextSourcePath: "stale/source",
     description: "Stale subject description",
+    learningObjectId: "stale-learning-object",
+    lensId: "stale-lens",
     locale: "en",
-    materialDomain: "mathematics",
-    route: SUBJECT_ROUTE,
-    score: 99,
+    materialDomain: "physics",
+    route: "stale/subject/route",
+    score: 2,
     section: "material",
     scopeMode: "global",
-    sourcePath: SUBJECT_ROUTE,
+    sourcePath: "stale/subject/source",
     title: "Stale Vector Addition",
     updatedAt: NOW - POPULARITY_DAY_MS,
     windowKey: "7d",
@@ -88,8 +99,14 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   await ctx.db.insert("learningPopularitySignals", {
     ...subject,
-    contextKey: "canonical",
-    contextMode: "canonical",
+    contextKey: "placement:mathematics:addition",
+    contextMaterialKey: "vector-addition",
+    contextMode: "placement",
+    contextNodeKey: "addition",
+    contextParentPath: "subjects/mathematics/vector",
+    contextProgramKey: "mathematics",
+    contextPublicPath: SUBJECT_ROUTE,
+    contextSourcePath: "material/lesson/mathematics/vector/addition",
     description: "Current subject description",
     locale: "en",
     materialDomain: "mathematics",
@@ -119,6 +136,44 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
   });
 }
 
+/** Reads stored counters and their aggregate ranking output together. */
+async function readPopularitySnapshot(
+  target: ReturnType<typeof createPopularityConvexTest>
+) {
+  return await target.query(async (ctx) => {
+    const counters = await ctx.db.query("learningPopularityCounters").collect();
+    const ranking = await learningPopularityRankings.paginate(ctx, {
+      namespace: ["material", "en", "global", "7d"],
+      order: "asc",
+      pageSize: 10,
+    });
+
+    return {
+      counters,
+      ranking: ranking.page,
+    };
+  });
+}
+
+/** Runs the registered refresh interface and exposes its transaction cost. */
+async function runRefresh(
+  target: ReturnType<typeof createPopularityConvexTest>
+) {
+  return await target.mutation(async (ctx) => {
+    const result = await ctx.runMutation(
+      internal.contents.mutations.popularity
+        .refreshLearningPopularityWindowPage,
+      {
+        scopeMode: "global",
+        windowKey: "7d",
+      }
+    );
+    const metrics = await ctx.meta.getTransactionMetrics();
+
+    return { metrics, result };
+  });
+}
+
 describe("contents/mutations/popularity", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -130,35 +185,72 @@ describe("contents/mutations/popularity", () => {
     vi.restoreAllMocks();
   });
 
-  it("rebuilds finite windows from daily signals and removes expired counters", async () => {
+  it("repairs finite windows from daily signals and removes expired counters", async () => {
     const t = createPopularityConvexTest();
 
     await t.mutation(insertPopularityRefreshRows);
 
-    const result = await t.mutation(
-      internal.contents.mutations.popularity
-        .refreshLearningPopularityWindowPage,
-      {
-        scopeMode: "global",
-        windowKey: "7d",
-      }
-    );
+    const refresh = await runRefresh(t);
     const counters = await t.query(
       async (ctx) => await ctx.db.query("learningPopularityCounters").collect()
     );
+    const subject = withContentId(
+      testMaterialGraph("vector", "addition", "en", "mathematics")
+    );
 
-    expect(result).toEqual({
+    expect(refresh.result).toEqual({
       continueCursor: expect.any(String),
       isDone: true,
       refreshedCounters: 1,
       removedCounters: 1,
       skipped: false,
     });
+    expect(refresh.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(counters).toHaveLength(1);
     expect(counters[0]).toMatchObject({
+      alignmentId: subject.alignmentId,
+      assetId: subject.assetId,
+      conceptId: subject.conceptId,
+      contextKey: "placement:mathematics:addition",
+      contextMaterialKey: "vector-addition",
+      contextMode: "placement",
+      contextNodeKey: "addition",
+      contextParentPath: "subjects/mathematics/vector",
+      contextProgramKey: "mathematics",
+      contextPublicPath: SUBJECT_ROUTE,
+      contextSourcePath: "material/lesson/mathematics/vector/addition",
+      description: "Current subject description",
+      learningObjectId: subject.learningObjectId,
+      lensId: subject.lensId,
+      materialDomain: "mathematics",
       route: SUBJECT_ROUTE,
       score: 2,
+      sourcePath: SUBJECT_ROUTE,
       title: "Current Vector Addition",
+      updatedAt: NOW,
     });
+  });
+
+  it("does not rewrite or rerank an unchanged rebuilt counter", async () => {
+    const t = createPopularityConvexTest();
+
+    await t.mutation(insertPopularityRefreshRows);
+    await runRefresh(t);
+    const before = await readPopularitySnapshot(t);
+
+    vi.setSystemTime(new Date(NOW + POPULARITY_DAY_MS / 2));
+    const replay = await runRefresh(t);
+    const after = await readPopularitySnapshot(t);
+
+    expect(replay.result).toEqual({
+      continueCursor: expect.any(String),
+      isDone: true,
+      refreshedCounters: 0,
+      removedCounters: 0,
+      skipped: false,
+    });
+    expect(replay.metrics.documentsWritten.used).toBe(0);
+    expect(after).toEqual(before);
+    expect(after.counters[0]?.updatedAt).toBe(NOW);
   });
 });

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -205,7 +205,6 @@ describe("contents/mutations/popularity", () => {
       removedCounters: 1,
       skipped: false,
     });
-    expect(refresh.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(counters).toHaveLength(1);
     expect(counters[0]).toMatchObject({
       alignmentId: subject.alignmentId,
@@ -235,13 +234,14 @@ describe("contents/mutations/popularity", () => {
     const t = createPopularityConvexTest();
 
     await t.mutation(insertPopularityRefreshRows);
-    await runRefresh(t);
+    const repair = await runRefresh(t);
     const before = await readPopularitySnapshot(t);
 
     vi.setSystemTime(new Date(NOW + POPULARITY_DAY_MS / 2));
     const replay = await runRefresh(t);
     const after = await readPopularitySnapshot(t);
 
+    expect(repair.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(replay.result).toEqual({
       continueCursor: expect.any(String),
       isDone: true,
@@ -251,6 +251,5 @@ describe("contents/mutations/popularity", () => {
     });
     expect(replay.metrics.documentsWritten.used).toBe(0);
     expect(after).toEqual(before);
-    expect(after.counters[0]?.updatedAt).toBe(NOW);
   });
 });


### PR DESCRIPTION
## Summary

- keep the authoritative finite-window signal recomputation and expired-counter deletion paths
- compare score and every copied latest-signal field before patching a counter
- treat updatedAt as the last semantic change and avoid unchanged aggregate replacement work

## Evidence

- the repair fixture holds score constant while making every copied counter field stale, then proves the registered mutation repairs them and removes an expired counter
- transaction metrics prove the repair control writes documents and an immediate identical replay has documentsWritten.used equal to zero
- stored counter documents and aggregate ranking output are exactly unchanged after the no-op replay

## Verification

- pnpm --filter @repo/backend exec vitest run convex/contents/mutations/popularity.test.ts convex/contents/metrics/apply.test.ts convex/contents/queries/trending.test.ts
- pnpm --filter @repo/backend typecheck
- pnpm exec ultracite check packages/backend/convex/contents/metrics/refresh.ts packages/backend/convex/contents/mutations/popularity.test.ts
- pnpm lint reaches the repository-wide Ultracite step, then reports pre-existing violations on current main in unrelated E2E and content-runtime CI files

No schema change, production query, deployment, or incremental subtraction is included.