### PR TITLE
feat(content): persist signed runtime archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
+      CONTENT_ARCHIVE_TOKEN: ci-archive
       CONTENT_RUNTIME_TOKEN: ci-runtime
       AKSARA_PUBLICATION_TOKEN: ci-runtime
       NAKAFA_API_EDGE_SECRET: ci-runtime-api-edge
@@ -269,6 +270,7 @@ jobs:
           AUTH_GOOGLE_ID=ci-disabled
           AUTH_GOOGLE_SECRET=ci-disabled
           BETTER_AUTH_SECRET=ci-inert-secret-00000000
+          CONTENT_ARCHIVE_TOKEN=$CONTENT_ARCHIVE_TOKEN
           CONTENT_RUNTIME_TOKEN=$CONTENT_RUNTIME_TOKEN
           FIRECRAWL_API_KEY=ci-disabled
           JWKS=[]
@@ -346,6 +348,7 @@ jobs:
           CONTENT_RUNTIME_STATE_HASH: ""
           CONTENT_RUNTIME_SELECTION_HASH: ""
           CONTENT_RUNTIME_SCHEMA_HASH: ""
+          CONTENT_ARCHIVE_TOKEN: ""
           CONTENT_RUNTIME_TOKEN: ""
           AKSARA_PUBLICATION_TOKEN: ""
           CONVEX_SITE_URL: ""

--- a/apps/www/e2e/guest-sidebar.browser.ts
+++ b/apps/www/e2e/guest-sidebar.browser.ts
@@ -185,26 +185,24 @@ test("guest auth link preserves a dynamic query and hash for native actions", as
           expect(loginLink).toHaveAttribute("href", fallbackHref)
         );
 
-        const nativePagePromise = page
-          .context()
-          .waitForEvent("page", (candidate) => candidate !== page);
-        yield* Effect.promise(() => loginLink.click({ button: "middle" }));
-        const nativePage = yield* Effect.promise(() => nativePagePromise);
-        yield* Effect.promise(() =>
-          expect(nativePage).toHaveURL(
-            new URL(exactHref, page.url()).toString()
-          )
-        );
-        yield* Effect.promise(() => nativePage.close());
-
-        yield* Effect.promise(() =>
-          page.reload({ waitUntil: "domcontentloaded" })
-        );
-        yield* Effect.promise(() => expect(loginLink).toBeVisible());
-        yield* Effect.promise(() => loginLink.dispatchEvent("contextmenu"));
-        yield* Effect.promise(() =>
-          expect(loginLink).toHaveAttribute("href", exactHref)
-        );
+        const nativeActions = [
+          { button: 1, event: "pointerdown" },
+          { button: 1, event: "auxclick" },
+          { button: 2, event: "contextmenu" },
+        ] as const;
+        for (const action of nativeActions) {
+          yield* Effect.promise(() =>
+            loginLink.evaluate((link, href) => {
+              link.setAttribute("href", href);
+            }, fallbackHref)
+          );
+          yield* Effect.promise(() =>
+            loginLink.dispatchEvent(action.event, { button: action.button })
+          );
+          yield* Effect.promise(() =>
+            expect(loginLink).toHaveAttribute("href", exactHref)
+          );
+        }
       })
     )
   );

--- a/packages/backend/content/archive.ts
+++ b/packages/backend/content/archive.ts
@@ -6,6 +6,7 @@ export const MAX_CONTENT_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024;
 export const MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_BYTES = 2048;
 export const MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES = 4096;
 export const CONTENT_RUNTIME_ARCHIVE_LEASE_MS = 15 * 60 * 1000;
+export const CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS = 10 * 60 * 1000;
 
 export const ContentRuntimeArchiveHashSchema = Schema.String.pipe(
   Schema.check(Schema.isPattern(/^[a-f0-9]{64}$/))
@@ -26,7 +27,7 @@ export const ContentRuntimeArchiveByteLengthSchema = Schema.Finite.pipe(
 );
 
 export const ContentRuntimeArchiveIdentitySchema = Schema.Struct({
-  contentStateHash: ContentRuntimeArchiveHashSchema,
+  runtimeSelectionHash: ContentRuntimeArchiveHashSchema,
   runtimeSchemaFingerprint: ContentRuntimeArchiveHashSchema,
 });
 
@@ -38,6 +39,7 @@ export const ContentRuntimeArchiveMetadataSchema = Schema.Struct({
     Schema.check(Schema.isInt()),
     Schema.check(Schema.isGreaterThan(0))
   ),
+  sourceStateHash: ContentRuntimeArchiveHashSchema,
 });
 
 export const ContentRuntimeArchiveClaimSchema = Schema.Struct({
@@ -70,6 +72,7 @@ export const ContentRuntimeArchiveFinalizeSchema = Schema.Struct({
   ...ContentRuntimeArchiveClaimSchema.fields,
   archiveSha256: ContentRuntimeArchiveHashSchema,
   byteLength: ContentRuntimeArchiveByteLengthSchema,
+  sourceStateHash: ContentRuntimeArchiveHashSchema,
   storageId: Schema.Trimmed.pipe(Schema.check(Schema.isNonEmpty())),
 });
 

--- a/packages/backend/content/archive.ts
+++ b/packages/backend/content/archive.ts
@@ -1,0 +1,151 @@
+import { Schema } from "effect";
+
+export const CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE =
+  "application/vnd.nakafa.runtime-archive";
+export const MAX_CONTENT_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024;
+export const MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_BYTES = 2048;
+export const MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES = 4096;
+export const CONTENT_RUNTIME_ARCHIVE_LEASE_MS = 15 * 60 * 1000;
+
+export const ContentRuntimeArchiveHashSchema = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^[a-f0-9]{64}$/))
+);
+
+export const ContentRuntimeArchiveClaimIdSchema = Schema.String.pipe(
+  Schema.check(
+    Schema.isPattern(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    )
+  )
+);
+
+export const ContentRuntimeArchiveByteLengthSchema = Schema.Finite.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isGreaterThan(0)),
+  Schema.check(Schema.isLessThanOrEqualTo(MAX_CONTENT_RUNTIME_ARCHIVE_BYTES))
+);
+
+export const ContentRuntimeArchiveIdentitySchema = Schema.Struct({
+  contentStateHash: ContentRuntimeArchiveHashSchema,
+  runtimeSchemaFingerprint: ContentRuntimeArchiveHashSchema,
+});
+
+export const ContentRuntimeArchiveMetadataSchema = Schema.Struct({
+  ...ContentRuntimeArchiveIdentitySchema.fields,
+  archiveSha256: ContentRuntimeArchiveHashSchema,
+  byteLength: ContentRuntimeArchiveByteLengthSchema,
+  createdAt: Schema.Finite.pipe(
+    Schema.check(Schema.isInt()),
+    Schema.check(Schema.isGreaterThan(0))
+  ),
+});
+
+export const ContentRuntimeArchiveClaimSchema = Schema.Struct({
+  ...ContentRuntimeArchiveIdentitySchema.fields,
+  claimId: ContentRuntimeArchiveClaimIdSchema,
+});
+
+export const ContentRuntimeArchiveClaimResultSchema = Schema.Union([
+  Schema.Struct({
+    expiresAt: Schema.Finite.pipe(
+      Schema.check(Schema.isInt()),
+      Schema.check(Schema.isGreaterThan(0))
+    ),
+    kind: Schema.Literal("claimed"),
+  }),
+  Schema.Struct({
+    expiresAt: Schema.Finite.pipe(
+      Schema.check(Schema.isInt()),
+      Schema.check(Schema.isGreaterThan(0))
+    ),
+    kind: Schema.Literal("busy"),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("existing"),
+    metadata: ContentRuntimeArchiveMetadataSchema,
+  }),
+]);
+
+export const ContentRuntimeArchiveFinalizeSchema = Schema.Struct({
+  ...ContentRuntimeArchiveClaimSchema.fields,
+  archiveSha256: ContentRuntimeArchiveHashSchema,
+  byteLength: ContentRuntimeArchiveByteLengthSchema,
+  storageId: Schema.Trimmed.pipe(Schema.check(Schema.isNonEmpty())),
+});
+
+export const ContentRuntimeArchiveAbortSchema = Schema.Struct({
+  ...ContentRuntimeArchiveClaimSchema.fields,
+  storageId: Schema.Trimmed.pipe(Schema.check(Schema.isNonEmpty())),
+});
+
+export const ContentRuntimeArchiveAbortResultSchema = Schema.Union([
+  Schema.Struct({ kind: Schema.Literal("deleted") }),
+  Schema.Struct({ kind: Schema.Literal("deferred") }),
+  Schema.Struct({
+    kind: Schema.Literal("canonical"),
+    metadata: ContentRuntimeArchiveMetadataSchema,
+  }),
+]);
+
+export const ContentRuntimeArchiveReleaseResultSchema = Schema.Struct({
+  released: Schema.Boolean,
+});
+
+export const ContentRuntimeArchiveUploadSchema = Schema.Struct({
+  uploadUrl: Schema.String.pipe(
+    Schema.check(
+      Schema.makeFilter((value) => URL.canParse(value), {
+        message: "Expected a valid URL.",
+      })
+    )
+  ),
+});
+
+export const ContentRuntimeArchiveDownloadSchema = Schema.Struct({
+  ...ContentRuntimeArchiveMetadataSchema.fields,
+  downloadUrl: Schema.String.pipe(
+    Schema.check(
+      Schema.makeFilter((value) => URL.canParse(value), {
+        message: "Expected a valid URL.",
+      })
+    )
+  ),
+});
+
+export const ContentRuntimeArchiveFinalizeResultSchema = Schema.Struct({
+  kind: Schema.Literals(["stored", "unchanged"]),
+  metadata: ContentRuntimeArchiveMetadataSchema,
+});
+
+export const ContentRuntimeArchiveStorageResultSchema = Schema.Struct({
+  storageId: Schema.Trimmed.pipe(Schema.check(Schema.isNonEmpty())),
+});
+
+export const ContentRuntimeArchiveErrorCodeSchema = Schema.Literals([
+  "CONTENT_RUNTIME_ARCHIVE_BUSY",
+  "CONTENT_RUNTIME_ARCHIVE_CONFLICT",
+  "CONTENT_RUNTIME_ARCHIVE_INTERNAL",
+  "CONTENT_RUNTIME_ARCHIVE_INVALID",
+  "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND",
+  "CONTENT_RUNTIME_ARCHIVE_UNAUTHORIZED",
+]);
+
+export const ContentRuntimeArchiveErrorSchema = Schema.Struct({
+  code: ContentRuntimeArchiveErrorCodeSchema,
+});
+
+export type ContentRuntimeArchiveAbort = Schema.Schema.Type<
+  typeof ContentRuntimeArchiveAbortSchema
+>;
+export type ContentRuntimeArchiveClaim = Schema.Schema.Type<
+  typeof ContentRuntimeArchiveClaimSchema
+>;
+export type ContentRuntimeArchiveFinalize = Schema.Schema.Type<
+  typeof ContentRuntimeArchiveFinalizeSchema
+>;
+export type ContentRuntimeArchiveIdentity = Schema.Schema.Type<
+  typeof ContentRuntimeArchiveIdentitySchema
+>;
+export type ContentRuntimeArchiveMetadata = Schema.Schema.Type<
+  typeof ContentRuntimeArchiveMetadataSchema
+>;

--- a/packages/backend/content/deployment.ts
+++ b/packages/backend/content/deployment.ts
@@ -1,2 +1,5 @@
 /** Production deployment identity shared by trusted content boundaries. */
 export const CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT = "dapper-antelope-269";
+
+/** Production HTTP origin for trusted signed-runtime artifact operations. */
+export const CONTENT_RUNTIME_PRODUCTION_SITE_URL = `https://${CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT}.convex.site`;

--- a/packages/backend/content/endpoint.ts
+++ b/packages/backend/content/endpoint.ts
@@ -9,6 +9,26 @@ export const PUBLIC_CONTENT_RUNTIME_BATCH_PATH = `${PUBLIC_CONTENT_RUNTIME_PATH}
 /** Canonical unversioned endpoint for protected content reads. */
 export const PROTECTED_CONTENT_RUNTIME_PATH = `${CONTENT_RUNTIME_PATH}/protected`;
 
+const CONTENT_RUNTIME_ARCHIVE_PATH = `${CONTENT_RUNTIME_PATH}/archive`;
+
+/** Producer-only lease acquisition before an expensive runtime export. */
+export const CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/claim`;
+
+/** Authenticated capability creation for one encrypted runtime upload. */
+export const CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/upload`;
+
+/** Authenticated immutable binding for one completed runtime upload. */
+export const CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/finalize`;
+
+/** Producer-only cleanup for one upload whose final state is uncertain. */
+export const CONTENT_RUNTIME_ARCHIVE_ABORT_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/abort`;
+
+/** Producer-only release for an export lease that did not publish. */
+export const CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/release`;
+
+/** Authenticated download boundary for one immutable runtime archive. */
+export const CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH = `${CONTENT_RUNTIME_ARCHIVE_PATH}/download`;
+
 /**
  * Marks responses built by the private runtime route after contract encoding.
  * This diagnostic signal does not replace signed response verification.

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -116,6 +116,13 @@ import type * as contentRelease_activation_model from "../contentRelease/activat
 import type * as contentRelease_activation_recovery from "../contentRelease/activation/recovery.js";
 import type * as contentRelease_activation_spec from "../contentRelease/activation/spec.js";
 import type * as contentRelease_activation_validate from "../contentRelease/activation/validate.js";
+import type * as contentRelease_archive_cleanup from "../contentRelease/archive/cleanup.js";
+import type * as contentRelease_archive_internal from "../contentRelease/archive/internal.js";
+import type * as contentRelease_archive_model from "../contentRelease/archive/model.js";
+import type * as contentRelease_archive_request from "../contentRelease/archive/request.js";
+import type * as contentRelease_archive_retention from "../contentRelease/archive/retention.js";
+import type * as contentRelease_archive_route from "../contentRelease/archive/route.js";
+import type * as contentRelease_archive_spec from "../contentRelease/archive/spec.js";
 import type * as contentRelease_article from "../contentRelease/article.js";
 import type * as contentRelease_article_agent from "../contentRelease/article/agent.js";
 import type * as contentRelease_article_bucket from "../contentRelease/article/bucket.js";
@@ -710,6 +717,13 @@ declare const fullApi: ApiFromModules<{
   "contentRelease/activation/recovery": typeof contentRelease_activation_recovery;
   "contentRelease/activation/spec": typeof contentRelease_activation_spec;
   "contentRelease/activation/validate": typeof contentRelease_activation_validate;
+  "contentRelease/archive/cleanup": typeof contentRelease_archive_cleanup;
+  "contentRelease/archive/internal": typeof contentRelease_archive_internal;
+  "contentRelease/archive/model": typeof contentRelease_archive_model;
+  "contentRelease/archive/request": typeof contentRelease_archive_request;
+  "contentRelease/archive/retention": typeof contentRelease_archive_retention;
+  "contentRelease/archive/route": typeof contentRelease_archive_route;
+  "contentRelease/archive/spec": typeof contentRelease_archive_spec;
   "contentRelease/article": typeof contentRelease_article;
   "contentRelease/article/agent": typeof contentRelease_article_agent;
   "contentRelease/article/bucket": typeof contentRelease_article_bucket;

--- a/packages/backend/convex/_generated/server.d.ts
+++ b/packages/backend/convex/_generated/server.d.ts
@@ -33,6 +33,7 @@ type Env = {
   readonly AKSARA_AGENT_SIGNING_KEY_ID: string | undefined;
   readonly AKSARA_AGENT_SIGNING_PUBLIC_KEY: string | undefined;
   readonly AKSARA_PUBLICATION_TOKEN: string;
+  readonly CONTENT_ARCHIVE_TOKEN: string;
   readonly CONTENT_RUNTIME_TOKEN: string;
   readonly NAKAFA_API_EDGE_SECRET: string;
   readonly NAKAFA_MCP_ALLOWED_ORIGINS: string | undefined;

--- a/packages/backend/convex/contentRelease/archive/cleanup.test.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.test.ts
@@ -66,9 +66,10 @@ describe("content runtime archive orphan cleanup", () => {
           .update(canonicalValue)
           .digest("hex"),
         byteLength: Buffer.byteLength(canonicalValue),
-        contentStateHash: "1".repeat(64),
         createdAt: NOW,
+        runtimeSelectionHash: "1".repeat(64),
         runtimeSchemaFingerprint: "2".repeat(64),
+        sourceStateHash: "3".repeat(64),
         storageId: canonicalId,
       })
     );
@@ -161,9 +162,10 @@ describe("content runtime archive orphan cleanup", () => {
         ctx.db.insert("contentRuntimeArchives", {
           archiveSha256: createHash("sha256").update(value).digest("hex"),
           byteLength: Buffer.byteLength(value),
-          contentStateHash: index.toString(16).padStart(64, "0"),
           createdAt,
+          runtimeSelectionHash: index.toString(16).padStart(64, "0"),
           runtimeSchemaFingerprint: "3".repeat(64),
+          sourceStateHash: "6".repeat(64),
           storageId,
         });
       await insertArchive(
@@ -185,15 +187,15 @@ describe("content runtime archive orphan cleanup", () => {
       ) {
         await ctx.db.insert("contentRuntimeArchiveClaims", {
           claimId: `expired-${index}`,
-          contentStateHash: (index + 10).toString(16).padStart(64, "0"),
           expiresAt: NOW - 1,
+          runtimeSelectionHash: (index + 10).toString(16).padStart(64, "0"),
           runtimeSchemaFingerprint: "4".repeat(64),
         });
       }
       await ctx.db.insert("contentRuntimeArchiveClaims", {
         claimId: "live",
-        contentStateHash: "5".repeat(64),
         expiresAt: NOW + 1,
+        runtimeSelectionHash: "5".repeat(64),
         runtimeSchemaFingerprint: "4".repeat(64),
       });
     });

--- a/packages/backend/convex/contentRelease/archive/cleanup.test.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.test.ts
@@ -2,151 +2,36 @@
 
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it } from "@effect/vitest";
-import {
-  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
-  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
-} from "@repo/backend/content/archive";
+import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
 import { internal } from "@repo/backend/convex/_generated/api";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
-import {
-  CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS,
-  CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-} from "@repo/backend/convex/contentRelease/archive/spec";
+import { CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE } from "@repo/backend/convex/contentRelease/archive/spec";
 import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import { storeArchiveFixture } from "@repo/backend/test/archive";
 
-declare const Convex: {
-  asyncSyscall: (operation: string, input: string) => Promise<string>;
-};
-
 const NOW = 1_800_000_000_000;
-type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
-function store(target: RuntimeTest, value: string, contentType: string) {
-  return storeArchiveFixture(target, value, contentType);
-}
 
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
-describe("content runtime archive orphan cleanup", () => {
-  it("resumes bounded scans and removes only old unreferenced archive uploads", async () => {
-    vi.useFakeTimers({ now: NOW });
-    const target = createConvexTestWithBetterAuth();
-    expect(CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS).toBeGreaterThan(
-      CONTENT_RUNTIME_ARCHIVE_LEASE_MS
-    );
-
-    for (
-      let index = 0;
-      index < CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE;
-      index += 1
-    ) {
-      await store(target, `foreign-${index}`, "application/octet-stream");
-    }
-
-    vi.setSystemTime(NOW + 1000);
-    const orphanId = await store(
-      target,
-      "upload-response-lost",
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
-    const canonicalValue = "canonical-archive";
-    const canonicalId = await store(
-      target,
-      canonicalValue,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
-    await target.run((ctx) =>
-      ctx.db.insert("contentRuntimeArchives", {
-        archiveSha256: createHash("sha256")
-          .update(canonicalValue)
-          .digest("hex"),
-        byteLength: Buffer.byteLength(canonicalValue),
-        createdAt: NOW,
-        runtimeSelectionHash: "1".repeat(64),
-        runtimeSchemaFingerprint: "2".repeat(64),
-        sourceStateHash: "3".repeat(64),
-        storageId: canonicalId,
-      })
-    );
-
-    vi.setSystemTime(NOW + CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS + 2000);
-    const recentId = await store(
-      target,
-      "recent-upload",
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
-    const pageInputs: Record<string, unknown>[] = [];
-    await target.run(() => {
-      const asyncSyscall = Convex.asyncSyscall.bind(Convex);
-      vi.spyOn(Convex, "asyncSyscall").mockImplementation(
-        (operation, input) => {
-          if (operation === "1.0/queryPage") {
-            pageInputs.push(JSON.parse(input) as Record<string, unknown>);
-          }
-          return asyncSyscall(operation, input);
-        }
-      );
-      return Promise.resolve();
-    });
-
-    const first = await target.mutation(
-      internal.contentRelease.archive.cleanup.sweep,
-      {}
-    );
-    expect(first).toEqual({
-      archivesDeleted: 0,
-      claimsDeleted: 0,
-      deleted: 0,
-      scanned: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-    });
-    expect(pageInputs).toContainEqual(
-      expect.objectContaining({
-        maximumRowsRead: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-        pageSize: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-      })
-    );
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", orphanId))
-    ).resolves.not.toBeNull();
-
-    const second = await target.mutation(
-      internal.contentRelease.archive.cleanup.sweep,
-      {}
-    );
-    expect(second).toEqual({
-      archivesDeleted: 0,
-      claimsDeleted: 0,
-      deleted: 1,
-      scanned: 3,
-    });
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", orphanId))
-    ).resolves.toBeNull();
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
-    ).resolves.not.toBeNull();
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", recentId))
-    ).resolves.not.toBeNull();
-    await expect(
-      target.run((ctx) => ctx.db.query("contentRuntimeArchiveSweeps").unique())
-    ).resolves.toMatchObject({ cursor: null });
-  });
-
+describe("content runtime archive cleanup", () => {
   it("bounds expired lease cleanup and enforces archive age without another finalize", async () => {
     vi.useFakeTimers({ now: NOW });
     const target = createConvexTestWithBetterAuth();
-    const expiredStorageId = await store(
+    const unownedStorageId = await storeArchiveFixture(
+      target,
+      "unowned-archive-mime",
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const expiredStorageId = await storeArchiveFixture(
       target,
       "expired-canonical-archive",
       CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
     );
-    const retainedStorageId = await store(
+    const retainedStorageId = await storeArchiveFixture(
       target,
       "retained-canonical-archive",
       CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
@@ -180,6 +65,12 @@ describe("content runtime archive orphan cleanup", () => {
         "retained-canonical-archive",
         NOW - ROLLBACK_RETENTION_MS + 1
       );
+      await insertArchive(
+        3,
+        retainedStorageId,
+        "retained-canonical-archive",
+        NOW - ROLLBACK_RETENTION_MS - 1
+      );
       for (
         let index = 0;
         index < CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE + 1;
@@ -205,9 +96,16 @@ describe("content runtime archive orphan cleanup", () => {
       {}
     );
     expect(first).toMatchObject({
-      archivesDeleted: 1,
+      archivesDeleted: 2,
       claimsDeleted: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
     });
+    expect(Object.keys(first).sort()).toEqual([
+      "archivesDeleted",
+      "claimsDeleted",
+    ]);
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", unownedStorageId))
+    ).resolves.not.toBeNull();
     await expect(
       target.run((ctx) => ctx.db.system.get("_storage", expiredStorageId))
     ).resolves.toBeNull();

--- a/packages/backend/convex/contentRelease/archive/cleanup.test.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 
-import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
 import { internal } from "@repo/backend/convex/_generated/api";
@@ -8,7 +7,7 @@ import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE } from "@repo/backend/convex/contentRelease/archive/spec";
 import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import { storeArchiveFixture } from "@repo/backend/test/archive";
+import { hash, storeArchiveFixture as store } from "@repo/backend/test/archive";
 
 const NOW = 1_800_000_000_000;
 
@@ -21,17 +20,17 @@ describe("content runtime archive cleanup", () => {
   it("bounds expired lease cleanup and enforces archive age without another finalize", async () => {
     vi.useFakeTimers({ now: NOW });
     const target = createConvexTestWithBetterAuth();
-    const unownedStorageId = await storeArchiveFixture(
+    const unownedStorageId = await store(
       target,
       "unowned-archive-mime",
       CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
     );
-    const expiredStorageId = await storeArchiveFixture(
+    const expiredStorageId = await store(
       target,
       "expired-canonical-archive",
       CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
     );
-    const retainedStorageId = await storeArchiveFixture(
+    const retainedStorageId = await store(
       target,
       "retained-canonical-archive",
       CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
@@ -45,7 +44,7 @@ describe("content runtime archive cleanup", () => {
         createdAt: number
       ) =>
         ctx.db.insert("contentRuntimeArchives", {
-          archiveSha256: createHash("sha256").update(value).digest("hex"),
+          archiveSha256: hash(value),
           byteLength: Buffer.byteLength(value),
           createdAt,
           runtimeSelectionHash: index.toString(16).padStart(64, "0"),

--- a/packages/backend/convex/contentRelease/archive/cleanup.test.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
+} from "@repo/backend/content/archive";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS,
+  CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+} from "@repo/backend/convex/contentRelease/archive/spec";
+import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { storeArchiveFixture } from "@repo/backend/test/archive";
+
+declare const Convex: {
+  asyncSyscall: (operation: string, input: string) => Promise<string>;
+};
+
+const NOW = 1_800_000_000_000;
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+function store(target: RuntimeTest, value: string, contentType: string) {
+  return storeArchiveFixture(target, value, contentType);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("content runtime archive orphan cleanup", () => {
+  it("resumes bounded scans and removes only old unreferenced archive uploads", async () => {
+    vi.useFakeTimers({ now: NOW });
+    const target = createConvexTestWithBetterAuth();
+    expect(CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS).toBeGreaterThan(
+      CONTENT_RUNTIME_ARCHIVE_LEASE_MS
+    );
+
+    for (
+      let index = 0;
+      index < CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE;
+      index += 1
+    ) {
+      await store(target, `foreign-${index}`, "application/octet-stream");
+    }
+
+    vi.setSystemTime(NOW + 1000);
+    const orphanId = await store(
+      target,
+      "upload-response-lost",
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const canonicalValue = "canonical-archive";
+    const canonicalId = await store(
+      target,
+      canonicalValue,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await target.run((ctx) =>
+      ctx.db.insert("contentRuntimeArchives", {
+        archiveSha256: createHash("sha256")
+          .update(canonicalValue)
+          .digest("hex"),
+        byteLength: Buffer.byteLength(canonicalValue),
+        contentStateHash: "1".repeat(64),
+        createdAt: NOW,
+        runtimeSchemaFingerprint: "2".repeat(64),
+        storageId: canonicalId,
+      })
+    );
+
+    vi.setSystemTime(NOW + CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS + 2000);
+    const recentId = await store(
+      target,
+      "recent-upload",
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const pageInputs: Record<string, unknown>[] = [];
+    await target.run(() => {
+      const asyncSyscall = Convex.asyncSyscall.bind(Convex);
+      vi.spyOn(Convex, "asyncSyscall").mockImplementation(
+        (operation, input) => {
+          if (operation === "1.0/queryPage") {
+            pageInputs.push(JSON.parse(input) as Record<string, unknown>);
+          }
+          return asyncSyscall(operation, input);
+        }
+      );
+      return Promise.resolve();
+    });
+
+    const first = await target.mutation(
+      internal.contentRelease.archive.cleanup.sweep,
+      {}
+    );
+    expect(first).toEqual({
+      archivesDeleted: 0,
+      claimsDeleted: 0,
+      deleted: 0,
+      scanned: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+    });
+    expect(pageInputs).toContainEqual(
+      expect.objectContaining({
+        maximumRowsRead: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+        pageSize: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+      })
+    );
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", orphanId))
+    ).resolves.not.toBeNull();
+
+    const second = await target.mutation(
+      internal.contentRelease.archive.cleanup.sweep,
+      {}
+    );
+    expect(second).toEqual({
+      archivesDeleted: 0,
+      claimsDeleted: 0,
+      deleted: 1,
+      scanned: 3,
+    });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", orphanId))
+    ).resolves.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", recentId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchiveSweeps").unique())
+    ).resolves.toMatchObject({ cursor: null });
+  });
+
+  it("bounds expired lease cleanup and enforces archive age without another finalize", async () => {
+    vi.useFakeTimers({ now: NOW });
+    const target = createConvexTestWithBetterAuth();
+    const expiredStorageId = await store(
+      target,
+      "expired-canonical-archive",
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const retainedStorageId = await store(
+      target,
+      "retained-canonical-archive",
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+
+    await target.run(async (ctx) => {
+      const insertArchive = (
+        index: number,
+        storageId: Id<"_storage">,
+        value: string,
+        createdAt: number
+      ) =>
+        ctx.db.insert("contentRuntimeArchives", {
+          archiveSha256: createHash("sha256").update(value).digest("hex"),
+          byteLength: Buffer.byteLength(value),
+          contentStateHash: index.toString(16).padStart(64, "0"),
+          createdAt,
+          runtimeSchemaFingerprint: "3".repeat(64),
+          storageId,
+        });
+      await insertArchive(
+        1,
+        expiredStorageId,
+        "expired-canonical-archive",
+        NOW - ROLLBACK_RETENTION_MS - 1
+      );
+      await insertArchive(
+        2,
+        retainedStorageId,
+        "retained-canonical-archive",
+        NOW - ROLLBACK_RETENTION_MS + 1
+      );
+      for (
+        let index = 0;
+        index < CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE + 1;
+        index += 1
+      ) {
+        await ctx.db.insert("contentRuntimeArchiveClaims", {
+          claimId: `expired-${index}`,
+          contentStateHash: (index + 10).toString(16).padStart(64, "0"),
+          expiresAt: NOW - 1,
+          runtimeSchemaFingerprint: "4".repeat(64),
+        });
+      }
+      await ctx.db.insert("contentRuntimeArchiveClaims", {
+        claimId: "live",
+        contentStateHash: "5".repeat(64),
+        expiresAt: NOW + 1,
+        runtimeSchemaFingerprint: "4".repeat(64),
+      });
+    });
+
+    const first = await target.mutation(
+      internal.contentRelease.archive.cleanup.sweep,
+      {}
+    );
+    expect(first).toMatchObject({
+      archivesDeleted: 1,
+      claimsDeleted: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+    });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", expiredStorageId))
+    ).resolves.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", retainedStorageId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) =>
+        ctx.db
+          .query("contentRuntimeArchiveClaims")
+          .withIndex("by_expiresAt", (query) => query.lte("expiresAt", NOW - 1))
+          .collect()
+      )
+    ).resolves.toHaveLength(1);
+
+    const second = await target.mutation(
+      internal.contentRelease.archive.cleanup.sweep,
+      {}
+    );
+    expect(second.claimsDeleted).toBe(1);
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchiveClaims").collect())
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/cleanup.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.ts
@@ -1,20 +1,14 @@
-import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
 import type { MutationCtx } from "@repo/backend/convex/_generated/server";
 import { internalMutation } from "@repo/backend/convex/_generated/server";
-import { deleteUnreferencedArchiveStorage } from "@repo/backend/convex/contentRelease/archive/model";
 import { pruneArchives } from "@repo/backend/convex/contentRelease/archive/retention";
 import {
-  CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS,
   CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
   runtimeArchiveSweepResultValidator,
 } from "@repo/backend/convex/contentRelease/archive/spec";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { Clock, Effect } from "effect";
 
-/**
- * Advances one bounded storage page and removes only old, unreferenced archive
- * uploads. The persisted cursor spreads metadata reads across cron runs.
- */
+/** Removes expired producer claims and proven canonical archive history. */
 const sweepProgram = Effect.fn("contentRuntimeArchive.sweep")(function* (
   ctx: MutationCtx
 ) {
@@ -29,49 +23,9 @@ const sweepProgram = Effect.fn("contentRuntimeArchive.sweep")(function* (
     yield* Effect.promise(() => ctx.db.delete(claim._id));
   }
   const archivesDeleted = yield* pruneArchives(ctx, now);
-  const state = yield* Effect.promise(() =>
-    ctx.db.query("contentRuntimeArchiveSweeps").unique()
-  );
-  const page = yield* Effect.promise(() =>
-    ctx.db.system
-      .query("_storage")
-      .order("asc")
-      .paginate({
-        cursor: state?.cursor ?? null,
-        maximumRowsRead: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-        numItems: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
-      })
-  );
-  const cutoff = now - CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS;
-  let deleted = 0;
-
-  for (const stored of page.page) {
-    if (
-      stored.contentType !== CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE ||
-      stored._creationTime > cutoff
-    ) {
-      continue;
-    }
-    if (yield* deleteUnreferencedArchiveStorage(ctx, stored._id)) {
-      deleted += 1;
-    }
-  }
-
-  const cursor = page.isDone ? null : page.continueCursor;
-  if (state) {
-    yield* Effect.promise(() =>
-      ctx.db.patch(state._id, { cursor, updatedAt: now })
-    );
-  } else {
-    yield* Effect.promise(() =>
-      ctx.db.insert("contentRuntimeArchiveSweeps", { cursor, updatedAt: now })
-    );
-  }
   return {
     archivesDeleted,
     claimsDeleted: expiredClaims.length,
-    deleted,
-    scanned: page.page.length,
   };
 });
 

--- a/packages/backend/convex/contentRelease/archive/cleanup.ts
+++ b/packages/backend/convex/contentRelease/archive/cleanup.ts
@@ -1,0 +1,82 @@
+import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { internalMutation } from "@repo/backend/convex/_generated/server";
+import { deleteUnreferencedArchiveStorage } from "@repo/backend/convex/contentRelease/archive/model";
+import { pruneArchives } from "@repo/backend/convex/contentRelease/archive/retention";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS,
+  CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+  runtimeArchiveSweepResultValidator,
+} from "@repo/backend/convex/contentRelease/archive/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { Clock, Effect } from "effect";
+
+/**
+ * Advances one bounded storage page and removes only old, unreferenced archive
+ * uploads. The persisted cursor spreads metadata reads across cron runs.
+ */
+const sweepProgram = Effect.fn("contentRuntimeArchive.sweep")(function* (
+  ctx: MutationCtx
+) {
+  const now = yield* Clock.currentTimeMillis;
+  const expiredClaims = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentRuntimeArchiveClaims")
+      .withIndex("by_expiresAt", (query) => query.lte("expiresAt", now))
+      .take(CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE)
+  );
+  for (const claim of expiredClaims) {
+    yield* Effect.promise(() => ctx.db.delete(claim._id));
+  }
+  const archivesDeleted = yield* pruneArchives(ctx, now);
+  const state = yield* Effect.promise(() =>
+    ctx.db.query("contentRuntimeArchiveSweeps").unique()
+  );
+  const page = yield* Effect.promise(() =>
+    ctx.db.system
+      .query("_storage")
+      .order("asc")
+      .paginate({
+        cursor: state?.cursor ?? null,
+        maximumRowsRead: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+        numItems: CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE,
+      })
+  );
+  const cutoff = now - CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS;
+  let deleted = 0;
+
+  for (const stored of page.page) {
+    if (
+      stored.contentType !== CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE ||
+      stored._creationTime > cutoff
+    ) {
+      continue;
+    }
+    if (yield* deleteUnreferencedArchiveStorage(ctx, stored._id)) {
+      deleted += 1;
+    }
+  }
+
+  const cursor = page.isDone ? null : page.continueCursor;
+  if (state) {
+    yield* Effect.promise(() =>
+      ctx.db.patch(state._id, { cursor, updatedAt: now })
+    );
+  } else {
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentRuntimeArchiveSweeps", { cursor, updatedAt: now })
+    );
+  }
+  return {
+    archivesDeleted,
+    claimsDeleted: expiredClaims.length,
+    deleted,
+    scanned: page.page.length,
+  };
+});
+
+export const sweep = internalMutation({
+  args: {},
+  returns: runtimeArchiveSweepResultValidator,
+  handler: (ctx) => runConvexProgram(sweepProgram(ctx)),
+});

--- a/packages/backend/convex/contentRelease/archive/internal.test.ts
+++ b/packages/backend/convex/contentRelease/archive/internal.test.ts
@@ -1,0 +1,496 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  MAX_CONTENT_RUNTIME_ARCHIVE_BYTES,
+} from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+} from "@repo/backend/content/endpoint";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { storeArchiveFixture } from "@repo/backend/test/archive";
+
+const ARCHIVE_TOKEN = "technical-archive-token";
+const archiveTokenName = "CONTENT_ARCHIVE_TOKEN";
+const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
+const polarName = "POLAR_WEBHOOK_SECRET";
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+function identity(index: number) {
+  return {
+    contentStateHash: index.toString(16).padStart(64, "0"),
+    runtimeSchemaFingerprint: "f".repeat(64),
+  };
+}
+
+function claimId(index: number) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function write(target: RuntimeTest, path: string, body: unknown) {
+  return target.fetch(path, {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      "x-nakafa-archive-token": ARCHIVE_TOKEN,
+    },
+    method: "POST",
+  });
+}
+
+function claim(target: RuntimeTest, index: number) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
+    ...identity(index),
+    claimId: claimId(index),
+  });
+}
+
+function store(target: RuntimeTest, value: string, contentType: string) {
+  return storeArchiveFixture(target, value, contentType);
+}
+
+function finalize(
+  target: RuntimeTest,
+  index: number,
+  storageId: string,
+  value: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
+    ...identity(index),
+    archiveSha256: sha256(value),
+    byteLength: Buffer.byteLength(value),
+    claimId: claimId(index),
+    storageId,
+    ...overrides,
+  });
+}
+
+function abort(target: RuntimeTest, index: number, storageId: string) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
+    ...identity(index),
+    claimId: claimId(index),
+    storageId,
+  });
+}
+
+function insertCanonical(
+  target: RuntimeTest,
+  index: number,
+  storageId: Id<"_storage">,
+  value: string,
+  overrides: {
+    readonly archiveSha256?: string;
+    readonly byteLength?: number;
+  } = {}
+) {
+  return target.run((ctx) =>
+    ctx.db.insert("contentRuntimeArchives", {
+      ...identity(index),
+      archiveSha256: overrides.archiveSha256 ?? sha256(value),
+      byteLength: overrides.byteLength ?? Buffer.byteLength(value),
+      createdAt: Date.now(),
+      storageId,
+    })
+  );
+}
+
+function readCanonical(target: RuntimeTest, index: number) {
+  return target.run((ctx) =>
+    ctx.db
+      .query("contentRuntimeArchives")
+      .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
+        query
+          .eq("contentStateHash", identity(index).contentStateHash)
+          .eq(
+            "runtimeSchemaFingerprint",
+            identity(index).runtimeSchemaFingerprint
+          )
+      )
+      .unique()
+  );
+}
+
+beforeEach(() => {
+  process.env[archiveTokenName] = ARCHIVE_TOKEN;
+  process.env[runtimeTokenName] = "technical-runtime-token";
+  process.env[polarName] = "technical-webhook-secret";
+});
+
+afterEach(() => {
+  delete process.env[archiveTokenName];
+  delete process.env[runtimeTokenName];
+  delete process.env[polarName];
+});
+
+describe("content runtime archive mutation boundary", () => {
+  it("converges duplicates but rejects any digest or length identity conflict", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const value = "canonical-runtime-archive";
+    const canonicalId = await store(
+      target,
+      value,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await claim(target, 1);
+    await finalize(target, 1, canonicalId, value);
+
+    const duplicateId = await store(
+      target,
+      value,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const duplicate = await finalize(target, 1, duplicateId, value);
+    const digestConflict = await finalize(target, 1, canonicalId, value, {
+      archiveSha256: "a".repeat(64),
+    });
+    const lengthConflict = await finalize(target, 1, canonicalId, value, {
+      byteLength: Buffer.byteLength(value) + 1,
+    });
+
+    await expect(duplicate.json()).resolves.toMatchObject({
+      kind: "unchanged",
+    });
+    expect(digestConflict.status).toBe(409);
+    expect(lengthConflict.status).toBe(409);
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", duplicateId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("never reports unchanged for missing or corrupted canonical storage", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const cases = [
+      { deleted: true, name: "missing" },
+      { contentType: "application/octet-stream", name: "content-type" },
+      { archiveSha256: "b".repeat(64), name: "sha256" },
+      { byteLength: 1, name: "size" },
+    ];
+
+    for (const [offset, testCase] of cases.entries()) {
+      const index = offset + 40;
+      const value = `corrupted-canonical-${testCase.name}`;
+      const storageId = await store(
+        target,
+        value,
+        testCase.contentType ?? CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+      );
+      const archiveSha256 = testCase.archiveSha256 ?? sha256(value);
+      const byteLength = testCase.byteLength ?? Buffer.byteLength(value);
+      await insertCanonical(target, index, storageId, value, {
+        archiveSha256,
+        byteLength,
+      });
+      if (testCase.deleted) {
+        await target.run((ctx) => ctx.storage.delete(storageId));
+      }
+      if (testCase.name === "sha256") {
+        await target.run((ctx) =>
+          ctx.db.insert("contentRuntimeArchiveClaims", {
+            ...identity(index),
+            claimId: claimId(index),
+            expiresAt: Date.now() + 60_000,
+          })
+        );
+      }
+
+      const response = await finalize(target, index, storageId, value, {
+        archiveSha256,
+        byteLength,
+      });
+
+      expect(response.status).toBe(testCase.name === "sha256" ? 400 : 409);
+      await expect(readCanonical(target, index)).resolves.toBeNull();
+      const stored = await target.run((ctx) =>
+        ctx.db.system.get("_storage", storageId)
+      );
+      if (testCase.contentType) {
+        expect(stored).not.toBeNull();
+      } else {
+        expect(stored).toBeNull();
+      }
+    }
+  });
+
+  it("replaces a stale row with a separately uploaded valid archive", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const index = 50;
+    const staleValue = "stale-runtime-archive";
+    const staleId = await store(
+      target,
+      staleValue,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const replacementValue = "replacement-runtime-archive";
+    const replacementId = await store(
+      target,
+      replacementValue,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await claim(target, index);
+    await insertCanonical(target, index, staleId, staleValue, {
+      archiveSha256: "d".repeat(64),
+    });
+
+    await expect(
+      (await finalize(target, index, replacementId, replacementValue)).json()
+    ).resolves.toMatchObject({ kind: "stored" });
+    await expect(readCanonical(target, index)).resolves.toMatchObject({
+      storageId: replacementId,
+    });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", staleId))
+    ).resolves.toBeNull();
+  });
+
+  it("normalizes storage IDs and rejects archive metadata above the hard bound", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const value = "bounded-runtime-archive";
+    const storageId = await store(
+      target,
+      value,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await claim(target, 2);
+
+    const malformed = await finalize(target, 2, "not-a-storage-id", value);
+    const oversized = await finalize(target, 2, storageId, value, {
+      byteLength: MAX_CONTENT_RUNTIME_ARCHIVE_BYTES + 1,
+    });
+    const malformedAbort = await write(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+      {
+        ...identity(2),
+        claimId: claimId(2),
+        storageId: "not-a-storage-id",
+      }
+    );
+    const cleanup = await write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
+      ...identity(2),
+      claimId: claimId(2),
+      storageId,
+    });
+
+    expect(malformed.status).toBe(400);
+    expect(oversized.status).toBe(400);
+    expect(malformedAbort.status).toBe(400);
+    await expect(cleanup.json()).resolves.toEqual({ kind: "deferred" });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("defers every unproven stored upload to bounded cleanup", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const cases = [
+      { contentType: CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE, deleted: true },
+      { contentType: "application/octet-stream" },
+      {
+        contentType: CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+        overrides: { archiveSha256: "b".repeat(64) },
+      },
+      {
+        contentType: CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+        overrides: { byteLength: 1 },
+      },
+    ];
+
+    for (const [offset, testCase] of cases.entries()) {
+      const index = offset + 10;
+      const value = `invalid-runtime-archive-${index}`;
+      const storageId = await store(target, value, testCase.contentType);
+      await claim(target, index);
+      if (testCase.deleted) {
+        await target.run((ctx) => ctx.storage.delete(storageId));
+      }
+      const response = await finalize(
+        target,
+        index,
+        storageId,
+        value,
+        testCase.overrides
+      );
+      expect(response.status).toBe(400);
+      const stored = await target.run((ctx) =>
+        ctx.db.system.get("_storage", storageId)
+      );
+      if (testCase.deleted) {
+        expect(stored).toBeNull();
+      } else {
+        expect(stored).not.toBeNull();
+      }
+    }
+
+    const unclaimedValue = "unclaimed-runtime-archive";
+    const unclaimedId = await store(
+      target,
+      unclaimedValue,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    const unclaimed = await finalize(target, 20, unclaimedId, unclaimedValue);
+    expect(unclaimed.status).toBe(409);
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", unclaimedId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("never deletes foreign or another identity's canonical storage", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const foreignValue = "foreign-storage";
+    const foreignId = await store(
+      target,
+      foreignValue,
+      "application/octet-stream"
+    );
+    const canonicalValue = "other-identity-canonical";
+    const canonicalId = await store(
+      target,
+      canonicalValue,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await claim(target, 60);
+    await finalize(target, 60, canonicalId, canonicalValue);
+
+    let index = 61;
+    for (const candidate of [
+      { storageId: foreignId, value: foreignValue },
+      { storageId: canonicalId, value: canonicalValue },
+    ]) {
+      for (const operation of ["finalize", "abort"] as const) {
+        for (const claimState of ["missing", "expired"] as const) {
+          if (claimState === "expired") {
+            await target.run((ctx) =>
+              ctx.db.insert("contentRuntimeArchiveClaims", {
+                ...identity(index),
+                claimId: claimId(index),
+                expiresAt: Date.now() - 1,
+              })
+            );
+          }
+          const response =
+            operation === "finalize"
+              ? await finalize(
+                  target,
+                  index,
+                  candidate.storageId,
+                  candidate.value
+                )
+              : await abort(target, index, candidate.storageId);
+          expect(response.status).toBe(operation === "finalize" ? 409 : 200);
+          index += 1;
+        }
+      }
+    }
+
+    await claim(target, index);
+    expect(
+      (await finalize(target, index, canonicalId, canonicalValue)).status
+    ).toBe(409);
+    await expect(readCanonical(target, index)).resolves.toBeNull();
+    await expect(readCanonical(target, 60)).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", foreignId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("repairs corrupt canonical rows during abort without false convergence", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const cases = [
+      { deleted: true, kind: "deferred", name: "missing" },
+      {
+        contentType: "application/octet-stream",
+        kind: "deferred",
+        name: "content-type",
+      },
+      { archiveSha256: "c".repeat(64), kind: "deleted", name: "sha256" },
+      { byteLength: 1, kind: "deferred", name: "size" },
+    ];
+
+    for (const [offset, testCase] of cases.entries()) {
+      const index = offset + 80;
+      const value = `abort-corrupt-${testCase.name}`;
+      const storageId = await store(
+        target,
+        value,
+        testCase.contentType ?? CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+      );
+      await insertCanonical(target, index, storageId, value, testCase);
+      if (testCase.deleted) {
+        await target.run((ctx) => ctx.storage.delete(storageId));
+      }
+      const abortStorageId =
+        testCase.name === "size"
+          ? await store(
+              target,
+              "unproven-abort-candidate",
+              CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+            )
+          : storageId;
+
+      await expect(
+        (await abort(target, index, abortStorageId)).json()
+      ).resolves.toEqual({ kind: testCase.kind });
+      await expect(readCanonical(target, index)).resolves.toBeNull();
+      const stored = await target.run((ctx) =>
+        ctx.db.system.get("_storage", storageId)
+      );
+      if (testCase.contentType) {
+        expect(stored).not.toBeNull();
+      } else {
+        expect(stored).toBeNull();
+      }
+      if (abortStorageId !== storageId) {
+        await expect(
+          target.run((ctx) => ctx.db.system.get("_storage", abortStorageId))
+        ).resolves.not.toBeNull();
+      }
+    }
+  });
+
+  it("defers uncertain duplicates and preserves canonical storage", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const value = "uncertain-finalization-runtime-archive";
+    const storageId = await store(
+      target,
+      value,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+    await claim(target, 30);
+    await finalize(target, 30, storageId, value);
+    const duplicateId = await store(
+      target,
+      value,
+      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    );
+
+    await expect(
+      (await abort(target, 30, duplicateId)).json()
+    ).resolves.toEqual({ kind: "deferred" });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", duplicateId))
+    ).resolves.not.toBeNull();
+
+    const aborted = await abort(target, 30, storageId);
+
+    await expect(aborted.json()).resolves.toMatchObject({ kind: "canonical" });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageId))
+    ).resolves.not.toBeNull();
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/internal.test.ts
+++ b/packages/backend/convex/contentRelease/archive/internal.test.ts
@@ -23,9 +23,13 @@ type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
 
 function identity(index: number) {
   return {
-    contentStateHash: index.toString(16).padStart(64, "0"),
+    runtimeSelectionHash: index.toString(16).padStart(64, "0"),
     runtimeSchemaFingerprint: "f".repeat(64),
   };
+}
+
+function sourceStateHash(index: number) {
+  return (index + 1000).toString(16).padStart(64, "0");
 }
 
 function claimId(index: number) {
@@ -70,6 +74,7 @@ function finalize(
     archiveSha256: sha256(value),
     byteLength: Buffer.byteLength(value),
     claimId: claimId(index),
+    sourceStateHash: sourceStateHash(index),
     storageId,
     ...overrides,
   });
@@ -99,6 +104,7 @@ function insertCanonical(
       archiveSha256: overrides.archiveSha256 ?? sha256(value),
       byteLength: overrides.byteLength ?? Buffer.byteLength(value),
       createdAt: Date.now(),
+      sourceStateHash: sourceStateHash(index),
       storageId,
     })
   );
@@ -108,13 +114,15 @@ function readCanonical(target: RuntimeTest, index: number) {
   return target.run((ctx) =>
     ctx.db
       .query("contentRuntimeArchives")
-      .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
-        query
-          .eq("contentStateHash", identity(index).contentStateHash)
-          .eq(
-            "runtimeSchemaFingerprint",
-            identity(index).runtimeSchemaFingerprint
-          )
+      .withIndex(
+        "by_runtimeSelectionHash_and_runtimeSchemaFingerprint",
+        (query) =>
+          query
+            .eq("runtimeSelectionHash", identity(index).runtimeSelectionHash)
+            .eq(
+              "runtimeSchemaFingerprint",
+              identity(index).runtimeSchemaFingerprint
+            )
       )
       .unique()
   );

--- a/packages/backend/convex/contentRelease/archive/internal.test.ts
+++ b/packages/backend/convex/contentRelease/archive/internal.test.ts
@@ -1,162 +1,47 @@
 // @vitest-environment node
 
-import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
   CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
   MAX_CONTENT_RUNTIME_ARCHIVE_BYTES,
 } from "@repo/backend/content/archive";
 import {
-  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
   CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
 } from "@repo/backend/content/endpoint";
-import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import { storeArchiveFixture } from "@repo/backend/test/archive";
+import {
+  claim,
+  claimId,
+  clearEnvironment,
+  finalize,
+  hash,
+  identity,
+  insert,
+  read,
+  setEnvironment,
+  storeArchiveFixture as store,
+  write,
+} from "@repo/backend/test/archive";
 
-const ARCHIVE_TOKEN = "technical-archive-token";
-const archiveTokenName = "CONTENT_ARCHIVE_TOKEN";
-const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
-const polarName = "POLAR_WEBHOOK_SECRET";
-type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
-function identity(index: number) {
-  return {
-    runtimeSelectionHash: index.toString(16).padStart(64, "0"),
-    runtimeSchemaFingerprint: "f".repeat(64),
-  };
-}
-
-function sourceStateHash(index: number) {
-  return (index + 1000).toString(16).padStart(64, "0");
-}
-
-function claimId(index: number) {
-  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
-}
-
-function sha256(value: string) {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function write(target: RuntimeTest, path: string, body: unknown) {
-  return target.fetch(path, {
-    body: JSON.stringify(body),
-    headers: {
-      "content-type": "application/json",
-      "x-nakafa-archive-token": ARCHIVE_TOKEN,
-    },
-    method: "POST",
-  });
-}
-
-function claim(target: RuntimeTest, index: number) {
-  return write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
-    ...identity(index),
-    claimId: claimId(index),
-  });
-}
-
-function store(target: RuntimeTest, value: string, contentType: string) {
-  return storeArchiveFixture(target, value, contentType);
-}
-
-function finalize(
-  target: RuntimeTest,
-  index: number,
-  storageId: string,
-  value: string,
-  overrides: Record<string, unknown> = {}
-) {
-  return write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
-    ...identity(index),
-    archiveSha256: sha256(value),
-    byteLength: Buffer.byteLength(value),
-    claimId: claimId(index),
-    sourceStateHash: sourceStateHash(index),
-    storageId,
-    ...overrides,
-  });
-}
-
-function abort(target: RuntimeTest, index: number, storageId: string) {
-  return write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
-    ...identity(index),
-    claimId: claimId(index),
-    storageId,
-  });
-}
-
-function insertCanonical(
-  target: RuntimeTest,
-  index: number,
-  storageId: Id<"_storage">,
-  value: string,
-  overrides: {
-    readonly archiveSha256?: string;
-    readonly byteLength?: number;
-  } = {}
-) {
-  return target.run((ctx) =>
-    ctx.db.insert("contentRuntimeArchives", {
-      ...identity(index),
-      archiveSha256: overrides.archiveSha256 ?? sha256(value),
-      byteLength: overrides.byteLength ?? Buffer.byteLength(value),
-      createdAt: Date.now(),
-      sourceStateHash: sourceStateHash(index),
-      storageId,
-    })
-  );
-}
-
-function readCanonical(target: RuntimeTest, index: number) {
-  return target.run((ctx) =>
-    ctx.db
-      .query("contentRuntimeArchives")
-      .withIndex(
-        "by_runtimeSelectionHash_and_runtimeSchemaFingerprint",
-        (query) =>
-          query
-            .eq("runtimeSelectionHash", identity(index).runtimeSelectionHash)
-            .eq(
-              "runtimeSchemaFingerprint",
-              identity(index).runtimeSchemaFingerprint
-            )
-      )
-      .unique()
-  );
-}
-
-beforeEach(() => {
-  process.env[archiveTokenName] = ARCHIVE_TOKEN;
-  process.env[runtimeTokenName] = "technical-runtime-token";
-  process.env[polarName] = "technical-webhook-secret";
-});
+beforeEach(setEnvironment);
 
 afterEach(() => {
-  delete process.env[archiveTokenName];
-  delete process.env[runtimeTokenName];
-  delete process.env[polarName];
+  vi.useRealTimers();
+  clearEnvironment();
 });
 
-describe("content runtime archive mutation boundary", () => {
+describe("content runtime archive internals", () => {
   it("converges duplicates but rejects any digest or length identity conflict", async () => {
     const target = createConvexTestWithBetterAuth();
     const value = "canonical-runtime-archive";
-    const canonicalId = await store(
-      target,
-      value,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const canonicalId = await store(target, value);
     await claim(target, 1);
     await finalize(target, 1, canonicalId, value);
 
-    const duplicateId = await store(
-      target,
-      value,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const duplicateId = await store(target, value);
     const duplicate = await finalize(target, 1, duplicateId, value);
     const digestConflict = await finalize(target, 1, canonicalId, value, {
       archiveSha256: "a".repeat(64),
@@ -195,9 +80,9 @@ describe("content runtime archive mutation boundary", () => {
         value,
         testCase.contentType ?? CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
       );
-      const archiveSha256 = testCase.archiveSha256 ?? sha256(value);
+      const archiveSha256 = testCase.archiveSha256 ?? hash(value);
       const byteLength = testCase.byteLength ?? Buffer.byteLength(value);
-      await insertCanonical(target, index, storageId, value, {
+      await insert(target, index, storageId, value, {
         archiveSha256,
         byteLength,
       });
@@ -220,7 +105,7 @@ describe("content runtime archive mutation boundary", () => {
       });
 
       expect(response.status).toBe(testCase.name === "sha256" ? 400 : 409);
-      await expect(readCanonical(target, index)).resolves.toBeNull();
+      await expect(read(target, index)).resolves.toBeNull();
       const stored = await target.run((ctx) =>
         ctx.db.system.get("_storage", storageId)
       );
@@ -236,26 +121,18 @@ describe("content runtime archive mutation boundary", () => {
     const target = createConvexTestWithBetterAuth();
     const index = 50;
     const staleValue = "stale-runtime-archive";
-    const staleId = await store(
-      target,
-      staleValue,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const staleId = await store(target, staleValue);
     const replacementValue = "replacement-runtime-archive";
-    const replacementId = await store(
-      target,
-      replacementValue,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const replacementId = await store(target, replacementValue);
     await claim(target, index);
-    await insertCanonical(target, index, staleId, staleValue, {
+    await insert(target, index, staleId, staleValue, {
       archiveSha256: "d".repeat(64),
     });
 
     await expect(
       (await finalize(target, index, replacementId, replacementValue)).json()
     ).resolves.toMatchObject({ kind: "stored" });
-    await expect(readCanonical(target, index)).resolves.toMatchObject({
+    await expect(read(target, index)).resolves.toMatchObject({
       storageId: replacementId,
     });
     await expect(
@@ -266,36 +143,16 @@ describe("content runtime archive mutation boundary", () => {
   it("normalizes storage IDs and rejects archive metadata above the hard bound", async () => {
     const target = createConvexTestWithBetterAuth();
     const value = "bounded-runtime-archive";
-    const storageId = await store(
-      target,
-      value,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const storageId = await store(target, value);
     await claim(target, 2);
 
     const malformed = await finalize(target, 2, "not-a-storage-id", value);
     const oversized = await finalize(target, 2, storageId, value, {
       byteLength: MAX_CONTENT_RUNTIME_ARCHIVE_BYTES + 1,
     });
-    const malformedAbort = await write(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
-      {
-        ...identity(2),
-        claimId: claimId(2),
-        storageId: "not-a-storage-id",
-      }
-    );
-    const cleanup = await write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
-      ...identity(2),
-      claimId: claimId(2),
-      storageId,
-    });
 
     expect(malformed.status).toBe(400);
     expect(oversized.status).toBe(400);
-    expect(malformedAbort.status).toBe(400);
-    await expect(cleanup.json()).resolves.toEqual({ kind: "deferred" });
     await expect(
       target.run((ctx) => ctx.db.system.get("_storage", storageId))
     ).resolves.not.toBeNull();
@@ -343,11 +200,7 @@ describe("content runtime archive mutation boundary", () => {
     }
 
     const unclaimedValue = "unclaimed-runtime-archive";
-    const unclaimedId = await store(
-      target,
-      unclaimedValue,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
+    const unclaimedId = await store(target, unclaimedValue);
     const unclaimed = await finalize(target, 20, unclaimedId, unclaimedValue);
     expect(unclaimed.status).toBe(409);
     await expect(
@@ -355,150 +208,82 @@ describe("content runtime archive mutation boundary", () => {
     ).resolves.not.toBeNull();
   });
 
-  it("never deletes foreign or another identity's canonical storage", async () => {
+  it("serializes concurrent claims and recovers expired leases", async () => {
     const target = createConvexTestWithBetterAuth();
-    const foreignValue = "foreign-storage";
-    const foreignId = await store(
-      target,
-      foreignValue,
-      "application/octet-stream"
+    const archiveIdentity = identity(1);
+    const firstId = claimId(1);
+    const secondId = claimId(2);
+    const requestClaim = (id: string) =>
+      write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
+        ...archiveIdentity,
+        claimId: id,
+      });
+    const responses = await Promise.all([
+      requestClaim(firstId),
+      requestClaim(secondId),
+    ]);
+    const results = await Promise.all(
+      responses.map((response) => response.json())
     );
-    const canonicalValue = "other-identity-canonical";
-    const canonicalId = await store(
-      target,
-      canonicalValue,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+    const ownerIndex = results.findIndex(
+      (result) => (result as { kind?: string }).kind === "claimed"
     );
-    await claim(target, 60);
-    await finalize(target, 60, canonicalId, canonicalValue);
+    const ownerId = ownerIndex === 0 ? firstId : secondId;
+    const blockedId = ownerIndex === 0 ? secondId : firstId;
 
-    let index = 61;
-    for (const candidate of [
-      { storageId: foreignId, value: foreignValue },
-      { storageId: canonicalId, value: canonicalValue },
-    ]) {
-      for (const operation of ["finalize", "abort"] as const) {
-        for (const claimState of ["missing", "expired"] as const) {
-          if (claimState === "expired") {
-            await target.run((ctx) =>
-              ctx.db.insert("contentRuntimeArchiveClaims", {
-                ...identity(index),
-                claimId: claimId(index),
-                expiresAt: Date.now() - 1,
-              })
-            );
-          }
-          const response =
-            operation === "finalize"
-              ? await finalize(
-                  target,
-                  index,
-                  candidate.storageId,
-                  candidate.value
-                )
-              : await abort(target, index, candidate.storageId);
-          expect(response.status).toBe(operation === "finalize" ? 409 : 200);
-          index += 1;
-        }
-      }
-    }
-
-    await claim(target, index);
+    expect(responses.every((response) => response.status === 200)).toBe(true);
     expect(
-      (await finalize(target, index, canonicalId, canonicalValue)).status
-    ).toBe(409);
-    await expect(readCanonical(target, index)).resolves.toBeNull();
-    await expect(readCanonical(target, 60)).resolves.not.toBeNull();
+      results.map((result) => (result as { kind: string }).kind).sort()
+    ).toEqual(["busy", "claimed"]);
     await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", foreignId))
-    ).resolves.not.toBeNull();
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...archiveIdentity,
+        claimId: blockedId,
+      })
+    ).resolves.toMatchObject({ status: 409 });
     await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
-    ).resolves.not.toBeNull();
-  });
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...archiveIdentity,
+        claimId: ownerId,
+      })
+    ).resolves.toMatchObject({ status: 200 });
+    const released = await write(target, CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH, {
+      ...archiveIdentity,
+      claimId: ownerId,
+    });
+    expect(await released.json()).toEqual({ released: true });
 
-  it("repairs corrupt canonical rows during abort without false convergence", async () => {
-    const target = createConvexTestWithBetterAuth();
-    const cases = [
-      { deleted: true, kind: "deferred", name: "missing" },
-      {
-        contentType: "application/octet-stream",
-        kind: "deferred",
-        name: "content-type",
-      },
-      { archiveSha256: "c".repeat(64), kind: "deleted", name: "sha256" },
-      { byteLength: 1, kind: "deferred", name: "size" },
-    ];
-
-    for (const [offset, testCase] of cases.entries()) {
-      const index = offset + 80;
-      const value = `abort-corrupt-${testCase.name}`;
-      const storageId = await store(
-        target,
-        value,
-        testCase.contentType ?? CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-      );
-      await insertCanonical(target, index, storageId, value, testCase);
-      if (testCase.deleted) {
-        await target.run((ctx) => ctx.storage.delete(storageId));
+    await requestClaim(firstId);
+    await target.run(async (ctx) => {
+      const lease = await ctx.db.query("contentRuntimeArchiveClaims").unique();
+      if (lease) {
+        await ctx.db.patch(lease._id, { expiresAt: Date.now() - 1 });
       }
-      const abortStorageId =
-        testCase.name === "size"
-          ? await store(
-              target,
-              "unproven-abort-candidate",
-              CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-            )
-          : storageId;
-
-      await expect(
-        (await abort(target, index, abortStorageId)).json()
-      ).resolves.toEqual({ kind: testCase.kind });
-      await expect(readCanonical(target, index)).resolves.toBeNull();
-      const stored = await target.run((ctx) =>
-        ctx.db.system.get("_storage", storageId)
-      );
-      if (testCase.contentType) {
-        expect(stored).not.toBeNull();
-      } else {
-        expect(stored).toBeNull();
-      }
-      if (abortStorageId !== storageId) {
-        await expect(
-          target.run((ctx) => ctx.db.system.get("_storage", abortStorageId))
-        ).resolves.not.toBeNull();
-      }
-    }
-  });
-
-  it("defers uncertain duplicates and preserves canonical storage", async () => {
-    const target = createConvexTestWithBetterAuth();
-    const value = "uncertain-finalization-runtime-archive";
-    const storageId = await store(
+    });
+    await expect(
+      requestClaim(secondId).then((response) => response.json())
+    ).resolves.toMatchObject({ kind: "claimed" });
+    const claimedAt = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(claimedAt);
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...archiveIdentity,
+        claimId: secondId,
+      })
+    ).resolves.toMatchObject({ status: 200 });
+    vi.setSystemTime(claimedAt + CONTENT_RUNTIME_ARCHIVE_LEASE_MS + 1000);
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...archiveIdentity,
+        claimId: secondId,
+      })
+    ).resolves.toMatchObject({ status: 409 });
+    const staleRelease = await write(
       target,
-      value,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+      CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+      { ...archiveIdentity, claimId: firstId }
     );
-    await claim(target, 30);
-    await finalize(target, 30, storageId, value);
-    const duplicateId = await store(
-      target,
-      value,
-      CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-    );
-
-    await expect(
-      (await abort(target, 30, duplicateId)).json()
-    ).resolves.toEqual({ kind: "deferred" });
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", duplicateId))
-    ).resolves.not.toBeNull();
-
-    const aborted = await abort(target, 30, storageId);
-
-    await expect(aborted.json()).resolves.toMatchObject({ kind: "canonical" });
-    await expect(
-      target.run((ctx) => ctx.db.system.get("_storage", storageId))
-    ).resolves.not.toBeNull();
+    expect(await staleRelease.json()).toEqual({ released: false });
   });
 });

--- a/packages/backend/convex/contentRelease/archive/internal.ts
+++ b/packages/backend/convex/contentRelease/archive/internal.ts
@@ -101,6 +101,7 @@ const finalizeProgram = Effect.fn("contentRuntimeArchive.finalize")(function* (
   args: ContentRuntimeArchiveClaim & {
     readonly archiveSha256: string;
     readonly byteLength: number;
+    readonly sourceStateHash: string;
     readonly storageId: string;
   }
 ) {
@@ -173,9 +174,10 @@ const finalizeProgram = Effect.fn("contentRuntimeArchive.finalize")(function* (
   const metadata = {
     archiveSha256: args.archiveSha256,
     byteLength: args.byteLength,
-    contentStateHash: args.contentStateHash,
     createdAt: now,
+    runtimeSelectionHash: args.runtimeSelectionHash,
     runtimeSchemaFingerprint: args.runtimeSchemaFingerprint,
+    sourceStateHash: args.sourceStateHash,
   };
   yield* Effect.promise(() =>
     ctx.db.insert("contentRuntimeArchives", { ...metadata, storageId })
@@ -266,6 +268,7 @@ export const finalize = internalMutation({
     ...claimArgs,
     archiveSha256: v.string(),
     byteLength: v.number(),
+    sourceStateHash: v.string(),
     storageId: v.string(),
   },
   returns: runtimeArchiveFinalizeResultValidator,

--- a/packages/backend/convex/contentRelease/archive/internal.ts
+++ b/packages/backend/convex/contentRelease/archive/internal.ts
@@ -1,0 +1,279 @@
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
+  type ContentRuntimeArchiveClaim,
+  type ContentRuntimeArchiveIdentity,
+} from "@repo/backend/content/archive";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+} from "@repo/backend/convex/_generated/server";
+import {
+  archiveMetadata,
+  deleteUnreferencedArchiveStorage,
+  loadArchive,
+  loadClaim,
+  matchesArchiveStorage,
+} from "@repo/backend/convex/contentRelease/archive/model";
+import { pruneArchives } from "@repo/backend/convex/contentRelease/archive/retention";
+import {
+  runtimeArchiveAbortResultValidator,
+  runtimeArchiveClaimResultValidator,
+  runtimeArchiveDownloadValidator,
+  runtimeArchiveFinalizeResultValidator,
+  runtimeArchiveIdentityValidator,
+  runtimeArchiveReleaseResultValidator,
+} from "@repo/backend/convex/contentRelease/archive/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { v } from "convex/values";
+import { Clock, Effect } from "effect";
+
+const claimArgs = {
+  ...runtimeArchiveIdentityValidator,
+  claimId: v.string(),
+};
+
+/** Acquires or renews one exclusive lease before an expensive export. */
+const claimProgram = Effect.fn("contentRuntimeArchive.claim")(function* (
+  ctx: MutationCtx,
+  args: ContentRuntimeArchiveClaim
+) {
+  const existing = yield* Effect.promise(() => loadArchive(ctx, args));
+  if (existing) {
+    const stored = yield* Effect.promise(() =>
+      ctx.db.system.get("_storage", existing.storageId)
+    );
+    if (matchesArchiveStorage(existing, stored)) {
+      return { kind: "existing", metadata: archiveMetadata(existing) } as const;
+    }
+    yield* Effect.promise(() => ctx.db.delete(existing._id));
+    yield* deleteUnreferencedArchiveStorage(ctx, existing.storageId);
+  }
+
+  const now = yield* Clock.currentTimeMillis;
+  const expiresAt = now + CONTENT_RUNTIME_ARCHIVE_LEASE_MS;
+  const current = yield* Effect.promise(() => loadClaim(ctx, args));
+  if (current && current.claimId !== args.claimId && current.expiresAt > now) {
+    return { expiresAt: current.expiresAt, kind: "busy" } as const;
+  }
+  if (current) {
+    yield* Effect.promise(() =>
+      ctx.db.patch(current._id, { claimId: args.claimId, expiresAt })
+    );
+  } else {
+    yield* Effect.promise(() =>
+      ctx.db.insert("contentRuntimeArchiveClaims", { ...args, expiresAt })
+    );
+  }
+  return { expiresAt, kind: "claimed" } as const;
+});
+
+/** Releases a lease only when the exact claimant still owns it. */
+const releaseProgram = Effect.fn("contentRuntimeArchive.release")(function* (
+  ctx: MutationCtx,
+  args: ContentRuntimeArchiveClaim
+) {
+  const claim = yield* Effect.promise(() => loadClaim(ctx, args));
+  const released = claim?.claimId === args.claimId;
+  if (released) {
+    yield* Effect.promise(() => ctx.db.delete(claim._id));
+  }
+  return { released };
+});
+
+/** Confirms that an upload request still owns the unexpired producer lease. */
+const ownsProgram = Effect.fn("contentRuntimeArchive.owns")(function* (
+  ctx: MutationCtx,
+  args: ContentRuntimeArchiveClaim
+) {
+  const claim = yield* Effect.promise(() => loadClaim(ctx, args));
+  const now = yield* Clock.currentTimeMillis;
+  return claim?.claimId === args.claimId && claim.expiresAt > now;
+});
+
+/** Commits one uploaded archive exactly once for its immutable identity. */
+const finalizeProgram = Effect.fn("contentRuntimeArchive.finalize")(function* (
+  ctx: MutationCtx,
+  args: ContentRuntimeArchiveClaim & {
+    readonly archiveSha256: string;
+    readonly byteLength: number;
+    readonly storageId: string;
+  }
+) {
+  const storageId = ctx.db.system.normalizeId("_storage", args.storageId);
+  if (!storageId) {
+    return { kind: "invalid" } as const;
+  }
+
+  let ownsStorage = false;
+  const existing = yield* Effect.promise(() => loadArchive(ctx, args));
+  if (existing) {
+    const canonicalStorage = yield* Effect.promise(() =>
+      ctx.db.system.get("_storage", existing.storageId)
+    );
+    if (matchesArchiveStorage(existing, canonicalStorage)) {
+      if (
+        existing.archiveSha256 !== args.archiveSha256 ||
+        existing.byteLength !== args.byteLength
+      ) {
+        return { kind: "conflict" } as const;
+      }
+      return {
+        kind: "unchanged",
+        metadata: archiveMetadata(existing),
+      } as const;
+    }
+    yield* Effect.promise(() => ctx.db.delete(existing._id));
+    ownsStorage = existing.storageId === storageId;
+    if (!ownsStorage) {
+      yield* deleteUnreferencedArchiveStorage(ctx, existing.storageId);
+    }
+  }
+
+  const now = yield* Clock.currentTimeMillis;
+  const claim = yield* Effect.promise(() => loadClaim(ctx, args));
+  if (!claim || claim.claimId !== args.claimId || claim.expiresAt <= now) {
+    if (ownsStorage) {
+      yield* deleteUnreferencedArchiveStorage(ctx, storageId);
+    }
+    return { kind: "conflict" } as const;
+  }
+
+  const canonical = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentRuntimeArchives")
+      .withIndex("by_storageId", (query) => query.eq("storageId", storageId))
+      .first()
+  );
+  if (canonical) {
+    yield* Effect.promise(() => ctx.db.delete(claim._id));
+    return { kind: "conflict" } as const;
+  }
+
+  const stored = yield* Effect.promise(() =>
+    ctx.db.system.get("_storage", storageId)
+  );
+  if (
+    !stored ||
+    stored.contentType !== CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE ||
+    stored.sha256 !== args.archiveSha256 ||
+    stored.size !== args.byteLength
+  ) {
+    if (ownsStorage) {
+      yield* deleteUnreferencedArchiveStorage(ctx, storageId);
+    }
+    yield* Effect.promise(() => ctx.db.delete(claim._id));
+    return { kind: "invalid" } as const;
+  }
+
+  const metadata = {
+    archiveSha256: args.archiveSha256,
+    byteLength: args.byteLength,
+    contentStateHash: args.contentStateHash,
+    createdAt: now,
+    runtimeSchemaFingerprint: args.runtimeSchemaFingerprint,
+  };
+  yield* Effect.promise(() =>
+    ctx.db.insert("contentRuntimeArchives", { ...metadata, storageId })
+  );
+  yield* Effect.promise(() => ctx.db.delete(claim._id));
+  yield* pruneArchives(ctx, now);
+  return { kind: "stored", metadata } as const;
+});
+
+/** Deletes proven stale storage and defers unproven uploads to the bounded sweep. */
+const abortProgram = Effect.fn("contentRuntimeArchive.abort")(function* (
+  ctx: MutationCtx,
+  args: ContentRuntimeArchiveClaim & { readonly storageId: string }
+) {
+  const storageId = ctx.db.system.normalizeId("_storage", args.storageId);
+  if (!storageId) {
+    return { kind: "invalid" } as const;
+  }
+  let deleted = false;
+  const existing = yield* Effect.promise(() => loadArchive(ctx, args));
+  if (existing) {
+    const stored = yield* Effect.promise(() =>
+      ctx.db.system.get("_storage", existing.storageId)
+    );
+    if (matchesArchiveStorage(existing, stored)) {
+      if (existing.storageId === storageId) {
+        return {
+          kind: "canonical",
+          metadata: archiveMetadata(existing),
+        } as const;
+      }
+    } else {
+      yield* Effect.promise(() => ctx.db.delete(existing._id));
+      if (existing.storageId === storageId) {
+        deleted = yield* deleteUnreferencedArchiveStorage(
+          ctx,
+          existing.storageId
+        );
+      } else {
+        yield* deleteUnreferencedArchiveStorage(ctx, existing.storageId);
+      }
+    }
+  }
+  yield* releaseProgram(ctx, args);
+  return { kind: deleted ? "deleted" : "deferred" } as const;
+});
+
+/** Resolves one canonical archive and its bearer download capability once. */
+export const download = internalQuery({
+  args: runtimeArchiveIdentityValidator,
+  returns: v.union(v.null(), runtimeArchiveDownloadValidator),
+  handler: async (ctx: QueryCtx, args: ContentRuntimeArchiveIdentity) => {
+    const archive = await loadArchive(ctx, args);
+    if (!archive) {
+      return null;
+    }
+    const [stored, downloadUrl] = await Promise.all([
+      ctx.db.system.get("_storage", archive.storageId),
+      ctx.storage.getUrl(archive.storageId),
+    ]);
+    if (!(downloadUrl && matchesArchiveStorage(archive, stored))) {
+      return null;
+    }
+    return { ...archiveMetadata(archive), downloadUrl };
+  },
+});
+
+export const claim = internalMutation({
+  args: claimArgs,
+  returns: runtimeArchiveClaimResultValidator,
+  handler: (ctx, args) => runConvexProgram(claimProgram(ctx, args)),
+});
+
+export const release = internalMutation({
+  args: claimArgs,
+  returns: runtimeArchiveReleaseResultValidator,
+  handler: (ctx, args) => runConvexProgram(releaseProgram(ctx, args)),
+});
+
+export const owns = internalMutation({
+  args: claimArgs,
+  returns: v.boolean(),
+  handler: (ctx, args) => runConvexProgram(ownsProgram(ctx, args)),
+});
+
+export const finalize = internalMutation({
+  args: {
+    ...claimArgs,
+    archiveSha256: v.string(),
+    byteLength: v.number(),
+    storageId: v.string(),
+  },
+  returns: runtimeArchiveFinalizeResultValidator,
+  handler: (ctx, args) => runConvexProgram(finalizeProgram(ctx, args)),
+});
+
+export const abort = internalMutation({
+  args: { ...claimArgs, storageId: v.string() },
+  returns: runtimeArchiveAbortResultValidator,
+  handler: (ctx, args) => runConvexProgram(abortProgram(ctx, args)),
+});

--- a/packages/backend/convex/contentRelease/archive/model.test.ts
+++ b/packages/backend/convex/contentRelease/archive/model.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import {
+  abort,
+  claim,
+  claimId,
+  clearEnvironment,
+  finalize,
+  identity,
+  insert,
+  read,
+  setEnvironment,
+  storeArchiveFixture as store,
+} from "@repo/backend/test/archive";
+
+beforeEach(setEnvironment);
+afterEach(clearEnvironment);
+
+describe("content runtime archive model", () => {
+  it("preserves another identity's pending archive through finalize and abort", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const pendingIndex = 70;
+    const value = "pending-other-identity-archive";
+    const storageId = await store(target, value);
+    await claim(target, pendingIndex);
+
+    for (const [offset, attack] of [
+      { claimState: "missing", operation: "finalize" },
+      { claimState: "expired", operation: "finalize" },
+      { claimState: "missing", operation: "abort" },
+      { claimState: "expired", operation: "abort" },
+    ].entries()) {
+      const index = offset + 71;
+      if (attack.claimState === "expired") {
+        await target.run((ctx) =>
+          ctx.db.insert("contentRuntimeArchiveClaims", {
+            ...identity(index),
+            claimId: claimId(index),
+            expiresAt: Date.now() - 1,
+          })
+        );
+      }
+
+      const response =
+        attack.operation === "finalize"
+          ? await finalize(target, index, storageId, value)
+          : await abort(target, index, storageId);
+
+      expect(response.status).toBe(attack.operation === "finalize" ? 409 : 200);
+      if (attack.operation === "abort") {
+        await expect(response.json()).resolves.toEqual({ kind: "deferred" });
+      }
+      await expect(
+        target.run((ctx) => ctx.db.system.get("_storage", storageId))
+      ).resolves.not.toBeNull();
+    }
+
+    await expect(
+      (await finalize(target, pendingIndex, storageId, value)).json()
+    ).resolves.toMatchObject({ kind: "stored" });
+  });
+
+  it("never deletes foreign or another identity's canonical storage", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const foreignValue = "foreign-storage";
+    const foreignId = await store(
+      target,
+      foreignValue,
+      "application/octet-stream"
+    );
+    const canonicalValue = "other-identity-canonical";
+    const canonicalId = await store(target, canonicalValue);
+    await claim(target, 60);
+    await finalize(target, 60, canonicalId, canonicalValue);
+
+    let index = 61;
+    for (const candidate of [
+      { storageId: foreignId, value: foreignValue },
+      { storageId: canonicalId, value: canonicalValue },
+    ]) {
+      for (const operation of ["finalize", "abort"] as const) {
+        for (const claimState of ["missing", "expired"] as const) {
+          if (claimState === "expired") {
+            await target.run((ctx) =>
+              ctx.db.insert("contentRuntimeArchiveClaims", {
+                ...identity(index),
+                claimId: claimId(index),
+                expiresAt: Date.now() - 1,
+              })
+            );
+          }
+          const response =
+            operation === "finalize"
+              ? await finalize(
+                  target,
+                  index,
+                  candidate.storageId,
+                  candidate.value
+                )
+              : await abort(target, index, candidate.storageId);
+          expect(response.status).toBe(operation === "finalize" ? 409 : 200);
+          index += 1;
+        }
+      }
+    }
+
+    await claim(target, index);
+    expect(
+      (await finalize(target, index, canonicalId, canonicalValue)).status
+    ).toBe(409);
+    await expect(read(target, index)).resolves.toBeNull();
+    await expect(read(target, 60)).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", foreignId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", canonicalId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("repairs corrupt canonical rows during abort without false convergence", async () => {
+    const target = createConvexTestWithBetterAuth();
+    expect((await abort(target, 80, "not-a-storage-id")).status).toBe(400);
+    const cases = [
+      { deleted: true, kind: "deferred", name: "missing" },
+      {
+        contentType: "application/octet-stream",
+        kind: "deferred",
+        name: "content-type",
+      },
+      { archiveSha256: "c".repeat(64), kind: "deleted", name: "sha256" },
+      { byteLength: 1, kind: "deferred", name: "size" },
+    ];
+
+    for (const [offset, testCase] of cases.entries()) {
+      const index = offset + 80;
+      const value = `abort-corrupt-${testCase.name}`;
+      const storageId = await store(
+        target,
+        value,
+        testCase.contentType ?? CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+      );
+      await insert(target, index, storageId, value, testCase);
+      if (testCase.deleted) {
+        await target.run((ctx) => ctx.storage.delete(storageId));
+      }
+      const abortStorageId =
+        testCase.name === "size"
+          ? await store(target, "unproven-abort-candidate")
+          : storageId;
+
+      await expect(
+        (await abort(target, index, abortStorageId)).json()
+      ).resolves.toEqual({ kind: testCase.kind });
+      await expect(read(target, index)).resolves.toBeNull();
+      const stored = await target.run((ctx) =>
+        ctx.db.system.get("_storage", storageId)
+      );
+      if (testCase.contentType) {
+        expect(stored).not.toBeNull();
+      } else {
+        expect(stored).toBeNull();
+      }
+      if (abortStorageId !== storageId) {
+        await expect(
+          target.run((ctx) => ctx.db.system.get("_storage", abortStorageId))
+        ).resolves.not.toBeNull();
+      }
+    }
+  });
+
+  it("defers uncertain duplicates and preserves canonical storage", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const value = "uncertain-finalization-runtime-archive";
+    const storageId = await store(target, value);
+    await claim(target, 30);
+    await finalize(target, 30, storageId, value);
+    const duplicateId = await store(target, value);
+
+    await expect(
+      (await abort(target, 30, duplicateId)).json()
+    ).resolves.toEqual({ kind: "deferred" });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", duplicateId))
+    ).resolves.not.toBeNull();
+
+    const aborted = await abort(target, 30, storageId);
+
+    await expect(aborted.json()).resolves.toMatchObject({ kind: "canonical" });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageId))
+    ).resolves.not.toBeNull();
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/model.ts
+++ b/packages/backend/convex/contentRelease/archive/model.ts
@@ -1,0 +1,94 @@
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  type ContentRuntimeArchiveIdentity,
+} from "@repo/backend/content/archive";
+import type { Doc, Id } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import { Effect } from "effect";
+
+type ReadCtx = QueryCtx | MutationCtx;
+
+interface StoredArchiveMetadata {
+  readonly contentType?: string;
+  readonly sha256: string;
+  readonly size: number;
+}
+
+/** Loads one exact immutable archive identity. */
+export function loadArchive(
+  ctx: ReadCtx,
+  identity: ContentRuntimeArchiveIdentity
+) {
+  return ctx.db
+    .query("contentRuntimeArchives")
+    .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
+      query
+        .eq("contentStateHash", identity.contentStateHash)
+        .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
+    )
+    .unique();
+}
+
+/** Loads the single producer lease for one archive identity. */
+export function loadClaim(
+  ctx: ReadCtx,
+  identity: ContentRuntimeArchiveIdentity
+) {
+  return ctx.db
+    .query("contentRuntimeArchiveClaims")
+    .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
+      query
+        .eq("contentStateHash", identity.contentStateHash)
+        .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
+    )
+    .unique();
+}
+
+/** Projects storage-private state into authenticated transport metadata. */
+export function archiveMetadata(archive: Doc<"contentRuntimeArchives">) {
+  return {
+    archiveSha256: archive.archiveSha256,
+    byteLength: archive.byteLength,
+    contentStateHash: archive.contentStateHash,
+    createdAt: archive.createdAt,
+    runtimeSchemaFingerprint: archive.runtimeSchemaFingerprint,
+  };
+}
+
+/** Proves that canonical row metadata still names the exact stored bytes. */
+export function matchesArchiveStorage(
+  archive: Doc<"contentRuntimeArchives">,
+  stored: StoredArchiveMetadata | null
+) {
+  return (
+    stored?.contentType === CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE &&
+    stored.sha256 === archive.archiveSha256 &&
+    stored.size === archive.byteLength
+  );
+}
+
+/** Deletes only an unreferenced blob owned by the runtime archive protocol. */
+export const deleteUnreferencedArchiveStorage = Effect.fn(
+  "contentRuntimeArchive.deleteStorage"
+)(function* (ctx: MutationCtx, storageId: Id<"_storage">) {
+  const stored = yield* Effect.promise(() =>
+    ctx.db.system.get("_storage", storageId)
+  );
+  if (stored?.contentType !== CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE) {
+    return false;
+  }
+  const canonical = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentRuntimeArchives")
+      .withIndex("by_storageId", (query) => query.eq("storageId", storageId))
+      .first()
+  );
+  if (canonical) {
+    return false;
+  }
+  yield* Effect.promise(() => ctx.storage.delete(storageId));
+  return true;
+});

--- a/packages/backend/convex/contentRelease/archive/model.ts
+++ b/packages/backend/convex/contentRelease/archive/model.ts
@@ -24,10 +24,12 @@ export function loadArchive(
 ) {
   return ctx.db
     .query("contentRuntimeArchives")
-    .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
-      query
-        .eq("contentStateHash", identity.contentStateHash)
-        .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
+    .withIndex(
+      "by_runtimeSelectionHash_and_runtimeSchemaFingerprint",
+      (query) =>
+        query
+          .eq("runtimeSelectionHash", identity.runtimeSelectionHash)
+          .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
     )
     .unique();
 }
@@ -39,10 +41,12 @@ export function loadClaim(
 ) {
   return ctx.db
     .query("contentRuntimeArchiveClaims")
-    .withIndex("by_contentStateHash_and_runtimeSchemaFingerprint", (query) =>
-      query
-        .eq("contentStateHash", identity.contentStateHash)
-        .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
+    .withIndex(
+      "by_runtimeSelectionHash_and_runtimeSchemaFingerprint",
+      (query) =>
+        query
+          .eq("runtimeSelectionHash", identity.runtimeSelectionHash)
+          .eq("runtimeSchemaFingerprint", identity.runtimeSchemaFingerprint)
     )
     .unique();
 }
@@ -52,9 +56,10 @@ export function archiveMetadata(archive: Doc<"contentRuntimeArchives">) {
   return {
     archiveSha256: archive.archiveSha256,
     byteLength: archive.byteLength,
-    contentStateHash: archive.contentStateHash,
     createdAt: archive.createdAt,
+    runtimeSelectionHash: archive.runtimeSelectionHash,
     runtimeSchemaFingerprint: archive.runtimeSchemaFingerprint,
+    sourceStateHash: archive.sourceStateHash,
   };
 }
 

--- a/packages/backend/convex/contentRelease/archive/request.test.ts
+++ b/packages/backend/convex/contentRelease/archive/request.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+} from "@repo/backend/content/endpoint";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import {
+  claimId,
+  clearEnvironment,
+  identity,
+  post,
+  RUNTIME_TOKEN,
+  setEnvironment,
+  write,
+} from "@repo/backend/test/archive";
+
+beforeEach(setEnvironment);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearEnvironment();
+});
+
+describe("content runtime archive requests", () => {
+  it("preserves existing discovery and authentication routes", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const discovery = await target.fetch("/.well-known/openid-configuration", {
+      redirect: "manual",
+    });
+    const session = await target.fetch("/api/auth/get-session");
+
+    expect(discovery.status).toBe(302);
+    expect(discovery.headers.get("location")).toBe(
+      "/api/auth/convex/.well-known/openid-configuration"
+    );
+    expect(session.status).toBe(200);
+  });
+
+  it("keeps read and producer credentials least-privileged before body reads", async () => {
+    const target = createConvexTestWithBetterAuth();
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulls += 1;
+          controller.error(new Error("Unauthorized body was consumed."));
+        },
+      },
+      { highWaterMark: 0 }
+    );
+    const readCredentialOnWriteRoute = await target.fetch(
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      {
+        body,
+        duplex: "half",
+        headers: {
+          "content-type": "application/json",
+          "x-nakafa-content-token": RUNTIME_TOKEN,
+        },
+        method: "POST",
+      } as RequestInit & { readonly duplex: "half" }
+    );
+    const writeCredentialOnReadRoute = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(identity(1)),
+      "write"
+    );
+
+    expect(readCredentialOnWriteRoute.status).toBe(401);
+    expect(writeCredentialOnReadRoute.status).toBe(401);
+    expect(pulls).toBe(0);
+  });
+
+  it("fails closed on cryptographic and bounded-body failures", async () => {
+    const target = createConvexTestWithBetterAuth();
+    vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
+      new Error("digest unavailable")
+    );
+    const cryptoFailure = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(identity(1)),
+      "read"
+    );
+    const oversized = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      JSON.stringify({ source: "x".repeat(3000) }),
+      "write"
+    );
+    const unsupported = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      JSON.stringify(identity(1)),
+      "write",
+      "text/plain"
+    );
+    const malformed = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      "{",
+      "write"
+    );
+    const invalidEncoding = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      new Uint8Array([0xff]),
+      "write"
+    );
+    await target.run(async (ctx) => {
+      const expiresAt = Date.now() + 60_000;
+      await ctx.db.insert("contentRuntimeArchiveClaims", {
+        ...identity(90),
+        claimId: claimId(90),
+        expiresAt,
+      });
+      await ctx.db.insert("contentRuntimeArchiveClaims", {
+        ...identity(90),
+        claimId: claimId(91),
+        expiresAt,
+      });
+    });
+    const internalFailure = await write(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      { ...identity(90), claimId: claimId(92) }
+    );
+
+    expect(cryptoFailure.status).toBe(500);
+    expect(oversized.status).toBe(413);
+    expect(unsupported.status).toBe(415);
+    expect(malformed.status).toBe(400);
+    expect(invalidEncoding.status).toBe(400);
+    expect(internalFailure.status).toBe(500);
+    await expect(internalFailure.json()).resolves.toEqual({
+      code: "CONTENT_RUNTIME_ARCHIVE_INTERNAL",
+    });
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/request.ts
+++ b/packages/backend/convex/contentRelease/archive/request.ts
@@ -1,0 +1,94 @@
+import {
+  ContentRuntimeArchiveErrorCodeSchema,
+  MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_BYTES,
+} from "@repo/backend/content/archive";
+import { readJsonBody } from "@repo/backend/convex/contentRelease/http/body";
+import { matchesHttpSecret } from "@repo/backend/convex/contentRelease/http/secret";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { Effect, Result, Schema } from "effect";
+
+export class RuntimeArchiveHttpError extends Schema.TaggedError<RuntimeArchiveHttpError>()(
+  "RuntimeArchiveHttpError",
+  {
+    code: ContentRuntimeArchiveErrorCodeSchema,
+    status: Schema.Literals([400, 401, 404, 409, 413, 415, 500]),
+  }
+) {}
+
+export function archiveError(
+  code: RuntimeArchiveHttpError["code"],
+  status: RuntimeArchiveHttpError["status"]
+) {
+  return new RuntimeArchiveHttpError({ code, status });
+}
+
+/** Authenticates before consuming one bounded archive control body. */
+export const readArchiveRequest = Effect.fn(
+  "contentRuntimeArchive.readRequest"
+)(function* <A, I>(
+  request: Request,
+  schema: Schema.Codec<A, I, never, never>,
+  header: string,
+  secret: string
+) {
+  const authenticated = yield* matchesHttpSecret(
+    request.headers.get(header) ?? "",
+    secret
+  ).pipe(Effect.result);
+  if (Result.isFailure(authenticated)) {
+    return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_INTERNAL", 500);
+  }
+  if (!authenticated.success) {
+    return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_UNAUTHORIZED", 401);
+  }
+  const body = yield* readJsonBody(
+    request,
+    MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_BYTES
+  ).pipe(
+    Effect.mapError((error) => {
+      if (error.reason === "size") {
+        return archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 413);
+      }
+      if (error.reason === "unsupported") {
+        return archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 415);
+      }
+      return archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 400);
+    })
+  );
+  return yield* Schema.decodeEffect(Schema.fromJsonString(schema))(
+    body.source,
+    { onExcessProperty: "error" }
+  ).pipe(
+    Effect.mapError(() => archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 400))
+  );
+});
+
+/** Calls one internal archive operation without exposing backend failures. */
+export function callArchive<A>(operation: () => Promise<A>) {
+  return Effect.tryPromise({
+    catch: () => archiveError("CONTENT_RUNTIME_ARCHIVE_INTERNAL", 500),
+    try: operation,
+  });
+}
+
+/** Encodes one private archive control response. */
+export function archiveResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": "private, no-store",
+      "content-type": "application/json; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    },
+    status,
+  });
+}
+
+/** Runs one archive route at the HTTP framework boundary. */
+export async function runArchiveRoute(
+  program: Effect.Effect<Response, RuntimeArchiveHttpError>
+) {
+  const result = await runConvexProgram(program.pipe(Effect.result));
+  return Result.isFailure(result)
+    ? archiveResponse({ code: result.failure.code }, result.failure.status)
+    : result.success;
+}

--- a/packages/backend/convex/contentRelease/archive/retention.test.ts
+++ b/packages/backend/convex/contentRelease/archive/retention.test.ts
@@ -19,9 +19,13 @@ type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
 
 function identity(index: number) {
   return {
-    contentStateHash: index.toString(16).padStart(64, "0"),
+    runtimeSelectionHash: index.toString(16).padStart(64, "0"),
     runtimeSchemaFingerprint: "e".repeat(64),
   };
+}
+
+function sourceStateHash(index: number) {
+  return (index + 1000).toString(16).padStart(64, "0");
 }
 
 function claimId(index: number) {
@@ -57,6 +61,7 @@ async function insertArchive(
       archiveSha256,
       byteLength: Buffer.byteLength(value),
       createdAt,
+      sourceStateHash: sourceStateHash(index),
       storageId,
     })
   );
@@ -76,6 +81,7 @@ async function storeNewArchive(target: RuntimeTest, index: number) {
     ...input,
     archiveSha256: createHash("sha256").update(value).digest("hex"),
     byteLength: Buffer.byteLength(value),
+    sourceStateHash: sourceStateHash(index),
     storageId,
   });
   expect(response.status).toBe(200);

--- a/packages/backend/convex/contentRelease/archive/retention.test.ts
+++ b/packages/backend/convex/contentRelease/archive/retention.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+} from "@repo/backend/content/endpoint";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import { MAX_CONTENT_RUNTIME_ARCHIVES } from "@repo/backend/convex/contentRelease/archive/spec";
+import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { storeArchiveFixture } from "@repo/backend/test/archive";
+
+const ARCHIVE_TOKEN = "technical-archive-token";
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+function identity(index: number) {
+  return {
+    contentStateHash: index.toString(16).padStart(64, "0"),
+    runtimeSchemaFingerprint: "e".repeat(64),
+  };
+}
+
+function claimId(index: number) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+function write(target: RuntimeTest, path: string, body: unknown) {
+  return target.fetch(path, {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      "x-nakafa-archive-token": ARCHIVE_TOKEN,
+    },
+    method: "POST",
+  });
+}
+
+async function insertArchive(
+  target: RuntimeTest,
+  index: number,
+  createdAt: number
+) {
+  const value = `retained-runtime-archive-${index}`;
+  const archiveSha256 = createHash("sha256").update(value).digest("hex");
+  const storageId = await storeArchiveFixture(
+    target,
+    value,
+    CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+  );
+  await target.run((ctx) =>
+    ctx.db.insert("contentRuntimeArchives", {
+      ...identity(index),
+      archiveSha256,
+      byteLength: Buffer.byteLength(value),
+      createdAt,
+      storageId,
+    })
+  );
+  return storageId;
+}
+
+async function storeNewArchive(target: RuntimeTest, index: number) {
+  const value = `new-runtime-archive-${index}`;
+  const input = { ...identity(index), claimId: claimId(index) };
+  await write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, input);
+  const storageId = await storeArchiveFixture(
+    target,
+    value,
+    CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+  );
+  const response = await write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
+    ...input,
+    archiveSha256: createHash("sha256").update(value).digest("hex"),
+    byteLength: Buffer.byteLength(value),
+    storageId,
+  });
+  expect(response.status).toBe(200);
+}
+
+beforeEach(() => {
+  process.env.CONTENT_ARCHIVE_TOKEN = ARCHIVE_TOKEN;
+  process.env.CONTENT_RUNTIME_TOKEN = "technical-runtime-token";
+  process.env.POLAR_WEBHOOK_SECRET = "technical-webhook-secret";
+});
+
+afterEach(() => {
+  delete process.env.CONTENT_ARCHIVE_TOKEN;
+  delete process.env.CONTENT_RUNTIME_TOKEN;
+  delete process.env.POLAR_WEBHOOK_SECRET;
+});
+
+describe("content runtime archive retention", () => {
+  it("preserves the current archive when its identity remains unchanged", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const storageId = await insertArchive(
+      target,
+      0,
+      Date.now() - ROLLBACK_RETENTION_MS - 60_000
+    );
+
+    const result = await target.mutation(
+      internal.contentRelease.archive.cleanup.sweep,
+      {}
+    );
+
+    expect(result.archivesDeleted).toBe(0);
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchives").collect())
+    ).resolves.toHaveLength(1);
+  });
+
+  it("prunes expired storage while preserving the 30-day rollback window", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const now = Date.now();
+    const expiredId = await insertArchive(
+      target,
+      1,
+      now - ROLLBACK_RETENTION_MS - 60_000
+    );
+    const retainedId = await insertArchive(
+      target,
+      2,
+      now - ROLLBACK_RETENTION_MS + 60_000
+    );
+
+    await storeNewArchive(target, 3);
+
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", expiredId))
+    ).resolves.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", retainedId))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchives").collect())
+    ).resolves.toHaveLength(2);
+  });
+
+  it("deletes the oldest row and storage beyond the hard count ceiling", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const now = Date.now();
+    const storageIds: Id<"_storage">[] = [];
+    for (let index = 0; index < MAX_CONTENT_RUNTIME_ARCHIVES; index += 1) {
+      storageIds.push(
+        await insertArchive(
+          target,
+          index + 10,
+          now - (MAX_CONTENT_RUNTIME_ARCHIVES - index) * 1000
+        )
+      );
+    }
+
+    await storeNewArchive(target, 100);
+
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageIds[0]))
+    ).resolves.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageIds[1]))
+    ).resolves.not.toBeNull();
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchives").collect())
+    ).resolves.toHaveLength(MAX_CONTENT_RUNTIME_ARCHIVES);
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/retention.test.ts
+++ b/packages/backend/convex/contentRelease/archive/retention.test.ts
@@ -1,8 +1,6 @@
 // @vitest-environment node
 
-import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
-import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
 import {
   CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
   CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
@@ -12,92 +10,56 @@ import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import { MAX_CONTENT_RUNTIME_ARCHIVES } from "@repo/backend/convex/contentRelease/archive/spec";
 import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import { storeArchiveFixture } from "@repo/backend/test/archive";
-
-const ARCHIVE_TOKEN = "technical-archive-token";
-type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
-function identity(index: number) {
-  return {
-    runtimeSelectionHash: index.toString(16).padStart(64, "0"),
-    runtimeSchemaFingerprint: "e".repeat(64),
-  };
-}
-
-function sourceStateHash(index: number) {
-  return (index + 1000).toString(16).padStart(64, "0");
-}
-
-function claimId(index: number) {
-  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
-}
-
-function write(target: RuntimeTest, path: string, body: unknown) {
-  return target.fetch(path, {
-    body: JSON.stringify(body),
-    headers: {
-      "content-type": "application/json",
-      "x-nakafa-archive-token": ARCHIVE_TOKEN,
-    },
-    method: "POST",
-  });
-}
+import {
+  type ArchiveTest,
+  claimId,
+  clearEnvironment,
+  hash,
+  identity,
+  setEnvironment,
+  sourceHash,
+  storeArchiveFixture as store,
+  write,
+} from "@repo/backend/test/archive";
 
 async function insertArchive(
-  target: RuntimeTest,
+  target: ArchiveTest,
   index: number,
   createdAt: number
 ) {
   const value = `retained-runtime-archive-${index}`;
-  const archiveSha256 = createHash("sha256").update(value).digest("hex");
-  const storageId = await storeArchiveFixture(
-    target,
-    value,
-    CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-  );
+  const archiveSha256 = hash(value);
+  const storageId = await store(target, value);
   await target.run((ctx) =>
     ctx.db.insert("contentRuntimeArchives", {
       ...identity(index),
       archiveSha256,
       byteLength: Buffer.byteLength(value),
       createdAt,
-      sourceStateHash: sourceStateHash(index),
+      sourceStateHash: sourceHash(index),
       storageId,
     })
   );
   return storageId;
 }
 
-async function storeNewArchive(target: RuntimeTest, index: number) {
+async function storeNewArchive(target: ArchiveTest, index: number) {
   const value = `new-runtime-archive-${index}`;
   const input = { ...identity(index), claimId: claimId(index) };
   await write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, input);
-  const storageId = await storeArchiveFixture(
-    target,
-    value,
-    CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-  );
+  const storageId = await store(target, value);
   const response = await write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
     ...input,
-    archiveSha256: createHash("sha256").update(value).digest("hex"),
+    archiveSha256: hash(value),
     byteLength: Buffer.byteLength(value),
-    sourceStateHash: sourceStateHash(index),
+    sourceStateHash: sourceHash(index),
     storageId,
   });
   expect(response.status).toBe(200);
 }
 
-beforeEach(() => {
-  process.env.CONTENT_ARCHIVE_TOKEN = ARCHIVE_TOKEN;
-  process.env.CONTENT_RUNTIME_TOKEN = "technical-runtime-token";
-  process.env.POLAR_WEBHOOK_SECRET = "technical-webhook-secret";
-});
-
-afterEach(() => {
-  delete process.env.CONTENT_ARCHIVE_TOKEN;
-  delete process.env.CONTENT_RUNTIME_TOKEN;
-  delete process.env.POLAR_WEBHOOK_SECRET;
-});
+beforeEach(setEnvironment);
+afterEach(clearEnvironment);
 
 describe("content runtime archive retention", () => {
   it("preserves the current archive when its identity remains unchanged", async () => {

--- a/packages/backend/convex/contentRelease/archive/retention.ts
+++ b/packages/backend/convex/contentRelease/archive/retention.ts
@@ -1,0 +1,43 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { deleteUnreferencedArchiveStorage } from "@repo/backend/convex/contentRelease/archive/model";
+import { MAX_CONTENT_RUNTIME_ARCHIVES } from "@repo/backend/convex/contentRelease/archive/spec";
+import { ROLLBACK_RETENTION_MS } from "@repo/backend/convex/contentRelease/spec";
+import { Effect } from "effect";
+
+/** Prunes expired archives first, then bounds retained rollback history. */
+export const pruneArchives = Effect.fn("contentRuntimeArchive.prune")(
+  function* (ctx: MutationCtx, now: number) {
+    const [archives, newest] = yield* Effect.all([
+      Effect.promise(() =>
+        ctx.db
+          .query("contentRuntimeArchives")
+          .withIndex("by_createdAt")
+          .order("asc")
+          .take(MAX_CONTENT_RUNTIME_ARCHIVES + 1)
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("contentRuntimeArchives")
+          .withIndex("by_createdAt")
+          .order("desc")
+          .first()
+      ),
+    ]);
+    const cutoff = now - ROLLBACK_RETENTION_MS;
+    const retained = archives.filter((archive) => archive.createdAt >= cutoff);
+    const overflow = Math.max(
+      0,
+      retained.length - MAX_CONTENT_RUNTIME_ARCHIVES
+    );
+    const removals = [
+      ...archives.filter((archive) => archive.createdAt < cutoff),
+      ...retained.slice(0, overflow),
+    ].filter((archive) => archive._id !== newest?._id);
+
+    for (const archive of removals) {
+      yield* Effect.promise(() => ctx.db.delete(archive._id));
+      yield* deleteUnreferencedArchiveStorage(ctx, archive.storageId);
+    }
+    return removals.length;
+  }
+);

--- a/packages/backend/convex/contentRelease/archive/route.test.ts
+++ b/packages/backend/convex/contentRelease/archive/route.test.ts
@@ -22,8 +22,9 @@ const ARCHIVE_TOKEN = "technical-archive-token";
 const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
 const archiveTokenName = "CONTENT_ARCHIVE_TOKEN";
 const polarName = "POLAR_WEBHOOK_SECRET";
+const sourceStateHash = "3".repeat(64);
 const identity = {
-  contentStateHash: "1".repeat(64),
+  runtimeSelectionHash: "1".repeat(64),
   runtimeSchemaFingerprint: "2".repeat(64),
 };
 
@@ -86,6 +87,7 @@ function finalize(
     archiveSha256: sha256(value),
     byteLength: Buffer.byteLength(value),
     claimId: id,
+    sourceStateHash,
     storageId,
   });
 }
@@ -295,7 +297,7 @@ describe("content runtime archive HTTP routes", () => {
   it("preserves another identity's pending archive through finalize and abort", async () => {
     const target = createConvexTestWithBetterAuth();
     const pendingIdentity = {
-      contentStateHash: "7".repeat(64),
+      runtimeSelectionHash: "7".repeat(64),
       runtimeSchemaFingerprint: "6".repeat(64),
     };
     const pendingClaimId = claimId(70);
@@ -311,7 +313,7 @@ describe("content runtime archive HTTP routes", () => {
     ].entries()) {
       const index = offset + 71;
       const attackerIdentity = {
-        contentStateHash: index.toString(16).padStart(64, "0"),
+        runtimeSelectionHash: index.toString(16).padStart(64, "0"),
         runtimeSchemaFingerprint: "5".repeat(64),
       };
       const attackerClaimId = claimId(index);
@@ -387,6 +389,7 @@ describe("content runtime archive HTTP routes", () => {
       archiveSha256: sha256(value),
       byteLength: Buffer.byteLength(value),
       downloadUrl: expect.stringContaining("/api/storage/"),
+      sourceStateHash,
     });
     await expect(existingClaim.json()).resolves.toMatchObject({
       kind: "existing",
@@ -399,7 +402,7 @@ describe("content runtime archive HTTP routes", () => {
   it("turns every stale canonical storage invariant into a new export claim", async () => {
     const target = createConvexTestWithBetterAuth();
     const absentIdentity = {
-      contentStateHash: "9".repeat(64),
+      runtimeSelectionHash: "9".repeat(64),
       runtimeSchemaFingerprint: "8".repeat(64),
     };
     const absent = await post(
@@ -420,7 +423,7 @@ describe("content runtime archive HTTP routes", () => {
     for (const [offset, testCase] of cases.entries()) {
       const index = offset + 10;
       const archiveIdentity = {
-        contentStateHash: index.toString(16).padStart(64, "0"),
+        runtimeSelectionHash: index.toString(16).padStart(64, "0"),
         runtimeSchemaFingerprint: "c".repeat(64),
       };
       const value = `stale-runtime-archive-${index}`;
@@ -431,6 +434,7 @@ describe("content runtime archive HTTP routes", () => {
           archiveSha256: testCase.archiveSha256 ?? sha256(value),
           byteLength: testCase.byteLength ?? Buffer.byteLength(value),
           createdAt: Date.now(),
+          sourceStateHash,
           storageId,
         })
       );

--- a/packages/backend/convex/contentRelease/archive/route.test.ts
+++ b/packages/backend/convex/contentRelease/archive/route.test.ts
@@ -1,0 +1,461 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
+} from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
+} from "@repo/backend/content/endpoint";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { storeArchiveFixture } from "@repo/backend/test/archive";
+
+const RUNTIME_TOKEN = "technical-runtime-token";
+const ARCHIVE_TOKEN = "technical-archive-token";
+const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
+const archiveTokenName = "CONTENT_ARCHIVE_TOKEN";
+const polarName = "POLAR_WEBHOOK_SECRET";
+const identity = {
+  contentStateHash: "1".repeat(64),
+  runtimeSchemaFingerprint: "2".repeat(64),
+};
+
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+function claimId(index: number) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+function post(
+  target: RuntimeTest,
+  path: string,
+  body: BodyInit | null,
+  access: "read" | "write",
+  contentType = "application/json"
+) {
+  return target.fetch(path, {
+    body,
+    headers: {
+      "content-type": contentType,
+      [access === "read" ? "x-nakafa-content-token" : "x-nakafa-archive-token"]:
+        access === "read" ? RUNTIME_TOKEN : ARCHIVE_TOKEN,
+    },
+    method: "POST",
+  });
+}
+
+function write(target: RuntimeTest, path: string, body: unknown) {
+  return post(target, path, JSON.stringify(body), "write");
+}
+
+function claim(target: RuntimeTest, id: string, archiveIdentity = identity) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
+    ...archiveIdentity,
+    claimId: id,
+  });
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function storeArchive(
+  target: RuntimeTest,
+  value: string,
+  contentType = CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
+) {
+  return storeArchiveFixture(target, value, contentType);
+}
+
+function finalize(
+  target: RuntimeTest,
+  id: string,
+  storageId: string,
+  value: string,
+  archiveIdentity = identity
+) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
+    ...archiveIdentity,
+    archiveSha256: sha256(value),
+    byteLength: Buffer.byteLength(value),
+    claimId: id,
+    storageId,
+  });
+}
+
+beforeEach(() => {
+  process.env[runtimeTokenName] = RUNTIME_TOKEN;
+  process.env[archiveTokenName] = ARCHIVE_TOKEN;
+  process.env[polarName] = "technical-webhook-secret";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete process.env[runtimeTokenName];
+  delete process.env[archiveTokenName];
+  delete process.env[polarName];
+});
+
+describe("content runtime archive HTTP routes", () => {
+  it("preserves existing discovery and authentication routes", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const discovery = await target.fetch("/.well-known/openid-configuration", {
+      redirect: "manual",
+    });
+    const session = await target.fetch("/api/auth/get-session");
+
+    expect(discovery.status).toBe(302);
+    expect(discovery.headers.get("location")).toBe(
+      "/api/auth/convex/.well-known/openid-configuration"
+    );
+    expect(session.status).toBe(200);
+  });
+
+  it("keeps read and producer credentials least-privileged before body reads", async () => {
+    const target = createConvexTestWithBetterAuth();
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulls += 1;
+          controller.error(new Error("Unauthorized body was consumed."));
+        },
+      },
+      { highWaterMark: 0 }
+    );
+    const readCredentialOnWriteRoute = await target.fetch(
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      {
+        body,
+        duplex: "half",
+        headers: {
+          "content-type": "application/json",
+          "x-nakafa-content-token": RUNTIME_TOKEN,
+        },
+        method: "POST",
+      } as RequestInit & { readonly duplex: "half" }
+    );
+    const writeCredentialOnReadRoute = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(identity),
+      "write"
+    );
+
+    expect(readCredentialOnWriteRoute.status).toBe(401);
+    expect(writeCredentialOnReadRoute.status).toBe(401);
+    expect(pulls).toBe(0);
+  });
+
+  it("fails closed on cryptographic and bounded-body failures", async () => {
+    const target = createConvexTestWithBetterAuth();
+    vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
+      new Error("digest unavailable")
+    );
+    const cryptoFailure = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(identity),
+      "read"
+    );
+    const oversized = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      JSON.stringify({ source: "x".repeat(3000) }),
+      "write"
+    );
+    const unsupported = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      JSON.stringify(identity),
+      "write",
+      "text/plain"
+    );
+    const malformed = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      "{",
+      "write"
+    );
+    const invalidEncoding = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      new Uint8Array([0xff]),
+      "write"
+    );
+    await target.run(async (ctx) => {
+      const expiresAt = Date.now() + 60_000;
+      await ctx.db.insert("contentRuntimeArchiveClaims", {
+        ...identity,
+        claimId: claimId(90),
+        expiresAt,
+      });
+      await ctx.db.insert("contentRuntimeArchiveClaims", {
+        ...identity,
+        claimId: claimId(91),
+        expiresAt,
+      });
+    });
+    const internalFailure = await claim(target, claimId(92));
+
+    expect(cryptoFailure.status).toBe(500);
+    expect(oversized.status).toBe(413);
+    expect(unsupported.status).toBe(415);
+    expect(malformed.status).toBe(400);
+    expect(invalidEncoding.status).toBe(400);
+    expect(internalFailure.status).toBe(500);
+    await expect(internalFailure.json()).resolves.toEqual({
+      code: "CONTENT_RUNTIME_ARCHIVE_INTERNAL",
+    });
+  });
+
+  it("serializes concurrent claims and recovers expired leases", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const firstId = claimId(1);
+    const secondId = claimId(2);
+    const responses = await Promise.all([
+      claim(target, firstId),
+      claim(target, secondId),
+    ]);
+    const results = await Promise.all(
+      responses.map((response) => response.json())
+    );
+    const ownerIndex = results.findIndex(
+      (result) => (result as { kind?: string }).kind === "claimed"
+    );
+    const ownerId = ownerIndex === 0 ? firstId : secondId;
+    const blockedId = ownerIndex === 0 ? secondId : firstId;
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(
+      results.map((result) => (result as { kind: string }).kind).sort()
+    ).toEqual(["busy", "claimed"]);
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...identity,
+        claimId: blockedId,
+      })
+    ).resolves.toMatchObject({ status: 409 });
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...identity,
+        claimId: ownerId,
+      })
+    ).resolves.toMatchObject({ status: 200 });
+    const released = await write(target, CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH, {
+      ...identity,
+      claimId: ownerId,
+    });
+    expect(await released.json()).toEqual({ released: true });
+
+    await claim(target, firstId);
+    await target.run(async (ctx) => {
+      const lease = await ctx.db.query("contentRuntimeArchiveClaims").unique();
+      if (lease) {
+        await ctx.db.patch(lease._id, { expiresAt: Date.now() - 1 });
+      }
+    });
+    await expect(
+      claim(target, secondId).then((response) => response.json())
+    ).resolves.toMatchObject({
+      kind: "claimed",
+    });
+    const claimedAt = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(claimedAt);
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...identity,
+        claimId: secondId,
+      })
+    ).resolves.toMatchObject({ status: 200 });
+    vi.setSystemTime(claimedAt + CONTENT_RUNTIME_ARCHIVE_LEASE_MS + 1000);
+    await expect(
+      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
+        ...identity,
+        claimId: secondId,
+      })
+    ).resolves.toMatchObject({ status: 409 });
+    const staleRelease = await write(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+      { ...identity, claimId: firstId }
+    );
+    expect(await staleRelease.json()).toEqual({ released: false });
+  });
+
+  it("preserves another identity's pending archive through finalize and abort", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const pendingIdentity = {
+      contentStateHash: "7".repeat(64),
+      runtimeSchemaFingerprint: "6".repeat(64),
+    };
+    const pendingClaimId = claimId(70);
+    const value = "pending-other-identity-archive";
+    const storageId = await storeArchive(target, value);
+    await claim(target, pendingClaimId, pendingIdentity);
+
+    for (const [offset, attack] of [
+      { claimState: "missing", operation: "finalize" },
+      { claimState: "expired", operation: "finalize" },
+      { claimState: "missing", operation: "abort" },
+      { claimState: "expired", operation: "abort" },
+    ].entries()) {
+      const index = offset + 71;
+      const attackerIdentity = {
+        contentStateHash: index.toString(16).padStart(64, "0"),
+        runtimeSchemaFingerprint: "5".repeat(64),
+      };
+      const attackerClaimId = claimId(index);
+      if (attack.claimState === "expired") {
+        await target.run((ctx) =>
+          ctx.db.insert("contentRuntimeArchiveClaims", {
+            ...attackerIdentity,
+            claimId: attackerClaimId,
+            expiresAt: Date.now() - 1,
+          })
+        );
+      }
+
+      const response =
+        attack.operation === "finalize"
+          ? await finalize(
+              target,
+              attackerClaimId,
+              storageId,
+              value,
+              attackerIdentity
+            )
+          : await write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
+              ...attackerIdentity,
+              claimId: attackerClaimId,
+              storageId,
+            });
+
+      expect(response.status).toBe(attack.operation === "finalize" ? 409 : 200);
+      if (attack.operation === "abort") {
+        await expect(response.json()).resolves.toEqual({ kind: "deferred" });
+      }
+      await expect(
+        target.run((ctx) => ctx.db.system.get("_storage", storageId))
+      ).resolves.not.toBeNull();
+    }
+
+    await expect(
+      (
+        await finalize(
+          target,
+          pendingClaimId,
+          storageId,
+          value,
+          pendingIdentity
+        )
+      ).json()
+    ).resolves.toMatchObject({ kind: "stored" });
+  });
+
+  it("binds one archive and returns metadata with one download capability", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const id = claimId(3);
+    const value = "encrypted-runtime-archive";
+    const storageId = await storeArchive(target, value);
+    await claim(target, id);
+
+    const stored = await finalize(target, id, storageId, value);
+    const repeated = await finalize(target, id, storageId, value);
+    const download = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(identity),
+      "read"
+    );
+    const existingClaim = await claim(target, claimId(4));
+
+    expect(stored.status).toBe(200);
+    await expect(stored.json()).resolves.toMatchObject({ kind: "stored" });
+    await expect(repeated.json()).resolves.toMatchObject({ kind: "unchanged" });
+    await expect(download.json()).resolves.toMatchObject({
+      ...identity,
+      archiveSha256: sha256(value),
+      byteLength: Buffer.byteLength(value),
+      downloadUrl: expect.stringContaining("/api/storage/"),
+    });
+    await expect(existingClaim.json()).resolves.toMatchObject({
+      kind: "existing",
+    });
+    await expect(
+      target.run((ctx) => ctx.db.system.get("_storage", storageId))
+    ).resolves.not.toBeNull();
+  });
+
+  it("turns every stale canonical storage invariant into a new export claim", async () => {
+    const target = createConvexTestWithBetterAuth();
+    const absentIdentity = {
+      contentStateHash: "9".repeat(64),
+      runtimeSchemaFingerprint: "8".repeat(64),
+    };
+    const absent = await post(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      JSON.stringify(absentIdentity),
+      "read"
+    );
+    expect(absent.status).toBe(404);
+
+    const cases = [
+      { deleted: true },
+      { contentType: "application/octet-stream" },
+      { archiveSha256: "a".repeat(64) },
+      { byteLength: 1 },
+    ];
+
+    for (const [offset, testCase] of cases.entries()) {
+      const index = offset + 10;
+      const archiveIdentity = {
+        contentStateHash: index.toString(16).padStart(64, "0"),
+        runtimeSchemaFingerprint: "c".repeat(64),
+      };
+      const value = `stale-runtime-archive-${index}`;
+      const storageId = await storeArchive(target, value, testCase.contentType);
+      await target.run((ctx) =>
+        ctx.db.insert("contentRuntimeArchives", {
+          ...archiveIdentity,
+          archiveSha256: testCase.archiveSha256 ?? sha256(value),
+          byteLength: testCase.byteLength ?? Buffer.byteLength(value),
+          createdAt: Date.now(),
+          storageId,
+        })
+      );
+      if (testCase.deleted) {
+        await target.run((ctx) => ctx.storage.delete(storageId));
+      }
+
+      const missing = await post(
+        target,
+        CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+        JSON.stringify(archiveIdentity),
+        "read"
+      );
+      const reclaimed = await claim(target, claimId(index), archiveIdentity);
+
+      expect(missing.status).toBe(404);
+      await expect(missing.json()).resolves.toEqual({
+        code: "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND",
+      });
+      await expect(reclaimed.json()).resolves.toMatchObject({
+        kind: "claimed",
+      });
+    }
+    await expect(
+      target.run((ctx) => ctx.db.query("contentRuntimeArchives").collect())
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/packages/backend/convex/contentRelease/archive/route.test.ts
+++ b/packages/backend/convex/contentRelease/archive/route.test.ts
@@ -1,395 +1,60 @@
 // @vitest-environment node
 
-import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import {
-  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
-  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
-} from "@repo/backend/content/archive";
-import {
-  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
   CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
   CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
-  CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
-  CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
 } from "@repo/backend/content/endpoint";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
-import { storeArchiveFixture } from "@repo/backend/test/archive";
+import {
+  claim,
+  claimId,
+  clearEnvironment,
+  finalize,
+  hash,
+  identity,
+  insert,
+  post,
+  setEnvironment,
+  sourceHash,
+  storeArchiveFixture as store,
+  write,
+} from "@repo/backend/test/archive";
 
-const RUNTIME_TOKEN = "technical-runtime-token";
-const ARCHIVE_TOKEN = "technical-archive-token";
-const runtimeTokenName = "CONTENT_RUNTIME_TOKEN";
-const archiveTokenName = "CONTENT_ARCHIVE_TOKEN";
-const polarName = "POLAR_WEBHOOK_SECRET";
-const sourceStateHash = "3".repeat(64);
-const identity = {
-  runtimeSelectionHash: "1".repeat(64),
-  runtimeSchemaFingerprint: "2".repeat(64),
-};
+beforeEach(setEnvironment);
+afterEach(clearEnvironment);
 
-type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
-
-function claimId(index: number) {
-  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
-}
-
-function post(
-  target: RuntimeTest,
-  path: string,
-  body: BodyInit | null,
-  access: "read" | "write",
-  contentType = "application/json"
-) {
-  return target.fetch(path, {
-    body,
-    headers: {
-      "content-type": contentType,
-      [access === "read" ? "x-nakafa-content-token" : "x-nakafa-archive-token"]:
-        access === "read" ? RUNTIME_TOKEN : ARCHIVE_TOKEN,
-    },
-    method: "POST",
-  });
-}
-
-function write(target: RuntimeTest, path: string, body: unknown) {
-  return post(target, path, JSON.stringify(body), "write");
-}
-
-function claim(target: RuntimeTest, id: string, archiveIdentity = identity) {
-  return write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
-    ...archiveIdentity,
-    claimId: id,
-  });
-}
-
-function sha256(value: string) {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function storeArchive(
-  target: RuntimeTest,
-  value: string,
-  contentType = CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
-) {
-  return storeArchiveFixture(target, value, contentType);
-}
-
-function finalize(
-  target: RuntimeTest,
-  id: string,
-  storageId: string,
-  value: string,
-  archiveIdentity = identity
-) {
-  return write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
-    ...archiveIdentity,
-    archiveSha256: sha256(value),
-    byteLength: Buffer.byteLength(value),
-    claimId: id,
-    sourceStateHash,
-    storageId,
-  });
-}
-
-beforeEach(() => {
-  process.env[runtimeTokenName] = RUNTIME_TOKEN;
-  process.env[archiveTokenName] = ARCHIVE_TOKEN;
-  process.env[polarName] = "technical-webhook-secret";
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-  delete process.env[runtimeTokenName];
-  delete process.env[archiveTokenName];
-  delete process.env[polarName];
-});
-
-describe("content runtime archive HTTP routes", () => {
-  it("preserves existing discovery and authentication routes", async () => {
-    const target = createConvexTestWithBetterAuth();
-    const discovery = await target.fetch("/.well-known/openid-configuration", {
-      redirect: "manual",
-    });
-    const session = await target.fetch("/api/auth/get-session");
-
-    expect(discovery.status).toBe(302);
-    expect(discovery.headers.get("location")).toBe(
-      "/api/auth/convex/.well-known/openid-configuration"
-    );
-    expect(session.status).toBe(200);
-  });
-
-  it("keeps read and producer credentials least-privileged before body reads", async () => {
-    const target = createConvexTestWithBetterAuth();
-    let pulls = 0;
-    const body = new ReadableStream<Uint8Array>(
-      {
-        pull(controller) {
-          pulls += 1;
-          controller.error(new Error("Unauthorized body was consumed."));
-        },
-      },
-      { highWaterMark: 0 }
-    );
-    const readCredentialOnWriteRoute = await target.fetch(
-      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-      {
-        body,
-        duplex: "half",
-        headers: {
-          "content-type": "application/json",
-          "x-nakafa-content-token": RUNTIME_TOKEN,
-        },
-        method: "POST",
-      } as RequestInit & { readonly duplex: "half" }
-    );
-    const writeCredentialOnReadRoute = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-      JSON.stringify(identity),
-      "write"
-    );
-
-    expect(readCredentialOnWriteRoute.status).toBe(401);
-    expect(writeCredentialOnReadRoute.status).toBe(401);
-    expect(pulls).toBe(0);
-  });
-
-  it("fails closed on cryptographic and bounded-body failures", async () => {
-    const target = createConvexTestWithBetterAuth();
-    vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
-      new Error("digest unavailable")
-    );
-    const cryptoFailure = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-      JSON.stringify(identity),
-      "read"
-    );
-    const oversized = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-      JSON.stringify({ source: "x".repeat(3000) }),
-      "write"
-    );
-    const unsupported = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-      JSON.stringify(identity),
-      "write",
-      "text/plain"
-    );
-    const malformed = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-      "{",
-      "write"
-    );
-    const invalidEncoding = await post(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
-      new Uint8Array([0xff]),
-      "write"
-    );
-    await target.run(async (ctx) => {
-      const expiresAt = Date.now() + 60_000;
-      await ctx.db.insert("contentRuntimeArchiveClaims", {
-        ...identity,
-        claimId: claimId(90),
-        expiresAt,
-      });
-      await ctx.db.insert("contentRuntimeArchiveClaims", {
-        ...identity,
-        claimId: claimId(91),
-        expiresAt,
-      });
-    });
-    const internalFailure = await claim(target, claimId(92));
-
-    expect(cryptoFailure.status).toBe(500);
-    expect(oversized.status).toBe(413);
-    expect(unsupported.status).toBe(415);
-    expect(malformed.status).toBe(400);
-    expect(invalidEncoding.status).toBe(400);
-    expect(internalFailure.status).toBe(500);
-    await expect(internalFailure.json()).resolves.toEqual({
-      code: "CONTENT_RUNTIME_ARCHIVE_INTERNAL",
-    });
-  });
-
-  it("serializes concurrent claims and recovers expired leases", async () => {
-    const target = createConvexTestWithBetterAuth();
-    const firstId = claimId(1);
-    const secondId = claimId(2);
-    const responses = await Promise.all([
-      claim(target, firstId),
-      claim(target, secondId),
-    ]);
-    const results = await Promise.all(
-      responses.map((response) => response.json())
-    );
-    const ownerIndex = results.findIndex(
-      (result) => (result as { kind?: string }).kind === "claimed"
-    );
-    const ownerId = ownerIndex === 0 ? firstId : secondId;
-    const blockedId = ownerIndex === 0 ? secondId : firstId;
-
-    expect(responses.every((response) => response.status === 200)).toBe(true);
-    expect(
-      results.map((result) => (result as { kind: string }).kind).sort()
-    ).toEqual(["busy", "claimed"]);
-    await expect(
-      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
-        ...identity,
-        claimId: blockedId,
-      })
-    ).resolves.toMatchObject({ status: 409 });
-    await expect(
-      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
-        ...identity,
-        claimId: ownerId,
-      })
-    ).resolves.toMatchObject({ status: 200 });
-    const released = await write(target, CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH, {
-      ...identity,
-      claimId: ownerId,
-    });
-    expect(await released.json()).toEqual({ released: true });
-
-    await claim(target, firstId);
-    await target.run(async (ctx) => {
-      const lease = await ctx.db.query("contentRuntimeArchiveClaims").unique();
-      if (lease) {
-        await ctx.db.patch(lease._id, { expiresAt: Date.now() - 1 });
-      }
-    });
-    await expect(
-      claim(target, secondId).then((response) => response.json())
-    ).resolves.toMatchObject({
-      kind: "claimed",
-    });
-    const claimedAt = Date.now();
-    vi.useFakeTimers({ toFake: ["Date"] });
-    vi.setSystemTime(claimedAt);
-    await expect(
-      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
-        ...identity,
-        claimId: secondId,
-      })
-    ).resolves.toMatchObject({ status: 200 });
-    vi.setSystemTime(claimedAt + CONTENT_RUNTIME_ARCHIVE_LEASE_MS + 1000);
-    await expect(
-      write(target, CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, {
-        ...identity,
-        claimId: secondId,
-      })
-    ).resolves.toMatchObject({ status: 409 });
-    const staleRelease = await write(
-      target,
-      CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
-      { ...identity, claimId: firstId }
-    );
-    expect(await staleRelease.json()).toEqual({ released: false });
-  });
-
-  it("preserves another identity's pending archive through finalize and abort", async () => {
-    const target = createConvexTestWithBetterAuth();
-    const pendingIdentity = {
-      runtimeSelectionHash: "7".repeat(64),
-      runtimeSchemaFingerprint: "6".repeat(64),
-    };
-    const pendingClaimId = claimId(70);
-    const value = "pending-other-identity-archive";
-    const storageId = await storeArchive(target, value);
-    await claim(target, pendingClaimId, pendingIdentity);
-
-    for (const [offset, attack] of [
-      { claimState: "missing", operation: "finalize" },
-      { claimState: "expired", operation: "finalize" },
-      { claimState: "missing", operation: "abort" },
-      { claimState: "expired", operation: "abort" },
-    ].entries()) {
-      const index = offset + 71;
-      const attackerIdentity = {
-        runtimeSelectionHash: index.toString(16).padStart(64, "0"),
-        runtimeSchemaFingerprint: "5".repeat(64),
-      };
-      const attackerClaimId = claimId(index);
-      if (attack.claimState === "expired") {
-        await target.run((ctx) =>
-          ctx.db.insert("contentRuntimeArchiveClaims", {
-            ...attackerIdentity,
-            claimId: attackerClaimId,
-            expiresAt: Date.now() - 1,
-          })
-        );
-      }
-
-      const response =
-        attack.operation === "finalize"
-          ? await finalize(
-              target,
-              attackerClaimId,
-              storageId,
-              value,
-              attackerIdentity
-            )
-          : await write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
-              ...attackerIdentity,
-              claimId: attackerClaimId,
-              storageId,
-            });
-
-      expect(response.status).toBe(attack.operation === "finalize" ? 409 : 200);
-      if (attack.operation === "abort") {
-        await expect(response.json()).resolves.toEqual({ kind: "deferred" });
-      }
-      await expect(
-        target.run((ctx) => ctx.db.system.get("_storage", storageId))
-      ).resolves.not.toBeNull();
-    }
-
-    await expect(
-      (
-        await finalize(
-          target,
-          pendingClaimId,
-          storageId,
-          value,
-          pendingIdentity
-        )
-      ).json()
-    ).resolves.toMatchObject({ kind: "stored" });
-  });
-
+describe("content runtime archive routes", () => {
   it("binds one archive and returns metadata with one download capability", async () => {
     const target = createConvexTestWithBetterAuth();
-    const id = claimId(3);
+    const index = 3;
     const value = "encrypted-runtime-archive";
-    const storageId = await storeArchive(target, value);
-    await claim(target, id);
+    const storageId = await store(target, value);
+    await claim(target, index);
 
-    const stored = await finalize(target, id, storageId, value);
-    const repeated = await finalize(target, id, storageId, value);
+    const stored = await finalize(target, index, storageId, value);
+    const repeated = await finalize(target, index, storageId, value);
     const download = await post(
       target,
       CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-      JSON.stringify(identity),
+      JSON.stringify(identity(index)),
       "read"
     );
-    const existingClaim = await claim(target, claimId(4));
+    const existingClaim = await write(
+      target,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      { ...identity(index), claimId: claimId(4) }
+    );
 
     expect(stored.status).toBe(200);
     await expect(stored.json()).resolves.toMatchObject({ kind: "stored" });
     await expect(repeated.json()).resolves.toMatchObject({ kind: "unchanged" });
     await expect(download.json()).resolves.toMatchObject({
-      ...identity,
-      archiveSha256: sha256(value),
+      ...identity(index),
+      archiveSha256: hash(value),
       byteLength: Buffer.byteLength(value),
       downloadUrl: expect.stringContaining("/api/storage/"),
-      sourceStateHash,
+      sourceStateHash: sourceHash(index),
     });
     await expect(existingClaim.json()).resolves.toMatchObject({
       kind: "existing",
@@ -401,14 +66,10 @@ describe("content runtime archive HTTP routes", () => {
 
   it("turns every stale canonical storage invariant into a new export claim", async () => {
     const target = createConvexTestWithBetterAuth();
-    const absentIdentity = {
-      runtimeSelectionHash: "9".repeat(64),
-      runtimeSchemaFingerprint: "8".repeat(64),
-    };
     const absent = await post(
       target,
       CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-      JSON.stringify(absentIdentity),
+      JSON.stringify(identity(9)),
       "read"
     );
     expect(absent.status).toBe(404);
@@ -422,22 +83,9 @@ describe("content runtime archive HTTP routes", () => {
 
     for (const [offset, testCase] of cases.entries()) {
       const index = offset + 10;
-      const archiveIdentity = {
-        runtimeSelectionHash: index.toString(16).padStart(64, "0"),
-        runtimeSchemaFingerprint: "c".repeat(64),
-      };
       const value = `stale-runtime-archive-${index}`;
-      const storageId = await storeArchive(target, value, testCase.contentType);
-      await target.run((ctx) =>
-        ctx.db.insert("contentRuntimeArchives", {
-          ...archiveIdentity,
-          archiveSha256: testCase.archiveSha256 ?? sha256(value),
-          byteLength: testCase.byteLength ?? Buffer.byteLength(value),
-          createdAt: Date.now(),
-          sourceStateHash,
-          storageId,
-        })
-      );
+      const storageId = await store(target, value, testCase.contentType);
+      await insert(target, index, storageId, value, testCase);
       if (testCase.deleted) {
         await target.run((ctx) => ctx.storage.delete(storageId));
       }
@@ -445,10 +93,10 @@ describe("content runtime archive HTTP routes", () => {
       const missing = await post(
         target,
         CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
-        JSON.stringify(archiveIdentity),
+        JSON.stringify(identity(index)),
         "read"
       );
-      const reclaimed = await claim(target, claimId(index), archiveIdentity);
+      const reclaimed = await claim(target, index);
 
       expect(missing.status).toBe(404);
       await expect(missing.json()).resolves.toEqual({

--- a/packages/backend/convex/contentRelease/archive/route.ts
+++ b/packages/backend/convex/contentRelease/archive/route.ts
@@ -231,10 +231,11 @@ export function registerContentRuntimeArchiveRoutes<
           {
             archiveSha256: archive.archiveSha256,
             byteLength: archive.byteLength,
-            contentStateHash: archive.contentStateHash,
             createdAt: archive.createdAt,
             downloadUrl: archive.downloadUrl,
+            runtimeSelectionHash: archive.runtimeSelectionHash,
             runtimeSchemaFingerprint: archive.runtimeSchemaFingerprint,
+            sourceStateHash: archive.sourceStateHash,
           },
           200
         );

--- a/packages/backend/convex/contentRelease/archive/route.ts
+++ b/packages/backend/convex/contentRelease/archive/route.ts
@@ -1,0 +1,244 @@
+import {
+  type ContentRuntimeArchiveAbort,
+  ContentRuntimeArchiveAbortSchema,
+  type ContentRuntimeArchiveClaim,
+  ContentRuntimeArchiveClaimSchema,
+  type ContentRuntimeArchiveFinalize,
+  ContentRuntimeArchiveFinalizeSchema,
+  type ContentRuntimeArchiveIdentity,
+  ContentRuntimeArchiveIdentitySchema,
+} from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
+} from "@repo/backend/content/endpoint";
+import { type ActionCtx, env } from "@repo/backend/convex/_generated/server";
+import {
+  archiveError,
+  archiveResponse,
+  callArchive,
+  readArchiveRequest,
+  runArchiveRoute,
+} from "@repo/backend/convex/contentRelease/archive/request";
+import type {
+  runtimeArchiveAbortResultValidator,
+  runtimeArchiveClaimResultValidator,
+  runtimeArchiveDownloadValidator,
+  runtimeArchiveFinalizeResultValidator,
+  runtimeArchiveReleaseResultValidator,
+} from "@repo/backend/convex/contentRelease/archive/spec";
+import { makeFunctionReference } from "convex/server";
+import type { Infer } from "convex/values";
+import type { HonoWithConvex } from "convex-helpers/server/hono";
+import { Effect, type Schema } from "effect";
+
+type ArchiveDownload = Infer<typeof runtimeArchiveDownloadValidator>;
+type ClaimResult = Infer<typeof runtimeArchiveClaimResultValidator>;
+type FinalizeResult = Infer<typeof runtimeArchiveFinalizeResultValidator>;
+type AbortResult = Infer<typeof runtimeArchiveAbortResultValidator>;
+type ReleaseResult = Infer<typeof runtimeArchiveReleaseResultValidator>;
+
+const downloadReference = makeFunctionReference<
+  "query",
+  ContentRuntimeArchiveIdentity,
+  ArchiveDownload | null
+>("contentRelease/archive/internal:download");
+
+const claimReference = makeFunctionReference<
+  "mutation",
+  ContentRuntimeArchiveClaim,
+  ClaimResult
+>("contentRelease/archive/internal:claim");
+
+const finalizeReference = makeFunctionReference<
+  "mutation",
+  ContentRuntimeArchiveFinalize,
+  FinalizeResult
+>("contentRelease/archive/internal:finalize");
+
+const abortReference = makeFunctionReference<
+  "mutation",
+  ContentRuntimeArchiveAbort,
+  AbortResult
+>("contentRelease/archive/internal:abort");
+
+const releaseReference = makeFunctionReference<
+  "mutation",
+  ContentRuntimeArchiveClaim,
+  ReleaseResult
+>("contentRelease/archive/internal:release");
+
+const ownsReference = makeFunctionReference<
+  "mutation",
+  ContentRuntimeArchiveClaim,
+  boolean
+>("contentRelease/archive/internal:owns");
+
+function readRequest<A, I>(
+  request: Request,
+  schema: Schema.Codec<A, I, never, never>,
+  access: "read" | "write"
+) {
+  return access === "read"
+    ? readArchiveRequest(
+        request,
+        schema,
+        "x-nakafa-content-token",
+        env.CONTENT_RUNTIME_TOKEN
+      )
+    : readArchiveRequest(
+        request,
+        schema,
+        "x-nakafa-archive-token",
+        env.CONTENT_ARCHIVE_TOKEN
+      );
+}
+
+const loadArchive = Effect.fn("contentRuntimeArchive.load")(function* (
+  ctx: ActionCtx,
+  request: Request
+) {
+  const identity = yield* readRequest(
+    request,
+    ContentRuntimeArchiveIdentitySchema,
+    "read"
+  );
+  const archive = yield* callArchive(() =>
+    ctx.runQuery(downloadReference, identity)
+  );
+  if (!archive) {
+    return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_NOT_FOUND", 404);
+  }
+  return archive;
+});
+
+function claimArchive(ctx: ActionCtx, claim: ContentRuntimeArchiveClaim) {
+  return callArchive(() => ctx.runMutation(claimReference, claim));
+}
+
+/** Registers the authenticated immutable runtime archive protocol. */
+export function registerContentRuntimeArchiveRoutes<
+  Variables extends Record<string, unknown>,
+>(app: HonoWithConvex<ActionCtx, Variables>) {
+  app.post(CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const input = yield* readRequest(
+          context.req.raw,
+          ContentRuntimeArchiveClaimSchema,
+          "write"
+        );
+        const result = yield* claimArchive(context.env, input);
+        return archiveResponse(result, 200);
+      })
+    )
+  );
+
+  app.post(CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const input = yield* readRequest(
+          context.req.raw,
+          ContentRuntimeArchiveClaimSchema,
+          "write"
+        );
+        return archiveResponse(
+          yield* callArchive(() =>
+            context.env.runMutation(releaseReference, input)
+          ),
+          200
+        );
+      })
+    )
+  );
+
+  app.post(CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const input = yield* readRequest(
+          context.req.raw,
+          ContentRuntimeArchiveClaimSchema,
+          "write"
+        );
+        const ownsClaim = yield* callArchive(() =>
+          context.env.runMutation(ownsReference, input)
+        );
+        if (!ownsClaim) {
+          return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_BUSY", 409);
+        }
+        return archiveResponse(
+          {
+            uploadUrl: yield* callArchive(() =>
+              context.env.storage.generateUploadUrl()
+            ),
+          },
+          200
+        );
+      })
+    )
+  );
+
+  app.post(CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const input = yield* readRequest(
+          context.req.raw,
+          ContentRuntimeArchiveFinalizeSchema,
+          "write"
+        );
+        const result = yield* callArchive(() =>
+          context.env.runMutation(finalizeReference, input)
+        );
+        if (result.kind === "conflict") {
+          return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_CONFLICT", 409);
+        }
+        if (result.kind === "invalid") {
+          return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 400);
+        }
+        return archiveResponse(result, 200);
+      })
+    )
+  );
+
+  app.post(CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const input = yield* readRequest(
+          context.req.raw,
+          ContentRuntimeArchiveAbortSchema,
+          "write"
+        );
+        const result = yield* callArchive(() =>
+          context.env.runMutation(abortReference, input)
+        );
+        if (result.kind === "invalid") {
+          return yield* archiveError("CONTENT_RUNTIME_ARCHIVE_INVALID", 400);
+        }
+        return archiveResponse(result, 200);
+      })
+    )
+  );
+
+  app.post(CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH, (context) =>
+    runArchiveRoute(
+      Effect.gen(function* () {
+        const archive = yield* loadArchive(context.env, context.req.raw);
+        return archiveResponse(
+          {
+            archiveSha256: archive.archiveSha256,
+            byteLength: archive.byteLength,
+            contentStateHash: archive.contentStateHash,
+            createdAt: archive.createdAt,
+            downloadUrl: archive.downloadUrl,
+            runtimeSchemaFingerprint: archive.runtimeSchemaFingerprint,
+          },
+          200
+        );
+      })
+    )
+  );
+}

--- a/packages/backend/convex/contentRelease/archive/schema.ts
+++ b/packages/backend/convex/contentRelease/archive/schema.ts
@@ -31,12 +31,6 @@ const tables = {
       "runtimeSchemaFingerprint",
     ])
     .index("by_expiresAt", ["expiresAt"]),
-
-  /** Resumable cursor for the bounded orphan storage metadata sweep. */
-  contentRuntimeArchiveSweeps: defineTable({
-    cursor: v.union(v.null(), v.string()),
-    updatedAt: v.number(),
-  }),
 };
 
 export default tables;

--- a/packages/backend/convex/contentRelease/archive/schema.ts
+++ b/packages/backend/convex/contentRelease/archive/schema.ts
@@ -1,0 +1,41 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+const tables = {
+  /** Immutable encrypted runtime archives keyed by source and schema identity. */
+  contentRuntimeArchives: defineTable({
+    archiveSha256: v.string(),
+    byteLength: v.number(),
+    contentStateHash: v.string(),
+    createdAt: v.number(),
+    runtimeSchemaFingerprint: v.string(),
+    storageId: v.id("_storage"),
+  })
+    .index("by_contentStateHash_and_runtimeSchemaFingerprint", [
+      "contentStateHash",
+      "runtimeSchemaFingerprint",
+    ])
+    .index("by_createdAt", ["createdAt"])
+    .index("by_storageId", ["storageId"]),
+
+  /** One renewable producer lease for an archive identity that is still absent. */
+  contentRuntimeArchiveClaims: defineTable({
+    claimId: v.string(),
+    contentStateHash: v.string(),
+    expiresAt: v.number(),
+    runtimeSchemaFingerprint: v.string(),
+  })
+    .index("by_contentStateHash_and_runtimeSchemaFingerprint", [
+      "contentStateHash",
+      "runtimeSchemaFingerprint",
+    ])
+    .index("by_expiresAt", ["expiresAt"]),
+
+  /** Resumable cursor for the bounded orphan storage metadata sweep. */
+  contentRuntimeArchiveSweeps: defineTable({
+    cursor: v.union(v.null(), v.string()),
+    updatedAt: v.number(),
+  }),
+};
+
+export default tables;

--- a/packages/backend/convex/contentRelease/archive/schema.ts
+++ b/packages/backend/convex/contentRelease/archive/schema.ts
@@ -6,13 +6,14 @@ const tables = {
   contentRuntimeArchives: defineTable({
     archiveSha256: v.string(),
     byteLength: v.number(),
-    contentStateHash: v.string(),
     createdAt: v.number(),
+    runtimeSelectionHash: v.string(),
     runtimeSchemaFingerprint: v.string(),
+    sourceStateHash: v.string(),
     storageId: v.id("_storage"),
   })
-    .index("by_contentStateHash_and_runtimeSchemaFingerprint", [
-      "contentStateHash",
+    .index("by_runtimeSelectionHash_and_runtimeSchemaFingerprint", [
+      "runtimeSelectionHash",
       "runtimeSchemaFingerprint",
     ])
     .index("by_createdAt", ["createdAt"])
@@ -21,12 +22,12 @@ const tables = {
   /** One renewable producer lease for an archive identity that is still absent. */
   contentRuntimeArchiveClaims: defineTable({
     claimId: v.string(),
-    contentStateHash: v.string(),
     expiresAt: v.number(),
+    runtimeSelectionHash: v.string(),
     runtimeSchemaFingerprint: v.string(),
   })
-    .index("by_contentStateHash_and_runtimeSchemaFingerprint", [
-      "contentStateHash",
+    .index("by_runtimeSelectionHash_and_runtimeSchemaFingerprint", [
+      "runtimeSelectionHash",
       "runtimeSchemaFingerprint",
     ])
     .index("by_expiresAt", ["expiresAt"]),

--- a/packages/backend/convex/contentRelease/archive/spec.ts
+++ b/packages/backend/convex/contentRelease/archive/spec.ts
@@ -1,7 +1,6 @@
 import { v } from "convex/values";
 
 export const MAX_CONTENT_RUNTIME_ARCHIVES = 32;
-export const CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS = 60 * 60 * 1000;
 export const CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE = 32;
 
 export const runtimeArchiveIdentityValidator = {
@@ -62,6 +61,4 @@ export const runtimeArchiveReleaseResultValidator = v.object({
 export const runtimeArchiveSweepResultValidator = v.object({
   archivesDeleted: v.number(),
   claimsDeleted: v.number(),
-  deleted: v.number(),
-  scanned: v.number(),
 });

--- a/packages/backend/convex/contentRelease/archive/spec.ts
+++ b/packages/backend/convex/contentRelease/archive/spec.ts
@@ -5,7 +5,7 @@ export const CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS = 60 * 60 * 1000;
 export const CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE = 32;
 
 export const runtimeArchiveIdentityValidator = {
-  contentStateHash: v.string(),
+  runtimeSelectionHash: v.string(),
   runtimeSchemaFingerprint: v.string(),
 };
 
@@ -14,6 +14,7 @@ export const runtimeArchiveMetadataValidator = v.object({
   archiveSha256: v.string(),
   byteLength: v.number(),
   createdAt: v.number(),
+  sourceStateHash: v.string(),
 });
 
 export const runtimeArchiveStoredValidator = v.object({

--- a/packages/backend/convex/contentRelease/archive/spec.ts
+++ b/packages/backend/convex/contentRelease/archive/spec.ts
@@ -1,0 +1,66 @@
+import { v } from "convex/values";
+
+export const MAX_CONTENT_RUNTIME_ARCHIVES = 32;
+export const CONTENT_RUNTIME_ARCHIVE_ORPHAN_GRACE_MS = 60 * 60 * 1000;
+export const CONTENT_RUNTIME_ARCHIVE_SWEEP_BATCH_SIZE = 32;
+
+export const runtimeArchiveIdentityValidator = {
+  contentStateHash: v.string(),
+  runtimeSchemaFingerprint: v.string(),
+};
+
+export const runtimeArchiveMetadataValidator = v.object({
+  ...runtimeArchiveIdentityValidator,
+  archiveSha256: v.string(),
+  byteLength: v.number(),
+  createdAt: v.number(),
+});
+
+export const runtimeArchiveStoredValidator = v.object({
+  ...runtimeArchiveMetadataValidator.fields,
+  storageId: v.id("_storage"),
+});
+
+export const runtimeArchiveDownloadValidator = v.object({
+  ...runtimeArchiveMetadataValidator.fields,
+  downloadUrl: v.string(),
+});
+
+export const runtimeArchiveClaimResultValidator = v.union(
+  v.object({ expiresAt: v.number(), kind: v.literal("claimed") }),
+  v.object({ expiresAt: v.number(), kind: v.literal("busy") }),
+  v.object({
+    kind: v.literal("existing"),
+    metadata: runtimeArchiveMetadataValidator,
+  })
+);
+
+export const runtimeArchiveFinalizeResultValidator = v.union(
+  v.object({ kind: v.literal("conflict") }),
+  v.object({
+    kind: v.union(v.literal("stored"), v.literal("unchanged")),
+    metadata: runtimeArchiveMetadataValidator,
+  }),
+  v.object({ kind: v.literal("invalid") })
+);
+
+export const runtimeArchiveAbortResultValidator = v.union(
+  v.object({ kind: v.literal("deleted") }),
+  v.object({ kind: v.literal("deferred") }),
+  v.object({
+    kind: v.literal("canonical"),
+    metadata: runtimeArchiveMetadataValidator,
+  }),
+  v.object({ kind: v.literal("invalid") })
+);
+
+export const runtimeArchiveReleaseResultValidator = v.object({
+  released: v.boolean(),
+});
+
+export const runtimeArchiveSweepResultValidator = v.object({
+  archivesDeleted: v.number(),
+  claimsDeleted: v.number(),
+  deleted: v.number(),
+  scanned: v.number(),
+});

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -21,6 +21,7 @@ const app = defineApp({
     AKSARA_AGENT_SIGNING_KEY_ID: v.optional(v.string()),
     AKSARA_AGENT_SIGNING_PUBLIC_KEY: v.optional(v.string()),
     AKSARA_PUBLICATION_TOKEN: v.string(),
+    CONTENT_ARCHIVE_TOKEN: v.string(),
     CONTENT_RUNTIME_TOKEN: v.string(),
     [NAKAFA_API_EDGE_CONTRACT.secretEnvironment]: v.string(),
     [NAKAFA_MCP_ALLOWED_ORIGINS_ENVIRONMENT]: v.optional(v.string()),

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -8,6 +8,7 @@ import { cronJobs } from "convex/server";
 const crons = cronJobs();
 const CONTENT_ANALYTICS_BACKSTOP_INTERVAL_MINUTES = 10;
 const CONTENT_RELEASE_COMPACTION_INTERVAL_MINUTES = 10;
+const CONTENT_RUNTIME_ARCHIVE_SWEEP_INTERVAL_HOURS = 1;
 const CREDIT_RESET_PERIOD_RECONCILE_INTERVAL_MINUTES = 10;
 const EMAIL_RETENTION_SWEEP_INTERVAL_HOURS = 1;
 const NINA_CAPABILITY_TRACE_RETENTION_INTERVAL_HOURS = 24;
@@ -77,6 +78,14 @@ crons.interval(
   "compact content release history",
   { minutes: CONTENT_RELEASE_COMPACTION_INTERVAL_MINUTES },
   internal.contentRelease.compact.run,
+  {}
+);
+
+/** Advances one bounded page of old unreferenced runtime archive storage. */
+crons.interval(
+  "sweep runtime archive storage",
+  { hours: CONTENT_RUNTIME_ARCHIVE_SWEEP_INTERVAL_HOURS },
+  internal.contentRelease.archive.cleanup.sweep,
   {}
 );
 

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -81,7 +81,7 @@ crons.interval(
   {}
 );
 
-/** Advances one bounded page of old unreferenced runtime archive storage. */
+/** Removes expired archive claims and proven canonical rollback history. */
 crons.interval(
   "sweep runtime archive storage",
   { hours: CONTENT_RUNTIME_ARCHIVE_SWEEP_INTERVAL_HOURS },

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -5,6 +5,7 @@ import {
   isForumAttachmentUploadPath,
   registerForumAttachmentUploadRoute,
 } from "@repo/backend/convex/classes/forums/attachments/route";
+import { registerContentRuntimeArchiveRoutes } from "@repo/backend/convex/contentRelease/archive/route";
 import { registerPublicContentRuntimeBatchRoute } from "@repo/backend/convex/contentRelease/http/runtime/batch";
 import { registerProtectedContentRuntimeRoute } from "@repo/backend/convex/contentRelease/http/runtime/protected";
 import { registerPublicContentRuntimeRoute } from "@repo/backend/convex/contentRelease/http/runtime/public";
@@ -66,5 +67,6 @@ registerContentReleaseRoutes(app);
 registerPublicContentRuntimeBatchRoute(app);
 registerPublicContentRuntimeRoute(app);
 registerProtectedContentRuntimeRoute(app);
+registerContentRuntimeArchiveRoutes(app);
 
 export default new HttpRouterWithHono(app);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -4,6 +4,7 @@ import chatsSchema from "@repo/backend/convex/chats/tables/schema";
 import classesSchema from "@repo/backend/convex/classes/schema";
 import commentsSchema from "@repo/backend/convex/comments/schema";
 import consentsSchema from "@repo/backend/convex/consents/schema";
+import archiveSchema from "@repo/backend/convex/contentRelease/archive/schema";
 import contentReleaseSchema from "@repo/backend/convex/contentRelease/schema";
 import contentsSchema from "@repo/backend/convex/contents/schema";
 import creditsSchema from "@repo/backend/convex/credits/schema";
@@ -23,6 +24,7 @@ import { defineSchema } from "convex/server";
 export default defineSchema(
   {
     ...usersSchema,
+    ...archiveSchema,
     ...authDeletionSchema,
     ...chatsSchema,
     ...commentsSchema,

--- a/packages/backend/scripts/README.md
+++ b/packages/backend/scripts/README.md
@@ -35,11 +35,13 @@ Do not copy Convex deployment identity from another task.
 ## Signed runtime validation
 
 ```sh
-pnpm --filter @repo/backend runtime:ci
+pnpm --filter @repo/backend runtime:ci fingerprint
 ```
 
-`runtime:ci` validates the configured signed Aksara artifact and its Nakafa
-runtime projections without publishing or repairing content.
+`runtime:ci` requires an explicit mode. The validation, export, and import modes
+preserve the current signed runtime workflow. `produce` stores one encrypted
+archive for an active runtime selection, and `download` restores that exact
+archive. These modes never publish or repair authored content.
 
 ## Customer verification
 

--- a/packages/backend/scripts/content/runtime/ci/access.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/access.test.ts
@@ -8,7 +8,7 @@ import {
   readProducerConfig,
   readRuntimeArchiveAccessConfig,
 } from "@repo/backend/scripts/content/runtime/ci/access";
-import { ConfigProvider, Effect } from "effect";
+import { ConfigProvider, Effect, Redacted } from "effect";
 
 describe("content runtime archive access", () => {
   afterEach(() => {
@@ -17,14 +17,14 @@ describe("content runtime archive access", () => {
 
   it.live("grants archive downloads without the producer credential", () =>
     Effect.gen(function* () {
-      stubCacheIdentity("4".repeat(64));
+      stubArchiveIdentity("4".repeat(64));
       stubArchiveAccess("runtime-reader-token");
 
       expect(
         yield* withStubbedEnv(readRuntimeArchiveAccessConfig)
       ).toMatchObject({
-        contentStateHash: "4".repeat(64),
         runnerTemp: "/tmp",
+        runtimeSelectionHash: "4".repeat(64),
         siteUrl: CONTENT_RUNTIME_PRODUCTION_SITE_URL,
       });
       expect(process.env.CONTENT_ARCHIVE_TOKEN).toBeUndefined();
@@ -35,34 +35,46 @@ describe("content runtime archive access", () => {
     Effect.gen(function* () {
       stubProductionConfig();
       stubCacheIdentity("5".repeat(64));
-      stubArchiveAccess("runtime-reader-token");
+      stubArchiveIdentity("6".repeat(64));
       vi.stubEnv("CONTENT_ARCHIVE_TOKEN", "archive-producer-token");
 
       const config = yield* withStubbedEnv(readProducerConfig);
 
-      expect(config.archiveToken).not.toBe(config.runtimeToken);
+      expect(Redacted.value(config.archiveToken)).toBe(
+        "archive-producer-token"
+      );
+      expect("runtimeToken" in config).toBe(false);
+      expect(process.env.CONTENT_RUNTIME_TOKEN).toBeUndefined();
+      expect(config.runtimeSelectionHash).toBe("6".repeat(64));
       expect(config.siteUrl).toBe(CONTENT_RUNTIME_PRODUCTION_SITE_URL);
     })
   );
 
-  it.live.each([
-    { archiveToken: "archive-producer-token", runtimeToken: "invalid token" },
-    {
-      archiveToken: "archive-producer-token",
-      runtimeToken: "invalid\u0001token",
-    },
-    { archiveToken: "invalid token", runtimeToken: "runtime-reader-token" },
-    {
-      archiveToken: "invalid\u0080token",
-      runtimeToken: "runtime-reader-token",
-    },
-  ])(
-    "rejects unsafe archive credentials before network access: $archiveToken/$runtimeToken",
-    ({ archiveToken, runtimeToken }) =>
+  it.live.each(["invalid token", "invalid\u0001token"])(
+    "rejects unsafe download credentials before network access",
+    (token) =>
+      Effect.gen(function* () {
+        stubArchiveIdentity("6".repeat(64));
+        stubArchiveAccess(token);
+
+        const failure = yield* withStubbedEnv(
+          readRuntimeArchiveAccessConfig.pipe(Effect.flip)
+        );
+
+        expect(failure).toMatchObject({
+          _tag: "ContentRuntimeCiError",
+          message: "Content runtime artifact token is missing or invalid.",
+        });
+      })
+  );
+
+  it.live.each(["invalid token", "invalid\u0080token"])(
+    "rejects unsafe producer credentials before network access",
+    (archiveToken) =>
       Effect.gen(function* () {
         stubProductionConfig();
         stubCacheIdentity("6".repeat(64));
-        stubArchiveAccess(runtimeToken);
+        stubArchiveIdentity("7".repeat(64));
         vi.stubEnv("CONTENT_ARCHIVE_TOKEN", archiveToken);
 
         const failure = yield* withStubbedEnv(
@@ -71,37 +83,43 @@ describe("content runtime archive access", () => {
 
         expect(failure).toMatchObject({
           _tag: "ContentRuntimeCiError",
-          message:
-            runtimeToken === "runtime-reader-token"
-              ? "Content archive producer token is missing or invalid."
-              : "Content runtime artifact token is missing or invalid.",
+          message: "Content archive producer token is missing or invalid.",
         });
       })
   );
 
-  it.live.each([
-    { name: "CONTENT_RUNTIME_TOKEN", value: undefined },
-    { name: "CONTENT_RUNTIME_TOKEN", value: "" },
-    { name: "CONTENT_ARCHIVE_TOKEN", value: undefined },
-    { name: "CONTENT_ARCHIVE_TOKEN", value: "" },
-  ])("fails closed when $name is absent or empty", ({ name, value }) =>
-    Effect.gen(function* () {
-      stubProductionConfig();
-      stubCacheIdentity("7".repeat(64));
-      if (name !== "CONTENT_RUNTIME_TOKEN") {
-        stubArchiveAccess("runtime-reader-token");
-      }
-      if (name !== "CONTENT_ARCHIVE_TOKEN") {
-        vi.stubEnv("CONTENT_ARCHIVE_TOKEN", "archive-producer-token");
-      }
-      if (value !== undefined) {
-        vi.stubEnv(name, value);
-      }
+  it.live.each([undefined, ""])(
+    "fails closed when the download credential is absent or empty",
+    (value) =>
+      Effect.gen(function* () {
+        stubArchiveIdentity("7".repeat(64));
+        if (value !== undefined) {
+          vi.stubEnv("CONTENT_RUNTIME_TOKEN", value);
+        }
 
-      expect(
-        yield* withStubbedEnv(readProducerConfig.pipe(Effect.flip))
-      ).toMatchObject({ _tag: "ConfigError" });
-    })
+        expect(
+          yield* withStubbedEnv(
+            readRuntimeArchiveAccessConfig.pipe(Effect.flip)
+          )
+        ).toMatchObject({ _tag: "ConfigError" });
+      })
+  );
+
+  it.live.each([undefined, ""])(
+    "fails closed when the producer credential is absent or empty",
+    (value) =>
+      Effect.gen(function* () {
+        stubProductionConfig();
+        stubCacheIdentity("7".repeat(64));
+        stubArchiveIdentity("8".repeat(64));
+        if (value !== undefined) {
+          vi.stubEnv("CONTENT_ARCHIVE_TOKEN", value);
+        }
+
+        expect(
+          yield* withStubbedEnv(readProducerConfig.pipe(Effect.flip))
+        ).toMatchObject({ _tag: "ConfigError" });
+      })
   );
 
   it.live("clears archive credentials without widening its ownership", () =>
@@ -130,6 +148,10 @@ function stubProductionConfig() {
 function stubCacheIdentity(contentStateHash: string) {
   vi.stubEnv("CONTENT_RUNTIME_CACHE_KEY", "k".repeat(43));
   vi.stubEnv("CONTENT_RUNTIME_STATE_HASH", contentStateHash);
+}
+
+function stubArchiveIdentity(runtimeSelectionHash: string) {
+  vi.stubEnv("CONTENT_RUNTIME_SELECTION_HASH", runtimeSelectionHash);
   vi.stubEnv("CONTENT_RUNTIME_SCHEMA_HASH", "3".repeat(64));
 }
 

--- a/packages/backend/scripts/content/runtime/ci/access.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/access.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT,
+  CONTENT_RUNTIME_PRODUCTION_SITE_URL,
+} from "@repo/backend/content/deployment";
+import {
+  clearRuntimeArchiveSecrets,
+  readProducerConfig,
+  readRuntimeArchiveAccessConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import { ConfigProvider, Effect } from "effect";
+
+describe("content runtime archive access", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.live("grants archive downloads without the producer credential", () =>
+    Effect.gen(function* () {
+      stubCacheIdentity("4".repeat(64));
+      stubArchiveAccess("runtime-reader-token");
+
+      expect(
+        yield* withStubbedEnv(readRuntimeArchiveAccessConfig)
+      ).toMatchObject({
+        contentStateHash: "4".repeat(64),
+        runnerTemp: "/tmp",
+        siteUrl: CONTENT_RUNTIME_PRODUCTION_SITE_URL,
+      });
+      expect(process.env.CONTENT_ARCHIVE_TOKEN).toBeUndefined();
+    })
+  );
+
+  it.live("requires a separate producer credential for archive writes", () =>
+    Effect.gen(function* () {
+      stubProductionConfig();
+      stubCacheIdentity("5".repeat(64));
+      stubArchiveAccess("runtime-reader-token");
+      vi.stubEnv("CONTENT_ARCHIVE_TOKEN", "archive-producer-token");
+
+      const config = yield* withStubbedEnv(readProducerConfig);
+
+      expect(config.archiveToken).not.toBe(config.runtimeToken);
+      expect(config.siteUrl).toBe(CONTENT_RUNTIME_PRODUCTION_SITE_URL);
+    })
+  );
+
+  it.live.each([
+    { archiveToken: "archive-producer-token", runtimeToken: "invalid token" },
+    {
+      archiveToken: "archive-producer-token",
+      runtimeToken: "invalid\u0001token",
+    },
+    { archiveToken: "invalid token", runtimeToken: "runtime-reader-token" },
+    {
+      archiveToken: "invalid\u0080token",
+      runtimeToken: "runtime-reader-token",
+    },
+  ])(
+    "rejects unsafe archive credentials before network access: $archiveToken/$runtimeToken",
+    ({ archiveToken, runtimeToken }) =>
+      Effect.gen(function* () {
+        stubProductionConfig();
+        stubCacheIdentity("6".repeat(64));
+        stubArchiveAccess(runtimeToken);
+        vi.stubEnv("CONTENT_ARCHIVE_TOKEN", archiveToken);
+
+        const failure = yield* withStubbedEnv(
+          readProducerConfig.pipe(Effect.flip)
+        );
+
+        expect(failure).toMatchObject({
+          _tag: "ContentRuntimeCiError",
+          message:
+            runtimeToken === "runtime-reader-token"
+              ? "Content archive producer token is missing or invalid."
+              : "Content runtime artifact token is missing or invalid.",
+        });
+      })
+  );
+
+  it.live.each([
+    { name: "CONTENT_RUNTIME_TOKEN", value: undefined },
+    { name: "CONTENT_RUNTIME_TOKEN", value: "" },
+    { name: "CONTENT_ARCHIVE_TOKEN", value: undefined },
+    { name: "CONTENT_ARCHIVE_TOKEN", value: "" },
+  ])("fails closed when $name is absent or empty", ({ name, value }) =>
+    Effect.gen(function* () {
+      stubProductionConfig();
+      stubCacheIdentity("7".repeat(64));
+      if (name !== "CONTENT_RUNTIME_TOKEN") {
+        stubArchiveAccess("runtime-reader-token");
+      }
+      if (name !== "CONTENT_ARCHIVE_TOKEN") {
+        vi.stubEnv("CONTENT_ARCHIVE_TOKEN", "archive-producer-token");
+      }
+      if (value !== undefined) {
+        vi.stubEnv(name, value);
+      }
+
+      expect(
+        yield* withStubbedEnv(readProducerConfig.pipe(Effect.flip))
+      ).toMatchObject({ _tag: "ConfigError" });
+    })
+  );
+
+  it.live("clears archive credentials without widening its ownership", () =>
+    Effect.gen(function* () {
+      vi.stubEnv("CONTENT_ARCHIVE_TOKEN", "archive-producer-token");
+      vi.stubEnv("CONTENT_RUNTIME_TOKEN", "runtime-reader-token");
+      vi.stubEnv("CONTENT_RUNTIME_CACHE_KEY", "cache-key");
+
+      yield* clearRuntimeArchiveSecrets;
+
+      expect(process.env.CONTENT_ARCHIVE_TOKEN).toBeUndefined();
+      expect(process.env.CONTENT_RUNTIME_TOKEN).toBeUndefined();
+      expect(process.env.CONTENT_RUNTIME_CACHE_KEY).toBe("cache-key");
+    })
+  );
+});
+
+function stubProductionConfig() {
+  vi.stubEnv(
+    "CONVEX_DEPLOY_KEY",
+    `prod:${CONTENT_RUNTIME_PRODUCTION_DEPLOYMENT}|test-secret`
+  );
+  vi.stubEnv("RUNNER_TEMP", "/tmp");
+}
+
+function stubCacheIdentity(contentStateHash: string) {
+  vi.stubEnv("CONTENT_RUNTIME_CACHE_KEY", "k".repeat(43));
+  vi.stubEnv("CONTENT_RUNTIME_STATE_HASH", contentStateHash);
+  vi.stubEnv("CONTENT_RUNTIME_SCHEMA_HASH", "3".repeat(64));
+}
+
+function stubArchiveAccess(runtimeToken: string) {
+  vi.stubEnv("RUNNER_TEMP", "/tmp");
+  vi.stubEnv("CONTENT_RUNTIME_TOKEN", runtimeToken);
+}
+
+function withStubbedEnv<Value, Error>(program: Effect.Effect<Value, Error>) {
+  return program.pipe(
+    Effect.provideService(
+      ConfigProvider.ConfigProvider,
+      ConfigProvider.fromEnvRecord(process.env)
+    )
+  );
+}

--- a/packages/backend/scripts/content/runtime/ci/access.ts
+++ b/packages/backend/scripts/content/runtime/ci/access.ts
@@ -1,9 +1,10 @@
+import type { ContentRuntimeArchiveIdentity } from "@repo/backend/content/archive";
 import { CONTENT_RUNTIME_PRODUCTION_SITE_URL } from "@repo/backend/content/deployment";
 import {
-  type CacheIdentity,
   type ExportConfig,
-  readCacheIdentity,
   readExportConfig,
+  readRuntimeSchemaIdentity,
+  readRuntimeSelectionIdentity,
 } from "@repo/backend/scripts/content/runtime/ci/config";
 import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
 import { Config, Effect, Redacted } from "effect";
@@ -20,13 +21,16 @@ const hasUnsafeTokenCharacter = (value: string) =>
     );
   });
 
-export interface RuntimeArchiveReadConfig extends CacheIdentity {
+interface RuntimeArchiveConfig extends ContentRuntimeArchiveIdentity {
   readonly runnerTemp: string;
-  readonly runtimeToken: Redacted.Redacted;
   readonly siteUrl: string;
 }
 
-export interface RuntimeArchiveWriteConfig extends RuntimeArchiveReadConfig {
+export interface RuntimeArchiveReadConfig extends RuntimeArchiveConfig {
+  readonly runtimeToken: Redacted.Redacted;
+}
+
+export interface RuntimeArchiveWriteConfig extends RuntimeArchiveConfig {
   readonly archiveToken: Redacted.Redacted;
 }
 
@@ -34,9 +38,21 @@ export interface ProducerConfig
   extends ExportConfig,
     RuntimeArchiveWriteConfig {}
 
-const readRuntimeArchiveAccess = Effect.gen(function* () {
-  const identity = yield* readCacheIdentity;
+const readRuntimeArchiveConfig = Effect.gen(function* () {
+  const selection = yield* readRuntimeSelectionIdentity;
+  const schema = yield* readRuntimeSchemaIdentity;
   const runnerTemp = yield* Config.nonEmptyString("RUNNER_TEMP");
+
+  return {
+    ...selection,
+    ...schema,
+    runnerTemp,
+    siteUrl: CONTENT_RUNTIME_PRODUCTION_SITE_URL,
+  } satisfies RuntimeArchiveConfig;
+});
+
+export const readRuntimeArchiveAccessConfig = Effect.gen(function* () {
+  const config = yield* readRuntimeArchiveConfig;
   const runtimeToken = yield* Config.redacted("CONTENT_RUNTIME_TOKEN");
 
   if (hasUnsafeTokenCharacter(Redacted.value(runtimeToken))) {
@@ -46,18 +62,14 @@ const readRuntimeArchiveAccess = Effect.gen(function* () {
   }
 
   return {
-    ...identity,
-    runnerTemp,
+    ...config,
     runtimeToken,
-    siteUrl: CONTENT_RUNTIME_PRODUCTION_SITE_URL,
   } satisfies RuntimeArchiveReadConfig;
 });
 
-export const readRuntimeArchiveAccessConfig = readRuntimeArchiveAccess;
-
 export const readProducerConfig = Effect.gen(function* () {
   const exportConfig = yield* readExportConfig;
-  const access = yield* readRuntimeArchiveAccess;
+  const archiveConfig = yield* readRuntimeArchiveConfig;
   const archiveToken = yield* Config.redacted("CONTENT_ARCHIVE_TOKEN");
 
   if (hasUnsafeTokenCharacter(Redacted.value(archiveToken))) {
@@ -66,7 +78,11 @@ export const readProducerConfig = Effect.gen(function* () {
     );
   }
 
-  return { ...exportConfig, ...access, archiveToken } satisfies ProducerConfig;
+  return {
+    ...exportConfig,
+    ...archiveConfig,
+    archiveToken,
+  } satisfies ProducerConfig;
 });
 
 export const clearRuntimeArchiveSecrets = Effect.sync(() => {

--- a/packages/backend/scripts/content/runtime/ci/access.ts
+++ b/packages/backend/scripts/content/runtime/ci/access.ts
@@ -1,0 +1,75 @@
+import { CONTENT_RUNTIME_PRODUCTION_SITE_URL } from "@repo/backend/content/deployment";
+import {
+  type CacheIdentity,
+  type ExportConfig,
+  readCacheIdentity,
+  readExportConfig,
+} from "@repo/backend/scripts/content/runtime/ci/config";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import { Config, Effect, Redacted } from "effect";
+
+const WHITESPACE = /\s/u;
+
+const hasUnsafeTokenCharacter = (value: string) =>
+  [...value].some((character) => {
+    const codePoint = character.charCodeAt(0);
+    return (
+      WHITESPACE.test(character) ||
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f)
+    );
+  });
+
+export interface RuntimeArchiveReadConfig extends CacheIdentity {
+  readonly runnerTemp: string;
+  readonly runtimeToken: Redacted.Redacted;
+  readonly siteUrl: string;
+}
+
+export interface RuntimeArchiveWriteConfig extends RuntimeArchiveReadConfig {
+  readonly archiveToken: Redacted.Redacted;
+}
+
+export interface ProducerConfig
+  extends ExportConfig,
+    RuntimeArchiveWriteConfig {}
+
+const readRuntimeArchiveAccess = Effect.gen(function* () {
+  const identity = yield* readCacheIdentity;
+  const runnerTemp = yield* Config.nonEmptyString("RUNNER_TEMP");
+  const runtimeToken = yield* Config.redacted("CONTENT_RUNTIME_TOKEN");
+
+  if (hasUnsafeTokenCharacter(Redacted.value(runtimeToken))) {
+    return yield* contentRuntimeCiError(
+      "Content runtime artifact token is missing or invalid."
+    );
+  }
+
+  return {
+    ...identity,
+    runnerTemp,
+    runtimeToken,
+    siteUrl: CONTENT_RUNTIME_PRODUCTION_SITE_URL,
+  } satisfies RuntimeArchiveReadConfig;
+});
+
+export const readRuntimeArchiveAccessConfig = readRuntimeArchiveAccess;
+
+export const readProducerConfig = Effect.gen(function* () {
+  const exportConfig = yield* readExportConfig;
+  const access = yield* readRuntimeArchiveAccess;
+  const archiveToken = yield* Config.redacted("CONTENT_ARCHIVE_TOKEN");
+
+  if (hasUnsafeTokenCharacter(Redacted.value(archiveToken))) {
+    return yield* contentRuntimeCiError(
+      "Content archive producer token is missing or invalid."
+    );
+  }
+
+  return { ...exportConfig, ...access, archiveToken } satisfies ProducerConfig;
+});
+
+export const clearRuntimeArchiveSecrets = Effect.sync(() => {
+  delete process.env.CONTENT_ARCHIVE_TOKEN;
+  delete process.env.CONTENT_RUNTIME_TOKEN;
+});

--- a/packages/backend/scripts/content/runtime/ci/artifact.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.test.ts
@@ -7,6 +7,7 @@ import type {
   RuntimeArchiveWriteConfig,
 } from "@repo/backend/scripts/content/runtime/ci/access";
 import {
+  CONTENT_RUNTIME_STATE_FILE,
   downloadRuntimeArchive,
   publishRuntimeArchive,
 } from "@repo/backend/scripts/content/runtime/ci/artifact";
@@ -218,16 +219,23 @@ describe("content runtime durable artifact", () => {
           .mockResolvedValueOnce(new Response(archiveBytes, { status: 200 }));
         const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
         const archivePath = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
+        const statePath = `${runnerTemp}/${CONTENT_RUNTIME_STATE_FILE}`;
         const rename = fileSystem.rename.bind(fileSystem);
         const renameSpy = vi
           .spyOn(fileSystem, "rename")
           .mockImplementation((temporaryPath, destinationPath) =>
             Effect.gen(function* () {
-              expect(destinationPath).toBe(archivePath);
-              expect(yield* fileSystem.exists(archivePath)).toBe(false);
-              expect(
-                Array.from(yield* fileSystem.readFile(temporaryPath))
-              ).toEqual(Array.from(archiveBytes));
+              if (destinationPath === archivePath) {
+                expect(yield* fileSystem.exists(archivePath)).toBe(false);
+                expect(
+                  Array.from(yield* fileSystem.readFile(temporaryPath))
+                ).toEqual(Array.from(archiveBytes));
+              } else {
+                expect(destinationPath).toBe(statePath);
+                expect(yield* fileSystem.readFileString(temporaryPath)).toBe(
+                  `CONTENT_RUNTIME_STATE_HASH=${metadata.sourceStateHash}\n`
+                );
+              }
               yield* rename(temporaryPath, destinationPath);
             })
           );
@@ -244,6 +252,10 @@ describe("content runtime durable artifact", () => {
         expect(yield* fileSystem.readDirectory(cacheRoot)).toEqual([
           CONTENT_RUNTIME_CACHE_FILE,
         ]);
+        expect(yield* fileSystem.readFileString(statePath)).toBe(
+          `CONTENT_RUNTIME_STATE_HASH=${metadata.sourceStateHash}\n`
+        );
+        expect((yield* fileSystem.stat(statePath)).mode % 0o1000).toBe(0o600);
       }).pipe(Effect.provide(NodeServices.layer))
     )
   );
@@ -258,6 +270,7 @@ describe("content runtime durable artifact", () => {
         });
         const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
         const archivePath = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
+        const statePath = `${runnerTemp}/${CONTENT_RUNTIME_STATE_FILE}`;
         const fetcher = vi
           .fn<typeof fetch>()
           .mockResolvedValueOnce(
@@ -270,8 +283,10 @@ describe("content runtime durable artifact", () => {
         const rename = fileSystem.rename.bind(fileSystem);
         const renameSpy = vi
           .spyOn(fileSystem, "rename")
-          .mockImplementation((_temporaryPath, destinationPath) =>
-            rename(`${cacheRoot}/missing`, destinationPath)
+          .mockImplementation((temporaryPath, destinationPath) =>
+            destinationPath === statePath
+              ? rename(`${cacheRoot}/missing`, destinationPath)
+              : rename(temporaryPath, destinationPath)
           );
 
         expect(
@@ -281,6 +296,7 @@ describe("content runtime durable artifact", () => {
           )
         ).toMatchObject({ _tag: "PlatformError" });
         expect(yield* fileSystem.exists(archivePath)).toBe(false);
+        expect(yield* fileSystem.exists(statePath)).toBe(false);
         expect(yield* fileSystem.readDirectory(cacheRoot)).toEqual([]);
       }).pipe(Effect.provide(NodeServices.layer))
     )

--- a/packages/backend/scripts/content/runtime/ci/artifact.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.test.ts
@@ -21,26 +21,33 @@ const metadata = {
   archiveSha256:
     "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
   byteLength: archiveBytes.byteLength,
-  contentStateHash: "1".repeat(64),
   createdAt: 1_800_000_000_000,
+  runtimeSelectionHash: "1".repeat(64),
   runtimeSchemaFingerprint: "2".repeat(64),
+  sourceStateHash: "3".repeat(64),
 };
 const claimId = "00000000-0000-4000-8000-000000000001";
 
 function readConfig(runnerTemp: string): RuntimeArchiveReadConfig {
   return {
-    contentStateHash: metadata.contentStateHash,
     runnerTemp,
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
     runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
     runtimeToken: Redacted.make("technical-runtime-token"),
     siteUrl: "https://production.example.test",
   };
 }
 
-function writeConfig(runnerTemp: string): RuntimeArchiveWriteConfig {
+function writeConfig(
+  runnerTemp: string
+): RuntimeArchiveWriteConfig & { readonly contentStateHash: string } {
   return {
-    ...readConfig(runnerTemp),
     archiveToken: Redacted.make("technical-archive-token"),
+    contentStateHash: metadata.sourceStateHash,
+    runnerTemp,
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    siteUrl: "https://production.example.test",
   };
 }
 

--- a/packages/backend/scripts/content/runtime/ci/artifact.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.test.ts
@@ -89,7 +89,6 @@ describe("content runtime durable artifact", () => {
             fetcher
           )
         ).toEqual({ kind: "stored", metadata });
-        expect(fetcher).toHaveBeenCalledTimes(3);
         expect(fetcher.mock.calls[0]?.[0]).toContain("/archive/upload");
         expect(
           new Headers(fetcher.mock.calls[0]?.[1]?.headers).get(
@@ -245,10 +244,6 @@ describe("content runtime durable artifact", () => {
             Effect.ensuring(Effect.sync(() => renameSpy.mockRestore()))
           )
         ).toEqual(metadata);
-        expect(fetcher).toHaveBeenCalledTimes(2);
-        expect(Array.from(yield* fileSystem.readFile(archivePath))).toEqual(
-          Array.from(archiveBytes)
-        );
         expect(yield* fileSystem.readDirectory(cacheRoot)).toEqual([
           CONTENT_RUNTIME_CACHE_FILE,
         ]);

--- a/packages/backend/scripts/content/runtime/ci/artifact.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.test.ts
@@ -1,0 +1,281 @@
+import { truncate } from "node:fs/promises";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { MAX_CONTENT_RUNTIME_ARCHIVE_BYTES } from "@repo/backend/content/archive";
+import type {
+  RuntimeArchiveReadConfig,
+  RuntimeArchiveWriteConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import {
+  downloadRuntimeArchive,
+  publishRuntimeArchive,
+} from "@repo/backend/scripts/content/runtime/ci/artifact";
+import {
+  CONTENT_RUNTIME_CACHE_DIRECTORY,
+  CONTENT_RUNTIME_CACHE_FILE,
+} from "@repo/backend/scripts/content/runtime/ci/snapshot";
+import { Effect, FileSystem, Redacted } from "effect";
+
+const archiveBytes = new TextEncoder().encode("encrypted-runtime-archive");
+const metadata = {
+  archiveSha256:
+    "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
+  byteLength: archiveBytes.byteLength,
+  contentStateHash: "1".repeat(64),
+  createdAt: 1_800_000_000_000,
+  runtimeSchemaFingerprint: "2".repeat(64),
+};
+const claimId = "00000000-0000-4000-8000-000000000001";
+
+function readConfig(runnerTemp: string): RuntimeArchiveReadConfig {
+  return {
+    contentStateHash: metadata.contentStateHash,
+    runnerTemp,
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    runtimeToken: Redacted.make("technical-runtime-token"),
+    siteUrl: "https://production.example.test",
+  };
+}
+
+function writeConfig(runnerTemp: string): RuntimeArchiveWriteConfig {
+  return {
+    ...readConfig(runnerTemp),
+    archiveToken: Redacted.make("technical-archive-token"),
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+describe("content runtime durable artifact", () => {
+  it.live("publishes the exact bounded local encrypted file", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-artifact-publish-",
+        });
+        const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+        yield* fileSystem.makeDirectory(cacheRoot);
+        yield* fileSystem.writeFile(
+          `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`,
+          archiveBytes
+        );
+        const fetcher = vi.fn<typeof fetch>();
+        fetcher
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockResolvedValueOnce(jsonResponse({ kind: "stored", metadata }));
+
+        expect(
+          yield* publishRuntimeArchive(
+            writeConfig(runnerTemp),
+            claimId,
+            fetcher
+          )
+        ).toEqual({ kind: "stored", metadata });
+        expect(fetcher).toHaveBeenCalledTimes(3);
+        expect(fetcher.mock.calls[0]?.[0]).toContain("/archive/upload");
+        expect(
+          new Headers(fetcher.mock.calls[0]?.[1]?.headers).get(
+            "x-nakafa-archive-token"
+          )
+        ).toBe("technical-archive-token");
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live(
+    "rejects missing, non-file, empty, and oversized local archives",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const root = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-artifact-invalid-",
+          });
+          const fetcher = vi.fn<typeof fetch>();
+          const cases = ["missing", "directory", "empty", "oversized"];
+
+          for (const kind of cases) {
+            const runnerTemp = `${root}/${kind}`;
+            const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+            const path = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
+            yield* fileSystem.makeDirectory(cacheRoot, { recursive: true });
+            if (kind === "directory") {
+              yield* fileSystem.makeDirectory(path);
+            }
+            if (kind === "empty" || kind === "oversized") {
+              yield* fileSystem.writeFile(path, new Uint8Array());
+            }
+            if (kind === "oversized") {
+              yield* Effect.promise(() =>
+                truncate(path, MAX_CONTENT_RUNTIME_ARCHIVE_BYTES + 1)
+              );
+            }
+
+            expect(
+              yield* publishRuntimeArchive(
+                writeConfig(runnerTemp),
+                claimId,
+                fetcher
+              ).pipe(Effect.flip)
+            ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+          }
+          expect(fetcher).not.toHaveBeenCalled();
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("checks an empty destination before any remote request", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-artifact-preflight-",
+        });
+        const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+        yield* fileSystem.makeDirectory(cacheRoot);
+        yield* fileSystem.writeFileString(`${cacheRoot}/foreign`, "occupied");
+        const fetcher = vi.fn<typeof fetch>();
+
+        expect(
+          yield* downloadRuntimeArchive(readConfig(runnerTemp), fetcher).pipe(
+            Effect.flip
+          )
+        ).toMatchObject({
+          message:
+            "Signed runtime cache directory must be empty before download.",
+        });
+        expect(fetcher).not.toHaveBeenCalled();
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live("reports authenticated remote absence without creating a cache", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-artifact-absent-",
+        });
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(
+            jsonResponse({ code: "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND" }, 404)
+          );
+
+        expect(
+          yield* downloadRuntimeArchive(readConfig(runnerTemp), fetcher).pipe(
+            Effect.flip
+          )
+        ).toMatchObject({
+          message: "Immutable signed runtime archive is not available.",
+        });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(
+          yield* fileSystem.exists(
+            `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`
+          )
+        ).toBe(false);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live("downloads one metadata-bound capability into a private cache", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-artifact-download-",
+        });
+        const fetcher = vi.fn<typeof fetch>();
+        fetcher
+          .mockResolvedValueOnce(
+            jsonResponse({
+              ...metadata,
+              downloadUrl: "https://storage.example.test/archive",
+            })
+          )
+          .mockResolvedValueOnce(new Response(archiveBytes, { status: 200 }));
+        const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+        const archivePath = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
+        const rename = fileSystem.rename.bind(fileSystem);
+        const renameSpy = vi
+          .spyOn(fileSystem, "rename")
+          .mockImplementation((temporaryPath, destinationPath) =>
+            Effect.gen(function* () {
+              expect(destinationPath).toBe(archivePath);
+              expect(yield* fileSystem.exists(archivePath)).toBe(false);
+              expect(
+                Array.from(yield* fileSystem.readFile(temporaryPath))
+              ).toEqual(Array.from(archiveBytes));
+              yield* rename(temporaryPath, destinationPath);
+            })
+          );
+
+        expect(
+          yield* downloadRuntimeArchive(readConfig(runnerTemp), fetcher).pipe(
+            Effect.ensuring(Effect.sync(() => renameSpy.mockRestore()))
+          )
+        ).toEqual(metadata);
+        expect(fetcher).toHaveBeenCalledTimes(2);
+        expect(Array.from(yield* fileSystem.readFile(archivePath))).toEqual(
+          Array.from(archiveBytes)
+        );
+        expect(yield* fileSystem.readDirectory(cacheRoot)).toEqual([
+          CONTENT_RUNTIME_CACHE_FILE,
+        ]);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live("removes staged bytes when atomic promotion fails", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-artifact-atomic-",
+        });
+        const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+        const archivePath = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({
+              ...metadata,
+              downloadUrl: "https://storage.example.test/archive",
+            })
+          )
+          .mockResolvedValueOnce(new Response(archiveBytes, { status: 200 }));
+        const rename = fileSystem.rename.bind(fileSystem);
+        const renameSpy = vi
+          .spyOn(fileSystem, "rename")
+          .mockImplementation((_temporaryPath, destinationPath) =>
+            rename(`${cacheRoot}/missing`, destinationPath)
+          );
+
+        expect(
+          yield* downloadRuntimeArchive(readConfig(runnerTemp), fetcher).pipe(
+            Effect.flip,
+            Effect.ensuring(Effect.sync(() => renameSpy.mockRestore()))
+          )
+        ).toMatchObject({ _tag: "PlatformError" });
+        expect(yield* fileSystem.exists(archivePath)).toBe(false);
+        expect(yield* fileSystem.readDirectory(cacheRoot)).toEqual([]);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/artifact.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.ts
@@ -13,6 +13,8 @@ import {
 } from "@repo/backend/scripts/content/runtime/ci/snapshot";
 import { Effect, FileSystem, Option } from "effect";
 
+export const CONTENT_RUNTIME_STATE_FILE = "runtime-state.env";
+
 function encryptedArchivePath(config: { readonly runnerTemp: string }) {
   return `${config.runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}/${CONTENT_RUNTIME_CACHE_FILE}`;
 }
@@ -57,6 +59,7 @@ export const downloadRuntimeArchive = Effect.fn(
 )(function* (config: RuntimeArchiveReadConfig, fetcher: typeof fetch) {
   const fileSystem = yield* FileSystem.FileSystem;
   const cacheRoot = `${config.runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+  const statePath = `${config.runnerTemp}/${CONTENT_RUNTIME_STATE_FILE}`;
   if (
     (yield* fileSystem.exists(cacheRoot)) &&
     (yield* fileSystem.readDirectory(cacheRoot)).length > 0
@@ -75,15 +78,37 @@ export const downloadRuntimeArchive = Effect.fn(
   yield* fileSystem.makeDirectory(cacheRoot, { recursive: true });
   yield* fileSystem.chmod(cacheRoot, 0o700);
   yield* Effect.acquireUseRelease(
-    Effect.succeed(
-      `${cacheRoot}/.${CONTENT_RUNTIME_CACHE_FILE}.${randomUUID()}.tmp`
-    ),
-    (temporaryPath) =>
+    Effect.succeed({
+      archive: `${cacheRoot}/.${CONTENT_RUNTIME_CACHE_FILE}.${randomUUID()}.tmp`,
+      state: `${config.runnerTemp}/.${CONTENT_RUNTIME_STATE_FILE}.${randomUUID()}.tmp`,
+    }),
+    (temporary) =>
       Effect.gen(function* () {
-        yield* fileSystem.writeFile(temporaryPath, bytes, { mode: 0o600 });
-        yield* fileSystem.rename(temporaryPath, encryptedArchivePath(config));
+        yield* fileSystem.writeFile(temporary.archive, bytes, { mode: 0o600 });
+        yield* fileSystem.writeFileString(
+          temporary.state,
+          `CONTENT_RUNTIME_STATE_HASH=${metadata.sourceStateHash}\n`,
+          { mode: 0o600 }
+        );
+        yield* fileSystem.rename(
+          temporary.archive,
+          encryptedArchivePath(config)
+        );
+        yield* fileSystem
+          .rename(temporary.state, statePath)
+          .pipe(
+            Effect.onError(() =>
+              fileSystem
+                .remove(encryptedArchivePath(config), { force: true })
+                .pipe(Effect.ignore)
+            )
+          );
       }),
-    (temporaryPath) => fileSystem.remove(temporaryPath, { force: true })
+    (temporary) =>
+      Effect.all([
+        fileSystem.remove(temporary.archive, { force: true }),
+        fileSystem.remove(temporary.state, { force: true }),
+      ])
   );
   return metadata;
 });

--- a/packages/backend/scripts/content/runtime/ci/artifact.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+import { MAX_CONTENT_RUNTIME_ARCHIVE_BYTES } from "@repo/backend/content/archive";
+import type {
+  RuntimeArchiveReadConfig,
+  RuntimeArchiveWriteConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import { storeRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/publish";
+import { fetchRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/remote";
+import {
+  CONTENT_RUNTIME_CACHE_DIRECTORY,
+  CONTENT_RUNTIME_CACHE_FILE,
+} from "@repo/backend/scripts/content/runtime/ci/snapshot";
+import { Effect, FileSystem, Option } from "effect";
+
+function encryptedArchivePath(config: RuntimeArchiveReadConfig) {
+  return `${config.runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}/${CONTENT_RUNTIME_CACHE_FILE}`;
+}
+
+/** Uploads and immutably binds the locally encrypted runtime archive. */
+export const publishRuntimeArchive = Effect.fn(
+  "contentRuntimeArtifact.publish"
+)(function* (
+  config: RuntimeArchiveWriteConfig,
+  claimId: string,
+  fetcher: typeof fetch
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = encryptedArchivePath(config);
+  if (!(yield* fileSystem.exists(path))) {
+    return yield* contentRuntimeCiError(
+      "Encrypted signed runtime archive is missing before publication."
+    );
+  }
+  const info = yield* fileSystem.stat(path);
+  if (info.type !== "File" || info.size <= 0n) {
+    return yield* contentRuntimeCiError(
+      "Encrypted signed runtime archive is missing before publication."
+    );
+  }
+  if (info.size > BigInt(MAX_CONTENT_RUNTIME_ARCHIVE_BYTES)) {
+    return yield* contentRuntimeCiError(
+      `Encrypted signed runtime archive exceeds ${MAX_CONTENT_RUNTIME_ARCHIVE_BYTES} bytes.`
+    );
+  }
+  return yield* storeRuntimeArchive(
+    config,
+    claimId,
+    yield* fileSystem.readFile(path),
+    fetcher
+  );
+});
+
+/** Downloads one verified archive into an empty private cache directory. */
+export const downloadRuntimeArchive = Effect.fn(
+  "contentRuntimeArtifact.download"
+)(function* (config: RuntimeArchiveReadConfig, fetcher: typeof fetch) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const cacheRoot = `${config.runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+  if (
+    (yield* fileSystem.exists(cacheRoot)) &&
+    (yield* fileSystem.readDirectory(cacheRoot)).length > 0
+  ) {
+    return yield* contentRuntimeCiError(
+      "Signed runtime cache directory must be empty before download."
+    );
+  }
+  const archive = yield* fetchRuntimeArchive(config, fetcher);
+  if (Option.isNone(archive)) {
+    return yield* contentRuntimeCiError(
+      "Immutable signed runtime archive is not available."
+    );
+  }
+  const { bytes, metadata } = archive.value;
+  yield* fileSystem.makeDirectory(cacheRoot, { recursive: true });
+  yield* fileSystem.chmod(cacheRoot, 0o700);
+  yield* Effect.acquireUseRelease(
+    Effect.succeed(
+      `${cacheRoot}/.${CONTENT_RUNTIME_CACHE_FILE}.${randomUUID()}.tmp`
+    ),
+    (temporaryPath) =>
+      Effect.gen(function* () {
+        yield* fileSystem.writeFile(temporaryPath, bytes, { mode: 0o600 });
+        yield* fileSystem.rename(temporaryPath, encryptedArchivePath(config));
+      }),
+    (temporaryPath) => fileSystem.remove(temporaryPath, { force: true })
+  );
+  return metadata;
+});

--- a/packages/backend/scripts/content/runtime/ci/artifact.ts
+++ b/packages/backend/scripts/content/runtime/ci/artifact.ts
@@ -13,7 +13,7 @@ import {
 } from "@repo/backend/scripts/content/runtime/ci/snapshot";
 import { Effect, FileSystem, Option } from "effect";
 
-function encryptedArchivePath(config: RuntimeArchiveReadConfig) {
+function encryptedArchivePath(config: { readonly runnerTemp: string }) {
   return `${config.runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}/${CONTENT_RUNTIME_CACHE_FILE}`;
 }
 
@@ -21,7 +21,7 @@ function encryptedArchivePath(config: RuntimeArchiveReadConfig) {
 export const publishRuntimeArchive = Effect.fn(
   "contentRuntimeArtifact.publish"
 )(function* (
-  config: RuntimeArchiveWriteConfig,
+  config: RuntimeArchiveWriteConfig & { readonly contentStateHash: string },
   claimId: string,
   fetcher: typeof fetch
 ) {

--- a/packages/backend/scripts/content/runtime/ci/command.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/command.test.ts
@@ -455,10 +455,10 @@ describe("content runtime command diagnostics", () => {
         ).pipe(Effect.provide(NodeServices.layer));
 
         expect(result.failure.message).toContain(
-          "Usage: runtime:ci <fingerprint|generations|verify-generations|export|import>"
+          "Usage: runtime:ci <fingerprint|generations|verify-generations|export|import|produce|download>"
         );
         expect(result.stderr).toBe(
-          "ERROR: Usage: runtime:ci <fingerprint|generations|verify-generations|export|import>\n"
+          "ERROR: Usage: runtime:ci <fingerprint|generations|verify-generations|export|import|produce|download>\n"
         );
         expect(result.stdout).toBe("");
       }),

--- a/packages/backend/scripts/content/runtime/ci/config.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/config.test.ts
@@ -39,6 +39,7 @@ describe("content runtime CI config", () => {
     "prod:dapper-antelope-269| test-secret",
     "prod:dapper-antelope-269|test-secret ",
     "prod:dapper-antelope-269|test\nsecret",
+    "prod:dapper-antelope-269|test\u0001secret",
     "prod:dapper-antelope-269|test\u0080secret",
   ])("rejects an unsafe deploy key without exposing it", (deployKey) =>
     Effect.gen(function* () {
@@ -94,6 +95,21 @@ describe("content runtime CI config", () => {
         "CONTENT_RUNTIME_EXPORT_LIMIT",
         String(MAX_CONTENT_RUNTIME_EXPORT_LIMIT + 1)
       );
+
+      expect(
+        yield* withStubbedEnv(readExportConfig.pipe(Effect.flip))
+      ).toMatchObject({
+        _tag: "ContentRuntimeCiError",
+        message: `CONTENT_RUNTIME_EXPORT_LIMIT must be between 1 and ${MAX_CONTENT_RUNTIME_EXPORT_LIMIT}.`,
+      });
+    })
+  );
+
+  it.live("rejects a non-positive producer export limit", () =>
+    Effect.gen(function* () {
+      stubProductionConfig();
+      stubCacheIdentity("1".repeat(64));
+      vi.stubEnv("CONTENT_RUNTIME_EXPORT_LIMIT", "0");
 
       expect(
         yield* withStubbedEnv(readExportConfig.pipe(Effect.flip))

--- a/packages/backend/scripts/content/runtime/ci/config.ts
+++ b/packages/backend/scripts/content/runtime/ci/config.ts
@@ -92,7 +92,7 @@ export const validateProductionDeployKey = (deployKey: string) => {
   return Effect.succeed(deployKey);
 };
 
-const readCacheIdentity = Effect.gen(function* () {
+export const readCacheIdentity = Effect.gen(function* () {
   const values = yield* Config.all({
     contentStateHash: Config.nonEmptyString("CONTENT_RUNTIME_STATE_HASH"),
     runtimeSchemaFingerprint: Config.nonEmptyString(

--- a/packages/backend/scripts/content/runtime/ci/config.ts
+++ b/packages/backend/scripts/content/runtime/ci/config.ts
@@ -26,9 +26,12 @@ const hasDisallowedDeployKeyCharacter = (value: string) =>
     );
   });
 
-export interface CacheIdentity {
-  readonly contentStateHash: string;
+export interface RuntimeSchemaIdentity {
   readonly runtimeSchemaFingerprint: string;
+}
+
+export interface CacheIdentity extends RuntimeSchemaIdentity {
+  readonly contentStateHash: string;
 }
 
 export interface RuntimeSelectionIdentity {
@@ -92,29 +95,32 @@ export const validateProductionDeployKey = (deployKey: string) => {
   return Effect.succeed(deployKey);
 };
 
-export const readCacheIdentity = Effect.gen(function* () {
-  const values = yield* Config.all({
-    contentStateHash: Config.nonEmptyString("CONTENT_RUNTIME_STATE_HASH"),
-    runtimeSchemaFingerprint: Config.nonEmptyString(
-      "CONTENT_RUNTIME_SCHEMA_HASH"
-    ),
-  });
-
-  const contentStateHash = yield* validateHex(
-    "CONTENT_RUNTIME_STATE_HASH",
-    values.contentStateHash
-  );
+export const readRuntimeSchemaIdentity = Effect.gen(function* () {
+  const value = yield* Config.nonEmptyString("CONTENT_RUNTIME_SCHEMA_HASH");
   const runtimeSchemaFingerprint = yield* validateHex(
     "CONTENT_RUNTIME_SCHEMA_HASH",
-    values.runtimeSchemaFingerprint
+    value
   );
+
+  return { runtimeSchemaFingerprint } satisfies RuntimeSchemaIdentity;
+});
+
+export const readCacheIdentity = Effect.gen(function* () {
+  const contentStateHashValue = yield* Config.nonEmptyString(
+    "CONTENT_RUNTIME_STATE_HASH"
+  );
+  const contentStateHash = yield* validateHex(
+    "CONTENT_RUNTIME_STATE_HASH",
+    contentStateHashValue
+  );
+  const runtimeSchemaIdentity = yield* readRuntimeSchemaIdentity;
   return {
     contentStateHash,
-    runtimeSchemaFingerprint,
+    ...runtimeSchemaIdentity,
   } satisfies CacheIdentity;
 });
 
-const readRuntimeSelectionIdentity = Effect.gen(function* () {
+export const readRuntimeSelectionIdentity = Effect.gen(function* () {
   const runtimeSelectionHash = yield* Config.nonEmptyString(
     "CONTENT_RUNTIME_SELECTION_HASH"
   ).pipe(

--- a/packages/backend/scripts/content/runtime/ci/export.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/export.test.ts
@@ -1,0 +1,297 @@
+import { dirname } from "node:path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { beforeEach, describe, expect, it } from "@effect/vitest";
+import type { ExportConfig } from "@repo/backend/scripts/content/runtime/ci/config";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import { exportSignedRuntime } from "@repo/backend/scripts/content/runtime/ci/export";
+import {
+  CONTENT_RUNTIME_CACHE_DIRECTORY,
+  CONTENT_RUNTIME_CACHE_FILE,
+} from "@repo/backend/scripts/content/runtime/ci/snapshot";
+import { CONTENT_RUNTIME_TABLES } from "@repo/backend/scripts/content/runtime/tables";
+import { Effect, FileSystem, Redacted } from "effect";
+
+const mocks = vi.hoisted(() => ({
+  createArchive: vi.fn(),
+  readGenerations: vi.fn(),
+  readSchemaFingerprint: vi.fn(),
+  runData: vi.fn(),
+  verifyStable: vi.fn(),
+}));
+
+vi.mock("@repo/backend/scripts/content/runtime/ci/archive", () => ({
+  createEncryptedArchive: mocks.createArchive,
+}));
+
+vi.mock("@repo/backend/scripts/content/runtime/ci/command", () => ({
+  runConvexData: mocks.runData,
+}));
+
+vi.mock("@repo/backend/scripts/content/runtime/ci/generation", () => ({
+  readProductionGenerations: mocks.readGenerations,
+  verifyStableRuntimeExport: mocks.verifyStable,
+}));
+
+vi.mock(
+  "@repo/backend/scripts/content/runtime/tables",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    readContentRuntimeSchemaFingerprint: mocks.readSchemaFingerprint,
+  })
+);
+
+const contentStateHash = "1".repeat(64);
+const runtimeSchemaFingerprint = "2".repeat(64);
+const events: string[] = [];
+const rowsByTable = new Map<string, readonly Record<string, unknown>[]>();
+
+interface DataOptions {
+  readonly outputPath: string;
+  readonly table: string;
+}
+
+interface ArchiveOptions {
+  readonly encryptedPath: string;
+}
+
+function config(runnerTemp: string, exportLimit = 2): ExportConfig {
+  return {
+    cacheKey: Redacted.make("k".repeat(43)),
+    contentStateHash,
+    deployKey: Redacted.make("production-deploy-key"),
+    exportLimit,
+    runnerTemp,
+    runtimeSchemaFingerprint,
+  };
+}
+
+beforeEach(() => {
+  events.length = 0;
+  rowsByTable.clear();
+  mocks.createArchive.mockReset();
+  mocks.readGenerations.mockReset();
+  mocks.readSchemaFingerprint.mockReset();
+  mocks.runData.mockReset();
+  mocks.verifyStable.mockReset();
+
+  mocks.readGenerations.mockImplementation(() =>
+    Effect.sync(() => {
+      events.push("generation");
+      return { contentStateHash, runtimeSelectionHash: "3".repeat(64) };
+    })
+  );
+  mocks.verifyStable.mockImplementation(() =>
+    Effect.sync(() => {
+      events.push("verify");
+    })
+  );
+  mocks.runData.mockImplementation((options: DataOptions) =>
+    Effect.gen(function* () {
+      events.push(`data:${options.table}`);
+      const fileSystem = yield* FileSystem.FileSystem;
+      yield* fileSystem.writeFileString(
+        options.outputPath,
+        JSON.stringify(rowsByTable.get(options.table) ?? [])
+      );
+    })
+  );
+  mocks.createArchive.mockImplementation((options: ArchiveOptions) =>
+    Effect.gen(function* () {
+      events.push("archive");
+      const fileSystem = yield* FileSystem.FileSystem;
+      yield* fileSystem.writeFileString(options.encryptedPath, "encrypted");
+    })
+  );
+  mocks.readSchemaFingerprint.mockImplementation(() =>
+    Effect.sync(() => {
+      events.push("schema");
+      return runtimeSchemaFingerprint;
+    })
+  );
+});
+
+describe("signed runtime export", () => {
+  it.live(
+    "verifies a stable generation before and after exporting every table",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-export-stable-",
+          });
+          const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+          yield* fileSystem.makeDirectory(cacheRoot);
+          rowsByTable.set("contentState", [
+            { _creationTime: 1, _id: "source", value: "portable" },
+          ]);
+
+          yield* exportSignedRuntime(config(runnerTemp));
+
+          expect(mocks.verifyStable).toHaveBeenCalledTimes(2);
+          expect(mocks.runData).toHaveBeenCalledTimes(
+            CONTENT_RUNTIME_TABLES.length
+          );
+          expect(events.at(0)).toBe("generation");
+          expect(events.at(1)).toBe("verify");
+          expect(events.indexOf("verify")).toBeLessThan(
+            events.findIndex((event) => event.startsWith("data:"))
+          );
+          expect(events.lastIndexOf("verify")).toBeLessThan(
+            events.indexOf("archive")
+          );
+          expect(events.at(-1)).toBe("schema");
+          expect(
+            yield* fileSystem.exists(
+              `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`
+            )
+          ).toBe(true);
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("rejects a changed generation before any export side effect", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-export-preflight-",
+        });
+        mocks.verifyStable.mockReturnValueOnce(
+          Effect.fail(contentRuntimeCiError("generation changed"))
+        );
+
+        expect(
+          yield* exportSignedRuntime(config(runnerTemp)).pipe(Effect.flip)
+        ).toMatchObject({ message: "generation changed" });
+        expect(mocks.runData).not.toHaveBeenCalled();
+        expect(mocks.createArchive).not.toHaveBeenCalled();
+        expect(
+          yield* fileSystem.exists(
+            `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`
+          )
+        ).toBe(false);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live(
+    "rejects and removes a nonempty destination before fetching data",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-export-destination-",
+          });
+          const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+          yield* fileSystem.makeDirectory(cacheRoot);
+          yield* fileSystem.writeFileString(
+            `${cacheRoot}/unexpected`,
+            "unsafe"
+          );
+
+          expect(
+            yield* exportSignedRuntime(config(runnerTemp)).pipe(Effect.flip)
+          ).toMatchObject({
+            message:
+              "Signed runtime cache directory must be empty before export.",
+          });
+          expect(mocks.runData).not.toHaveBeenCalled();
+          expect(yield* fileSystem.exists(cacheRoot)).toBe(false);
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("fails closed when a table reaches the configured export bound", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-export-bound-",
+        });
+        const boundedTable = "contentState";
+        expect(CONTENT_RUNTIME_TABLES).toContain(boundedTable);
+        rowsByTable.set(boundedTable, [{ value: 1 }, { value: 2 }]);
+
+        expect(
+          yield* exportSignedRuntime(config(runnerTemp, 2)).pipe(Effect.flip)
+        ).toMatchObject({
+          message: `Content runtime table ${boundedTable} reached the export limit.`,
+        });
+        expect(mocks.createArchive).not.toHaveBeenCalled();
+        expect(
+          yield* fileSystem.exists(
+            `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`
+          )
+        ).toBe(false);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live("rejects missing and misnamed encrypted archive output", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        for (const mode of ["missing", "misnamed"] as const) {
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: `runtime-export-${mode}-`,
+          });
+          mocks.createArchive.mockImplementationOnce(
+            (options: ArchiveOptions) =>
+              mode === "missing"
+                ? Effect.void
+                : fileSystem.writeFileString(
+                    `${dirname(options.encryptedPath)}/unexpected.gpg`,
+                    "encrypted"
+                  )
+          );
+
+          expect(
+            yield* exportSignedRuntime(config(runnerTemp)).pipe(Effect.flip)
+          ).toMatchObject({
+            message: "Encrypted signed runtime must be the only cache entry.",
+          });
+          expect(
+            yield* fileSystem.exists(
+              `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`
+            )
+          ).toBe(false);
+        }
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live("removes a completed archive when its schema identity changed", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-export-schema-",
+        });
+        mocks.readSchemaFingerprint.mockReturnValueOnce(
+          Effect.succeed("f".repeat(64))
+        );
+
+        expect(
+          yield* exportSignedRuntime(config(runnerTemp)).pipe(Effect.flip)
+        ).toMatchObject({
+          message:
+            "Runtime schema fingerprint changed after cache identity creation.",
+        });
+        expect(mocks.createArchive).toHaveBeenCalledTimes(1);
+        expect(
+          yield* fileSystem.exists(
+            `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`
+          )
+        ).toBe(false);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/export.ts
+++ b/packages/backend/scripts/content/runtime/ci/export.ts
@@ -28,6 +28,11 @@ export const exportSignedRuntime = Effect.fn(
   const encryptedPath = `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`;
 
   return Effect.gen(function* () {
+    yield* verifyStableRuntimeExport(
+      config,
+      yield* readProductionGenerations(config)
+    );
+
     const fileSystem = yield* FileSystem.FileSystem;
     const cacheExists = yield* fileSystem.exists(cacheRoot);
     if (

--- a/packages/backend/scripts/content/runtime/ci/generation.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/generation.test.ts
@@ -60,7 +60,7 @@ describe("content runtime generations", () => {
   );
 
   it.live(
-    "accepts compaction and inactive-slot drift only for runtime selection",
+    "keeps candidate, recovery, compaction, and updatedAt drift on one archive identity",
     () =>
       Effect.gen(function* () {
         const baseline = yield* buildRuntimeGenerations(contentState);

--- a/packages/backend/scripts/content/runtime/ci/main.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/main.test.ts
@@ -1,0 +1,261 @@
+import { tmpdir } from "node:os";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import type {
+  ExportConfig,
+  ImportConfig,
+  ProductionConfig,
+  ProductionSelectionConfig,
+} from "@repo/backend/scripts/content/runtime/ci/config";
+import { ContentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import {
+  makeRuntimeCiProgram,
+  type RuntimeCiOperations,
+  reportRuntimeCiFailure,
+} from "@repo/backend/scripts/content/runtime/ci/main";
+import { DuplicateContentRuntimeTableError } from "@repo/backend/scripts/content/runtime/tables";
+import { Effect, FileSystem, Redacted } from "effect";
+
+vi.mock("@effect/platform-node/NodeRuntime", () => ({
+  runMain: vi.fn(),
+}));
+
+const contentStateHash = "1".repeat(64);
+const runtimeSchemaFingerprint = "2".repeat(64);
+const runtimeSelectionHash = "3".repeat(64);
+const metadata = {
+  archiveSha256: "4".repeat(64),
+  byteLength: 128,
+  contentStateHash,
+  createdAt: 1_800_000_000_000,
+  runtimeSchemaFingerprint,
+};
+
+function makeOperations(runnerTemp: string, events: string[]) {
+  const production: ProductionConfig = {
+    deployKey: Redacted.make("production-deploy-key"),
+    runnerTemp,
+  };
+  const selection: ProductionSelectionConfig = {
+    ...production,
+    runtimeSelectionHash,
+  };
+  const exported: ExportConfig = {
+    ...production,
+    cacheKey: Redacted.make("k".repeat(43)),
+    contentStateHash,
+    exportLimit: 100_000,
+    runtimeSchemaFingerprint,
+  };
+  const imported: ImportConfig = {
+    cacheKey: exported.cacheKey,
+    contentStateHash,
+    runnerTemp,
+    runtimeSchemaFingerprint,
+  };
+  const producer: ProducerConfig = {
+    ...exported,
+    archiveToken: Redacted.make("archive-token"),
+    runtimeToken: Redacted.make("runtime-token"),
+    siteUrl: "https://production.example.test",
+  };
+  const fetcher = vi.fn<typeof fetch>();
+
+  return {
+    clearArchiveSecrets: Effect.sync(() => {
+      events.push("clear-archive");
+    }),
+    clearContentSecrets: Effect.sync(() => {
+      events.push("clear-content");
+    }),
+    download: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("download");
+        return metadata;
+      })
+    ),
+    exportRuntime: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("export");
+      }).pipe(Effect.as(undefined))
+    ),
+    fetcher,
+    importRuntime: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("import");
+      }).pipe(Effect.as(undefined))
+    ),
+    produce: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("produce");
+        return { kind: "unchanged" as const, metadata };
+      })
+    ),
+    readExport: Effect.succeed(exported),
+    readGenerations: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("read-generations");
+        return { contentStateHash, runtimeSelectionHash };
+      })
+    ),
+    readImport: Effect.succeed(imported),
+    readProducer: Effect.succeed(producer),
+    readProduction: Effect.succeed(production),
+    readRuntimeArchive: Effect.succeed(producer),
+    readSchemaFingerprint: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("read-fingerprint");
+        return runtimeSchemaFingerprint;
+      })
+    ),
+    readSelection: Effect.succeed(selection),
+    runtimeTables: ["contentState"],
+    validateRegistry: Effect.succeed([]),
+    verifySelection: vi.fn(() =>
+      Effect.sync(() => {
+        events.push("verify-selection");
+      })
+    ),
+  } satisfies RuntimeCiOperations;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("content runtime CI entrypoint", () => {
+  it.live("dispatches every runtime mode and clears its owned secrets", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: tmpdir(),
+          prefix: "runtime-main-",
+        });
+        vi.stubEnv("RUNNER_TEMP", runnerTemp);
+
+        const cases = [
+          { event: "read-fingerprint", mode: "fingerprint" },
+          { event: "read-generations", mode: "generations" },
+          { event: "verify-selection", mode: "verify-generations" },
+          { event: "export", mode: "export" },
+          { event: "import", mode: "import" },
+          { event: "produce", mode: "produce" },
+          { event: "download", mode: "download" },
+        ] as const;
+
+        for (const testCase of cases) {
+          const events: string[] = [];
+          const operations = makeOperations(runnerTemp, events);
+          yield* makeRuntimeCiProgram(testCase.mode, operations);
+
+          expect(events).toContain(testCase.event);
+          expect(events.at(-2)).toBe("clear-content");
+          expect(events.at(-1)).toBe("clear-archive");
+          if (testCase.mode === "produce" || testCase.mode === "download") {
+            expect(events.indexOf("clear-content")).toBeLessThan(
+              events.indexOf(testCase.event)
+            );
+            expect(events.indexOf("clear-archive")).toBeLessThan(
+              events.indexOf(testCase.event)
+            );
+          }
+        }
+
+        expect(
+          yield* fileSystem.readFileString(`${runnerTemp}/runtime-schema.env`)
+        ).toBe(`CONTENT_RUNTIME_SCHEMA_HASH=${runtimeSchemaFingerprint}\n`);
+        expect(
+          yield* fileSystem.readFileString(`${runnerTemp}/runtime-state.env`)
+        ).toBe(
+          `CONTENT_RUNTIME_STATE_HASH=${contentStateHash}\nCONTENT_RUNTIME_SELECTION_HASH=${runtimeSelectionHash}\n`
+        );
+        expect(NodeRuntime.runMain).toHaveBeenCalledTimes(1);
+      })
+    ).pipe(Effect.provide(NodeServices.layer))
+  );
+
+  it.live("rejects empty and unsafe runtime table registries before work", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: tmpdir(),
+          prefix: "runtime-main-tables-",
+        });
+        vi.stubEnv("RUNNER_TEMP", runnerTemp);
+        vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+        for (const runtimeTables of [[], [""], ["contentState", "bad-name"]]) {
+          const operations = {
+            ...makeOperations(runnerTemp, []),
+            runtimeTables,
+          };
+          expect(
+            yield* makeRuntimeCiProgram("fingerprint", operations).pipe(
+              Effect.flip
+            )
+          ).toMatchObject({
+            message: "Signed runtime must contain safe table names.",
+          });
+        }
+      })
+    ).pipe(Effect.provide(NodeServices.layer))
+  );
+
+  it.live(
+    "reports duplicate registries and unsupported modes without secrets",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: tmpdir(),
+            prefix: "runtime-main-failure-",
+          });
+          const write = vi
+            .spyOn(process.stderr, "write")
+            .mockImplementation(() => true);
+          const duplicate = {
+            ...makeOperations(runnerTemp, []),
+            validateRegistry: Effect.fail(
+              new DuplicateContentRuntimeTableError({ table: "duplicate" })
+            ),
+          };
+
+          expect(
+            yield* makeRuntimeCiProgram("export", duplicate).pipe(Effect.flip)
+          ).toMatchObject({
+            message: "Signed runtime table registry contains a duplicate name.",
+          });
+          expect(
+            yield* makeRuntimeCiProgram(
+              "unsupported",
+              makeOperations(runnerTemp, [])
+            ).pipe(Effect.flip)
+          ).toMatchObject({
+            message: expect.stringContaining("Usage: runtime:ci"),
+          });
+          yield* reportRuntimeCiFailure(
+            new Error("sensitive-internal-failure")
+          );
+          yield* reportRuntimeCiFailure(
+            new ContentRuntimeCiError({ message: "safe typed failure" })
+          );
+
+          expect(write.mock.calls.flat().join("")).not.toContain(
+            "sensitive-internal-failure"
+          );
+          expect(write.mock.calls.flat().join("")).toContain(
+            "ERROR: Content runtime CI failed."
+          );
+          expect(write.mock.calls.flat().join("")).toContain(
+            "ERROR: safe typed failure"
+          );
+        })
+      ).pipe(Effect.provide(NodeServices.layer))
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/main.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/main.test.ts
@@ -2,7 +2,10 @@ import { tmpdir } from "node:os";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { afterEach, describe, expect, it } from "@effect/vitest";
-import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import type {
+  ProducerConfig,
+  RuntimeArchiveReadConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
 import type {
   ExportConfig,
   ImportConfig,
@@ -28,9 +31,10 @@ const runtimeSelectionHash = "3".repeat(64);
 const metadata = {
   archiveSha256: "4".repeat(64),
   byteLength: 128,
-  contentStateHash,
   createdAt: 1_800_000_000_000,
+  runtimeSelectionHash,
   runtimeSchemaFingerprint,
+  sourceStateHash: contentStateHash,
 };
 
 function makeOperations(runnerTemp: string, events: string[]) {
@@ -58,6 +62,13 @@ function makeOperations(runnerTemp: string, events: string[]) {
   const producer: ProducerConfig = {
     ...exported,
     archiveToken: Redacted.make("archive-token"),
+    runtimeSelectionHash,
+    siteUrl: "https://production.example.test",
+  };
+  const reader: RuntimeArchiveReadConfig = {
+    runnerTemp,
+    runtimeSelectionHash,
+    runtimeSchemaFingerprint,
     runtimeToken: Redacted.make("runtime-token"),
     siteUrl: "https://production.example.test",
   };
@@ -103,7 +114,7 @@ function makeOperations(runnerTemp: string, events: string[]) {
     readImport: Effect.succeed(imported),
     readProducer: Effect.succeed(producer),
     readProduction: Effect.succeed(production),
-    readRuntimeArchive: Effect.succeed(producer),
+    readRuntimeArchive: Effect.succeed(reader),
     readSchemaFingerprint: vi.fn(() =>
       Effect.sync(() => {
         events.push("read-fingerprint");

--- a/packages/backend/scripts/content/runtime/ci/main.ts
+++ b/packages/backend/scripts/content/runtime/ci/main.ts
@@ -1,6 +1,12 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
+  clearRuntimeArchiveSecrets,
+  readProducerConfig,
+  readRuntimeArchiveAccessConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import { downloadRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/artifact";
+import {
   clearContentRuntimeSecrets,
   readExportConfig,
   readImportConfig,
@@ -18,6 +24,7 @@ import {
   verifyRuntimeSelection,
 } from "@repo/backend/scripts/content/runtime/ci/generation";
 import { importSignedRuntime } from "@repo/backend/scripts/content/runtime/ci/import";
+import { produceRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/producer";
 import {
   CONTENT_RUNTIME_TABLES,
   readContentRuntimeSchemaFingerprint,
@@ -28,6 +35,48 @@ import { Config, ConfigProvider, Effect, FileSystem } from "effect";
 const INVALID_TABLE_NAME = /[^A-Za-z0-9_]/;
 const FINGERPRINT_ENVIRONMENT_FILE = "runtime-schema.env";
 const GENERATION_ENVIRONMENT_FILE = "runtime-state.env";
+
+export interface RuntimeCiOperations {
+  readonly clearArchiveSecrets: typeof clearRuntimeArchiveSecrets;
+  readonly clearContentSecrets: typeof clearContentRuntimeSecrets;
+  readonly download: typeof downloadRuntimeArchive;
+  readonly exportRuntime: typeof exportSignedRuntime;
+  readonly fetcher: typeof fetch;
+  readonly importRuntime: typeof importSignedRuntime;
+  readonly produce: typeof produceRuntimeArchive;
+  readonly readExport: typeof readExportConfig;
+  readonly readGenerations: typeof readProductionGenerations;
+  readonly readImport: typeof readImportConfig;
+  readonly readProducer: typeof readProducerConfig;
+  readonly readProduction: typeof readProductionConfig;
+  readonly readRuntimeArchive: typeof readRuntimeArchiveAccessConfig;
+  readonly readSchemaFingerprint: typeof readContentRuntimeSchemaFingerprint;
+  readonly readSelection: typeof readProductionSelectionConfig;
+  readonly runtimeTables: readonly string[];
+  readonly validateRegistry: typeof validateContentRuntimeTableDefinitions;
+  readonly verifySelection: typeof verifyRuntimeSelection;
+}
+
+const liveOperations: RuntimeCiOperations = {
+  clearArchiveSecrets: clearRuntimeArchiveSecrets,
+  clearContentSecrets: clearContentRuntimeSecrets,
+  download: downloadRuntimeArchive,
+  exportRuntime: exportSignedRuntime,
+  fetcher: fetch,
+  importRuntime: importSignedRuntime,
+  produce: produceRuntimeArchive,
+  readExport: readExportConfig,
+  readGenerations: readProductionGenerations,
+  readImport: readImportConfig,
+  readProducer: readProducerConfig,
+  readProduction: readProductionConfig,
+  readRuntimeArchive: readRuntimeArchiveAccessConfig,
+  readSchemaFingerprint: readContentRuntimeSchemaFingerprint,
+  readSelection: readProductionSelectionConfig,
+  runtimeTables: CONTENT_RUNTIME_TABLES,
+  validateRegistry: validateContentRuntimeTableDefinitions,
+  verifySelection: verifyRuntimeSelection,
+};
 
 const writeEnvironmentFile = Effect.fn("contentRuntime.writeEnvironmentFile")(
   function* (runnerTemp: string, fileName: string, content: string) {
@@ -40,72 +89,91 @@ const writeEnvironmentFile = Effect.fn("contentRuntime.writeEnvironmentFile")(
   }
 );
 
-const writeFingerprintEnvironment = Effect.gen(function* () {
-  if (
-    CONTENT_RUNTIME_TABLES.length === 0 ||
-    CONTENT_RUNTIME_TABLES.some(
-      (table) => table.length === 0 || INVALID_TABLE_NAME.test(table)
-    )
-  ) {
-    return yield* contentRuntimeCiError(
-      "Signed runtime must contain safe table names."
+const writeFingerprintEnvironment = (operations: RuntimeCiOperations) =>
+  Effect.gen(function* () {
+    if (
+      operations.runtimeTables.length === 0 ||
+      operations.runtimeTables.some(
+        (table) => table.length === 0 || INVALID_TABLE_NAME.test(table)
+      )
+    ) {
+      return yield* contentRuntimeCiError(
+        "Signed runtime must contain safe table names."
+      );
+    }
+
+    const runnerTemp = yield* Config.nonEmptyString("RUNNER_TEMP");
+    const runtimeSchemaFingerprint = yield* operations.readSchemaFingerprint();
+    yield* writeEnvironmentFile(
+      runnerTemp,
+      FINGERPRINT_ENVIRONMENT_FILE,
+      `CONTENT_RUNTIME_SCHEMA_HASH=${runtimeSchemaFingerprint}`
     );
-  }
+  });
 
-  const runnerTemp = yield* Config.nonEmptyString("RUNNER_TEMP");
-  const runtimeSchemaFingerprint = yield* readContentRuntimeSchemaFingerprint();
-  yield* writeEnvironmentFile(
-    runnerTemp,
-    FINGERPRINT_ENVIRONMENT_FILE,
-    `CONTENT_RUNTIME_SCHEMA_HASH=${runtimeSchemaFingerprint}`
-  );
-});
-
-const runMode = (mode: string | undefined) => {
+const runMode = (mode: string | undefined, operations: RuntimeCiOperations) => {
   switch (mode) {
     case "fingerprint":
-      return writeFingerprintEnvironment;
+      return writeFingerprintEnvironment(operations);
     case "generations":
       return Effect.gen(function* () {
-        const config = yield* readProductionConfig;
-        yield* clearContentRuntimeSecrets;
+        const config = yield* operations.readProduction;
+        yield* operations.clearContentSecrets;
         yield* writeEnvironmentFile(
           config.runnerTemp,
           GENERATION_ENVIRONMENT_FILE,
-          formatGenerationEnvironment(yield* readProductionGenerations(config))
+          formatGenerationEnvironment(yield* operations.readGenerations(config))
         );
       });
     case "verify-generations":
       return Effect.gen(function* () {
-        const config = yield* readProductionSelectionConfig;
-        yield* clearContentRuntimeSecrets;
-        yield* verifyRuntimeSelection(
+        const config = yield* operations.readSelection;
+        yield* operations.clearContentSecrets;
+        yield* operations.verifySelection(
           config,
-          yield* readProductionGenerations(config)
+          yield* operations.readGenerations(config)
         );
       });
     case "export":
       return Effect.gen(function* () {
-        const config = yield* readExportConfig;
-        yield* clearContentRuntimeSecrets;
-        yield* exportSignedRuntime(config);
+        const config = yield* operations.readExport;
+        yield* operations.clearContentSecrets;
+        yield* operations.exportRuntime(config);
       });
     case "import":
       return Effect.gen(function* () {
-        const config = yield* readImportConfig;
-        yield* clearContentRuntimeSecrets;
-        yield* importSignedRuntime(config);
+        const config = yield* operations.readImport;
+        yield* operations.clearContentSecrets;
+        yield* operations.importRuntime(config);
+      });
+    case "produce":
+      return Effect.gen(function* () {
+        const config = yield* operations.readProducer;
+        yield* operations.clearContentSecrets;
+        yield* operations.clearArchiveSecrets;
+        yield* operations.produce(
+          config,
+          operations.fetcher,
+          operations.exportRuntime
+        );
+      });
+    case "download":
+      return Effect.gen(function* () {
+        const config = yield* operations.readRuntimeArchive;
+        yield* operations.clearContentSecrets;
+        yield* operations.clearArchiveSecrets;
+        yield* operations.download(config, operations.fetcher);
       });
     default:
       return Effect.fail(
         contentRuntimeCiError(
-          "Usage: runtime:ci <fingerprint|generations|verify-generations|export|import>"
+          "Usage: runtime:ci <fingerprint|generations|verify-generations|export|import|produce|download>"
         )
       );
   }
 };
 
-const reportFailure = (error: unknown) =>
+export const reportRuntimeCiFailure = (error: unknown) =>
   Effect.sync(() => {
     const message =
       error instanceof ContentRuntimeCiError
@@ -114,26 +182,34 @@ const reportFailure = (error: unknown) =>
     process.stderr.write(`ERROR: ${message}\n`);
   });
 
-const validateTableRegistry = validateContentRuntimeTableDefinitions.pipe(
-  Effect.mapError(() =>
-    contentRuntimeCiError(
-      "Signed runtime table registry contains a duplicate name."
+export function makeRuntimeCiProgram(
+  mode: string | undefined,
+  operations: RuntimeCiOperations
+) {
+  const validateTableRegistry = operations.validateRegistry.pipe(
+    Effect.mapError(() =>
+      contentRuntimeCiError(
+        "Signed runtime table registry contains a duplicate name."
+      )
     )
-  )
-);
+  );
 
-const main = Effect.gen(function* () {
-  yield* validateTableRegistry;
-  yield* runMode(process.argv[2]);
-}).pipe(
-  Effect.ensuring(clearContentRuntimeSecrets),
-  Effect.tapError(reportFailure),
-  Effect.scoped,
-  Effect.provide(NodeServices.layer),
-  Effect.provideService(
-    ConfigProvider.ConfigProvider,
-    ConfigProvider.fromEnvRecord(process.env)
-  )
-);
+  return Effect.gen(function* () {
+    yield* validateTableRegistry;
+    yield* runMode(mode, operations);
+  }).pipe(
+    Effect.ensuring(operations.clearContentSecrets),
+    Effect.ensuring(operations.clearArchiveSecrets),
+    Effect.tapError(reportRuntimeCiFailure),
+    Effect.scoped,
+    Effect.provide(NodeServices.layer),
+    Effect.provideService(
+      ConfigProvider.ConfigProvider,
+      ConfigProvider.fromEnvRecord(process.env)
+    )
+  );
+}
+
+const main = makeRuntimeCiProgram(process.argv[2], liveOperations);
 
 NodeRuntime.runMain(main, { disableErrorReporting: true });

--- a/packages/backend/scripts/content/runtime/ci/main.ts
+++ b/packages/backend/scripts/content/runtime/ci/main.ts
@@ -5,7 +5,10 @@ import {
   readProducerConfig,
   readRuntimeArchiveAccessConfig,
 } from "@repo/backend/scripts/content/runtime/ci/access";
-import { downloadRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/artifact";
+import {
+  CONTENT_RUNTIME_STATE_FILE,
+  downloadRuntimeArchive,
+} from "@repo/backend/scripts/content/runtime/ci/artifact";
 import {
   clearContentRuntimeSecrets,
   readExportConfig,
@@ -34,7 +37,7 @@ import { Config, ConfigProvider, Effect, FileSystem } from "effect";
 
 const INVALID_TABLE_NAME = /[^A-Za-z0-9_]/;
 const FINGERPRINT_ENVIRONMENT_FILE = "runtime-schema.env";
-const GENERATION_ENVIRONMENT_FILE = "runtime-state.env";
+const GENERATION_ENVIRONMENT_FILE = CONTENT_RUNTIME_STATE_FILE;
 
 export interface RuntimeCiOperations {
   readonly clearArchiveSecrets: typeof clearRuntimeArchiveSecrets;

--- a/packages/backend/scripts/content/runtime/ci/producer.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/producer.test.ts
@@ -52,39 +52,32 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 describe("content runtime archive producer", () => {
-  it.live("reuses the selection archive after source state drift", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-          directory: "/tmp",
-          prefix: "runtime-producer-existing-",
-        });
-        const fetcher = vi
-          .fn<typeof fetch>()
-          .mockResolvedValue(jsonResponse({ kind: "existing", metadata }));
-        const exporter = vi.fn(exportSignedRuntime);
+  it.effect("reuses the selection archive after source state drift", () =>
+    Effect.gen(function* () {
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(jsonResponse({ kind: "existing", metadata }));
+      const exporter = vi.fn(exportSignedRuntime);
 
-        expect(
-          yield* produceRuntimeArchive(
-            config(runnerTemp, "9".repeat(64)),
-            fetcher,
-            exporter
-          )
-        ).toEqual({ kind: "unchanged", metadata });
-        expect(exporter).not.toHaveBeenCalled();
-        expect(fetcher).toHaveBeenCalledTimes(1);
-        expect(
-          JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))
-        ).toMatchObject({
-          runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
-          runtimeSelectionHash: metadata.runtimeSelectionHash,
-        });
-        expect(String(fetcher.mock.calls[0]?.[1]?.body)).not.toContain(
-          "contentStateHash"
-        );
-      }).pipe(Effect.provide(NodeServices.layer))
-    )
+      expect(
+        yield* produceRuntimeArchive(
+          config("/tmp", "9".repeat(64)),
+          fetcher,
+          exporter
+        )
+      ).toEqual({ kind: "unchanged", metadata });
+      expect(exporter).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(
+        JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))
+      ).toMatchObject({
+        runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+        runtimeSelectionHash: metadata.runtimeSelectionHash,
+      });
+      expect(String(fetcher.mock.calls[0]?.[1]?.body)).not.toContain(
+        "contentStateHash"
+      );
+    }).pipe(Effect.provide(NodeServices.layer))
   );
 
   it.effect("interrupts export before the producer lease can expire", () =>
@@ -125,35 +118,26 @@ describe("content runtime archive producer", () => {
     })
   );
 
-  it.live("does not export while another producer owns the lease", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-          directory: "/tmp",
-          prefix: "runtime-producer-busy-",
-        });
-        const fetcher = vi
-          .fn<typeof fetch>()
-          .mockResolvedValue(
-            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
-          );
-        const exporter = vi.fn(exportSignedRuntime);
+  it.effect("does not export while another producer owns the lease", () =>
+    Effect.gen(function* () {
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
+        );
+      const exporter = vi.fn(exportSignedRuntime);
 
-        expect(
-          yield* produceRuntimeArchive(
-            config(runnerTemp),
-            fetcher,
-            exporter
-          ).pipe(Effect.flip)
-        ).toMatchObject({
-          message:
-            "Immutable signed runtime archive is being produced by another run.",
-        });
-        expect(exporter).not.toHaveBeenCalled();
-        expect(fetcher).toHaveBeenCalledTimes(1);
-      }).pipe(Effect.provide(NodeServices.layer))
-    )
+      expect(
+        yield* produceRuntimeArchive(config("/tmp"), fetcher, exporter).pipe(
+          Effect.flip
+        )
+      ).toMatchObject({
+        message:
+          "Immutable signed runtime archive is being produced by another run.",
+      });
+      expect(exporter).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    }).pipe(Effect.provide(NodeServices.layer))
   );
 
   it.live(
@@ -208,82 +192,32 @@ describe("content runtime archive producer", () => {
       )
   );
 
-  it.live("releases its claim without masking an export failure", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-          directory: "/tmp",
-          prefix: "runtime-producer-failure-",
-        });
-        const fetcher = vi
-          .fn<typeof fetch>()
-          .mockResolvedValueOnce(
-            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
-          )
-          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 500));
-        const exporter = vi.fn<typeof exportSignedRuntime>(() =>
-          Effect.fail(contentRuntimeCiError("export failed"))
-        );
+  it.effect("releases its claim without masking an export failure", () =>
+    Effect.gen(function* () {
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+        )
+        .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 500));
+      const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+        Effect.fail(contentRuntimeCiError("export failed"))
+      );
 
-        expect(
-          yield* produceRuntimeArchive(
-            config(runnerTemp),
-            fetcher,
-            exporter
-          ).pipe(Effect.flip)
-        ).toMatchObject({ message: "export failed" });
-        expect(fetcher).toHaveBeenCalledTimes(2);
-        expect(String(fetcher.mock.calls[1]?.[0])).toContain(
-          "/archive/release"
-        );
-      }).pipe(Effect.provide(NodeServices.layer))
-    )
+      expect(
+        yield* produceRuntimeArchive(config("/tmp"), fetcher, exporter).pipe(
+          Effect.flip
+        )
+      ).toMatchObject({ message: "export failed" });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      expect(String(fetcher.mock.calls[1]?.[0])).toContain("/archive/release");
+    }).pipe(Effect.provide(NodeServices.layer))
   );
 
-  it.live(
+  it.effect(
     "does not upload when another run stores the archive during export",
     () =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const fileSystem = yield* FileSystem.FileSystem;
-          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-            directory: "/tmp",
-            prefix: "runtime-producer-converged-",
-          });
-          const exporter = vi.fn<typeof exportSignedRuntime>(() =>
-            Effect.void.pipe(Effect.as(undefined))
-          );
-          const fetcher = vi
-            .fn<typeof fetch>()
-            .mockResolvedValueOnce(
-              jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
-            )
-            .mockResolvedValueOnce(jsonResponse({ kind: "existing", metadata }))
-            .mockResolvedValueOnce(jsonResponse({ released: false }));
-
-          expect(
-            yield* produceRuntimeArchive(config(runnerTemp), fetcher, exporter)
-          ).toEqual({ kind: "unchanged", metadata });
-          expect(exporter).toHaveBeenCalledTimes(1);
-          expect(fetcher).toHaveBeenCalledTimes(3);
-          expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
-            expect.stringContaining("/archive/claim"),
-            expect.stringContaining("/archive/claim"),
-            expect.stringContaining("/archive/release"),
-          ]);
-        }).pipe(Effect.provide(NodeServices.layer))
-      )
-  );
-
-  it.live("stops before upload when its lease changes during export", () =>
-    Effect.scoped(
       Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-          directory: "/tmp",
-          prefix: "runtime-producer-lease-change-",
-        });
         const exporter = vi.fn<typeof exportSignedRuntime>(() =>
           Effect.void.pipe(Effect.as(undefined))
         );
@@ -292,21 +226,12 @@ describe("content runtime archive producer", () => {
           .mockResolvedValueOnce(
             jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
           )
-          .mockResolvedValueOnce(
-            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
-          )
+          .mockResolvedValueOnce(jsonResponse({ kind: "existing", metadata }))
           .mockResolvedValueOnce(jsonResponse({ released: false }));
 
         expect(
-          yield* produceRuntimeArchive(
-            config(runnerTemp),
-            fetcher,
-            exporter
-          ).pipe(Effect.flip)
-        ).toMatchObject({
-          message:
-            "Immutable signed runtime archive lease changed during export.",
-        });
+          yield* produceRuntimeArchive(config("/tmp"), fetcher, exporter)
+        ).toEqual({ kind: "unchanged", metadata });
         expect(exporter).toHaveBeenCalledTimes(1);
         expect(fetcher).toHaveBeenCalledTimes(3);
         expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
@@ -315,6 +240,38 @@ describe("content runtime archive producer", () => {
           expect.stringContaining("/archive/release"),
         ]);
       }).pipe(Effect.provide(NodeServices.layer))
-    )
+  );
+
+  it.effect("stops before upload when its lease changes during export", () =>
+    Effect.gen(function* () {
+      const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+        Effect.void.pipe(Effect.as(undefined))
+      );
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
+        )
+        .mockResolvedValueOnce(jsonResponse({ released: false }));
+
+      expect(
+        yield* produceRuntimeArchive(config("/tmp"), fetcher, exporter).pipe(
+          Effect.flip
+        )
+      ).toMatchObject({
+        message:
+          "Immutable signed runtime archive lease changed during export.",
+      });
+      expect(exporter).toHaveBeenCalledTimes(1);
+      expect(fetcher).toHaveBeenCalledTimes(3);
+      expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
+        expect.stringContaining("/archive/claim"),
+        expect.stringContaining("/archive/claim"),
+        expect.stringContaining("/archive/release"),
+      ]);
+    }).pipe(Effect.provide(NodeServices.layer))
   );
 });

--- a/packages/backend/scripts/content/runtime/ci/producer.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/producer.test.ts
@@ -1,5 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
+import {
+  CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS,
+  CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
+} from "@repo/backend/content/archive";
 import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
 import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
 import { exportSignedRuntime } from "@repo/backend/scripts/content/runtime/ci/export";
@@ -8,28 +12,34 @@ import {
   CONTENT_RUNTIME_CACHE_DIRECTORY,
   CONTENT_RUNTIME_CACHE_FILE,
 } from "@repo/backend/scripts/content/runtime/ci/snapshot";
-import { Effect, FileSystem, Redacted } from "effect";
+import { Effect, Fiber, FileSystem, Redacted } from "effect";
+import { TestClock } from "effect/testing";
 
+const MINIMUM_LEASE_SAFETY_MARGIN_MS = 5 * 60 * 1000;
 const bytes = new TextEncoder().encode("encrypted-runtime-archive");
 const metadata = {
   archiveSha256:
     "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
   byteLength: bytes.byteLength,
-  contentStateHash: "1".repeat(64),
   createdAt: 1_800_000_000_000,
+  runtimeSelectionHash: "1".repeat(64),
   runtimeSchemaFingerprint: "2".repeat(64),
+  sourceStateHash: "3".repeat(64),
 };
 
-function config(runnerTemp: string): ProducerConfig {
+function config(
+  runnerTemp: string,
+  contentStateHash = metadata.sourceStateHash
+): ProducerConfig {
   return {
     archiveToken: Redacted.make("technical-archive-token"),
     cacheKey: Redacted.make("k".repeat(43)),
-    contentStateHash: metadata.contentStateHash,
+    contentStateHash,
     deployKey: Redacted.make("production-deploy-key"),
     exportLimit: 100_000,
     runnerTemp,
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
     runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
-    runtimeToken: Redacted.make("technical-runtime-token"),
     siteUrl: "https://production.example.test",
   };
 }
@@ -42,28 +52,77 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 describe("content runtime archive producer", () => {
-  it.live(
-    "skips every export side effect when the immutable archive exists",
-    () =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const fileSystem = yield* FileSystem.FileSystem;
-          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
-            directory: "/tmp",
-            prefix: "runtime-producer-existing-",
-          });
-          const fetcher = vi
-            .fn<typeof fetch>()
-            .mockResolvedValue(jsonResponse({ kind: "existing", metadata }));
-          const exporter = vi.fn(exportSignedRuntime);
+  it.live("reuses the selection archive after source state drift", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-producer-existing-",
+        });
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(jsonResponse({ kind: "existing", metadata }));
+        const exporter = vi.fn(exportSignedRuntime);
 
-          expect(
-            yield* produceRuntimeArchive(config(runnerTemp), fetcher, exporter)
-          ).toEqual({ kind: "unchanged", metadata });
-          expect(exporter).not.toHaveBeenCalled();
-          expect(fetcher).toHaveBeenCalledTimes(1);
-        }).pipe(Effect.provide(NodeServices.layer))
-      )
+        expect(
+          yield* produceRuntimeArchive(
+            config(runnerTemp, "9".repeat(64)),
+            fetcher,
+            exporter
+          )
+        ).toEqual({ kind: "unchanged", metadata });
+        expect(exporter).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(
+          JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))
+        ).toMatchObject({
+          runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+          runtimeSelectionHash: metadata.runtimeSelectionHash,
+        });
+        expect(String(fetcher.mock.calls[0]?.[1]?.body)).not.toContain(
+          "contentStateHash"
+        );
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.effect("interrupts export before the producer lease can expire", () =>
+    Effect.gen(function* () {
+      expect(
+        CONTENT_RUNTIME_ARCHIVE_LEASE_MS -
+          CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS
+      ).toBeGreaterThanOrEqual(MINIMUM_LEASE_SAFETY_MARGIN_MS);
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            expiresAt: Date.now() + CONTENT_RUNTIME_ARCHIVE_LEASE_MS,
+            kind: "claimed",
+          })
+        )
+        .mockResolvedValueOnce(jsonResponse({ released: true }));
+      const exporter = vi.fn<typeof exportSignedRuntime>(() => Effect.never);
+      const fiber = yield* produceRuntimeArchive(
+        config("/tmp"),
+        fetcher,
+        exporter
+      ).pipe(
+        Effect.flip,
+        Effect.provide(NodeServices.layer),
+        Effect.forkChild({ startImmediately: true })
+      );
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS);
+
+      expect(yield* Fiber.join(fiber)).toMatchObject({
+        message:
+          "Signed runtime export exceeded its producer lease safety window.",
+      });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      expect(String(fetcher.mock.calls[1]?.[0])).toContain("/archive/release");
+    })
   );
 
   it.live("does not export while another producer owns the lease", () =>

--- a/packages/backend/scripts/content/runtime/ci/producer.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/producer.test.ts
@@ -1,0 +1,261 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import { exportSignedRuntime } from "@repo/backend/scripts/content/runtime/ci/export";
+import { produceRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/producer";
+import {
+  CONTENT_RUNTIME_CACHE_DIRECTORY,
+  CONTENT_RUNTIME_CACHE_FILE,
+} from "@repo/backend/scripts/content/runtime/ci/snapshot";
+import { Effect, FileSystem, Redacted } from "effect";
+
+const bytes = new TextEncoder().encode("encrypted-runtime-archive");
+const metadata = {
+  archiveSha256:
+    "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
+  byteLength: bytes.byteLength,
+  contentStateHash: "1".repeat(64),
+  createdAt: 1_800_000_000_000,
+  runtimeSchemaFingerprint: "2".repeat(64),
+};
+
+function config(runnerTemp: string): ProducerConfig {
+  return {
+    archiveToken: Redacted.make("technical-archive-token"),
+    cacheKey: Redacted.make("k".repeat(43)),
+    contentStateHash: metadata.contentStateHash,
+    deployKey: Redacted.make("production-deploy-key"),
+    exportLimit: 100_000,
+    runnerTemp,
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    runtimeToken: Redacted.make("technical-runtime-token"),
+    siteUrl: "https://production.example.test",
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+describe("content runtime archive producer", () => {
+  it.live(
+    "skips every export side effect when the immutable archive exists",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-producer-existing-",
+          });
+          const fetcher = vi
+            .fn<typeof fetch>()
+            .mockResolvedValue(jsonResponse({ kind: "existing", metadata }));
+          const exporter = vi.fn(exportSignedRuntime);
+
+          expect(
+            yield* produceRuntimeArchive(config(runnerTemp), fetcher, exporter)
+          ).toEqual({ kind: "unchanged", metadata });
+          expect(exporter).not.toHaveBeenCalled();
+          expect(fetcher).toHaveBeenCalledTimes(1);
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("does not export while another producer owns the lease", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-producer-busy-",
+        });
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(
+            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
+          );
+        const exporter = vi.fn(exportSignedRuntime);
+
+        expect(
+          yield* produceRuntimeArchive(
+            config(runnerTemp),
+            fetcher,
+            exporter
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message:
+            "Immutable signed runtime archive is being produced by another run.",
+        });
+        expect(exporter).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live(
+    "exports only after claiming and releases after immutable storage",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-producer-store-",
+          });
+          const cacheRoot = `${runnerTemp}/${CONTENT_RUNTIME_CACHE_DIRECTORY}`;
+          const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+            Effect.gen(function* () {
+              yield* fileSystem.makeDirectory(cacheRoot);
+              yield* fileSystem.writeFile(
+                `${cacheRoot}/${CONTENT_RUNTIME_CACHE_FILE}`,
+                bytes
+              );
+            }).pipe(Effect.as(undefined))
+          );
+          const fetcher = vi
+            .fn<typeof fetch>()
+            .mockResolvedValueOnce(
+              jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+            )
+            .mockResolvedValueOnce(
+              jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+            )
+            .mockResolvedValueOnce(
+              jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+            )
+            .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+            .mockResolvedValueOnce(jsonResponse({ kind: "stored", metadata }))
+            .mockResolvedValueOnce(jsonResponse({ released: false }));
+
+          expect(
+            yield* produceRuntimeArchive(config(runnerTemp), fetcher, exporter)
+          ).toEqual({ kind: "stored", metadata });
+          expect(exporter).toHaveBeenCalledTimes(1);
+          expect(fetcher).toHaveBeenCalledTimes(6);
+          expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
+            expect.stringContaining("/archive/claim"),
+            expect.stringContaining("/archive/claim"),
+            expect.stringContaining("/archive/upload"),
+            "https://upload.example.test/archive",
+            expect.stringContaining("/archive/finalize"),
+            expect.stringContaining("/archive/release"),
+          ]);
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("releases its claim without masking an export failure", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-producer-failure-",
+        });
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 500));
+        const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+          Effect.fail(contentRuntimeCiError("export failed"))
+        );
+
+        expect(
+          yield* produceRuntimeArchive(
+            config(runnerTemp),
+            fetcher,
+            exporter
+          ).pipe(Effect.flip)
+        ).toMatchObject({ message: "export failed" });
+        expect(fetcher).toHaveBeenCalledTimes(2);
+        expect(String(fetcher.mock.calls[1]?.[0])).toContain(
+          "/archive/release"
+        );
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+
+  it.live(
+    "does not upload when another run stores the archive during export",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+            directory: "/tmp",
+            prefix: "runtime-producer-converged-",
+          });
+          const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+            Effect.void.pipe(Effect.as(undefined))
+          );
+          const fetcher = vi
+            .fn<typeof fetch>()
+            .mockResolvedValueOnce(
+              jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+            )
+            .mockResolvedValueOnce(jsonResponse({ kind: "existing", metadata }))
+            .mockResolvedValueOnce(jsonResponse({ released: false }));
+
+          expect(
+            yield* produceRuntimeArchive(config(runnerTemp), fetcher, exporter)
+          ).toEqual({ kind: "unchanged", metadata });
+          expect(exporter).toHaveBeenCalledTimes(1);
+          expect(fetcher).toHaveBeenCalledTimes(3);
+          expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
+            expect.stringContaining("/archive/claim"),
+            expect.stringContaining("/archive/claim"),
+            expect.stringContaining("/archive/release"),
+          ]);
+        }).pipe(Effect.provide(NodeServices.layer))
+      )
+  );
+
+  it.live("stops before upload when its lease changes during export", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const runnerTemp = yield* fileSystem.makeTempDirectoryScoped({
+          directory: "/tmp",
+          prefix: "runtime-producer-lease-change-",
+        });
+        const exporter = vi.fn<typeof exportSignedRuntime>(() =>
+          Effect.void.pipe(Effect.as(undefined))
+        );
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "claimed" })
+          )
+          .mockResolvedValueOnce(
+            jsonResponse({ expiresAt: Date.now() + 60_000, kind: "busy" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ released: false }));
+
+        expect(
+          yield* produceRuntimeArchive(
+            config(runnerTemp),
+            fetcher,
+            exporter
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message:
+            "Immutable signed runtime archive lease changed during export.",
+        });
+        expect(exporter).toHaveBeenCalledTimes(1);
+        expect(fetcher).toHaveBeenCalledTimes(3);
+        expect(fetcher.mock.calls.map((call) => String(call[0]))).toEqual([
+          expect.stringContaining("/archive/claim"),
+          expect.stringContaining("/archive/claim"),
+          expect.stringContaining("/archive/release"),
+        ]);
+      }).pipe(Effect.provide(NodeServices.layer))
+    )
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/producer.ts
+++ b/packages/backend/scripts/content/runtime/ci/producer.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import { publishRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/artifact";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import type { exportSignedRuntime } from "@repo/backend/scripts/content/runtime/ci/export";
+import {
+  claimRuntimeArchive,
+  releaseRuntimeArchiveClaim,
+} from "@repo/backend/scripts/content/runtime/ci/remote";
+import { Console, Effect } from "effect";
+
+/** Produces and stores one archive only when its exact identity is absent. */
+export const produceRuntimeArchive = Effect.fn(
+  "contentRuntimeArtifact.produce"
+)(function* (
+  config: ProducerConfig,
+  fetcher: typeof fetch,
+  exporter: typeof exportSignedRuntime
+) {
+  const claimId = randomUUID();
+  const claim = yield* claimRuntimeArchive(config, claimId, fetcher);
+  if (claim.kind === "existing") {
+    yield* Console.log("Immutable signed runtime archive already exists.");
+    return { kind: "unchanged", metadata: claim.metadata } as const;
+  }
+  if (claim.kind === "busy") {
+    return yield* contentRuntimeCiError(
+      "Immutable signed runtime archive is being produced by another run."
+    );
+  }
+  return yield* Effect.acquireUseRelease(
+    Effect.succeed(claimId),
+    (ownedClaimId) =>
+      Effect.gen(function* () {
+        yield* exporter(config);
+        const renewed = yield* claimRuntimeArchive(
+          config,
+          ownedClaimId,
+          fetcher
+        );
+        if (renewed.kind === "existing") {
+          yield* Console.log(
+            "Immutable signed runtime archive was stored by another run."
+          );
+          return { kind: "unchanged", metadata: renewed.metadata } as const;
+        }
+        if (renewed.kind === "busy") {
+          return yield* contentRuntimeCiError(
+            "Immutable signed runtime archive lease changed during export."
+          );
+        }
+        return yield* publishRuntimeArchive(config, ownedClaimId, fetcher);
+      }),
+    (ownedClaimId) =>
+      releaseRuntimeArchiveClaim(config, ownedClaimId, fetcher).pipe(
+        Effect.ignore
+      )
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/producer.ts
+++ b/packages/backend/scripts/content/runtime/ci/producer.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS } from "@repo/backend/content/archive";
 import type { ProducerConfig } from "@repo/backend/scripts/content/runtime/ci/access";
 import { publishRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/artifact";
 import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
@@ -32,7 +33,17 @@ export const produceRuntimeArchive = Effect.fn(
     Effect.succeed(claimId),
     (ownedClaimId) =>
       Effect.gen(function* () {
-        yield* exporter(config);
+        yield* exporter(config).pipe(
+          Effect.timeoutOrElse({
+            duration: CONTENT_RUNTIME_ARCHIVE_EXPORT_TIMEOUT_MS,
+            orElse: () =>
+              Effect.fail(
+                contentRuntimeCiError(
+                  "Signed runtime export exceeded its producer lease safety window."
+                )
+              ),
+          })
+        );
         const renewed = yield* claimRuntimeArchive(
           config,
           ownedClaimId,

--- a/packages/backend/scripts/content/runtime/ci/publish.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/publish.test.ts
@@ -9,19 +9,22 @@ const metadata = {
   archiveSha256:
     "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
   byteLength: bytes.byteLength,
-  contentStateHash: "1".repeat(64),
   createdAt: 1_800_000_000_000,
+  runtimeSelectionHash: "1".repeat(64),
   runtimeSchemaFingerprint: "2".repeat(64),
+  sourceStateHash: "3".repeat(64),
 };
 const claimId = "00000000-0000-4000-8000-000000000001";
 
-function config(): RuntimeArchiveWriteConfig {
+function config(): RuntimeArchiveWriteConfig & {
+  readonly contentStateHash: string;
+} {
   return {
     archiveToken: Redacted.make("technical-archive-token"),
-    contentStateHash: metadata.contentStateHash,
+    contentStateHash: metadata.sourceStateHash,
     runnerTemp: "/tmp",
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
     runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
-    runtimeToken: Redacted.make("technical-runtime-token"),
     siteUrl: "https://production.example.test",
   };
 }

--- a/packages/backend/scripts/content/runtime/ci/publish.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/publish.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "@effect/vitest";
+import { MAX_CONTENT_RUNTIME_ARCHIVE_BYTES } from "@repo/backend/content/archive";
+import type { RuntimeArchiveWriteConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import { storeRuntimeArchive } from "@repo/backend/scripts/content/runtime/ci/publish";
+import { Effect, Redacted } from "effect";
+
+const bytes = new TextEncoder().encode("encrypted-runtime-archive");
+const metadata = {
+  archiveSha256:
+    "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
+  byteLength: bytes.byteLength,
+  contentStateHash: "1".repeat(64),
+  createdAt: 1_800_000_000_000,
+  runtimeSchemaFingerprint: "2".repeat(64),
+};
+const claimId = "00000000-0000-4000-8000-000000000001";
+
+function config(): RuntimeArchiveWriteConfig {
+  return {
+    archiveToken: Redacted.make("technical-archive-token"),
+    contentStateHash: metadata.contentStateHash,
+    runnerTemp: "/tmp",
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    runtimeToken: Redacted.make("technical-runtime-token"),
+    siteUrl: "https://production.example.test",
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function oversizedBytes() {
+  return new Proxy(new Uint8Array(), {
+    get(target, property) {
+      if (property === "byteLength") {
+        return MAX_CONTENT_RUNTIME_ARCHIVE_BYTES + 1;
+      }
+      return Reflect.get(target, property, target);
+    },
+  });
+}
+
+describe("content runtime archive publication", () => {
+  it.effect(
+    "rejects empty and oversized direct inputs before any network call",
+    () =>
+      Effect.gen(function* () {
+        for (const invalid of [new Uint8Array(), oversizedBytes()]) {
+          const fetcher = vi.fn<typeof fetch>();
+          expect(
+            yield* storeRuntimeArchive(
+              config(),
+              claimId,
+              invalid,
+              fetcher
+            ).pipe(Effect.flip)
+          ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+          expect(fetcher).not.toHaveBeenCalled();
+        }
+      })
+  );
+
+  it.effect(
+    "retries the same uploaded storage identity across transient failures",
+    () =>
+      Effect.gen(function* () {
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockRejectedValueOnce(new Error("response lost"))
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 503))
+          .mockResolvedValueOnce(jsonResponse({ kind: "stored", metadata }));
+
+        expect(
+          yield* storeRuntimeArchive(config(), claimId, bytes, fetcher)
+        ).toEqual({ kind: "stored", metadata });
+        const finalizeBodies = fetcher.mock.calls
+          .slice(2)
+          .map((call) => call[1]?.body);
+        expect(finalizeBodies).toHaveLength(3);
+        expect(new Set(finalizeBodies).size).toBe(1);
+      })
+  );
+
+  it.effect(
+    "recovers when finalization committed but every response was lost",
+    () =>
+      Effect.gen(function* () {
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockRejectedValueOnce(new Error("response lost"))
+          .mockRejectedValueOnce(new Error("response lost"))
+          .mockRejectedValueOnce(new Error("response lost"))
+          .mockResolvedValueOnce(jsonResponse({ kind: "canonical", metadata }));
+
+        expect(
+          yield* storeRuntimeArchive(config(), claimId, bytes, fetcher)
+        ).toEqual({ kind: "unchanged", metadata });
+        expect(fetcher).toHaveBeenCalledTimes(6);
+        expect(String(fetcher.mock.calls[5]?.[0])).toContain("/archive/abort");
+      })
+  );
+
+  it.effect(
+    "returns the terminal finalization failure after bounded cleanup",
+    () =>
+      Effect.gen(function* () {
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockResolvedValueOnce(jsonResponse({ code: "conflict" }, 409))
+          .mockResolvedValueOnce(jsonResponse({ kind: "deferred" }));
+
+        expect(
+          yield* storeRuntimeArchive(config(), claimId, bytes, fetcher).pipe(
+            Effect.flip
+          )
+        ).toMatchObject({
+          message: "Runtime archive finalization failed with HTTP 409.",
+        });
+        expect(fetcher).toHaveBeenCalledTimes(4);
+
+        const unavailable = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 503))
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 503))
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 503))
+          .mockResolvedValueOnce(jsonResponse({ kind: "deleted" }));
+
+        expect(
+          yield* storeRuntimeArchive(
+            config(),
+            claimId,
+            bytes,
+            unavailable
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message: "Runtime archive finalization failed with HTTP 503.",
+        });
+        expect(unavailable).toHaveBeenCalledTimes(6);
+      })
+  );
+
+  it.effect(
+    "fails closed at each upload boundary without widening retries",
+    () =>
+      Effect.gen(function* () {
+        const capabilityFailure = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(jsonResponse({ code: "unauthorized" }, 401));
+        expect(
+          yield* storeRuntimeArchive(
+            config(),
+            claimId,
+            bytes,
+            capabilityFailure
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message: "Runtime archive upload capability failed with HTTP 401.",
+        });
+        expect(capabilityFailure).toHaveBeenCalledTimes(1);
+
+        const storageFailure = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ code: "unavailable" }, 503));
+        expect(
+          yield* storeRuntimeArchive(
+            config(),
+            claimId,
+            bytes,
+            storageFailure
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message: "Runtime archive upload failed with HTTP 503.",
+        });
+        expect(storageFailure).toHaveBeenCalledTimes(2);
+
+        const cleanupFailure = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            jsonResponse({ uploadUrl: "https://upload.example.test/archive" })
+          )
+          .mockResolvedValueOnce(jsonResponse({ storageId: "storage-1" }))
+          .mockResolvedValueOnce(jsonResponse({ code: "conflict" }, 409))
+          .mockResolvedValueOnce(jsonResponse({ code: "internal" }, 500));
+        expect(
+          yield* storeRuntimeArchive(
+            config(),
+            claimId,
+            bytes,
+            cleanupFailure
+          ).pipe(Effect.flip)
+        ).toMatchObject({
+          message: "Runtime archive finalization failed with HTTP 409.",
+        });
+        expect(cleanupFailure).toHaveBeenCalledTimes(4);
+      })
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/publish.ts
+++ b/packages/backend/scripts/content/runtime/ci/publish.ts
@@ -3,6 +3,7 @@ import {
   CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
   ContentRuntimeArchiveAbortResultSchema,
   ContentRuntimeArchiveFinalizeResultSchema,
+  type ContentRuntimeArchiveIdentity,
   ContentRuntimeArchiveStorageResultSchema,
   ContentRuntimeArchiveUploadSchema,
   MAX_CONTENT_RUNTIME_ARCHIVE_BYTES,
@@ -24,9 +25,9 @@ import { Effect, Result } from "effect";
 
 const MAX_FINALIZE_ATTEMPTS = 3;
 
-function identity(config: RuntimeArchiveWriteConfig) {
+function identity(config: ContentRuntimeArchiveIdentity) {
   return {
-    contentStateHash: config.contentStateHash,
+    runtimeSelectionHash: config.runtimeSelectionHash,
     runtimeSchemaFingerprint: config.runtimeSchemaFingerprint,
   };
 }
@@ -45,8 +46,9 @@ const finalizeUpload = Effect.fn("contentRuntimePublish.finalize")(function* (
     readonly archiveSha256: string;
     readonly byteLength: number;
     readonly claimId: string;
-    readonly contentStateHash: string;
+    readonly runtimeSelectionHash: string;
     readonly runtimeSchemaFingerprint: string;
+    readonly sourceStateHash: string;
     readonly storageId: string;
   },
   fetcher: typeof fetch
@@ -113,7 +115,7 @@ const abortUpload = Effect.fn("contentRuntimePublish.abort")(function* (
 /** Uploads bytes and binds them exactly once to their runtime identity. */
 export const storeRuntimeArchive = Effect.fn("contentRuntimePublish.store")(
   function* (
-    config: RuntimeArchiveWriteConfig,
+    config: RuntimeArchiveWriteConfig & { readonly contentStateHash: string },
     claimId: string,
     bytes: Uint8Array,
     fetcher: typeof fetch
@@ -176,6 +178,7 @@ export const storeRuntimeArchive = Effect.fn("contentRuntimePublish.store")(
         archiveSha256,
         byteLength,
         claimId,
+        sourceStateHash: config.contentStateHash,
         storageId,
       },
       fetcher

--- a/packages/backend/scripts/content/runtime/ci/publish.ts
+++ b/packages/backend/scripts/content/runtime/ci/publish.ts
@@ -1,0 +1,203 @@
+import { createHash } from "node:crypto";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+  ContentRuntimeArchiveAbortResultSchema,
+  ContentRuntimeArchiveFinalizeResultSchema,
+  ContentRuntimeArchiveStorageResultSchema,
+  ContentRuntimeArchiveUploadSchema,
+  MAX_CONTENT_RUNTIME_ARCHIVE_BYTES,
+} from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+  CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
+} from "@repo/backend/content/endpoint";
+import type { RuntimeArchiveWriteConfig } from "@repo/backend/scripts/content/runtime/ci/access";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import {
+  archiveHttpError,
+  decodeControlResponse,
+  fetchArchive,
+  postArchiveControl,
+} from "@repo/backend/scripts/content/runtime/ci/transport";
+import { Effect, Result } from "effect";
+
+const MAX_FINALIZE_ATTEMPTS = 3;
+
+function identity(config: RuntimeArchiveWriteConfig) {
+  return {
+    contentStateHash: config.contentStateHash,
+    runtimeSchemaFingerprint: config.runtimeSchemaFingerprint,
+  };
+}
+
+function credential(config: RuntimeArchiveWriteConfig) {
+  return {
+    header: "x-nakafa-archive-token",
+    token: config.archiveToken,
+  };
+}
+
+/** Retries only the same uploaded storage identity across transient failures. */
+const finalizeUpload = Effect.fn("contentRuntimePublish.finalize")(function* (
+  config: RuntimeArchiveWriteConfig,
+  body: {
+    readonly archiveSha256: string;
+    readonly byteLength: number;
+    readonly claimId: string;
+    readonly contentStateHash: string;
+    readonly runtimeSchemaFingerprint: string;
+    readonly storageId: string;
+  },
+  fetcher: typeof fetch
+) {
+  const operation = "Runtime archive finalization";
+  for (let attempt = 1; ; attempt += 1) {
+    const outcome = yield* postArchiveControl(
+      fetcher,
+      config.siteUrl,
+      CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+      body,
+      credential(config),
+      operation
+    ).pipe(Effect.result);
+    if (Result.isFailure(outcome)) {
+      if (attempt === MAX_FINALIZE_ATTEMPTS) {
+        return yield* outcome.failure;
+      }
+      continue;
+    }
+    if (outcome.success.ok) {
+      return yield* decodeControlResponse(
+        outcome.success,
+        ContentRuntimeArchiveFinalizeResultSchema,
+        operation
+      );
+    }
+    const failure = archiveHttpError(operation, outcome.success.status);
+    if (outcome.success.status < 500) {
+      return yield* failure;
+    }
+    if (attempt === MAX_FINALIZE_ATTEMPTS) {
+      return yield* failure;
+    }
+  }
+});
+
+/** Requests cleanup while the server defers storage with unproven ownership. */
+const abortUpload = Effect.fn("contentRuntimePublish.abort")(function* (
+  config: RuntimeArchiveWriteConfig,
+  claimId: string,
+  storageId: string,
+  fetcher: typeof fetch
+) {
+  const operation = "Runtime archive upload cleanup";
+  const response = yield* postArchiveControl(
+    fetcher,
+    config.siteUrl,
+    CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+    { ...identity(config), claimId, storageId },
+    credential(config),
+    operation
+  );
+  if (!response.ok) {
+    return yield* archiveHttpError(operation, response.status);
+  }
+  return yield* decodeControlResponse(
+    response,
+    ContentRuntimeArchiveAbortResultSchema,
+    operation
+  );
+});
+
+/** Uploads bytes and binds them exactly once to their runtime identity. */
+export const storeRuntimeArchive = Effect.fn("contentRuntimePublish.store")(
+  function* (
+    config: RuntimeArchiveWriteConfig,
+    claimId: string,
+    bytes: Uint8Array,
+    fetcher: typeof fetch
+  ) {
+    if (bytes.byteLength === 0) {
+      return yield* contentRuntimeCiError(
+        "Encrypted signed runtime archive must not be empty."
+      );
+    }
+    if (bytes.byteLength > MAX_CONTENT_RUNTIME_ARCHIVE_BYTES) {
+      return yield* contentRuntimeCiError(
+        `Encrypted signed runtime archive exceeds ${MAX_CONTENT_RUNTIME_ARCHIVE_BYTES} bytes.`
+      );
+    }
+
+    const archiveSha256 = createHash("sha256").update(bytes).digest("hex");
+    const byteLength = bytes.byteLength;
+    const uploadOperation = "Runtime archive upload capability";
+    const uploadControl = yield* postArchiveControl(
+      fetcher,
+      config.siteUrl,
+      CONTENT_RUNTIME_ARCHIVE_UPLOAD_PATH,
+      { ...identity(config), claimId },
+      credential(config),
+      uploadOperation
+    );
+    if (!uploadControl.ok) {
+      return yield* archiveHttpError(uploadOperation, uploadControl.status);
+    }
+    const { uploadUrl } = yield* decodeControlResponse(
+      uploadControl,
+      ContentRuntimeArchiveUploadSchema,
+      uploadOperation
+    );
+    const upload = yield* fetchArchive(
+      fetcher,
+      "Runtime archive upload",
+      uploadUrl,
+      {
+        body: new Blob([new Uint8Array(bytes)], {
+          type: CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE,
+        }),
+        headers: { "content-type": CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE },
+        method: "POST",
+        redirect: "error",
+      }
+    );
+    if (!upload.ok) {
+      return yield* archiveHttpError("Runtime archive upload", upload.status);
+    }
+    const { storageId } = yield* decodeControlResponse(
+      upload,
+      ContentRuntimeArchiveStorageResultSchema,
+      "Runtime archive upload"
+    );
+    const finalized = yield* finalizeUpload(
+      config,
+      {
+        ...identity(config),
+        archiveSha256,
+        byteLength,
+        claimId,
+        storageId,
+      },
+      fetcher
+    ).pipe(Effect.result);
+    if (Result.isSuccess(finalized)) {
+      return finalized.success;
+    }
+
+    const aborted = yield* abortUpload(
+      config,
+      claimId,
+      storageId,
+      fetcher
+    ).pipe(Effect.result);
+    if (
+      Result.isSuccess(aborted) &&
+      aborted.success.kind === "canonical" &&
+      aborted.success.metadata.archiveSha256 === archiveSha256 &&
+      aborted.success.metadata.byteLength === byteLength
+    ) {
+      return { kind: "unchanged", metadata: aborted.success.metadata } as const;
+    }
+    return yield* finalized.failure;
+  }
+);

--- a/packages/backend/scripts/content/runtime/ci/remote.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/remote.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "@effect/vitest";
+import { MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES } from "@repo/backend/content/archive";
+import type {
+  RuntimeArchiveReadConfig,
+  RuntimeArchiveWriteConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import {
+  claimRuntimeArchive,
+  fetchRuntimeArchive,
+  releaseRuntimeArchiveClaim,
+} from "@repo/backend/scripts/content/runtime/ci/remote";
+import { Effect, Option, Redacted } from "effect";
+
+const bytes = new TextEncoder().encode("encrypted-runtime-archive");
+const metadata = {
+  archiveSha256:
+    "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
+  byteLength: bytes.byteLength,
+  contentStateHash: "1".repeat(64),
+  createdAt: 1_800_000_000_000,
+  runtimeSchemaFingerprint: "2".repeat(64),
+};
+const claimId = "00000000-0000-4000-8000-000000000001";
+
+function readConfig(): RuntimeArchiveReadConfig {
+  return {
+    contentStateHash: metadata.contentStateHash,
+    runnerTemp: "/tmp",
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    runtimeToken: Redacted.make("technical-runtime-token"),
+    siteUrl: "https://production.example.test",
+  };
+}
+
+function writeConfig(): RuntimeArchiveWriteConfig {
+  return {
+    ...readConfig(),
+    archiveToken: Redacted.make("technical-archive-token"),
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function capability() {
+  return jsonResponse({
+    ...metadata,
+    downloadUrl: "https://storage.example.test/archive",
+  });
+}
+
+describe("content runtime archive remote boundary", () => {
+  it.effect("maps only the exact typed not-found response to absence", () =>
+    Effect.gen(function* () {
+      const exact = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          jsonResponse({ code: "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND" }, 404)
+        );
+      expect(
+        Option.isNone(yield* fetchRuntimeArchive(readConfig(), exact))
+      ).toBe(true);
+
+      for (const response of [
+        jsonResponse({ code: "CONTENT_RUNTIME_ARCHIVE_INVALID" }, 404),
+        new Response("gateway missing", { status: 404 }),
+        jsonResponse({ code: "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND" }, 500),
+      ]) {
+        const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response);
+        expect(
+          yield* fetchRuntimeArchive(readConfig(), fetcher).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+      }
+    })
+  );
+
+  it.effect("fails closed on transport and untrusted control responses", () =>
+    Effect.gen(function* () {
+      const brokenBody = new Response(
+        new ReadableStream({
+          type: "bytes",
+          pull(controller) {
+            controller.error(new Error("body unavailable"));
+          },
+        }),
+        { status: 404 }
+      );
+      let cancelled = false;
+      let largestRead = 0;
+      let supplied = 0;
+      const oversizedBody = new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+          pull(controller) {
+            const request = controller.byobRequest;
+            if (!request) {
+              controller.error(new Error("Expected a bounded byte request."));
+              return;
+            }
+            const view = request.view;
+            if (!view) {
+              controller.error(new Error("Expected a byte buffer."));
+              return;
+            }
+            largestRead = Math.max(largestRead, view.byteLength);
+            const bytes = new Uint8Array(
+              view.buffer,
+              view.byteOffset,
+              view.byteLength
+            );
+            bytes.fill(120);
+            supplied += bytes.byteLength;
+            request.respond(bytes.byteLength);
+          },
+          type: "bytes",
+        }),
+        { status: 404 }
+      );
+      const responses = [
+        brokenBody,
+        oversizedBody,
+        new Response(null, { status: 404 }),
+        jsonResponse({ downloadUrl: "not-a-url" }),
+      ];
+      for (const response of responses) {
+        const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response);
+        expect(
+          yield* fetchRuntimeArchive(readConfig(), fetcher).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+      }
+      expect(cancelled).toBe(true);
+      expect(largestRead).toBeLessThanOrEqual(1024);
+      expect(supplied).toBe(
+        MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES + 1
+      );
+
+      const unreachable = vi
+        .fn<typeof fetch>()
+        .mockRejectedValue(new Error("network unavailable"));
+      expect(
+        yield* fetchRuntimeArchive(readConfig(), unreachable).pipe(Effect.flip)
+      ).toMatchObject({
+        message:
+          "Runtime archive download capability could not reach Convex storage.",
+      });
+    })
+  );
+
+  it.effect("rejects every incomplete or oversized download body", () =>
+    Effect.gen(function* () {
+      const bodyFailure = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.error(new Error("stream unavailable"));
+        },
+      });
+      const responses = [
+        new Response("unavailable", { status: 502 }),
+        new Response(bytes, {
+          headers: { "content-length": String(bytes.byteLength + 1) },
+          status: 200,
+        }),
+        new Response(null, { status: 200 }),
+        new Response(bytes.slice(0, -1), { status: 200 }),
+        new Response(new Uint8Array(bytes.byteLength + 1), { status: 200 }),
+        new Response(bodyFailure, { status: 200 }),
+        new Response(new Uint8Array(bytes.byteLength).fill(1), { status: 200 }),
+      ];
+
+      for (const response of responses) {
+        const fetcher = vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(capability())
+          .mockResolvedValueOnce(response);
+        expect(
+          yield* fetchRuntimeArchive(readConfig(), fetcher).pipe(Effect.flip)
+        ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+      }
+    })
+  );
+
+  it.effect("accepts an exact declared download length", () =>
+    Effect.gen(function* () {
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(capability())
+        .mockResolvedValueOnce(
+          new Response(bytes, {
+            headers: { "content-length": String(bytes.byteLength) },
+            status: 200,
+          })
+        );
+      const result = yield* fetchRuntimeArchive(readConfig(), fetcher);
+      expect(Option.isSome(result)).toBe(true);
+    })
+  );
+
+  it.effect("enforces authenticated metadata size before downloading", () =>
+    Effect.gen(function* () {
+      const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          ...metadata,
+          byteLength: 256 * 1024 * 1024 + 1,
+          downloadUrl: "https://storage.example.test/archive",
+        })
+      );
+      expect(
+        yield* fetchRuntimeArchive(readConfig(), fetcher).pipe(Effect.flip)
+      ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it.effect("surfaces claim and release authorization failures", () =>
+    Effect.gen(function* () {
+      const claimFetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(jsonResponse({ code: "unauthorized" }, 401));
+      const releaseFetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(jsonResponse({ code: "internal" }, 500));
+
+      expect(
+        yield* claimRuntimeArchive(writeConfig(), claimId, claimFetcher).pipe(
+          Effect.flip
+        )
+      ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+      expect(
+        yield* releaseRuntimeArchiveClaim(
+          writeConfig(),
+          claimId,
+          releaseFetcher
+        ).pipe(Effect.flip)
+      ).toMatchObject({ _tag: "ContentRuntimeCiError" });
+    })
+  );
+});

--- a/packages/backend/scripts/content/runtime/ci/remote.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/remote.test.ts
@@ -131,6 +131,11 @@ describe("content runtime archive remote boundary", () => {
         oversizedBody,
         new Response(null, { status: 404 }),
         jsonResponse({ downloadUrl: "not-a-url" }),
+        jsonResponse({
+          ...metadata,
+          downloadUrl: "https://storage.example.test/archive",
+          sourceStateHash: "invalid\nCONTENT_RUNTIME_STATE_HASH=unsafe",
+        }),
       ];
       for (const response of responses) {
         const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response);

--- a/packages/backend/scripts/content/runtime/ci/remote.test.ts
+++ b/packages/backend/scripts/content/runtime/ci/remote.test.ts
@@ -16,16 +16,17 @@ const metadata = {
   archiveSha256:
     "e3765fbb7ee79916de02fe557bafe7aa37641457f1c4e8db73e4768b49d61745",
   byteLength: bytes.byteLength,
-  contentStateHash: "1".repeat(64),
   createdAt: 1_800_000_000_000,
+  runtimeSelectionHash: "1".repeat(64),
   runtimeSchemaFingerprint: "2".repeat(64),
+  sourceStateHash: "3".repeat(64),
 };
 const claimId = "00000000-0000-4000-8000-000000000001";
 
 function readConfig(): RuntimeArchiveReadConfig {
   return {
-    contentStateHash: metadata.contentStateHash,
     runnerTemp: "/tmp",
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
     runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
     runtimeToken: Redacted.make("technical-runtime-token"),
     siteUrl: "https://production.example.test",
@@ -34,8 +35,11 @@ function readConfig(): RuntimeArchiveReadConfig {
 
 function writeConfig(): RuntimeArchiveWriteConfig {
   return {
-    ...readConfig(),
     archiveToken: Redacted.make("technical-archive-token"),
+    runnerTemp: "/tmp",
+    runtimeSelectionHash: metadata.runtimeSelectionHash,
+    runtimeSchemaFingerprint: metadata.runtimeSchemaFingerprint,
+    siteUrl: "https://production.example.test",
   };
 }
 

--- a/packages/backend/scripts/content/runtime/ci/remote.ts
+++ b/packages/backend/scripts/content/runtime/ci/remote.ts
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto";
+import {
+  ContentRuntimeArchiveClaimResultSchema,
+  ContentRuntimeArchiveDownloadSchema,
+  ContentRuntimeArchiveErrorSchema,
+  ContentRuntimeArchiveReleaseResultSchema,
+} from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+  CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+} from "@repo/backend/content/endpoint";
+import type {
+  RuntimeArchiveReadConfig,
+  RuntimeArchiveWriteConfig,
+} from "@repo/backend/scripts/content/runtime/ci/access";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import {
+  archiveHttpError,
+  decodeControlResponse,
+  fetchArchive,
+  postArchiveControl,
+} from "@repo/backend/scripts/content/runtime/ci/transport";
+import { Effect, Option, Result } from "effect";
+
+function identity(config: RuntimeArchiveReadConfig) {
+  return {
+    contentStateHash: config.contentStateHash,
+    runtimeSchemaFingerprint: config.runtimeSchemaFingerprint,
+  };
+}
+
+function readCredential(config: RuntimeArchiveReadConfig) {
+  return {
+    header: "x-nakafa-content-token",
+    token: config.runtimeToken,
+  };
+}
+
+function writeCredential(config: RuntimeArchiveWriteConfig) {
+  return {
+    header: "x-nakafa-archive-token",
+    token: config.archiveToken,
+  };
+}
+
+/** Acquires one producer lease for an archive identity that is still absent. */
+export const claimRuntimeArchive = Effect.fn("contentRuntimeRemote.claim")(
+  function* (
+    config: RuntimeArchiveWriteConfig,
+    claimId: string,
+    fetcher: typeof fetch
+  ) {
+    const operation = "Runtime archive producer claim";
+    const response = yield* postArchiveControl(
+      fetcher,
+      config.siteUrl,
+      CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+      { ...identity(config), claimId },
+      writeCredential(config),
+      operation
+    );
+    if (!response.ok) {
+      return yield* archiveHttpError(operation, response.status);
+    }
+    return yield* decodeControlResponse(
+      response,
+      ContentRuntimeArchiveClaimResultSchema,
+      operation
+    );
+  }
+);
+
+/** Idempotently releases one producer lease after its scoped work exits. */
+export const releaseRuntimeArchiveClaim = Effect.fn(
+  "contentRuntimeRemote.release"
+)(function* (
+  config: RuntimeArchiveWriteConfig,
+  claimId: string,
+  fetcher: typeof fetch
+) {
+  const operation = "Runtime archive producer release";
+  const response = yield* postArchiveControl(
+    fetcher,
+    config.siteUrl,
+    CONTENT_RUNTIME_ARCHIVE_RELEASE_PATH,
+    { ...identity(config), claimId },
+    writeCredential(config),
+    operation
+  );
+  if (!response.ok) {
+    return yield* archiveHttpError(operation, response.status);
+  }
+  return yield* decodeControlResponse(
+    response,
+    ContentRuntimeArchiveReleaseResultSchema,
+    operation
+  );
+});
+
+/** Reads exactly the authenticated metadata length without unbounded buffering. */
+const readExactArchiveBody = Effect.fn("contentRuntimeRemote.readBody")(
+  function* (response: Response, expectedBytes: number) {
+    const declaredLength = response.headers.get("content-length");
+    if (
+      declaredLength !== null &&
+      Number.parseInt(declaredLength, 10) !== expectedBytes
+    ) {
+      return yield* contentRuntimeCiError(
+        "Runtime archive download length did not match authenticated metadata."
+      );
+    }
+    if (!response.body) {
+      return yield* contentRuntimeCiError(
+        "Runtime archive download returned no body."
+      );
+    }
+    const body = response.body;
+
+    return yield* Effect.tryPromise({
+      catch: () =>
+        contentRuntimeCiError(
+          "Runtime archive download body did not match authenticated metadata."
+        ),
+      try: async () => {
+        const bytes = new Uint8Array(expectedBytes);
+        const reader = body.getReader();
+        let offset = 0;
+        while (true) {
+          const chunk = await reader.read();
+          if (chunk.done) {
+            break;
+          }
+          if (offset + chunk.value.byteLength > expectedBytes) {
+            await reader.cancel();
+            throw new Error("Archive body exceeded its authenticated length.");
+          }
+          bytes.set(chunk.value, offset);
+          offset += chunk.value.byteLength;
+        }
+        if (offset !== expectedBytes) {
+          throw new Error(
+            "Archive body ended before its authenticated length."
+          );
+        }
+        return bytes;
+      },
+    });
+  }
+);
+
+/** Returns one authenticated capability with its downloaded and verified bytes. */
+export const fetchRuntimeArchive = Effect.fn("contentRuntimeRemote.download")(
+  function* (config: RuntimeArchiveReadConfig, fetcher: typeof fetch) {
+    const operation = "Runtime archive download capability";
+    const capabilityResponse = yield* postArchiveControl(
+      fetcher,
+      config.siteUrl,
+      CONTENT_RUNTIME_ARCHIVE_DOWNLOAD_PATH,
+      identity(config),
+      readCredential(config),
+      operation
+    );
+    if (!capabilityResponse.ok) {
+      const typedFailure = yield* decodeControlResponse(
+        capabilityResponse,
+        ContentRuntimeArchiveErrorSchema,
+        operation
+      ).pipe(Effect.result);
+      if (
+        capabilityResponse.status === 404 &&
+        Result.isSuccess(typedFailure) &&
+        typedFailure.success.code === "CONTENT_RUNTIME_ARCHIVE_NOT_FOUND"
+      ) {
+        return Option.none();
+      }
+      return yield* archiveHttpError(operation, capabilityResponse.status);
+    }
+    const capability = yield* decodeControlResponse(
+      capabilityResponse,
+      ContentRuntimeArchiveDownloadSchema,
+      operation
+    );
+    const response = yield* fetchArchive(
+      fetcher,
+      "Runtime archive download",
+      capability.downloadUrl,
+      { method: "GET", redirect: "follow" }
+    );
+    if (!response.ok) {
+      return yield* archiveHttpError(
+        "Runtime archive download",
+        response.status
+      );
+    }
+    const bytes = yield* readExactArchiveBody(response, capability.byteLength);
+    if (
+      createHash("sha256").update(bytes).digest("hex") !==
+      capability.archiveSha256
+    ) {
+      return yield* contentRuntimeCiError(
+        "Downloaded signed runtime archive failed its integrity check."
+      );
+    }
+    const metadata = {
+      archiveSha256: capability.archiveSha256,
+      byteLength: capability.byteLength,
+      contentStateHash: capability.contentStateHash,
+      createdAt: capability.createdAt,
+      runtimeSchemaFingerprint: capability.runtimeSchemaFingerprint,
+    };
+    return Option.some({ bytes, metadata });
+  }
+);

--- a/packages/backend/scripts/content/runtime/ci/remote.ts
+++ b/packages/backend/scripts/content/runtime/ci/remote.ts
@@ -3,6 +3,7 @@ import {
   ContentRuntimeArchiveClaimResultSchema,
   ContentRuntimeArchiveDownloadSchema,
   ContentRuntimeArchiveErrorSchema,
+  type ContentRuntimeArchiveIdentity,
   ContentRuntimeArchiveReleaseResultSchema,
 } from "@repo/backend/content/archive";
 import {
@@ -23,9 +24,9 @@ import {
 } from "@repo/backend/scripts/content/runtime/ci/transport";
 import { Effect, Option, Result } from "effect";
 
-function identity(config: RuntimeArchiveReadConfig) {
+function identity(config: ContentRuntimeArchiveIdentity) {
   return {
-    contentStateHash: config.contentStateHash,
+    runtimeSelectionHash: config.runtimeSelectionHash,
     runtimeSchemaFingerprint: config.runtimeSchemaFingerprint,
   };
 }
@@ -205,9 +206,10 @@ export const fetchRuntimeArchive = Effect.fn("contentRuntimeRemote.download")(
     const metadata = {
       archiveSha256: capability.archiveSha256,
       byteLength: capability.byteLength,
-      contentStateHash: capability.contentStateHash,
       createdAt: capability.createdAt,
+      runtimeSelectionHash: capability.runtimeSelectionHash,
       runtimeSchemaFingerprint: capability.runtimeSchemaFingerprint,
+      sourceStateHash: capability.sourceStateHash,
     };
     return Option.some({ bytes, metadata });
   }

--- a/packages/backend/scripts/content/runtime/ci/transport.ts
+++ b/packages/backend/scripts/content/runtime/ci/transport.ts
@@ -1,0 +1,115 @@
+import { MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES } from "@repo/backend/content/archive";
+import { contentRuntimeCiError } from "@repo/backend/scripts/content/runtime/ci/error";
+import { Effect, Redacted, Schema } from "effect";
+
+export interface ArchiveCredential {
+  readonly header: string;
+  readonly token: Redacted.Redacted;
+}
+
+const readControlSource = Effect.fn("contentRuntimeTransport.read")(function* (
+  response: Response,
+  operation: string
+) {
+  return yield* Effect.tryPromise({
+    catch: () => contentRuntimeCiError(`${operation} returned no JSON body.`),
+    try: async () => {
+      if (!response.body) {
+        return { kind: "source", source: "" } as const;
+      }
+      const reader = response.body.getReader({ mode: "byob" });
+      const decoder = new TextDecoder();
+      let byteLength = 0;
+      let source = "";
+      try {
+        while (true) {
+          const remaining =
+            MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES - byteLength;
+          const chunk = await reader.read(
+            new Uint8Array(Math.min(1024, remaining + 1))
+          );
+          if (chunk.done) {
+            return {
+              kind: "source",
+              source: source + decoder.decode(),
+            } as const;
+          }
+          byteLength += chunk.value.byteLength;
+          if (byteLength > MAX_CONTENT_RUNTIME_ARCHIVE_CONTROL_RESPONSE_BYTES) {
+            await reader.cancel();
+            return { kind: "oversized" } as const;
+          }
+          source += decoder.decode(chunk.value, { stream: true });
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  });
+});
+
+/** Performs one archive HTTP operation without retaining sensitive response text. */
+export const fetchArchive = Effect.fn("contentRuntimeTransport.fetch")(
+  function* (
+    fetcher: typeof fetch,
+    operation: string,
+    url: string,
+    init: RequestInit
+  ) {
+    return yield* Effect.tryPromise({
+      catch: () =>
+        contentRuntimeCiError(`${operation} could not reach Convex storage.`),
+      try: () => fetcher(url, init),
+    });
+  }
+);
+
+/** Strictly decodes one bounded archive control response. */
+export const decodeControlResponse = Effect.fn(
+  "contentRuntimeTransport.decode"
+)(function* <A, I>(
+  response: Response,
+  schema: Schema.Codec<A, I, never, never>,
+  operation: string
+) {
+  const body = yield* readControlSource(response, operation);
+  if (body.kind === "oversized") {
+    return yield* contentRuntimeCiError(
+      `${operation} returned an oversized control response.`
+    );
+  }
+  return yield* Schema.decodeEffect(Schema.fromJsonString(schema))(
+    body.source,
+    { onExcessProperty: "error" }
+  ).pipe(
+    Effect.mapError(() =>
+      contentRuntimeCiError(`${operation} returned an invalid response.`)
+    )
+  );
+});
+
+/** Posts one authenticated JSON control request without following redirects. */
+export const postArchiveControl = Effect.fn("contentRuntimeTransport.post")(
+  function* (
+    fetcher: typeof fetch,
+    siteUrl: string,
+    path: string,
+    body: unknown,
+    credential: ArchiveCredential,
+    operation: string
+  ) {
+    return yield* fetchArchive(fetcher, operation, `${siteUrl}${path}`, {
+      body: JSON.stringify(body),
+      headers: {
+        "content-type": "application/json",
+        [credential.header]: Redacted.value(credential.token),
+      },
+      method: "POST",
+      redirect: "error",
+    });
+  }
+);
+
+export function archiveHttpError(operation: string, status: number) {
+  return contentRuntimeCiError(`${operation} failed with HTTP ${status}.`);
+}

--- a/packages/backend/test/archive.ts
+++ b/packages/backend/test/archive.ts
@@ -1,4 +1,10 @@
 import { createHash } from "node:crypto";
+import { CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE } from "@repo/backend/content/archive";
+import {
+  CONTENT_RUNTIME_ARCHIVE_ABORT_PATH,
+  CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH,
+  CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH,
+} from "@repo/backend/content/endpoint";
 import type { Id } from "@repo/backend/convex/_generated/dataModel";
 import type { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 
@@ -6,13 +12,101 @@ declare const Convex: {
   readonly asyncSyscall: (operation: string, input: string) => Promise<string>;
 };
 
-type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+export const ARCHIVE_TOKEN = "technical-archive-token";
+export const RUNTIME_TOKEN = "technical-runtime-token";
+export type ArchiveTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+export function setEnvironment() {
+  process.env.CONTENT_ARCHIVE_TOKEN = ARCHIVE_TOKEN;
+  process.env.CONTENT_RUNTIME_TOKEN = RUNTIME_TOKEN;
+  process.env.POLAR_WEBHOOK_SECRET = "technical-webhook-secret";
+}
+
+export function clearEnvironment() {
+  delete process.env.CONTENT_ARCHIVE_TOKEN;
+  delete process.env.CONTENT_RUNTIME_TOKEN;
+  delete process.env.POLAR_WEBHOOK_SECRET;
+}
+
+export function identity(index: number) {
+  return {
+    runtimeSelectionHash: index.toString(16).padStart(64, "0"),
+    runtimeSchemaFingerprint: "f".repeat(64),
+  };
+}
+
+export function sourceHash(index: number) {
+  return (index + 1000).toString(16).padStart(64, "0");
+}
+
+export function claimId(index: number) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+export function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function post(
+  target: ArchiveTest,
+  path: string,
+  body: BodyInit | null,
+  access: "read" | "write",
+  contentType = "application/json"
+) {
+  return target.fetch(path, {
+    body,
+    headers: {
+      "content-type": contentType,
+      [access === "read" ? "x-nakafa-content-token" : "x-nakafa-archive-token"]:
+        access === "read" ? RUNTIME_TOKEN : ARCHIVE_TOKEN,
+    },
+    method: "POST",
+  });
+}
+
+export function write(target: ArchiveTest, path: string, body: unknown) {
+  return post(target, path, JSON.stringify(body), "write");
+}
+
+export function claim(target: ArchiveTest, index: number) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_CLAIM_PATH, {
+    ...identity(index),
+    claimId: claimId(index),
+  });
+}
+
+export function finalize(
+  target: ArchiveTest,
+  index: number,
+  storageId: string,
+  value: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_FINALIZE_PATH, {
+    ...identity(index),
+    archiveSha256: hash(value),
+    byteLength: Buffer.byteLength(value),
+    claimId: claimId(index),
+    sourceStateHash: sourceHash(index),
+    storageId,
+    ...overrides,
+  });
+}
+
+export function abort(target: ArchiveTest, index: number, storageId: string) {
+  return write(target, CONTENT_RUNTIME_ARCHIVE_ABORT_PATH, {
+    ...identity(index),
+    claimId: claimId(index),
+    storageId,
+  });
+}
 
 /** Seeds official hex and MIME metadata around convex-test's legacy fake. */
 export function storeArchiveFixture(
-  target: RuntimeTest,
+  target: ArchiveTest,
   value: string,
-  contentType: string
+  contentType = CONTENT_RUNTIME_ARCHIVE_CONTENT_TYPE
 ) {
   return target.run(async () => {
     const source = await Convex.asyncSyscall(
@@ -29,4 +123,45 @@ export function storeArchiveFixture(
     const result = JSON.parse(source) as { readonly _id: Id<"_storage"> };
     return result._id;
   });
+}
+
+export function insert(
+  target: ArchiveTest,
+  index: number,
+  storageId: Id<"_storage">,
+  value: string,
+  overrides: {
+    readonly archiveSha256?: string;
+    readonly byteLength?: number;
+  } = {}
+) {
+  return target.run((ctx) =>
+    ctx.db.insert("contentRuntimeArchives", {
+      ...identity(index),
+      archiveSha256: overrides.archiveSha256 ?? hash(value),
+      byteLength: overrides.byteLength ?? Buffer.byteLength(value),
+      createdAt: Date.now(),
+      sourceStateHash: sourceHash(index),
+      storageId,
+    })
+  );
+}
+
+export function read(target: ArchiveTest, index: number) {
+  const archiveIdentity = identity(index);
+  return target.run((ctx) =>
+    ctx.db
+      .query("contentRuntimeArchives")
+      .withIndex(
+        "by_runtimeSelectionHash_and_runtimeSchemaFingerprint",
+        (query) =>
+          query
+            .eq("runtimeSelectionHash", archiveIdentity.runtimeSelectionHash)
+            .eq(
+              "runtimeSchemaFingerprint",
+              archiveIdentity.runtimeSchemaFingerprint
+            )
+      )
+      .unique()
+  );
 }

--- a/packages/backend/test/archive.ts
+++ b/packages/backend/test/archive.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import type { Id } from "@repo/backend/convex/_generated/dataModel";
+import type { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+
+declare const Convex: {
+  readonly asyncSyscall: (operation: string, input: string) => Promise<string>;
+};
+
+type RuntimeTest = ReturnType<typeof createConvexTestWithBetterAuth>;
+
+/** Seeds official hex and MIME metadata around convex-test's legacy fake. */
+export function storeArchiveFixture(
+  target: RuntimeTest,
+  value: string,
+  contentType: string
+) {
+  return target.run(async () => {
+    const source = await Convex.asyncSyscall(
+      "1.0/insert",
+      JSON.stringify({
+        table: "_storage",
+        value: {
+          contentType,
+          sha256: createHash("sha256").update(value).digest("hex"),
+          size: Buffer.byteLength(value),
+        },
+      })
+    );
+    const result = JSON.parse(source) as { readonly _id: Id<"_storage"> };
+    return result._id;
+  });
+}


### PR DESCRIPTION
## Outcome

- persist one immutable encrypted runtime archive keyed only by the active runtime selection and runtime schema
- serialize competing producers with a bounded lease and return the existing canonical archive before any production table export
- verify archive size, SHA-256, source state hash, upload ownership, and exact storage identity
- download the archive and its authenticated source state hash atomically into private temporary files
- prune only indexed archive claims and canonical archive rows; no global storage scan or MIME-based ownership inference
- expose explicit `produce` and `download` runtime modes with separate least-privilege credentials

## Cost impact

This is the durable producer and storage foundation. The first request for a new active selection and schema exports production once. Repeated requests for the same identity return `unchanged` before the expensive table export.

This PR does not claim the full cost reduction by itself. The stacked consumer switch removes the legacy Actions cache and production export path after this archive is deployed and bootstrapped.

## Scope and size

The branch contains 2,105 implementation, configuration, and documentation additions plus 2,988 behavior-test additions. The protocol spans authenticated HTTP routes, transactional storage ownership, lease arbitration, encrypted local artifacts, remote transport, and producer orchestration. Each production module owns one of those seams. All new hand-written modules are at or below 300 lines.

The final simplification commit removed 182 net lines from the prior head and split tests by real capability. It does not add a test merely because a TypeScript file exists.

## Verification

- backend: 374 files and 1,712 tests passed
- backend coverage: 100% statements, branches, functions, and lines
- focused archive suite: 8 files and 32 tests passed
- protected WWW typecheck against an isolated local Convex target passed
- backend typecheck passed
- formatting, lint, test ownership, and boundaries passed
- focused production Playwright auth navigation passed in 2.5 seconds
- the flaky browser-tab assumption from the prior head was removed while preserving pointer, auxiliary-click, context-menu, query, and hash behavior

GitHub exact-head checks remain authoritative and must pass before merge.