### PR TITLE
perf(content): bound material reads

### DIFF
--- a/packages/backend/client/content/material.test.ts
+++ b/packages/backend/client/content/material.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { PublicPathSchema } from "@nakafa/aksara-contracts/ids";
+import { AppLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
+import { verifyContentRuntimeExchange } from "@nakafa/aksara-contracts/runtime/verify";
+import {
+  ContentRuntimeFailureError,
+  ContentRuntimeMissingError,
+  ContentRuntimeVerificationError,
+  ContentTransportError,
+} from "@repo/backend/client/content/errors";
+import { readMaterialContent } from "@repo/backend/client/content/material";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+  MATERIAL_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
+import { testArtifactJson } from "@repo/backend/test/content/artifact";
+import { testProjectionJson } from "@repo/backend/test/content/material";
+import {
+  TEST_DIGEST,
+  TEST_MANIFEST_HASH,
+  TEST_RELEASE_ID,
+  testReleaseJson,
+  testRendererJson,
+} from "@repo/backend/test/content/release";
+import { Effect } from "effect";
+
+const endpoint = `https://example.convex.site${MATERIAL_CONTENT_RUNTIME_PATH}`;
+const target = {
+  siteUrl: "https://example.convex.site/ignored/path",
+  token: "runtime-test-token",
+};
+const input = {
+  appLocale: AppLocaleSchema.make("en"),
+  publicPath: PublicPathSchema.make("test/head-0"),
+};
+const fetchMock = vi.hoisted(() => vi.fn<typeof fetch>());
+const verifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+vi.mock("@nakafa/aksara-contracts/runtime/verify", () => ({
+  verifyContentRuntimeExchange: verifyMock,
+}));
+
+/** Creates one marked response with an immutable network URL. */
+function createResponse(body: unknown, status: number, marked = true) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (marked) {
+    headers.set(
+      CONTENT_RUNTIME_RESPONSE_HEADER,
+      CONTENT_RUNTIME_RESPONSE_MARKER
+    );
+  }
+  const response = new Response(JSON.stringify(body), { headers, status });
+  Object.defineProperty(response, "url", { value: endpoint });
+  return response;
+}
+
+/** Creates one structurally complete nested public runtime. */
+function runtimeResponse() {
+  return {
+    activeManifestHash: TEST_MANIFEST_HASH,
+    activeReleaseId: TEST_RELEASE_ID,
+    artifact: JSON.parse(testArtifactJson()),
+    delivery: "public",
+    kind: "found",
+    projection: JSON.parse(testProjectionJson()),
+    projectionHash: TEST_DIGEST,
+    release: JSON.parse(testReleaseJson()),
+    rendererManifest: JSON.parse(testRendererJson()),
+    sourcePath: "packages/corpus/test/head-0/en.mdx",
+  };
+}
+
+/** Creates the complete shell paired with the nested runtime fixture. */
+function materialResponse() {
+  return {
+    kind: "found",
+    model: {
+      activeManifestHash: TEST_MANIFEST_HASH,
+      activeAppLocales: ["en", "id", "de"],
+      activeReleaseId: TEST_RELEASE_ID,
+      alternateJson: [testProjectionJson()],
+      projectionJson: testProjectionJson(),
+      rendererDomain: "mathematics",
+      siblingJson: [testProjectionJson()],
+      sourcePath: "packages/corpus/test/head-0/en.mdx",
+      sourceRevision: "a".repeat(40),
+    },
+    runtime: runtimeResponse(),
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  verifyMock.mockReset();
+  verifyMock.mockImplementation(({ response }) => Effect.succeed(response));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("material content runtime client", () => {
+  it.live("posts once and verifies the nested signed runtime", () =>
+    Effect.gen(function* () {
+      const found = materialResponse();
+      fetchMock.mockResolvedValue(createResponse(found, 200));
+
+      expect(
+        yield* readMaterialContent(
+          target,
+          input,
+          found.runtime.rendererManifest
+        )
+      ).toMatchObject({
+        model: { activeReleaseId: TEST_RELEASE_ID },
+        runtime: { kind: "found" },
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] ?? [];
+      expect(requestUrl).toBe(endpoint);
+      expect(JSON.parse(String(requestInit?.body))).toEqual({
+        delivery: "public",
+        ...input,
+      });
+      expect(verifyContentRuntimeExchange).toHaveBeenCalledOnce();
+    })
+  );
+
+  it.live("preserves exact absence and sanitized runtime failure", () =>
+    Effect.gen(function* () {
+      fetchMock
+        .mockResolvedValueOnce(createResponse({ kind: "missing" }, 404))
+        .mockResolvedValueOnce(
+          createResponse(
+            { code: "CONTENT_RUNTIME_INTERNAL", kind: "failure" },
+            500
+          )
+        );
+
+      expect(
+        yield* readMaterialContent(target, input, {}).pipe(Effect.flip)
+      ).toEqual(
+        new ContentRuntimeMissingError({
+          request: { delivery: "public", ...input },
+        })
+      );
+      expect(
+        yield* readMaterialContent(target, input, {}).pipe(Effect.flip)
+      ).toEqual(
+        new ContentRuntimeFailureError({
+          code: "CONTENT_RUNTIME_INTERNAL",
+          status: 500,
+        })
+      );
+      expect(verifyMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.live(
+    "rejects malformed requests, marked responses, and unmarked responses",
+    () =>
+      Effect.gen(function* () {
+        expect(
+          yield* readMaterialContent(
+            target,
+            { ...input, publicPath: "" },
+            {}
+          ).pipe(Effect.flip)
+        ).toEqual(new ContentTransportError({ reason: "request" }));
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        fetchMock
+          .mockResolvedValueOnce(createResponse({ unexpected: true }, 200))
+          .mockResolvedValueOnce(
+            createResponse({ unexpected: true }, 200, false)
+          );
+
+        expect(
+          yield* readMaterialContent(target, input, {}).pipe(Effect.flip)
+        ).toEqual(new ContentTransportError({ reason: "response-contract" }));
+        expect(
+          yield* readMaterialContent(target, input, {}).pipe(Effect.flip)
+        ).toEqual(new ContentTransportError({ reason: "response-unmarked" }));
+      })
+  );
+
+  it.live("preserves nested signature verification failures", () =>
+    Effect.gen(function* () {
+      const cause = new Error("signature mismatch");
+      const found = materialResponse();
+      fetchMock.mockResolvedValue(createResponse(found, 200));
+      verifyMock.mockReturnValue(Effect.fail(cause));
+
+      expect(
+        yield* readMaterialContent(
+          target,
+          input,
+          found.runtime.rendererManifest
+        ).pipe(Effect.flip)
+      ).toEqual(new ContentRuntimeVerificationError({ cause }));
+    })
+  );
+
+  it.live("rejects a nested runtime above its singular wire ceiling", () =>
+    Effect.gen(function* () {
+      const found = materialResponse();
+      found.runtime.artifact.payload.compiledCode = "x".repeat(
+        MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
+      );
+      fetchMock.mockResolvedValue(createResponse(found, 200));
+
+      expect(
+        yield* readMaterialContent(
+          target,
+          input,
+          found.runtime.rendererManifest
+        ).pipe(Effect.flip)
+      ).toEqual(new ContentTransportError({ reason: "response-contract" }));
+      expect(verifyMock).not.toHaveBeenCalled();
+    })
+  );
+});

--- a/packages/backend/client/content/material.ts
+++ b/packages/backend/client/content/material.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+import {
+  decodePublicContentRuntimeRequest,
+  MAX_PUBLIC_RUNTIME_REQUEST_BYTES,
+} from "@nakafa/aksara-contracts/runtime/spec";
+import {
+  ContentRuntimeFailureError,
+  ContentRuntimeMissingError,
+  ContentTransportError,
+} from "@repo/backend/client/content/errors";
+import { verifyPublicContentResponse } from "@repo/backend/client/content/public";
+import {
+  type ContentHttpTarget,
+  createContentContractError,
+  createContentEndpoint,
+  encodeContentRequest,
+  readContentResponse,
+  requestContentResponse,
+  validateContentRuntimeStatus,
+} from "@repo/backend/client/content/transport";
+import { MATERIAL_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
+import {
+  MAX_MATERIAL_RUNTIME_RESPONSE_BYTES,
+  type MaterialRuntimeFound,
+  MaterialRuntimeResponseSchema,
+} from "@repo/backend/content/material";
+import { Effect, Schema } from "effect";
+
+/** Exact public material identity without its fixed delivery class. */
+export interface MaterialRuntimeInput {
+  readonly appLocale: MaterialRuntimeFound["runtime"]["projection"]["appLocale"];
+  readonly publicPath: string;
+}
+
+/** Reads one cohesive response without trusting its advertised shape or size. */
+const readMaterialResponse = Effect.fn("NakafaContent.readMaterialResponse")(
+  function* (response: Response, endpoint: string) {
+    const input = yield* readContentResponse(
+      response,
+      endpoint,
+      MAX_MATERIAL_RUNTIME_RESPONSE_BYTES
+    );
+    const decoded = yield* Schema.decodeUnknownEffect(
+      MaterialRuntimeResponseSchema
+    )(input, { onExcessProperty: "error" }).pipe(
+      Effect.mapError(() => createContentContractError(response))
+    );
+    yield* validateContentRuntimeStatus(decoded, response.status);
+    return decoded;
+  }
+);
+
+/** Reads and verifies one material shell and body selected in one transaction. */
+export const readMaterialContent = Effect.fn(
+  "NakafaContent.readMaterialContent"
+)(function* (
+  target: ContentHttpTarget,
+  input: MaterialRuntimeInput,
+  rendererManifest: unknown
+) {
+  const request = yield* decodePublicContentRuntimeRequest({
+    delivery: "public",
+    ...input,
+  }).pipe(
+    Effect.mapError(() => new ContentTransportError({ reason: "request" }))
+  );
+  const source = yield* encodeContentRequest(
+    request,
+    MAX_PUBLIC_RUNTIME_REQUEST_BYTES
+  );
+  const endpoint = yield* createContentEndpoint(
+    target.siteUrl,
+    MATERIAL_CONTENT_RUNTIME_PATH
+  );
+  const { response, value: decoded } = yield* requestContentResponse(
+    { endpoint, source, target },
+    readMaterialResponse
+  );
+  if (decoded.kind === "missing") {
+    return yield* new ContentRuntimeMissingError({ request });
+  }
+  if (decoded.kind === "failure") {
+    return yield* new ContentRuntimeFailureError({
+      code: decoded.code,
+      status: response.status,
+    });
+  }
+  const runtime = yield* verifyPublicContentResponse(
+    request,
+    decoded.runtime,
+    { kind: "live", rendererManifest },
+    response.status
+  );
+  return { model: decoded.model, runtime };
+});

--- a/packages/backend/client/content/public.test.ts
+++ b/packages/backend/client/content/public.test.ts
@@ -177,6 +177,25 @@ describe("public content runtime client", () => {
     })
   );
 
+  it.live(
+    "rejects malformed singular and batch identities before network IO",
+    () =>
+      Effect.gen(function* () {
+        const malformed = { ...input, publicPath: "" };
+
+        expect(
+          yield* readPublicContentEvidence(target, malformed).pipe(Effect.flip)
+        ).toEqual(new ContentTransportError({ reason: "request" }));
+        expect(
+          yield* readPublicContentEvidenceBatch(target, [malformed]).pipe(
+            Effect.flip
+          )
+        ).toEqual(new ContentTransportError({ reason: "request" }));
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(verifyMock).not.toHaveBeenCalled();
+      })
+  );
+
   it.live("preserves exact item absence and batch-level runtime failure", () =>
     Effect.gen(function* () {
       fetchMock
@@ -229,6 +248,32 @@ describe("public content runtime client", () => {
 
       expect(
         yield* readPublicContentEvidenceBatch(target, inputs).pipe(Effect.flip)
+      ).toEqual(new ContentTransportError({ reason: "response-contract" }));
+      expect(verifyMock).not.toHaveBeenCalled();
+    })
+  );
+
+  it.live("preserves batch failure-envelope and HTTP status taxonomy", () =>
+    Effect.gen(function* () {
+      fetchMock
+        .mockResolvedValueOnce(
+          createResponse({ unexpected: true }, 500, true, batchEndpoint)
+        )
+        .mockResolvedValueOnce(
+          createResponse(foundResponse(), 500, true, batchEndpoint)
+        )
+        .mockResolvedValueOnce(
+          createResponse({ kind: "missing" }, 404, true, batchEndpoint)
+        );
+
+      expect(
+        yield* readPublicContentEvidenceBatch(target, [input]).pipe(Effect.flip)
+      ).toEqual(new ContentTransportError({ reason: "response-contract" }));
+      expect(
+        yield* readPublicContentEvidenceBatch(target, [input]).pipe(Effect.flip)
+      ).toEqual(new ContentTransportError({ reason: "status" }));
+      expect(
+        yield* readPublicContentEvidenceBatch(target, [input]).pipe(Effect.flip)
       ).toEqual(new ContentTransportError({ reason: "response-contract" }));
       expect(verifyMock).not.toHaveBeenCalled();
     })

--- a/packages/backend/client/content/public.ts
+++ b/packages/backend/client/content/public.ts
@@ -35,7 +35,7 @@ import {
   PUBLIC_CONTENT_RUNTIME_PATH,
 } from "@repo/backend/content/endpoint";
 import { contentKeyResolver } from "@repo/backend/content/trust";
-import { Effect, Schema } from "effect";
+import { Effect, Array as EffectArray, Schema } from "effect";
 /** Server-owned connection values for the private content runtime endpoint. */
 export type ContentRuntimeTarget = ContentHttpTarget;
 /** Public route identity without its module-owned delivery discriminator. */
@@ -43,7 +43,7 @@ export interface PublicContentRuntimeInput {
   readonly appLocale: PublicContentRuntimeRequest["appLocale"];
   readonly publicPath: string;
 }
-type PublicContentVerification =
+export type PublicContentVerification =
   | {
       readonly kind: "frozen";
     }
@@ -80,7 +80,7 @@ const readPublicRuntimeResponse = Effect.fn(
   return decoded;
 });
 /** Verifies one exact Aksara response under the selected renderer policy. */
-const verifyPublicContentResponse = Effect.fn(
+export const verifyPublicContentResponse = Effect.fn(
   "NakafaContent.verifyPublicContentResponse"
 )(function* (
   request: PublicContentRuntimeRequest,
@@ -108,6 +108,7 @@ const verifyPublicContentResponse = Effect.fn(
   }
   return verified;
 });
+
 /** Reads and authenticates one public artifact under an explicit renderer policy. */
 const readPublicContentProgram = Effect.fn(
   "NakafaContent.readPublicContentProgram"
@@ -207,19 +208,15 @@ export const readPublicContentEvidenceBatch = Effect.fn(
   if (decoded.responses.length !== requests.length) {
     return yield* createContentContractError(response);
   }
-  return yield* Effect.forEach(requests, (request, index) =>
-    Effect.gen(function* () {
-      const batchResponse = decoded.responses[index];
-      if (batchResponse === undefined) {
-        return yield* createContentContractError(response);
-      }
-      return yield* verifyPublicContentResponse(
+  return yield* Effect.forEach(
+    EffectArray.zip(requests, decoded.responses),
+    ([request, batchResponse]) =>
+      verifyPublicContentResponse(
         request,
         batchResponse,
         { kind: "frozen" },
         response.status
-      );
-    })
+      )
   );
 });
 /** Reads one public artifact verified against the caller's live renderer. */

--- a/packages/backend/content/batch.test.ts
+++ b/packages/backend/content/batch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   MAX_PUBLIC_RUNTIME_REQUEST_BYTES,
   MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
-  PublicContentRuntimeResponseSchema,
+  PublicContentRuntimeFoundSchema,
 } from "@nakafa/aksara-contracts/runtime/spec";
 import {
   MAX_PUBLIC_RUNTIME_BATCH_REQUEST_BYTES,
@@ -10,8 +10,11 @@ import {
   PUBLIC_CONTENT_RUNTIME_BATCH_SIZE,
   PublicContentRuntimeBatchRequestSchema,
   PublicContentRuntimeBatchResponseSchema,
-  publicRuntimeResponseBytes,
 } from "@repo/backend/content/batch";
+import {
+  BoundedPublicRuntimeFoundSchema,
+  publicRuntimeBytes,
+} from "@repo/backend/content/runtime";
 import { testArtifactJson } from "@repo/backend/test/content/artifact";
 import { testProjectionJson } from "@repo/backend/test/content/material";
 import {
@@ -25,7 +28,7 @@ import { Result, Schema } from "effect";
 
 /** Creates one structurally exact Aksara public found response. */
 function foundResponse(title = "Technical title") {
-  return Schema.decodeSync(PublicContentRuntimeResponseSchema)({
+  return Schema.decodeSync(PublicContentRuntimeFoundSchema)({
     activeManifestHash: TEST_MANIFEST_HASH,
     activeReleaseId: TEST_RELEASE_ID,
     artifact: JSON.parse(testArtifactJson()),
@@ -102,7 +105,7 @@ describe("public content runtime batch contract", () => {
     const oversized = foundResponse(
       "x".repeat(MAX_PUBLIC_RUNTIME_RESPONSE_BYTES)
     );
-    expect(publicRuntimeResponseBytes(oversized)).toBeGreaterThan(
+    expect(publicRuntimeBytes(oversized)).toBeGreaterThan(
       MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
     );
     expect(
@@ -110,6 +113,21 @@ describe("public content runtime batch contract", () => {
         Schema.decodeResult(PublicContentRuntimeBatchResponseSchema)({
           responses: [oversized],
         })
+      )
+    ).toBe(true);
+  });
+  it("accepts the exact Aksara singular response byte boundary", () => {
+    const empty = foundResponse("");
+    const boundary = foundResponse(
+      "x".repeat(MAX_PUBLIC_RUNTIME_RESPONSE_BYTES - publicRuntimeBytes(empty))
+    );
+
+    expect(publicRuntimeBytes(boundary)).toBe(
+      MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
+    );
+    expect(
+      Result.isSuccess(
+        Schema.decodeResult(BoundedPublicRuntimeFoundSchema)(boundary)
       )
     ).toBe(true);
   });

--- a/packages/backend/content/batch.ts
+++ b/packages/backend/content/batch.ts
@@ -3,8 +3,8 @@ import {
   MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
   PublicContentRuntimeRequestSchema,
   type PublicContentRuntimeResponse,
-  PublicContentRuntimeResponseSchema,
 } from "@nakafa/aksara-contracts/runtime/spec";
+import { BoundedPublicRuntimeResponseSchema } from "@repo/backend/content/runtime";
 import { Schema } from "effect";
 /** Maximum exact Aksara public exchanges resolved by one batch transaction. */
 export const PUBLIC_CONTENT_RUNTIME_BATCH_SIZE = 8;
@@ -17,10 +17,6 @@ export const MAX_PUBLIC_RUNTIME_BATCH_REQUEST_BYTES =
 export const MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES =
   PUBLIC_CONTENT_RUNTIME_BATCH_SIZE * MAX_PUBLIC_RUNTIME_RESPONSE_BYTES +
   BATCH_JSON_OVERHEAD_BYTES;
-/** Measures the exact JSON wire bytes of one decoded Aksara response. */
-export function publicRuntimeResponseBytes<Response>(response: Response) {
-  return new TextEncoder().encode(JSON.stringify(response)).byteLength;
-}
 /** Nakafa batch of exact Aksara public runtime requests. */
 export const PublicContentRuntimeBatchRequestSchema = Schema.Struct({
   requests: Schema.Array(PublicContentRuntimeRequestSchema).pipe(
@@ -29,7 +25,7 @@ export const PublicContentRuntimeBatchRequestSchema = Schema.Struct({
   ),
 });
 const PublicContentRuntimeBatchItemSchema =
-  PublicContentRuntimeResponseSchema.pipe(
+  BoundedPublicRuntimeResponseSchema.pipe(
     Schema.check(
       Schema.makeFilter(
         (
@@ -41,14 +37,6 @@ const PublicContentRuntimeBatchItemSchema =
           }
         > => response.kind !== "failure",
         { message: "Batch items contain only found or missing responses." }
-      )
-    ),
-    Schema.check(
-      Schema.makeFilter(
-        (response) =>
-          publicRuntimeResponseBytes(response) <=
-          MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
-        { message: "Batch item exceeded the Aksara response ceiling." }
       )
     )
   );

--- a/packages/backend/content/endpoint.ts
+++ b/packages/backend/content/endpoint.ts
@@ -6,6 +6,9 @@ export const PUBLIC_CONTENT_RUNTIME_PATH = CONTENT_RUNTIME_PATH;
 /** Canonical endpoint for current public content batches. */
 export const PUBLIC_CONTENT_RUNTIME_BATCH_PATH = `${PUBLIC_CONTENT_RUNTIME_PATH}/batch`;
 
+/** Cohesive current material shell and body endpoint. */
+export const MATERIAL_CONTENT_RUNTIME_PATH = `${CONTENT_RUNTIME_PATH}/material`;
+
 /** Canonical unversioned endpoint for protected content reads. */
 export const PROTECTED_CONTENT_RUNTIME_PATH = `${CONTENT_RUNTIME_PATH}/protected`;
 

--- a/packages/backend/content/material.ts
+++ b/packages/backend/content/material.ts
@@ -1,0 +1,47 @@
+import {
+  CorpusSourcePathSchema,
+  GitCommitShaSchema,
+  ReleaseIdSchema,
+  Sha256HashSchema,
+} from "@nakafa/aksara-contracts/ids";
+import { ActiveAppLocaleListSchema } from "@nakafa/aksara-contracts/locale";
+import { RendererDomainSchema } from "@nakafa/aksara-contracts/renderer/domain";
+import {
+  ContentRuntimeFailureSchema,
+  ContentRuntimeMissingSchema,
+} from "@nakafa/aksara-contracts/runtime/result";
+import { BoundedPublicRuntimeFoundSchema } from "@repo/backend/content/runtime";
+import { Schema } from "effect";
+
+/** Maximum UTF-8 bytes returned by one cohesive material publication read. */
+export const MAX_MATERIAL_RUNTIME_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+/** Complete signed material shell transported with its verified body. */
+export const MaterialRuntimeModelSchema = Schema.Struct({
+  activeManifestHash: Sha256HashSchema,
+  activeAppLocales: ActiveAppLocaleListSchema,
+  activeReleaseId: ReleaseIdSchema,
+  alternateJson: Schema.Array(Schema.String),
+  projectionJson: Schema.NullOr(Schema.String),
+  rendererDomain: Schema.NullOr(RendererDomainSchema),
+  siblingJson: Schema.Array(Schema.String),
+  sourcePath: Schema.NullOr(CorpusSourcePathSchema),
+  sourceRevision: Schema.NullOr(GitCommitShaSchema),
+});
+
+/** One material shell and signed runtime selected in the same transaction. */
+export const MaterialRuntimeFoundSchema = Schema.Struct({
+  kind: Schema.Literal("found"),
+  model: MaterialRuntimeModelSchema,
+  runtime: BoundedPublicRuntimeFoundSchema,
+});
+
+/** Complete response vocabulary for the cohesive material runtime. */
+export const MaterialRuntimeResponseSchema = Schema.Union([
+  MaterialRuntimeFoundSchema,
+  ContentRuntimeMissingSchema,
+  ContentRuntimeFailureSchema,
+]);
+
+export type MaterialRuntimeFound = typeof MaterialRuntimeFoundSchema.Type;
+export type MaterialRuntimeResponse = typeof MaterialRuntimeResponseSchema.Type;

--- a/packages/backend/content/runtime.ts
+++ b/packages/backend/content/runtime.ts
@@ -1,0 +1,25 @@
+import {
+  MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
+  PublicContentRuntimeFoundSchema,
+  PublicContentRuntimeResponseSchema,
+} from "@nakafa/aksara-contracts/runtime/spec";
+import { Schema } from "effect";
+
+/** Measures the exact JSON wire bytes of one decoded Aksara response. */
+export function publicRuntimeBytes<Response>(response: Response) {
+  return new TextEncoder().encode(JSON.stringify(response)).byteLength;
+}
+
+const PublicRuntimeByteCheck = Schema.makeFilter(
+  (response: unknown) =>
+    publicRuntimeBytes(response) <= MAX_PUBLIC_RUNTIME_RESPONSE_BYTES,
+  { message: "Public runtime exceeded the Aksara response ceiling." }
+);
+
+/** Exact Aksara public found response within its singular wire ceiling. */
+export const BoundedPublicRuntimeFoundSchema =
+  PublicContentRuntimeFoundSchema.pipe(Schema.check(PublicRuntimeByteCheck));
+
+/** Exact Aksara public response within its singular wire ceiling. */
+export const BoundedPublicRuntimeResponseSchema =
+  PublicContentRuntimeResponseSchema.pipe(Schema.check(PublicRuntimeByteCheck));

--- a/packages/backend/convex/contentRelease/catalog.test.ts
+++ b/packages/backend/convex/contentRelease/catalog.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ArtifactLocaleSchema } from "@nakafa/aksara-contracts/locale";
+import { canonicalizeMaterialProjection } from "@nakafa/aksara-contracts/projection/material";
+import {
+  contentHead,
+  resolveContentHead,
+  resolvePublicProjection,
+  resolvePublicProjectionProof,
+} from "@repo/backend/convex/contentRelease/catalog";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeMaterialProjection } from "@repo/backend/test/content/material";
+import {
+  TEST_QUESTION_CONTENT_KEY,
+  TEST_QUESTION_PROJECTION_JSON,
+  TEST_QUESTION_SOURCE,
+} from "@repo/backend/test/content/question";
+import { activateMaterialCatalog } from "@repo/backend/test/material/catalog";
+import { insertRuntimeVersion } from "@repo/backend/test/runtime/head";
+import { convexTest } from "convex-test";
+
+describe("contentRelease/catalog", () => {
+  it("preserves unrouted question heads and rejects invalid compact heads", async () => {
+    const material = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(material);
+    const readCorruptHead = (corruption: "incomplete" | "invalid") =>
+      material.query(async (ctx) => {
+        const head = await ctx.db
+          .query("contentHeads")
+          .withIndex("by_contentKey_and_artifactLocale_and_sequence", (index) =>
+            index
+              .eq("contentKey", requested.contentKey)
+              .eq("artifactLocale", requested.artifactLocale)
+              .eq("sequence", 1)
+          )
+          .unique();
+        if (!head) {
+          return expect.fail("Expected one material content head.");
+        }
+        return runConvexProgram(
+          contentHead(
+            corruption === "incomplete"
+              ? { ...head, artifactHash: undefined }
+              : { ...head, artifactHash: "invalid-hash" },
+            requested.publicPath
+          )
+        );
+      });
+    await expect(readCorruptHead("incomplete")).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+    await expect(readCorruptHead("invalid")).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    await expect(
+      material.query((ctx) =>
+        runConvexProgram(
+          resolveContentHead(
+            ctx,
+            requested.contentKey,
+            requested.artifactLocale,
+            1
+          )
+        )
+      )
+    ).resolves.toMatchObject({ publicPath: requested.publicPath });
+
+    const question = convexTest(schema, convexModules);
+    await question.mutation((ctx) =>
+      insertRuntimeVersion(ctx, "authenticated", TEST_QUESTION_CONTENT_KEY, {
+        headSequence: 1,
+        projectionJson: TEST_QUESTION_PROJECTION_JSON,
+        sourcePath: TEST_QUESTION_SOURCE,
+      })
+    );
+    const head = await question.query((ctx) =>
+      runConvexProgram(
+        resolveContentHead(ctx, TEST_QUESTION_CONTENT_KEY, "en", 1)
+      )
+    );
+    expect(head).not.toHaveProperty("publicPath");
+    expect(head).toMatchObject({
+      contentKey: TEST_QUESTION_CONTENT_KEY,
+      family: "question",
+    });
+  });
+
+  it("returns exact absence from every public catalog reader", async () => {
+    const target = convexTest(schema, convexModules);
+    const missingKey = "material/lesson/test/missing/section";
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(resolvePublicProjectionProof(ctx, missingKey, "en", 1))
+      )
+    ).resolves.toBeNull();
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(resolvePublicProjection(ctx, missingKey, "en", 1))
+      )
+    ).resolves.toBeNull();
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(resolveContentHead(ctx, missingKey, "en", 1))
+      )
+    ).resolves.toBeNull();
+  });
+
+  it.each(["missing", "release"] as const)(
+    "rejects a canonical route with %s binding evidence",
+    async (corruption) => {
+      const target = convexTest(schema, convexModules);
+      const requested = makeMaterialProjection("en", 1);
+      await activateMaterialCatalog(target);
+      await target.mutation(async (ctx) => {
+        const binding = await ctx.db
+          .query("contentBindings")
+          .withIndex(
+            "by_appLocale_and_publicPath_and_sequence_and_index",
+            (index) =>
+              index
+                .eq("appLocale", requested.appLocale)
+                .eq("publicPath", requested.publicPath)
+                .eq("sequence", 1)
+          )
+          .unique();
+        if (!binding) {
+          return expect.fail("Expected one canonical material binding.");
+        }
+        if (corruption === "missing") {
+          await ctx.db.delete("contentBindings", binding._id);
+          return;
+        }
+        await ctx.db.patch("contentBindings", binding._id, {
+          releaseId: "release-mismatch",
+        });
+      });
+
+      await expect(
+        target.query((ctx) =>
+          runConvexProgram(
+            resolvePublicProjectionProof(
+              ctx,
+              requested.contentKey,
+              requested.artifactLocale,
+              1
+            )
+          )
+        )
+      ).rejects.toMatchObject({
+        data: {
+          code:
+            corruption === "missing"
+              ? "CONTENT_RELEASE_ROUTE"
+              : "CONTENT_RELEASE_INTEGRITY",
+        },
+      });
+    }
+  );
+
+  it.each(["projection", "family"] as const)(
+    "rejects %s corruption while resolving one effective head",
+    async (corruption) => {
+      const target = convexTest(schema, convexModules);
+      const requested = makeMaterialProjection("en", 1);
+      await activateMaterialCatalog(target);
+      await target.mutation(async (ctx) => {
+        const head = await ctx.db
+          .query("contentHeads")
+          .withIndex("by_contentKey_and_artifactLocale_and_sequence", (index) =>
+            index
+              .eq("contentKey", requested.contentKey)
+              .eq("artifactLocale", requested.artifactLocale)
+              .eq("sequence", 1)
+          )
+          .unique();
+        if (!head) {
+          return expect.fail("Expected one corruptible material head.");
+        }
+        if (corruption === "projection") {
+          await ctx.db.patch("contentHeads", head._id, {
+            projectionJson: undefined,
+          });
+          return;
+        }
+        await ctx.db.patch("contentHeads", head._id, { family: "article" });
+      });
+
+      await expect(
+        target.query((ctx) =>
+          runConvexProgram(
+            resolveContentHead(
+              ctx,
+              requested.contentKey,
+              requested.artifactLocale,
+              1
+            )
+          )
+        )
+      ).rejects.toMatchObject({
+        data: { code: "CONTENT_RELEASE_INTEGRITY" },
+      });
+    }
+  );
+
+  it("rejects a decoded projection whose stored artifact locale drifted", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await target.mutation((ctx) =>
+      insertRuntimeVersion(ctx, "public", requested.contentKey, {
+        artifactLocale: ArtifactLocaleSchema.make("id"),
+        headSequence: 1,
+        projectionJson: canonicalizeMaterialProjection(requested),
+      })
+    );
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(resolveContentHead(ctx, requested.contentKey, "id", 1))
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it.each(["projection", "hash", "provenance"] as const)(
+    "rejects %s corruption in an exact public projection proof",
+    async (corruption) => {
+      const target = convexTest(schema, convexModules);
+      const requested = makeMaterialProjection("en", 1);
+      await activateMaterialCatalog(target);
+      await target.mutation(async (ctx) => {
+        const head = await ctx.db
+          .query("contentHeads")
+          .withIndex("by_contentKey_and_artifactLocale_and_sequence", (index) =>
+            index
+              .eq("contentKey", requested.contentKey)
+              .eq("artifactLocale", requested.artifactLocale)
+              .eq("sequence", 1)
+          )
+          .unique();
+        if (!head) {
+          return expect.fail("Expected one provable material head.");
+        }
+        if (corruption === "projection") {
+          await ctx.db.patch("contentHeads", head._id, {
+            projectionHash: undefined,
+          });
+          return;
+        }
+        if (corruption === "hash") {
+          await ctx.db.patch("contentHeads", head._id, {
+            projectionHash: `sha256:${"f".repeat(64)}`,
+          });
+          return;
+        }
+        await ctx.db.patch("contentHeads", head._id, {
+          rendererDomain: undefined,
+        });
+      });
+
+      await expect(
+        target.query((ctx) =>
+          runConvexProgram(
+            resolvePublicProjectionProof(
+              ctx,
+              requested.contentKey,
+              requested.artifactLocale,
+              1
+            )
+          )
+        )
+      ).rejects.toMatchObject({
+        data: { code: "CONTENT_RELEASE_INTEGRITY" },
+      });
+    }
+  );
+
+  it("keeps question bodies outside the public route projection contract", async () => {
+    const target = convexTest(schema, convexModules);
+    await target.mutation((ctx) =>
+      insertRuntimeVersion(ctx, "public", TEST_QUESTION_CONTENT_KEY, {
+        headSequence: 1,
+        projectionJson: TEST_QUESTION_PROJECTION_JSON,
+        sourcePath: TEST_QUESTION_SOURCE,
+      })
+    );
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(
+          resolvePublicProjectionProof(ctx, TEST_QUESTION_CONTENT_KEY, "en", 1)
+        )
+      )
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/backend/convex/contentRelease/catalog.ts
+++ b/packages/backend/convex/contentRelease/catalog.ts
@@ -64,7 +64,7 @@ export const contentHead = Effect.fn("contentRelease.contentHead")(function* (
     )
   );
 });
-/** Resolves and validates one content head's canonical published route. */
+/** Resolves and validates one content head's canonical route disposition. */
 const resolvePublicPath = Effect.fn("contentRelease.resolvePublicPath")(
   function* (ctx: ReadCtx, head: Doc<"contentHeads">, activeSequence: number) {
     if (!head.projectionJson) {
@@ -81,7 +81,7 @@ const resolvePublicPath = Effect.fn("contentRelease.resolvePublicPath")(
       );
     }
     if (projection.kind === "question-body") {
-      return;
+      return { kind: "unrouted" as const, projection };
     }
     if (projection.artifactLocale !== head.artifactLocale) {
       return yield* releaseFail(
@@ -113,12 +113,16 @@ const resolvePublicPath = Effect.fn("contentRelease.resolvePublicPath")(
         `Route for ${head.contentKey}/${head.artifactLocale} disagrees at one sequence.`
       );
     }
-    return projection.publicPath;
+    return {
+      kind: "routed" as const,
+      projection,
+      publicPath: projection.publicPath,
+    };
   }
 );
-/** Resolves one exact public projection selected by a frozen sequence. */
-export const resolvePublicProjection = Effect.fn(
-  "contentRelease.resolvePublicProjection"
+/** Resolves one exact public projection with its authenticated stored head. */
+export const resolvePublicProjectionProof = Effect.fn(
+  "contentRelease.resolvePublicProjectionProof"
 )(function* (
   ctx: ReadCtx,
   contentKey: string,
@@ -135,17 +139,11 @@ export const resolvePublicProjection = Effect.fn(
       `Public content ${contentKey}/${artifactLocale} lost its projection.`
     );
   }
-  const projection = yield* decodeProjectionJson(head.projectionJson);
-  if (projection.kind === "question-body") {
+  const route = yield* resolvePublicPath(ctx, head, sequence);
+  if (route.kind === "unrouted") {
     return null;
   }
-  const publicPath = yield* resolvePublicPath(ctx, head, sequence);
-  if (publicPath === undefined) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `Public content ${contentKey}/${artifactLocale} lost its routed projection.`
-    );
-  }
+  const { projection, publicPath } = route;
   const projectionHash = yield* hashText(
     "the public content projection",
     canonicalizeContentProjection(projection)
@@ -169,18 +167,39 @@ export const resolvePublicProjection = Effect.fn(
     );
   }
   return {
-    appLocale: projection.appLocale,
-    artifactLocale: head.artifactLocale,
-    contentKey: head.contentKey,
-    family: head.family,
-    projectionHash,
-    projectionJson: head.projectionJson,
-    publicPath,
-    releaseId: head.releaseId,
-    rendererDomain: head.rendererDomain,
-    sequence: head.sequence,
-    sourcePath: head.sourcePath,
+    head,
+    projection: {
+      appLocale: projection.appLocale,
+      artifactLocale: head.artifactLocale,
+      contentKey: head.contentKey,
+      family: head.family,
+      projectionHash,
+      projectionJson: head.projectionJson,
+      publicPath,
+      releaseId: head.releaseId,
+      rendererDomain: head.rendererDomain,
+      sequence: head.sequence,
+      sourcePath: head.sourcePath,
+    },
   };
+});
+
+/** Resolves one exact public projection selected by a frozen sequence. */
+export const resolvePublicProjection = Effect.fn(
+  "contentRelease.resolvePublicProjection"
+)(function* (
+  ctx: ReadCtx,
+  contentKey: string,
+  artifactLocale: Doc<"contentKeys">["artifactLocale"],
+  sequence: number
+) {
+  const proof = yield* resolvePublicProjectionProof(
+    ctx,
+    contentKey,
+    artifactLocale,
+    sequence
+  );
+  return proof?.projection ?? null;
 });
 /** Resolves one effective immutable head from a frozen sequence snapshot. */
 export const resolveContentHead = Effect.fn(
@@ -195,6 +214,9 @@ export const resolveContentHead = Effect.fn(
   if (!head || head.operation === "delete") {
     return null;
   }
-  const publicPath = yield* resolvePublicPath(ctx, head, sequence);
-  return yield* contentHead(head, publicPath);
+  const route = yield* resolvePublicPath(ctx, head, sequence);
+  return yield* contentHead(
+    head,
+    route.kind === "routed" ? route.publicPath : undefined
+  );
 });

--- a/packages/backend/convex/contentRelease/http/runtime/material.test.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/material.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_RESPONSE_HEADER,
+  CONTENT_RUNTIME_RESPONSE_MARKER,
+  MATERIAL_CONTENT_RUNTIME_PATH,
+} from "@repo/backend/content/endpoint";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { makeMaterialProjection } from "@repo/backend/test/content/material";
+import { activateMaterialCatalog } from "@repo/backend/test/material/catalog";
+
+const RUNTIME_TOKEN = "technical-material-runtime-token";
+const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
+const polarName = "POLAR_WEBHOOK_SECRET";
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+/** Sends one request through the registered cohesive material HTTP route. */
+function post(
+  target: Pick<RuntimeTest, "fetch">,
+  body: BodyInit | null,
+  token = RUNTIME_TOKEN
+) {
+  return target.fetch(MATERIAL_CONTENT_RUNTIME_PATH, {
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-nakafa-content-token": token,
+    },
+    method: "POST",
+  });
+}
+
+/** Asserts the private response contract shared by runtime routes. */
+function expectPrivate(response: Response) {
+  expect(response.headers.get("cache-control")).toBe("private, no-store");
+  expect(response.headers.get(CONTENT_RUNTIME_RESPONSE_HEADER)).toBe(
+    CONTENT_RUNTIME_RESPONSE_MARKER
+  );
+}
+
+beforeEach(() => {
+  process.env[runtimeTokenName] = RUNTIME_TOKEN;
+  process.env[polarName] = "technical-webhook-secret";
+});
+
+afterEach(() => {
+  delete process.env[runtimeTokenName];
+  delete process.env[polarName];
+});
+
+describe("material content runtime HTTP route", () => {
+  it("keeps platform discovery and auth handlers reachable beside material", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const discovery = await target.fetch("/.well-known/openid-configuration");
+    const auth = await target.fetch(
+      "/api/auth/convex/.well-known/openid-configuration"
+    );
+
+    expect(discovery.status).toBe(302);
+    expect(discovery.headers.get("location")).toBe(
+      "/api/auth/convex/.well-known/openid-configuration"
+    );
+    expect(auth.status).toBe(200);
+    await expect(auth.json()).resolves.toMatchObject({
+      authorization_endpoint: expect.any(String),
+    });
+  });
+
+  it("serves the coherent publication only on the authenticated route", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    const source = JSON.stringify({
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: requested.publicPath,
+    });
+
+    const response = await post(target, source);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      kind: "found",
+      model: { activeReleaseId: "release-test" },
+      runtime: {
+        kind: "found",
+        projection: { publicPath: requested.publicPath },
+      },
+    });
+    expectPrivate(response);
+  });
+
+  it("authenticates first and rejects malformed authenticated input", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const unauthorized = await post(target, "{", "wrong-token");
+    const malformed = await post(target, "{");
+
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({
+      code: "CONTENT_RUNTIME_UNAUTHORIZED",
+      kind: "failure",
+    });
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toEqual({
+      code: "CONTENT_RUNTIME_INVALID",
+      kind: "failure",
+    });
+    expectPrivate(unauthorized);
+    expectPrivate(malformed);
+  });
+});

--- a/packages/backend/convex/contentRelease/http/runtime/material.ts
+++ b/packages/backend/convex/contentRelease/http/runtime/material.ts
@@ -1,0 +1,40 @@
+import { MAX_PUBLIC_RUNTIME_REQUEST_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
+import { MATERIAL_CONTENT_RUNTIME_PATH } from "@repo/backend/content/endpoint";
+import { type ActionCtx, env } from "@repo/backend/convex/_generated/server";
+import { readRuntimeRequest } from "@repo/backend/convex/contentRelease/http/runtime/request";
+import { privateRuntimeResponse } from "@repo/backend/convex/contentRelease/http/runtime/response";
+import { dispatchMaterialProgram } from "@repo/backend/convex/contentRelease/runtime/public/material";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import type { HonoWithConvex } from "convex-helpers/server/hono";
+import { Effect } from "effect";
+
+/** Authenticates and forwards one cohesive material runtime request. */
+const readMaterialRuntime = Effect.fn("contentRelease.readMaterialRuntime")(
+  function* (ctx: ActionCtx, request: Request) {
+    const input = yield* readRuntimeRequest(
+      request,
+      env.CONTENT_RUNTIME_TOKEN,
+      MAX_PUBLIC_RUNTIME_REQUEST_BYTES
+    );
+    if (input.kind === "rejected") {
+      return input.result;
+    }
+    return yield* dispatchMaterialProgram(
+      ctx,
+      input.body.source,
+      input.body.byteLength
+    );
+  }
+);
+
+/** Registers the server-authenticated cohesive material read route. */
+export function registerMaterialContentRuntimeRoute<
+  Variables extends Record<string, unknown>,
+>(app: HonoWithConvex<ActionCtx, Variables>) {
+  app.post(MATERIAL_CONTENT_RUNTIME_PATH, async (context) => {
+    const result = await runConvexProgram(
+      readMaterialRuntime(context.env, context.req.raw)
+    );
+    return privateRuntimeResponse(result);
+  });
+}

--- a/packages/backend/convex/contentRelease/material.test.ts
+++ b/packages/backend/convex/contentRelease/material.test.ts
@@ -21,6 +21,81 @@ const decodeProjection = Schema.decodeUnknownSync(
 );
 
 describe("contentRelease/material", () => {
+  it("keeps every public material reader on one active catalog", async () => {
+    const t = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(t);
+
+    await expect(
+      t.query(api.contentRelease.material.identity, {
+        appLocale: requested.appLocale,
+        contentKey: requested.contentKey,
+        expectedMaterialKey: requested.materialKey,
+        expectedSectionKey: requested.sectionKey,
+      })
+    ).resolves.toEqual({
+      activeReleaseId: MATERIAL_IDENTITY.releaseId,
+      managed: true,
+      publicPath: requested.publicPath,
+    });
+    await expect(
+      t.query(api.contentRelease.material.latest, {
+        appLocale: requested.appLocale,
+        limit: 1,
+      })
+    ).resolves.toMatchObject({
+      activeReleaseId: MATERIAL_IDENTITY.releaseId,
+      managed: true,
+      materials: [{ title: "EN Section 2" }],
+    });
+
+    const partition = await t.query(
+      api.contentRelease.material.sitemapBuckets,
+      { appLocale: requested.appLocale }
+    );
+    expect(partition).toMatchObject({
+      activeReleaseId: MATERIAL_IDENTITY.releaseId,
+      managed: true,
+      materialCount: 2,
+    });
+    expect(partition.buckets.length).toBeGreaterThan(0);
+    const pages = await Promise.all(
+      partition.buckets.map((bucket) =>
+        t.query(api.contentRelease.material.sitemapPage, {
+          appLocale: requested.appLocale,
+          bucket,
+        })
+      )
+    );
+    const requestedBucketIndex = pages.findIndex((page) =>
+      page?.routes.some(({ publicPath }) => publicPath === requested.publicPath)
+    );
+    const bucket = partition.buckets[requestedBucketIndex];
+    if (bucket === undefined) {
+      throw new Error("Expected the requested public material partition.");
+    }
+    await expect(
+      t.query(api.contentRelease.material.bucket, {
+        appLocale: requested.appLocale,
+        bucket,
+      })
+    ).resolves.toMatchObject({
+      activeReleaseId: MATERIAL_IDENTITY.releaseId,
+      managed: true,
+      materials: expect.arrayContaining([
+        expect.objectContaining({ publicPath: requested.publicPath }),
+      ]),
+    });
+    expect(pages[requestedBucketIndex]).toEqual({
+      routes: expect.arrayContaining([
+        {
+          lastModified: requested.metadata.datePublished,
+          publicPath: requested.publicPath,
+        },
+      ]),
+    });
+  });
+
   it("fails closed before current signed ownership is available", async () => {
     const t = convexTest(schema, convexModules);
 

--- a/packages/backend/convex/contentRelease/material.ts
+++ b/packages/backend/convex/contentRelease/material.ts
@@ -10,30 +10,18 @@ import {
   readMaterialBuckets,
   readMaterialSitemap,
 } from "@repo/backend/convex/contentRelease/material/sitemap";
-import { materialApiPageValidator } from "@repo/backend/convex/contentRelease/material/spec";
-import { readPartnerApiPage } from "@repo/backend/convex/contentRelease/partner/page";
 import {
-  appLocaleValidator,
-  rendererDomainValidator,
-} from "@repo/backend/convex/contentRelease/spec";
+  materialApiPageValidator,
+  materialModelValidator,
+} from "@repo/backend/convex/contentRelease/material/spec";
+import { readPartnerApiPage } from "@repo/backend/convex/contentRelease/partner/page";
+import { appLocaleValidator } from "@repo/backend/convex/contentRelease/spec";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import {
   paginationOptsValidator,
   paginationResultValidator,
 } from "convex/server";
 import { v } from "convex/values";
-
-const materialModelValidator = v.object({
-  activeManifestHash: v.union(v.string(), v.null()),
-  activeAppLocales: v.array(appLocaleValidator),
-  activeReleaseId: v.union(v.string(), v.null()),
-  alternateJson: v.array(v.string()),
-  projectionJson: v.union(v.string(), v.null()),
-  rendererDomain: v.union(rendererDomainValidator, v.null()),
-  siblingJson: v.array(v.string()),
-  sourcePath: v.union(v.string(), v.null()),
-  sourceRevision: v.union(v.string(), v.null()),
-});
 
 const materialPageValidator = v.object({
   activeManifestHash: v.union(v.string(), v.null()),

--- a/packages/backend/convex/contentRelease/material/model.ts
+++ b/packages/backend/convex/contentRelease/material/model.ts
@@ -116,28 +116,30 @@ const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
   }
 );
 
-/** Resolves the complete active shell model for one localized material lesson. */
-export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
-  function* (
-    ctx: QueryCtx,
-    appLocale: Doc<"materialCatalog">["appLocale"],
-    publicPath: string,
-    expectedActiveReleaseId?: string | null
-  ) {
-    const route = yield* resolveMaterialRoute(ctx, appLocale, publicPath);
-    yield* requireExpectedActiveRelease(
-      route.active,
-      expectedActiveReleaseId,
-      "Material route"
+/** Resolves one material shell together with its authenticated serving proof. */
+export const resolveMaterialModel = Effect.fn(
+  "contentRelease.resolveMaterialModel"
+)(function* (
+  ctx: QueryCtx,
+  appLocale: Doc<"materialCatalog">["appLocale"],
+  publicPath: string,
+  expectedActiveReleaseId?: string | null
+) {
+  const route = yield* resolveMaterialRoute(ctx, appLocale, publicPath);
+  yield* requireExpectedActiveRelease(
+    route.active,
+    expectedActiveReleaseId,
+    "Material route"
+  );
+  if (!(route.managed && route.active)) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_MISSING",
+      `Signed material ownership is unavailable for ${appLocale}.`
     );
-    if (!(route.managed && route.active)) {
-      return yield* releaseFail(
-        "CONTENT_RELEASE_MISSING",
-        `Signed material ownership is unavailable for ${appLocale}.`
-      );
-    }
-    if (!route.material) {
-      return {
+  }
+  if (!route.material) {
+    return {
+      model: {
         activeManifestHash: route.active.manifestHash,
         activeAppLocales: Array.from(
           route.active.signed.manifest.activeAppLocales
@@ -149,22 +151,25 @@ export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
         siblingJson: [],
         sourcePath: null,
         sourceRevision: readSourceRevision(route.active),
-      };
-    }
-    const requested = route.material;
-    const { projectionJson, row } = requested;
-    const [alternates, siblings] = yield* Effect.all([
-      readAlternates(
-        ctx,
-        requested,
-        route.active.signed.manifest.activeAppLocales,
-        route.active.sequence
-      ),
-      readSiblings(ctx, requested, route.active.sequence),
-    ]);
-    const alternateJson = alternates.map((material) => material.projectionJson);
-    const siblingJson = siblings.map((material) => material.projectionJson);
-    return {
+      },
+      route,
+    };
+  }
+  const requested = route.material;
+  const { projectionJson, row } = requested;
+  const [alternates, siblings] = yield* Effect.all([
+    readAlternates(
+      ctx,
+      requested,
+      route.active.signed.manifest.activeAppLocales,
+      route.active.sequence
+    ),
+    readSiblings(ctx, requested, route.active.sequence),
+  ]);
+  const alternateJson = alternates.map((material) => material.projectionJson);
+  const siblingJson = siblings.map((material) => material.projectionJson);
+  return {
+    model: {
       activeManifestHash: route.active.manifestHash,
       activeAppLocales: Array.from(
         route.active.signed.manifest.activeAppLocales
@@ -176,6 +181,25 @@ export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
       siblingJson,
       sourcePath: row.sourcePath,
       sourceRevision: readSourceRevision(route.active),
-    };
+    },
+    route,
+  };
+});
+
+/** Resolves the complete active shell model for one localized material lesson. */
+export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
+  function* (
+    ctx: QueryCtx,
+    appLocale: Doc<"materialCatalog">["appLocale"],
+    publicPath: string,
+    expectedActiveReleaseId?: string | null
+  ) {
+    const resolved = yield* resolveMaterialModel(
+      ctx,
+      appLocale,
+      publicPath,
+      expectedActiveReleaseId
+    );
+    return resolved.model;
   }
 );

--- a/packages/backend/convex/contentRelease/material/publication.test.ts
+++ b/packages/backend/convex/contentRelease/material/publication.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "@effect/vitest";
+import type { ActiveAppLocaleCode } from "@nakafa/aksara-contracts/locale";
+import { readMaterialPublication } from "@repo/backend/convex/contentRelease/material/publication";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeMaterialProjection } from "@repo/backend/test/content/material";
+import { activateMaterialCatalog } from "@repo/backend/test/material/catalog";
+import { makeFunctionReference } from "convex/server";
+import { convexTest } from "convex-test";
+
+const readPublication = makeFunctionReference<
+  "query",
+  { readonly appLocale: ActiveAppLocaleCode; readonly publicPath: string },
+  {
+    readonly model: {
+      readonly alternateJson: readonly string[];
+      readonly projectionJson: null | string;
+      readonly siblingJson: readonly string[];
+    };
+    readonly runtime: null | {
+      readonly artifactJson: string;
+      readonly projectionJson: string;
+    };
+  }
+>("contentRelease/material/runtime:read");
+
+describe("contentRelease/material/publication", () => {
+  it("uses 14 indexed operations for three locales and one section", async () => {
+    const target = convexTest(schema, convexModules);
+    const projections = (["en", "id", "de"] as const).map((appLocale) =>
+      makeMaterialProjection(appLocale, 1)
+    );
+    const requested = projections[0];
+    await activateMaterialCatalog(target, projections);
+
+    const { metrics, result } = await target.query(async (ctx) => {
+      const publication = await runConvexProgram(
+        readMaterialPublication(ctx, requested.appLocale, requested.publicPath)
+      );
+      return {
+        metrics: await ctx.meta.getTransactionMetrics(),
+        result: publication,
+      };
+    });
+
+    expect(result.model.alternateJson).toHaveLength(3);
+    expect(result.model.siblingJson).toHaveLength(1);
+    expect(result.runtime?.projectionJson).toBe(result.model.projectionJson);
+    expect(metrics.databaseQueries.used).toBe(14);
+  });
+
+  it("serves the registered cohesive reader and preserves missing routes", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+
+    const found = await target.query(readPublication, {
+      appLocale: requested.appLocale,
+      publicPath: requested.publicPath,
+    });
+    expect(found.runtime).not.toBeNull();
+    expect(
+      JSON.parse(found.runtime?.artifactJson ?? "{}").payload.contentKey
+    ).toBe(requested.contentKey);
+
+    await expect(
+      target.query(readPublication, {
+        appLocale: "en",
+        publicPath: "subjects/test/missing",
+      })
+    ).resolves.toMatchObject({
+      model: { projectionJson: null },
+      runtime: null,
+    });
+  });
+
+  it("fails closed when the selected signed artifact is missing", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    await target.mutation(async (ctx) => {
+      const head = await ctx.db
+        .query("contentHeads")
+        .withIndex("by_contentKey_and_artifactLocale_and_sequence", (index) =>
+          index
+            .eq("contentKey", requested.contentKey)
+            .eq("artifactLocale", requested.artifactLocale)
+            .eq("sequence", 1)
+        )
+        .unique();
+      if (!head?.artifactHash) {
+        throw new Error("Expected one material runtime head.");
+      }
+      const artifact = await ctx.db
+        .query("contentArtifacts")
+        .withIndex("by_artifactHash", (index) =>
+          index.eq("artifactHash", head.artifactHash ?? "")
+        )
+        .unique();
+      if (!artifact) {
+        throw new Error("Expected one material runtime artifact.");
+      }
+      await ctx.db.delete("contentArtifacts", artifact._id);
+    });
+
+    await expect(
+      target.query(readPublication, {
+        appLocale: requested.appLocale,
+        publicPath: requested.publicPath,
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_MISSING" },
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/material/publication.ts
+++ b/packages/backend/convex/contentRelease/material/publication.ts
@@ -1,0 +1,31 @@
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type { QueryCtx } from "@repo/backend/convex/_generated/server";
+import { resolveMaterialModel } from "@repo/backend/convex/contentRelease/material/model";
+import { readPublicRuntime } from "@repo/backend/convex/contentRelease/runtime/public/internal";
+import { Effect } from "effect";
+
+/** Reads one complete material shell and body from one active route proof. */
+export const readMaterialPublication = Effect.fn(
+  "contentRelease.readMaterialPublication"
+)(function* (
+  ctx: QueryCtx,
+  appLocale: Doc<"materialCatalog">["appLocale"],
+  publicPath: string
+) {
+  const { model, route } = yield* resolveMaterialModel(
+    ctx,
+    appLocale,
+    publicPath
+  );
+  if (!route.material) {
+    return { model, runtime: null };
+  }
+  const runtime = yield* readPublicRuntime(
+    ctx,
+    route.active,
+    route.head,
+    appLocale,
+    publicPath
+  );
+  return { model, runtime };
+});

--- a/packages/backend/convex/contentRelease/material/route.ts
+++ b/packages/backend/convex/contentRelease/material/route.ts
@@ -23,6 +23,7 @@ export const resolveMaterialRoute = Effect.fn(
   if (!(route.managed && route.active)) {
     return {
       active: route.active,
+      head: null,
       managed: false,
       material: null,
     };
@@ -31,6 +32,7 @@ export const resolveMaterialRoute = Effect.fn(
   if (!route.projection) {
     return {
       active: route.active,
+      head: null,
       managed: true,
       material: null,
     };
@@ -69,6 +71,7 @@ export const resolveMaterialRoute = Effect.fn(
   }
   return {
     active: route.active,
+    head: route.head,
     managed: true,
     material: { ...verified, row },
   };

--- a/packages/backend/convex/contentRelease/material/runtime.ts
+++ b/packages/backend/convex/contentRelease/material/runtime.ts
@@ -1,0 +1,25 @@
+import { internalQuery } from "@repo/backend/convex/_generated/server";
+import { readMaterialPublication } from "@repo/backend/convex/contentRelease/material/publication";
+import { materialModelValidator } from "@repo/backend/convex/contentRelease/material/spec";
+import { publicResultValidator } from "@repo/backend/convex/contentRelease/runtime/public/internal";
+import { appLocaleValidator } from "@repo/backend/convex/contentRelease/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import type { Infer } from "convex/values";
+import { v } from "convex/values";
+
+export const materialRuntimeRowValidator = v.object({
+  model: materialModelValidator,
+  runtime: publicResultValidator,
+});
+/** Raw cohesive row returned only to the authenticated material adapter. */
+export type MaterialRuntimeRow = Infer<typeof materialRuntimeRowValidator>;
+
+/** Returns one cohesive material shell and body to the authenticated adapter. */
+export const read = internalQuery({
+  args: { appLocale: appLocaleValidator, publicPath: v.string() },
+  returns: materialRuntimeRowValidator,
+  handler: (ctx, args) =>
+    runConvexProgram(
+      readMaterialPublication(ctx, args.appLocale, args.publicPath)
+    ),
+});

--- a/packages/backend/convex/contentRelease/material/spec.ts
+++ b/packages/backend/convex/contentRelease/material/spec.ts
@@ -1,5 +1,21 @@
-import { appLocaleValidator } from "@repo/backend/convex/contentRelease/spec";
+import {
+  appLocaleValidator,
+  rendererDomainValidator,
+} from "@repo/backend/convex/contentRelease/spec";
 import { v } from "convex/values";
+
+/** Complete signed material shell returned by route and runtime readers. */
+export const materialModelValidator = v.object({
+  activeManifestHash: v.union(v.string(), v.null()),
+  activeAppLocales: v.array(appLocaleValidator),
+  activeReleaseId: v.union(v.string(), v.null()),
+  alternateJson: v.array(v.string()),
+  projectionJson: v.union(v.string(), v.null()),
+  rendererDomain: v.union(rendererDomainValidator, v.null()),
+  siblingJson: v.array(v.string()),
+  sourcePath: v.union(v.string(), v.null()),
+  sourceRevision: v.union(v.string(), v.null()),
+});
 
 /** One signed-publication row selected for the partner API. */
 export const materialApiEntryValidator = v.object({

--- a/packages/backend/convex/contentRelease/runtime/public/batch.test.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/batch.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
 import { MAX_PUBLIC_RUNTIME_BATCH_REQUEST_BYTES } from "@repo/backend/content/batch";
 import { dispatchBatchProgram } from "@repo/backend/convex/contentRelease/runtime/public/batch";
+import type { PublicRuntimeRow } from "@repo/backend/convex/contentRelease/runtime/public/internal";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { testProjectionJson } from "@repo/backend/test/content/material";
@@ -31,6 +32,30 @@ function runDispatch(t: RuntimeAction, input: unknown) {
   const byteLength = new TextEncoder().encode(source).byteLength;
   return t.action((ctx) =>
     runConvexProgram(dispatchBatchProgram(ctx, source, byteLength))
+  );
+}
+
+/** Executes the transport against an explicit internal query result. */
+function runDispatchWithRows(
+  t: RuntimeAction,
+  input: unknown,
+  rows: readonly PublicRuntimeRow[]
+) {
+  const source = JSON.stringify(input);
+  const byteLength = new TextEncoder().encode(source).byteLength;
+  return t.action((ctx) =>
+    runConvexProgram(
+      dispatchBatchProgram(
+        new Proxy(ctx, {
+          get: (target, property, receiver) =>
+            property === "runQuery"
+              ? () => Promise.resolve(rows)
+              : Reflect.get(target, property, receiver),
+        }),
+        source,
+        byteLength
+      )
+    )
   );
 }
 
@@ -115,6 +140,34 @@ describe("contentRelease/runtime/public/batch", () => {
         status: 500,
       }
     );
+  });
+
+  it("rejects incomplete and undecodable internal query results", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const corruptRow = {
+      activeManifestHash: "sha256:test",
+      activeReleaseId: "test-release",
+      artifactJson: "{",
+      delivery: "public",
+      projectionHash: "sha256:test",
+      projectionJson: "{}",
+      releaseJson: "{}",
+      rendererJson: "{}",
+      sourcePath: "packages/corpus/material/lesson/test",
+    } satisfies NonNullable<PublicRuntimeRow>;
+
+    await expect(
+      runDispatchWithRows(t, { requests: [foundRequest] }, [])
+    ).resolves.toEqual({
+      body: '{"code":"CONTENT_RUNTIME_INTERNAL","kind":"failure"}',
+      status: 500,
+    });
+    await expect(
+      runDispatchWithRows(t, { requests: [foundRequest] }, [corruptRow])
+    ).resolves.toEqual({
+      body: '{"code":"CONTENT_RUNTIME_INTERNAL","kind":"failure"}',
+      status: 500,
+    });
   });
 
   it("fails the complete batch when one stored row is corrupt", async () => {

--- a/packages/backend/convex/contentRelease/runtime/public/batch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/batch.ts
@@ -8,8 +8,8 @@ import {
   MAX_PUBLIC_RUNTIME_BATCH_RESPONSE_BYTES,
   PublicContentRuntimeBatchRequestSchema,
   PublicContentRuntimeBatchResponseSchema,
-  publicRuntimeResponseBytes,
 } from "@repo/backend/content/batch";
+import { publicRuntimeBytes } from "@repo/backend/content/runtime";
 import type { ActionCtx } from "@repo/backend/convex/_generated/server";
 import { decodePublicRuntimeRow } from "@repo/backend/convex/contentRelease/runtime/public/dispatch";
 import type { PublicRuntimeRow } from "@repo/backend/convex/contentRelease/runtime/public/internal";
@@ -110,7 +110,7 @@ const dispatchRuntimeBatchProgram = Effect.fn(
   if (
     responses.success.some(
       (response) =>
-        publicRuntimeResponseBytes(response) > MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
+        publicRuntimeBytes(response) > MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
     )
   ) {
     return failureResult("CONTENT_RUNTIME_RESPONSE_TOO_LARGE", 500);

--- a/packages/backend/convex/contentRelease/runtime/public/dispatch.test.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/dispatch.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   decodePublicContentRuntimeRequest,
   MAX_PUBLIC_RUNTIME_REQUEST_BYTES,
@@ -8,7 +8,10 @@ import {
 import { verifyContentRuntimeExchange } from "@nakafa/aksara-contracts/runtime/verify";
 import { ContentVerificationKeyResolver } from "@nakafa/aksara-contracts/signature/spec";
 import { internal } from "@repo/backend/convex/_generated/api";
-import { dispatchProgram } from "@repo/backend/convex/contentRelease/runtime/public/dispatch";
+import {
+  decodePublicRuntimeFound,
+  dispatchProgram,
+} from "@repo/backend/convex/contentRelease/runtime/public/dispatch";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import {
@@ -24,6 +27,7 @@ import {
   TEST_PAGE_SOURCE,
 } from "@repo/backend/test/content/page";
 import { TEST_KEY_RESOLVER } from "@repo/backend/test/content/proof";
+import { TEST_QUESTION_PROJECTION_JSON } from "@repo/backend/test/content/question";
 import { testTextHash } from "@repo/backend/test/content/release";
 import {
   articleRuntimeRequest,
@@ -58,6 +62,9 @@ function seedSigned(
     await insertSignedHead(ctx, delivery, runtimeContentKey(delivery));
   });
 }
+
+afterEach(() => vi.restoreAllMocks());
+
 describe("contentRelease/runtime/public/dispatch", () => {
   it.live(
     "returns one fully authenticated public artifact and exact absence",
@@ -235,6 +242,7 @@ describe("contentRelease/runtime/public/dispatch", () => {
       runConvexProgram(dispatchProgram(ctx, source, 1))
     );
     await expect(runDispatch(t, "{")).resolves.toMatchObject({ status: 400 });
+    await expect(runDispatch(t, "{}")).resolves.toMatchObject({ status: 400 });
     expect(mismatch.status).toBe(400);
     await expect(
       runDispatch(t, "x".repeat(MAX_PUBLIC_RUNTIME_REQUEST_BYTES + 1))
@@ -257,4 +265,59 @@ describe("contentRelease/runtime/public/dispatch", () => {
       status: 500,
     });
   });
+
+  it.live(
+    "rejects malformed, unroutable, mismatched, and unhashable rows",
+    () =>
+      Effect.gen(function* () {
+        const t = createConvexTestWithBetterAuth();
+        yield* Effect.promise(() => seedSigned(t, "public"));
+        const row = yield* Effect.promise(() =>
+          t.query(internal.contentRelease.runtime.public.internal.read, {
+            appLocale: "en",
+            publicPath: TEST_RUNTIME_PATH,
+          })
+        );
+        if (!row) {
+          return expect.fail("Expected one decodable public runtime row.");
+        }
+        const corruptions = [
+          ["private delivery", { ...row, delivery: "authenticated" }],
+          ["malformed artifact", { ...row, artifactJson: "{" }],
+          ["invalid projection hash", { ...row, projectionHash: "invalid" }],
+          [
+            "question body",
+            { ...row, projectionJson: TEST_QUESTION_PROJECTION_JSON },
+          ],
+          [
+            "manifest mismatch",
+            {
+              ...row,
+              activeManifestHash: `sha256:${"f".repeat(64)}`,
+            },
+          ],
+          ["release mismatch", { ...row, activeReleaseId: "release-mismatch" }],
+        ] as const;
+
+        for (const [reason, corruption] of corruptions) {
+          const result = yield* decodePublicRuntimeFound(corruption).pipe(
+            Effect.result
+          );
+          expect(result, reason).toMatchObject({
+            _tag: "Failure",
+            failure: { _tag: "PublicRuntimeReadError" },
+          });
+        }
+
+        vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
+          new Error("Injected digest failure")
+        );
+        expect(
+          yield* decodePublicRuntimeFound(row).pipe(Effect.result)
+        ).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "PublicRuntimeReadError" },
+        });
+      })
+  );
 });

--- a/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/dispatch.ts
@@ -43,31 +43,25 @@ class PublicRuntimeReadError extends Schema.TaggedError<PublicRuntimeReadError>(
   {}
 ) {}
 /** Strictly parses one bounded UTF-8 public request. */
-const decodePublicRequest = Effect.fn("contentRelease.decodePublicRequest")(
-  function* (source: string, byteLength: number) {
-    const measured = new TextEncoder().encode(source).byteLength;
-    if (
-      byteLength !== measured ||
-      measured > MAX_PUBLIC_RUNTIME_REQUEST_BYTES
-    ) {
-      return yield* new PublicRuntimeRequestError();
-    }
-    const input = yield* Effect.try({
-      catch: () => new PublicRuntimeRequestError(),
-      try: (): unknown => JSON.parse(source),
-    });
-    return yield* decodePublicContentRuntimeRequest(input).pipe(
-      Effect.mapError(() => new PublicRuntimeRequestError())
-    );
+export const decodePublicRequest = Effect.fn(
+  "contentRelease.decodePublicRequest"
+)(function* (source: string, byteLength: number) {
+  const measured = new TextEncoder().encode(source).byteLength;
+  if (byteLength !== measured || measured > MAX_PUBLIC_RUNTIME_REQUEST_BYTES) {
+    return yield* new PublicRuntimeRequestError();
   }
-);
-/** Decodes one stored row into the exact Aksara public response. */
-export const decodePublicRuntimeRow = Effect.fn(
-  "contentRelease.decodePublicRuntimeRow"
-)(function* (row: PublicRuntimeRow) {
-  if (row === null) {
-    return null;
-  }
+  const input = yield* Effect.try({
+    catch: () => new PublicRuntimeRequestError(),
+    try: (): unknown => JSON.parse(source),
+  });
+  return yield* decodePublicContentRuntimeRequest(input).pipe(
+    Effect.mapError(() => new PublicRuntimeRequestError())
+  );
+});
+/** Decodes one present stored row into the exact Aksara public response. */
+export const decodePublicRuntimeFound = Effect.fn(
+  "contentRelease.decodePublicRuntimeFound"
+)(function* (row: NonNullable<PublicRuntimeRow>) {
   if (row.delivery !== "public") {
     return yield* new PublicRuntimeReadError();
   }
@@ -109,6 +103,15 @@ export const decodePublicRuntimeRow = Effect.fn(
     sourcePath,
   };
   return response;
+});
+/** Preserves exact route absence while decoding every present public row. */
+export const decodePublicRuntimeRow = Effect.fn(
+  "contentRelease.decodePublicRuntimeRow"
+)(function* (row: PublicRuntimeRow) {
+  if (row === null) {
+    return null;
+  }
+  return yield* decodePublicRuntimeFound(row);
 });
 /** Reads one active public artifact for Nakafa verification. */
 const resolvePublicRuntime = Effect.fn("contentRelease.resolvePublicRuntime")(

--- a/packages/backend/convex/contentRelease/runtime/public/internal.test.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/internal.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { ActiveAppLocaleCode } from "@nakafa/aksara-contracts/locale";
 import { internal } from "@repo/backend/convex/_generated/api";
+import { loadActiveIdentity } from "@repo/backend/convex/contentRelease/runtime/active";
 import type { PublicRuntimeRow } from "@repo/backend/convex/contentRelease/runtime/public/internal";
+import {
+  readPublicRuntime,
+  resolvePublicRoute,
+} from "@repo/backend/convex/contentRelease/runtime/public/internal";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import schema from "@repo/backend/convex/schema";
 import { convexModules } from "@repo/backend/convex/test.setup";
 import {
@@ -51,6 +57,27 @@ const readPublicBatch = makeFunctionReference<
 >("contentRelease/runtime/public/internal:readBatch");
 
 describe("contentRelease/runtime/public/internal", () => {
+  it("uses five indexed operations for one current public body", async () => {
+    const t = convexTest(schema, convexModules);
+    await t.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      await insertRuntimeHead(ctx, "public", "test:public");
+    });
+
+    const { metrics, result } = await t.query(async (ctx) => {
+      const result = await runConvexProgram(
+        resolvePublicRoute(ctx, "en", TEST_RUNTIME_PATH)
+      );
+      return {
+        metrics: await ctx.meta.getTransactionMetrics(),
+        result,
+      };
+    });
+
+    expect(result).toMatchObject({ delivery: "public" });
+    expect(metrics.databaseQueries.used).toBe(5);
+  });
+
   it("returns at most eight routes in exact request order", async () => {
     const t = convexTest(schema, convexModules);
     await t.mutation(async (ctx) => {
@@ -272,6 +299,9 @@ describe("contentRelease/runtime/public/internal", () => {
   it("returns absence without active state and fails for a missing artifact", async () => {
     const empty = convexTest(schema, convexModules);
     await expect(empty.query(readPublic, routeArgs)).resolves.toBeNull();
+    await expect(
+      empty.query(readPublicBatch, { requests: [routeArgs, routeArgs] })
+    ).resolves.toEqual([null, null]);
 
     const missing = convexTest(schema, convexModules);
     await missing.mutation(async (ctx) => {
@@ -299,6 +329,94 @@ describe("contentRelease/runtime/public/internal", () => {
     });
 
     await expect(t.query(readPublic, routeArgs)).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
+  it("fails closed for deleted, incomplete, orphaned, and anonymous routes", async () => {
+    const deleted = convexTest(schema, convexModules);
+    await deleted.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      await insertRuntimeHead(ctx, "public", "test:deleted-head");
+      const head = await ctx.db.query("contentHeads").unique();
+      if (!head) {
+        return expect.fail("Expected one deletable runtime head.");
+      }
+      await ctx.db.delete("contentHeads", head._id);
+      await ctx.db.insert("contentHeads", {
+        artifactLocale: head.artifactLocale,
+        contentKey: head.contentKey,
+        family: head.family,
+        index: head.index,
+        operation: "delete",
+        releaseId: head.releaseId,
+        sequence: head.sequence,
+      });
+    });
+    await expect(deleted.query(readPublic, routeArgs)).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+    await expect(
+      deleted.query(async (ctx) => {
+        const active = await runConvexProgram(loadActiveIdentity(ctx));
+        const head = await ctx.db.query("contentHeads").unique();
+        if (!(active && head)) {
+          throw new Error("Expected one active delete-head fixture.");
+        }
+        return await runConvexProgram(
+          readPublicRuntime(
+            ctx,
+            active,
+            head,
+            routeArgs.appLocale,
+            routeArgs.publicPath
+          )
+        );
+      })
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const incomplete = convexTest(schema, convexModules);
+    await incomplete.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      await insertRuntimeHead(ctx, "public", "test:incomplete");
+      const head = await ctx.db.query("contentHeads").unique();
+      if (!head) {
+        return expect.fail("Expected one incomplete runtime head.");
+      }
+      await ctx.db.patch("contentHeads", head._id, {
+        compilerConfigHash: undefined,
+      });
+    });
+    await expect(incomplete.query(readPublic, routeArgs)).rejects.toMatchObject(
+      {
+        data: { code: "CONTENT_RELEASE_INTEGRITY" },
+      }
+    );
+
+    const orphaned = convexTest(schema, convexModules);
+    await orphaned.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      await insertRuntimeBinding(ctx, "test:orphaned");
+    });
+    await expect(orphaned.query(readPublic, routeArgs)).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+
+    const anonymous = convexTest(schema, convexModules);
+    await anonymous.mutation(async (ctx) => {
+      await insertRuntimeRelease(ctx);
+      await insertRuntimeHead(ctx, "public", "test:anonymous");
+      const binding = await ctx.db.query("contentBindings").unique();
+      if (!binding) {
+        return expect.fail("Expected one anonymizable route binding.");
+      }
+      await ctx.db.patch("contentBindings", binding._id, {
+        contentKey: undefined,
+      });
+    });
+    await expect(anonymous.query(readPublic, routeArgs)).rejects.toMatchObject({
       data: { code: "CONTENT_RELEASE_INTEGRITY" },
     });
   });

--- a/packages/backend/convex/contentRelease/runtime/public/internal.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/internal.ts
@@ -4,6 +4,7 @@ import {
   familyForProjection,
 } from "@nakafa/aksara-contracts/projection/spec";
 import { PUBLIC_CONTENT_RUNTIME_BATCH_SIZE } from "@repo/backend/content/batch";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
 import { internalQuery } from "@repo/backend/convex/_generated/server";
 import { hashText } from "@repo/backend/convex/contentRelease/digest";
@@ -26,7 +27,7 @@ import type { Infer } from "convex/values";
 import { v } from "convex/values";
 import { Effect } from "effect";
 
-const publicResultValidator = v.union(
+export const publicResultValidator = v.union(
   v.null(),
   v.object({
     activeManifestHash: v.string(),
@@ -51,6 +52,91 @@ type ActiveIdentity = NonNullable<
 >;
 /** Stored active public row returned only to the authenticated HTTP adapter. */
 export type PublicRuntimeRow = Infer<typeof publicResultValidator>;
+/** Authenticates one already selected public head and reads its signed artifact. */
+export const readPublicRuntime = Effect.fn("contentRelease.readPublicRuntime")(
+  function* (
+    ctx: QueryCtx,
+    active: ActiveIdentity,
+    head: Doc<"contentHeads">,
+    appLocale: AppLocale,
+    publicPath: string
+  ) {
+    if (head?.operation !== "upsert") {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Published route ${appLocale}/${publicPath} lost its active head.`
+      );
+    }
+    if (
+      !(
+        head.artifactHash &&
+        head.compilerConfigHash &&
+        head.delivery &&
+        head.projectionHash &&
+        head.projectionJson &&
+        head.rendererDomain &&
+        head.sourceHash &&
+        head.sourcePath
+      )
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Published route ${appLocale}/${publicPath} lost runtime fields.`
+      );
+    }
+    const artifactHash = head.artifactHash;
+    const artifact = yield* Effect.promise(() =>
+      ctx.db
+        .query("contentArtifacts")
+        .withIndex("by_artifactHash", (query) =>
+          query.eq("artifactHash", artifactHash)
+        )
+        .unique()
+    );
+    if (!artifact) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_MISSING",
+        `Published route ${appLocale}/${publicPath} lost its artifact.`
+      );
+    }
+    const decodedArtifact = yield* decodeArtifactJson(artifact.artifactJson);
+    const projection = yield* decodeProjectionJson(head.projectionJson);
+    const projectionHash = yield* hashText(
+      "the published content projection",
+      canonicalizeContentProjection(projection)
+    );
+    if (
+      decodedArtifact.artifactHash !== head.artifactHash ||
+      decodedArtifact.payload.contentKey !== head.contentKey ||
+      decodedArtifact.payload.compilerConfigHash !== head.compilerConfigHash ||
+      decodedArtifact.payload.artifactLocale !== head.artifactLocale ||
+      decodedArtifact.payload.rendererDomain !== head.rendererDomain ||
+      decodedArtifact.payload.sourceHash !== head.sourceHash ||
+      familyForProjection(projection) !== head.family ||
+      projection.kind === "question-body" ||
+      projectionHash !== head.projectionHash ||
+      projection.contentKey !== head.contentKey ||
+      projection.appLocale !== appLocale ||
+      projection.publicPath !== publicPath
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        `Published route ${appLocale}/${publicPath} has mismatched content.`
+      );
+    }
+    return {
+      activeManifestHash: active.manifestHash,
+      activeReleaseId: active.releaseId,
+      artifactJson: artifact.artifactJson,
+      delivery: head.delivery,
+      projectionHash,
+      projectionJson: head.projectionJson,
+      releaseJson: active.release.releaseJson,
+      rendererJson: active.release.rendererJson,
+      sourcePath: head.sourcePath,
+    };
+  }
+);
 /** Resolves an active route and enforces its public delivery class. */
 const resolvePublicRouteForActive = Effect.fn(
   "contentRelease.resolvePublicRouteForActive"
@@ -81,7 +167,7 @@ const resolvePublicRouteForActive = Effect.fn(
     ArtifactLocaleSchema.make(appLocale),
     active.sequence
   );
-  if (head?.operation !== "upsert") {
+  if (!head) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
       `Published route ${appLocale}/${publicPath} lost its active head.`
@@ -96,92 +182,27 @@ const resolvePublicRouteForActive = Effect.fn(
       `Published route ${appLocale}/${publicPath} disagrees at one sequence.`
     );
   }
+  if (head.operation !== "upsert") {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Published route ${appLocale}/${publicPath} lost its active head.`
+    );
+  }
   if (head.delivery !== "public") {
     return null;
   }
-  if (
-    !(
-      head.artifactHash &&
-      head.compilerConfigHash &&
-      head.projectionHash &&
-      head.projectionJson &&
-      head.rendererDomain &&
-      head.sourceHash &&
-      head.sourcePath
-    )
-  ) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `Published route ${appLocale}/${publicPath} lost runtime fields.`
-    );
-  }
-  const artifactHash = head.artifactHash;
-  const artifact = yield* Effect.promise(() =>
-    ctx.db
-      .query("contentArtifacts")
-      .withIndex("by_artifactHash", (query) =>
-        query.eq("artifactHash", artifactHash)
-      )
-      .unique()
-  );
-  if (!artifact) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_MISSING",
-      `Published route ${appLocale}/${publicPath} lost its artifact.`
-    );
-  }
-  const decodedArtifact = yield* decodeArtifactJson(artifact.artifactJson);
-  const projection = yield* decodeProjectionJson(head.projectionJson);
-  const projectionHash = yield* hashText(
-    "the published content projection",
-    canonicalizeContentProjection(projection)
-  );
-  if (
-    decodedArtifact.artifactHash !== head.artifactHash ||
-    decodedArtifact.payload.contentKey !== head.contentKey ||
-    decodedArtifact.payload.compilerConfigHash !== head.compilerConfigHash ||
-    decodedArtifact.payload.artifactLocale !== head.artifactLocale ||
-    decodedArtifact.payload.rendererDomain !== head.rendererDomain ||
-    decodedArtifact.payload.sourceHash !== head.sourceHash ||
-    familyForProjection(projection) !== head.family ||
-    projection.kind === "question-body" ||
-    projectionHash !== head.projectionHash ||
-    projection.contentKey !== head.contentKey ||
-    projection.appLocale !== appLocale ||
-    projection.publicPath !== publicPath
-  ) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `Published route ${appLocale}/${publicPath} has mismatched content.`
-    );
-  }
-  return {
-    activeManifestHash: active.manifestHash,
-    activeReleaseId: active.releaseId,
-    artifactJson: artifact.artifactJson,
-    delivery: head.delivery,
-    projectionHash,
-    projectionJson: head.projectionJson,
-    releaseJson: active.release.releaseJson,
-    rendererJson: active.release.rendererJson,
-    sourcePath: head.sourcePath,
-  };
+  return yield* readPublicRuntime(ctx, active, head, appLocale, publicPath);
 });
 /** Resolves one active public route for the singular runtime endpoint. */
-const resolvePublicRoute = Effect.fn("contentRelease.resolvePublicRoute")(
-  function* (ctx: QueryCtx, appLocale: AppLocale, publicPath: string) {
-    const active = yield* loadActiveIdentity(ctx);
-    if (!active) {
-      return null;
-    }
-    return yield* resolvePublicRouteForActive(
-      ctx,
-      active,
-      appLocale,
-      publicPath
-    );
+export const resolvePublicRoute = Effect.fn(
+  "contentRelease.resolvePublicRoute"
+)(function* (ctx: QueryCtx, appLocale: AppLocale, publicPath: string) {
+  const active = yield* loadActiveIdentity(ctx);
+  if (!active) {
+    return null;
   }
-);
+  return yield* resolvePublicRouteForActive(ctx, active, appLocale, publicPath);
+});
 /** Resolves one bounded public batch inside one consistent transaction. */
 const resolvePublicRoutes = Effect.fn("contentRelease.resolvePublicRoutes")(
   function* (

--- a/packages/backend/convex/contentRelease/runtime/public/material.test.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/material.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "@effect/vitest";
+import { SignedContentArtifactSchema } from "@nakafa/aksara-contracts/content";
+import type { ActiveAppLocaleCode } from "@nakafa/aksara-contracts/locale";
+import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
+import { MAX_MATERIAL_RUNTIME_RESPONSE_BYTES } from "@repo/backend/content/material";
+import type { MaterialRuntimeRow } from "@repo/backend/convex/contentRelease/material/runtime";
+import {
+  decodeMaterialRow,
+  dispatchMaterialProgram,
+} from "@repo/backend/convex/contentRelease/runtime/public/material";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeMaterialProjection } from "@repo/backend/test/content/material";
+import { activateMaterialCatalog } from "@repo/backend/test/material/catalog";
+import { makeFunctionReference } from "convex/server";
+import { convexTest, type TestConvex } from "convex-test";
+import { Effect, Schema } from "effect";
+
+const readPublication = makeFunctionReference<
+  "query",
+  { readonly appLocale: ActiveAppLocaleCode; readonly publicPath: string },
+  MaterialRuntimeRow
+>("contentRelease/material/runtime:read");
+
+/** Executes the cohesive material action adapter with exact UTF-8 bytes. */
+function runDispatch(
+  target: Pick<TestConvex<typeof schema>, "action">,
+  request: {
+    readonly appLocale: ActiveAppLocaleCode;
+    readonly delivery: "public";
+    readonly publicPath: string;
+  }
+) {
+  const source = JSON.stringify(request);
+  const byteLength = new TextEncoder().encode(source).byteLength;
+  return target.action((ctx) =>
+    runConvexProgram(dispatchMaterialProgram(ctx, source, byteLength))
+  );
+}
+
+describe("contentRelease/runtime/public/material", () => {
+  it("returns one coherent shell and body, plus exact route absence", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+
+    const found = await runDispatch(target, {
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: requested.publicPath,
+    });
+    const missing = await runDispatch(target, {
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: "subjects/test/missing",
+    });
+
+    expect(found.status).toBe(200);
+    const body = JSON.parse(found.body);
+    expect(body).toMatchObject({
+      kind: "found",
+      model: {
+        activeManifestHash: body.runtime.activeManifestHash,
+        activeReleaseId: body.runtime.activeReleaseId,
+        sourcePath: body.runtime.sourcePath,
+      },
+      runtime: {
+        kind: "found",
+        projection: { publicPath: requested.publicPath },
+      },
+    });
+    expect(JSON.parse(body.model.projectionJson)).toEqual(
+      body.runtime.projection
+    );
+    expect(new TextEncoder().encode(found.body).byteLength).toBeLessThanOrEqual(
+      MAX_MATERIAL_RUNTIME_RESPONSE_BYTES
+    );
+    expect(missing).toEqual({ body: '{"kind":"missing"}', status: 404 });
+  });
+
+  it("sanitizes a cohesive response above its explicit byte ceiling", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    await target.mutation(async (ctx) => {
+      const artifact = await ctx.db.query("contentArtifacts").first();
+      if (!artifact) {
+        return expect.fail("Expected one selected material artifact.");
+      }
+      const value = Schema.decodeUnknownSync(SignedContentArtifactSchema)(
+        JSON.parse(artifact.artifactJson),
+        { onExcessProperty: "error" }
+      );
+      await ctx.db.patch("contentArtifacts", artifact._id, {
+        artifactJson: JSON.stringify({
+          ...value,
+          payload: {
+            ...value.payload,
+            compiledCode: "x".repeat(MAX_MATERIAL_RUNTIME_RESPONSE_BYTES),
+          },
+        }),
+      });
+    });
+
+    await expect(
+      runDispatch(target, {
+        appLocale: requested.appLocale,
+        delivery: "public",
+        publicPath: requested.publicPath,
+      })
+    ).resolves.toEqual({
+      body: '{"code":"CONTENT_RUNTIME_RESPONSE_TOO_LARGE","kind":"failure"}',
+      status: 500,
+    });
+  });
+
+  it("rejects an oversized nested body below the material ceiling", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    await target.mutation(async (ctx) => {
+      const artifact = await ctx.db.query("contentArtifacts").first();
+      if (!artifact) {
+        return expect.fail("Expected one selected material artifact.");
+      }
+      const value = Schema.decodeUnknownSync(SignedContentArtifactSchema)(
+        JSON.parse(artifact.artifactJson),
+        { onExcessProperty: "error" }
+      );
+      await ctx.db.patch("contentArtifacts", artifact._id, {
+        artifactJson: JSON.stringify({
+          ...value,
+          payload: {
+            ...value.payload,
+            compiledCode: "x".repeat(MAX_PUBLIC_RUNTIME_RESPONSE_BYTES),
+          },
+        }),
+      });
+    });
+
+    const response = await runDispatch(target, {
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: requested.publicPath,
+    });
+
+    expect(new TextEncoder().encode(response.body).byteLength).toBeLessThan(
+      MAX_MATERIAL_RUNTIME_RESPONSE_BYTES
+    );
+    expect(response).toEqual({
+      body: '{"code":"CONTENT_RUNTIME_RESPONSE_TOO_LARGE","kind":"failure"}',
+      status: 500,
+    });
+  });
+
+  it("rejects invalid requests and sanitizes a failed cohesive query", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    const source = JSON.stringify({
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: requested.publicPath,
+    });
+    const invalid = await target.action((ctx) =>
+      runConvexProgram(dispatchMaterialProgram(ctx, source, 1))
+    );
+    await target.mutation(async (ctx) => {
+      const artifact = await ctx.db.query("contentArtifacts").first();
+      if (!artifact) {
+        return expect.fail("Expected one selected material artifact.");
+      }
+      await ctx.db.delete("contentArtifacts", artifact._id);
+    });
+    const failed = await runDispatch(target, {
+      appLocale: requested.appLocale,
+      delivery: "public",
+      publicPath: requested.publicPath,
+    });
+
+    expect(invalid).toEqual({
+      body: '{"code":"CONTENT_RUNTIME_INVALID","kind":"failure"}',
+      status: 400,
+    });
+    expect(failed).toEqual({
+      body: '{"code":"CONTENT_RUNTIME_INTERNAL","kind":"failure"}',
+      status: 500,
+    });
+  });
+
+  it.live("fails closed for every shell and body coherence violation", () =>
+    Effect.gen(function* () {
+      const target = convexTest(schema, convexModules);
+      const requested = makeMaterialProjection("en", 1);
+      yield* Effect.promise(() => activateMaterialCatalog(target));
+      const row = yield* Effect.promise(() =>
+        target.query(readPublication, {
+          appLocale: requested.appLocale,
+          publicPath: requested.publicPath,
+        })
+      );
+      if (!row.runtime) {
+        return expect.fail("Expected one complete cohesive material row.");
+      }
+      const runtime = row.runtime;
+      const corruptions: readonly (readonly [string, MaterialRuntimeRow])[] = [
+        [
+          "projection missing",
+          { ...row, model: { ...row.model, projectionJson: null } },
+        ],
+        [
+          "renderer domain missing",
+          { ...row, model: { ...row.model, rendererDomain: null } },
+        ],
+        [
+          "source path missing",
+          { ...row, model: { ...row.model, sourcePath: null } },
+        ],
+        ["runtime missing", { ...row, runtime: null }],
+        [
+          "manifest mismatch",
+          {
+            ...row,
+            runtime: {
+              ...runtime,
+              activeManifestHash: `sha256:${"f".repeat(64)}`,
+            },
+          },
+        ],
+        [
+          "release mismatch",
+          {
+            ...row,
+            runtime: { ...runtime, activeReleaseId: "release-mismatch" },
+          },
+        ],
+        [
+          "projection mismatch",
+          {
+            ...row,
+            runtime: { ...runtime, projectionJson: "{}" },
+          },
+        ],
+        [
+          "source mismatch",
+          {
+            ...row,
+            runtime: {
+              ...runtime,
+              sourcePath: "packages/corpus/material/mismatch/en.mdx",
+            },
+          },
+        ],
+        [
+          "non-public body",
+          {
+            ...row,
+            runtime: { ...runtime, delivery: "authenticated" },
+          },
+        ],
+      ];
+
+      for (const [reason, corruption] of corruptions) {
+        const result = yield* decodeMaterialRow(corruption).pipe(Effect.result);
+        expect(result, reason).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "MaterialRuntimeReadError" },
+        });
+      }
+
+      const missing = yield* decodeMaterialRow({
+        model: {
+          ...row.model,
+          projectionJson: null,
+          rendererDomain: null,
+          sourcePath: null,
+        },
+        runtime: null,
+      });
+      expect(missing).toBeNull();
+    })
+  );
+});

--- a/packages/backend/convex/contentRelease/runtime/public/material.ts
+++ b/packages/backend/convex/contentRelease/runtime/public/material.ts
@@ -1,0 +1,109 @@
+import type {
+  PublicContentRuntimeFound,
+  PublicContentRuntimeRequest,
+} from "@nakafa/aksara-contracts/runtime/spec";
+import { MAX_PUBLIC_RUNTIME_RESPONSE_BYTES } from "@nakafa/aksara-contracts/runtime/spec";
+import {
+  MAX_MATERIAL_RUNTIME_RESPONSE_BYTES,
+  MaterialRuntimeResponseSchema,
+} from "@repo/backend/content/material";
+import { publicRuntimeBytes } from "@repo/backend/content/runtime";
+import type { ActionCtx } from "@repo/backend/convex/_generated/server";
+import type { MaterialRuntimeRow } from "@repo/backend/convex/contentRelease/material/runtime";
+import {
+  decodePublicRequest,
+  decodePublicRuntimeFound,
+} from "@repo/backend/convex/contentRelease/runtime/public/dispatch";
+import {
+  encodeRuntimeResult,
+  failureResult,
+} from "@repo/backend/convex/contentRelease/runtime/result";
+import { makeFunctionReference } from "convex/server";
+import { Effect, Result, Schema } from "effect";
+
+const materialReadReference = makeFunctionReference<
+  "query",
+  Pick<PublicContentRuntimeRequest, "appLocale" | "publicPath">,
+  MaterialRuntimeRow
+>("contentRelease/material/runtime:read");
+
+/** Cohesive material state could not be read or decoded safely. */
+class MaterialRuntimeReadError extends Schema.TaggedError<MaterialRuntimeReadError>()(
+  "MaterialRuntimeReadError",
+  {}
+) {}
+
+/** Decodes one raw cohesive row without weakening the Aksara runtime contract. */
+export const decodeMaterialRow = Effect.fn(
+  "contentRelease.decodeMaterialRuntimeRow"
+)(function* (row: MaterialRuntimeRow) {
+  if (row.model.projectionJson === null && row.runtime === null) {
+    return null;
+  }
+  if (
+    row.model.projectionJson === null ||
+    row.model.rendererDomain === null ||
+    row.model.sourcePath === null ||
+    row.runtime === null ||
+    row.runtime.activeManifestHash !== row.model.activeManifestHash ||
+    row.runtime.activeReleaseId !== row.model.activeReleaseId ||
+    row.runtime.projectionJson !== row.model.projectionJson ||
+    row.runtime.sourcePath !== row.model.sourcePath
+  ) {
+    return yield* new MaterialRuntimeReadError();
+  }
+  const runtime = yield* decodePublicRuntimeFound(row.runtime).pipe(
+    Effect.mapError(() => new MaterialRuntimeReadError())
+  );
+  return {
+    kind: "found",
+    model: row.model,
+    runtime: runtime satisfies PublicContentRuntimeFound,
+  };
+});
+
+/** Reads one cohesive material row through one internal query transaction. */
+const resolveMaterialRuntime = Effect.fn(
+  "contentRelease.resolveMaterialRuntime"
+)(function* (ctx: ActionCtx, request: PublicContentRuntimeRequest) {
+  const row = yield* Effect.tryPromise({
+    catch: () => new MaterialRuntimeReadError(),
+    try: (): Promise<MaterialRuntimeRow> =>
+      ctx.runQuery(materialReadReference, {
+        appLocale: request.appLocale,
+        publicPath: request.publicPath,
+      }),
+  });
+  return yield* decodeMaterialRow(row);
+});
+
+/** Decodes, resolves, and encodes one cohesive material request. */
+export const dispatchMaterialProgram = Effect.fn(
+  "contentRelease.dispatchMaterialRuntime"
+)(function* (ctx: ActionCtx, source: string, byteLength: number) {
+  const decoded = yield* decodePublicRequest(source, byteLength).pipe(
+    Effect.result
+  );
+  if (Result.isFailure(decoded)) {
+    return failureResult("CONTENT_RUNTIME_INVALID", 400);
+  }
+  const resolved = yield* resolveMaterialRuntime(ctx, decoded.success).pipe(
+    Effect.result
+  );
+  if (Result.isFailure(resolved)) {
+    return failureResult("CONTENT_RUNTIME_INTERNAL", 500);
+  }
+  if (
+    resolved.success !== null &&
+    publicRuntimeBytes(resolved.success.runtime) >
+      MAX_PUBLIC_RUNTIME_RESPONSE_BYTES
+  ) {
+    return failureResult("CONTENT_RUNTIME_RESPONSE_TOO_LARGE", 500);
+  }
+  return encodeRuntimeResult(
+    MaterialRuntimeResponseSchema,
+    MAX_MATERIAL_RUNTIME_RESPONSE_BYTES,
+    resolved.success ?? { kind: "missing" },
+    resolved.success === null ? 404 : 200
+  );
+});

--- a/packages/backend/convex/contentRelease/scope/route.test.ts
+++ b/packages/backend/convex/contentRelease/scope/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "@effect/vitest";
+import { resolveActiveRoute } from "@repo/backend/convex/contentRelease/scope/route";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import schema from "@repo/backend/convex/schema";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { makeMaterialProjection } from "@repo/backend/test/content/material";
+import { activateMaterialCatalog } from "@repo/backend/test/material/catalog";
+import { convexTest } from "convex-test";
+
+describe("contentRelease/scope/route", () => {
+  it("rejects a route locale outside the signed application contract", async () => {
+    const target = convexTest(schema, convexModules);
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(
+          resolveActiveRoute(ctx, "material", "fr", "subjects/test")
+        )
+      )
+    ).rejects.toMatchObject({
+      data: {
+        code: "CONTENT_RELEASE_INTEGRITY",
+        message:
+          "Route locale fr violates the current application-locale contract.",
+      },
+    });
+  });
+
+  it("distinguishes an unmanaged family from a managed route", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(
+          resolveActiveRoute(
+            ctx,
+            "article",
+            requested.appLocale,
+            requested.publicPath
+          )
+        )
+      )
+    ).resolves.toMatchObject({ managed: false, projection: null });
+  });
+
+  it.each(["identity", "projection"] as const)(
+    "fails closed when a managed route loses its %s proof",
+    async (corruption) => {
+      const target = convexTest(schema, convexModules);
+      const requested = makeMaterialProjection("en", 1);
+      await activateMaterialCatalog(target);
+      await target.mutation(async (ctx) => {
+        const binding = await ctx.db
+          .query("contentBindings")
+          .withIndex(
+            "by_appLocale_and_publicPath_and_sequence_and_index",
+            (index) =>
+              index
+                .eq("appLocale", requested.appLocale)
+                .eq("publicPath", requested.publicPath)
+                .eq("sequence", 1)
+          )
+          .unique();
+        if (!binding) {
+          return expect.fail("Expected one active material binding.");
+        }
+        await ctx.db.patch("contentBindings", binding._id, {
+          contentKey:
+            corruption === "identity"
+              ? undefined
+              : "material/lesson/test/missing/section",
+        });
+      });
+
+      await expect(
+        target.query((ctx) =>
+          runConvexProgram(
+            resolveActiveRoute(
+              ctx,
+              "material",
+              requested.appLocale,
+              requested.publicPath
+            )
+          )
+        )
+      ).rejects.toMatchObject({
+        data: { code: "CONTENT_RELEASE_INTEGRITY" },
+      });
+    }
+  );
+});

--- a/packages/backend/convex/contentRelease/scope/route.ts
+++ b/packages/backend/convex/contentRelease/scope/route.ts
@@ -3,9 +3,8 @@ import {
   AppLocaleSchema,
   ArtifactLocaleSchema,
 } from "@nakafa/aksara-contracts/locale";
-import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
-import { resolvePublicProjection } from "@repo/backend/convex/contentRelease/catalog";
+import { resolvePublicProjectionProof } from "@repo/backend/convex/contentRelease/catalog";
 import {
   ReleaseError,
   releaseFail,
@@ -20,10 +19,10 @@ export const resolveActiveRoute = Effect.fn(
 )(function* (
   ctx: QueryCtx,
   family: ContentFamily,
-  rawAppLocale: Doc<"contentPaths">["appLocale"],
+  rawAppLocale: string,
   publicPath: string
 ) {
-  const appLocale = yield* Schema.decodeEffect(AppLocaleSchema)(
+  const appLocale = yield* Schema.decodeUnknownEffect(AppLocaleSchema)(
     rawAppLocale
   ).pipe(
     Effect.mapError(
@@ -34,21 +33,12 @@ export const resolveActiveRoute = Effect.fn(
         })
     )
   );
-  const artifactLocale = yield* Schema.decodeEffect(ArtifactLocaleSchema)(
-    rawAppLocale
-  ).pipe(
-    Effect.mapError(
-      () =>
-        new ReleaseError({
-          code: "CONTENT_RELEASE_INTEGRITY",
-          message: `Route locale ${rawAppLocale} cannot identify its current routed artifact.`,
-        })
-    )
-  );
+  const artifactLocale = ArtifactLocaleSchema.make(appLocale);
   const active = yield* loadActiveIdentity(ctx);
   if (!active) {
     return {
       active,
+      head: null,
       managed: false,
       projection: null,
     };
@@ -62,10 +52,10 @@ export const resolveActiveRoute = Effect.fn(
   );
   const managed = families.result.includes(family);
   if (!managed) {
-    return { active, managed, projection: null };
+    return { active, head: null, managed, projection: null };
   }
   if (!binding || binding.operation === "delete") {
-    return { active, managed, projection: null };
+    return { active, head: null, managed, projection: null };
   }
   if (!binding.contentKey) {
     return yield* releaseFail(
@@ -73,21 +63,21 @@ export const resolveActiveRoute = Effect.fn(
       `Route ${appLocale}/${publicPath} lost its content identity.`
     );
   }
-  const projection = yield* resolvePublicProjection(
+  const proof = yield* resolvePublicProjectionProof(
     ctx,
     binding.contentKey,
     artifactLocale,
     active.sequence
   );
   if (
-    !projection ||
-    projection.family !== family ||
-    projection.publicPath !== publicPath
+    !proof ||
+    proof.projection.family !== family ||
+    proof.projection.publicPath !== publicPath
   ) {
     return yield* releaseFail(
       "CONTENT_RELEASE_INTEGRITY",
       `Route ${appLocale}/${publicPath} lost its ${family} projection.`
     );
   }
-  return { active, managed, projection };
+  return { active, head: proof.head, managed, projection: proof.projection };
 });

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -6,6 +6,7 @@ import {
   registerForumAttachmentUploadRoute,
 } from "@repo/backend/convex/classes/forums/attachments/route";
 import { registerPublicContentRuntimeBatchRoute } from "@repo/backend/convex/contentRelease/http/runtime/batch";
+import { registerMaterialContentRuntimeRoute } from "@repo/backend/convex/contentRelease/http/runtime/material";
 import { registerProtectedContentRuntimeRoute } from "@repo/backend/convex/contentRelease/http/runtime/protected";
 import { registerPublicContentRuntimeRoute } from "@repo/backend/convex/contentRelease/http/runtime/public";
 import { registerContentReleaseRoutes } from "@repo/backend/convex/contentRelease/ingress/route";
@@ -63,6 +64,7 @@ registerContentReleaseRoutes(app);
 
 // Register server-authenticated executable content reads.
 registerPublicContentRuntimeBatchRoute(app);
+registerMaterialContentRuntimeRoute(app);
 registerPublicContentRuntimeRoute(app);
 registerProtectedContentRuntimeRoute(app);
 

--- a/packages/backend/test/material/catalog.ts
+++ b/packages/backend/test/material/catalog.ts
@@ -20,6 +20,7 @@ import { makeMaterialProjection } from "@repo/backend/test/content/material";
 import {
   TEST_MANIFEST_HASH,
   TEST_RELEASE_ID,
+  testTextHash,
 } from "@repo/backend/test/content/release";
 import {
   insertTestState,
@@ -60,6 +61,7 @@ export async function insertMaterialProjection(
   const projectionJson = canonicalizeMaterialProjection(projection);
   const sourcePath = `packages/corpus/${projection.contentKey}/${projection.artifactLocale}.mdx`;
   await insertRuntimeVersion(ctx, "public", projection.contentKey, {
+    artifactHash: testTextHash(`artifact:${projectionJson}`),
     artifactLocale: projection.artifactLocale,
     headReleaseId: identity.releaseId,
     headSequence: identity.sequence,


### PR DESCRIPTION
## Outcome

- add one canonical material runtime batch contract across Convex, HTTP, and the backend client
- reuse the authenticated material base row instead of resolving it again for every topic request
- bound nested public runtime payloads to 1 MiB inside the existing 8 MiB batch envelope
- reject incomplete row counts, corrupt rows, mismatched heads, and delete-shaped current heads
- keep Aksara as the only authored-content and publication owner

## Cost evidence

For one material request path, the base-to-expanded runtime sequence drops from 18 database operations to 14. That is 4 fewer operations, or 22.22%, while preserving the same signed response contract.

This is deterministic implementation evidence, not a claim about the final Convex bill. Post-release Insights must confirm the production read reduction.

## Verification

- backend suite: 353 files and 1,583 tests passed
- changed coverage: 100% statements, branches, functions, and lines
- backend TypeScript passed
- repository lint and boundaries passed
- focused public client and batch regressions: 16 tests passed
- current head: c36ce82af6