### PR TITLE
test(backend): enforce changed coverage

### DIFF
--- a/packages/backend/vitest.config.mts
+++ b/packages/backend/vitest.config.mts
@@ -3,11 +3,30 @@ import config from "@repo/testing/node";
 import { mergeConfig } from "vitest/config";
 
 const defaultExcludes = ["**/node_modules/**", "coverage/**"];
+const coverageExcludes = [
+  "**/*.config.ts",
+  "**/*.d.ts",
+  "**/*.setup.ts",
+  "**/*.test.ts",
+  "**/_generated/**",
+  "convex/**/schema.ts",
+  "convex/crons.ts",
+  "convex/http.ts",
+  "convex/test.*.ts",
+  "test/**",
+];
 
 export default mergeConfig(config, {
   test: {
     coverage: {
+      changed: "origin/main",
+      exclude: coverageExcludes,
+      include: ["**/*.ts"],
       reportsDirectory: "./coverage",
+      thresholds: {
+        100: true,
+        perFile: true,
+      },
     },
     // Keep CPU available for Convex Edge VMs when Turbo runs package tests together.
     maxWorkers: "50%",


### PR DESCRIPTION
## Outcome\n\n- Requires 100% statements, branches, functions, and lines for every changed authored backend TypeScript module.\n- Includes changed files even when no test imports them, preventing invisible untested modules.\n- Excludes generated declarations, tests, test support, schemas, and declarative Convex wiring so coverage does not incentivize config-restatement tests.\n\n## Evidence\n\n- Positive proof on PR #567 material modules: 61/61 statements, 33/33 branches, 18/18 functions, and 58/58 lines.\n- Negative proof with a temporary unimported behavioral module: the gate failed it at 0% across all four metrics. The temporary file was removed.\n- Backend typecheck passed.\n- Focused Vitest execution passed on the config-only branch.\n\nNo production behavior changes.