### PR TITLE
perf(content): reuse verified material row

### DIFF
--- a/packages/backend/convex/contentRelease/material/model.test.ts
+++ b/packages/backend/convex/contentRelease/material/model.test.ts
@@ -62,7 +62,7 @@ describe("contentRelease/material/model", () => {
     ]);
   });
 
-  it("saves five queries by reusing the requested material", async () => {
+  it("uses 13 queries for three alternates and one sibling", async () => {
     const target = convexTest(schema, convexModules);
     const projections = (["en", "id", "de"] as const).map((appLocale) =>
       makeMaterialProjection(appLocale, 1)
@@ -82,16 +82,32 @@ describe("contentRelease/material/model", () => {
 
     expect(result.alternateJson).toHaveLength(3);
     expect(result.siblingJson).toHaveLength(1);
-    const priorDatabaseQueries = 18;
     expect(metrics.databaseQueries.used).toBe(13);
-    expect(priorDatabaseQueries - metrics.databaseQueries.used).toBe(5);
   });
 
   it.each([
-    ["requested", makeMaterialProjection("en", 1)],
-    ["locale counterpart", makeMaterialProjection("id", 1)],
-    ["sibling", makeMaterialProjection("en", 2)],
-  ])("rejects a stale %s row", async (_label, stale) => {
+    [
+      "requested publicPath",
+      makeMaterialProjection("en", 1),
+      { publicPath: "subjects/test/functions/corrupted-section" },
+    ],
+    [
+      "requested releaseId",
+      makeMaterialProjection("en", 1),
+      { releaseId: "stale-release" },
+    ],
+    ["requested sequence", makeMaterialProjection("en", 1), { sequence: 0 }],
+    [
+      "locale counterpart",
+      makeMaterialProjection("id", 1),
+      { releaseId: "stale-release", sequence: 0 },
+    ],
+    [
+      "sibling",
+      makeMaterialProjection("en", 2),
+      { releaseId: "stale-release", sequence: 0 },
+    ],
+  ])("rejects a corrupted %s row", async (_label, stale, patch) => {
     const target = convexTest(schema, convexModules);
     const requested = makeMaterialProjection("en", 1);
     await activateMaterialCatalog(target);
@@ -108,10 +124,7 @@ describe("contentRelease/material/model", () => {
       if (!row) {
         throw new Error("Expected one related material row.");
       }
-      await ctx.db.patch("materialCatalog", row._id, {
-        releaseId: "stale-release",
-        sequence: 0,
-      });
+      await ctx.db.patch("materialCatalog", row._id, patch);
     });
 
     await expect(

--- a/packages/backend/convex/contentRelease/material/model.test.ts
+++ b/packages/backend/convex/contentRelease/material/model.test.ts
@@ -62,7 +62,33 @@ describe("contentRelease/material/model", () => {
     ]);
   });
 
+  it("saves five queries by reusing the requested material", async () => {
+    const target = convexTest(schema, convexModules);
+    const projections = (["en", "id", "de"] as const).map((appLocale) =>
+      makeMaterialProjection(appLocale, 1)
+    );
+    const requested = projections[0];
+    await activateMaterialCatalog(target, projections);
+
+    const { metrics, result } = await target.query(async (ctx) => {
+      const material = await runConvexProgram(
+        readMaterialModel(ctx, requested.appLocale, requested.publicPath)
+      );
+      return {
+        metrics: await ctx.meta.getTransactionMetrics(),
+        result: material,
+      };
+    });
+
+    expect(result.alternateJson).toHaveLength(3);
+    expect(result.siblingJson).toHaveLength(1);
+    const priorDatabaseQueries = 18;
+    expect(metrics.databaseQueries.used).toBe(13);
+    expect(priorDatabaseQueries - metrics.databaseQueries.used).toBe(5);
+  });
+
   it.each([
+    ["requested", makeMaterialProjection("en", 1)],
     ["locale counterpart", makeMaterialProjection("id", 1)],
     ["sibling", makeMaterialProjection("en", 2)],
   ])("rejects a stale %s row", async (_label, stale) => {

--- a/packages/backend/convex/contentRelease/material/model.test.ts
+++ b/packages/backend/convex/contentRelease/material/model.test.ts
@@ -138,6 +138,37 @@ describe("contentRelease/material/model", () => {
     });
   });
 
+  it("rejects a published route whose catalog row was removed", async () => {
+    const target = convexTest(schema, convexModules);
+    const requested = makeMaterialProjection("en", 1);
+    await activateMaterialCatalog(target);
+    await target.mutation(async (ctx) => {
+      const row = await ctx.db
+        .query("materialCatalog")
+        .withIndex("by_slot_and_appLocale_and_publicPath", (index) =>
+          index
+            .eq("slot", "blue")
+            .eq("appLocale", requested.appLocale)
+            .eq("publicPath", requested.publicPath)
+        )
+        .unique();
+      if (!row) {
+        throw new Error("Expected one current material row.");
+      }
+      await ctx.db.delete("materialCatalog", row._id);
+    });
+
+    await expect(
+      target.query((ctx) =>
+        runConvexProgram(
+          readMaterialModel(ctx, requested.appLocale, requested.publicPath)
+        )
+      )
+    ).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
+    });
+  });
+
   it("returns a missing route inside the current signed family", async () => {
     const target = convexTest(schema, convexModules);
     await activateMaterialCatalog(target);
@@ -242,7 +273,7 @@ describe("contentRelease/material/model", () => {
       requested,
       conflicting,
       makeMaterialProjection("id", 1),
-      makeMaterialProjection("id", 2),
+      makeMaterialProjection("de", 1),
     ]);
 
     await expect(

--- a/packages/backend/convex/contentRelease/material/model.ts
+++ b/packages/backend/convex/contentRelease/material/model.ts
@@ -9,23 +9,30 @@ import { readSourceRevision } from "@repo/backend/convex/contentRelease/runtime/
 import { requireExpectedActiveRelease } from "@repo/backend/convex/contentRelease/runtime/pin";
 import { Effect } from "effect";
 
+type AuthenticatedMaterial = NonNullable<
+  Effect.Success<ReturnType<typeof resolveMaterialRoute>>["material"]
+>;
+
 /** Reads every locale-specific counterpart for one stable material identity. */
 const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
   function* (
     ctx: QueryCtx,
-    row: Doc<"materialCatalog">,
+    requested: AuthenticatedMaterial,
     activeAppLocales: ActiveAppLocaleList,
     activeSequence: number
   ) {
     const counterparts = yield* Effect.forEach(activeAppLocales, (appLocale) =>
       Effect.gen(function* () {
+        if (appLocale === requested.row.appLocale) {
+          return requested;
+        }
         const alternate = yield* Effect.promise(() =>
           ctx.db
             .query("materialCatalog")
             .withIndex("by_slot_and_contentKey_and_appLocale", (index) =>
               index
-                .eq("slot", row.slot)
-                .eq("contentKey", row.contentKey)
+                .eq("slot", requested.row.slot)
+                .eq("contentKey", requested.row.contentKey)
                 .eq("appLocale", appLocale)
             )
             .unique()
@@ -44,7 +51,7 @@ const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
         }
         return yield* releaseFail(
           "CONTENT_RELEASE_INTEGRITY",
-          `Material ${row.contentKey} lost locale ${appLocale}.`
+          `Material ${requested.row.contentKey} lost locale ${appLocale}.`
         );
       })
     );
@@ -56,7 +63,7 @@ const readAlternates = Effect.fn("contentRelease.readMaterialAlternates")(
 const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
   function* (
     ctx: QueryCtx,
-    row: Doc<"materialCatalog">,
+    requested: AuthenticatedMaterial,
     activeSequence: number
   ) {
     const siblings = yield* Effect.promise(() =>
@@ -66,20 +73,23 @@ const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
           "by_slot_and_appLocale_and_materialKey_and_order_and_publicPath",
           (index) =>
             index
-              .eq("slot", row.slot)
-              .eq("appLocale", row.appLocale)
-              .eq("materialKey", row.materialKey)
+              .eq("slot", requested.row.slot)
+              .eq("appLocale", requested.row.appLocale)
+              .eq("materialKey", requested.row.materialKey)
         )
         .take(MATERIAL_GROUP_LIMIT + 1)
     );
     if (siblings.length > MATERIAL_GROUP_LIMIT) {
       return yield* releaseFail(
         "CONTENT_RELEASE_LIMIT",
-        `Material ${row.appLocale}/${row.materialKey} exceeds ${MATERIAL_GROUP_LIMIT} lesson sections.`
+        `Material ${requested.row.appLocale}/${requested.row.materialKey} exceeds ${MATERIAL_GROUP_LIMIT} lesson sections.`
       );
     }
-    const verified = yield* Effect.forEach(siblings, (sibling) =>
-      Effect.gen(function* () {
+    const verified = yield* Effect.forEach(siblings, (sibling) => {
+      if (sibling._id === requested.row._id) {
+        return Effect.succeed(requested);
+      }
+      return Effect.gen(function* () {
         const { projection, resolved } = yield* verifyEffectiveMaterial(
           ctx,
           sibling,
@@ -90,17 +100,19 @@ const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
           projectionJson: resolved.projectionJson,
           row: sibling,
         };
-      })
-    );
+      });
+    });
     if (
-      !verified.some(({ row: candidate }) => candidate._id === row._id) ||
+      !verified.some(
+        ({ row: candidate }) => candidate._id === requested.row._id
+      ) ||
       verified.some(
-        ({ projection }) => projection.parentPath !== row.parentPath
+        ({ projection }) => projection.parentPath !== requested.row.parentPath
       )
     ) {
       return yield* releaseFail(
         "CONTENT_RELEASE_INTEGRITY",
-        `Material ${row.appLocale}/${row.materialKey} lost its coherent lesson group.`
+        `Material ${requested.row.appLocale}/${requested.row.materialKey} lost its coherent lesson group.`
       );
     }
     return verified;
@@ -142,15 +154,16 @@ export const readMaterialModel = Effect.fn("contentRelease.readMaterialModel")(
         sourceRevision: readSourceRevision(route.active),
       };
     }
-    const { projectionJson, row } = route.material;
+    const requested = route.material;
+    const { projectionJson, row } = requested;
     const [alternates, siblings] = yield* Effect.all([
       readAlternates(
         ctx,
-        row,
+        requested,
         route.active.signed.manifest.activeAppLocales,
         route.active.sequence
       ),
-      readSiblings(ctx, row, route.active.sequence),
+      readSiblings(ctx, requested, route.active.sequence),
     ]);
     const alternateJson = alternates.map((material) => material.projectionJson);
     const siblingJson = siblings.map((material) => material.projectionJson);

--- a/packages/backend/convex/contentRelease/material/model.ts
+++ b/packages/backend/convex/contentRelease/material/model.ts
@@ -103,9 +103,6 @@ const readSiblings = Effect.fn("contentRelease.readMaterialSiblings")(
       });
     });
     if (
-      !verified.some(
-        ({ row: candidate }) => candidate._id === requested.row._id
-      ) ||
       verified.some(
         ({ projection }) => projection.parentPath !== requested.row.parentPath
       )

--- a/packages/backend/convex/contentRelease/material/route.ts
+++ b/packages/backend/convex/contentRelease/material/route.ts
@@ -55,7 +55,10 @@ export const resolveMaterialRoute = Effect.fn(
   const verified = yield* verifyMaterial(row);
   if (
     row.projectionHash !== route.projection.projectionHash ||
+    row.publicPath !== route.projection.publicPath ||
+    row.releaseId !== route.projection.releaseId ||
     row.rendererDomain !== route.projection.rendererDomain ||
+    row.sequence !== route.projection.sequence ||
     row.sourcePath !== route.projection.sourcePath ||
     verified.projectionJson !== route.projection.projectionJson
   ) {


### PR DESCRIPTION
## Summary

- reuse the already authenticated requested material for its own locale and sibling slot
- preserve full verification for every distinct alternate and sibling row
- strengthen route identity checks for public path, release, and sequence
- delete the redundant post-query requested-row membership scan

## Cost evidence

For three active locales and one lesson section, the behavior test records 13 Convex database queries after reuse. The prior implementation repeated verification for the requested row in both alternate and sibling traversal.

## Verification

- backend suite: 361 files and 1,652 tests passed
- changed backend coverage: 100% statements, branches, functions, and lines
- backend typecheck passed
- Ultracite and diff checks passed