### PR TITLE
perf(content): skip unchanged popularity writes

### DIFF
--- a/packages/backend/convex/contents/metrics/refresh.test.ts
+++ b/packages/backend/convex/contents/metrics/refresh.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { internal } from "@repo/backend/convex/_generated/api";
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { LEARNING_POPULARITY_REFRESH_BATCH_SIZE } from "@repo/backend/convex/contents/constants";
+import { learningPopularityRankings } from "@repo/backend/convex/contents/rankings";
+import schema from "@repo/backend/convex/schema";
+import { registerLearningPopularityAggregate } from "@repo/backend/convex/test.helpers";
+import { convexModules } from "@repo/backend/convex/test.setup";
+import { testMaterialGraph } from "@repo/backend/test/content/material";
+import { convexTest } from "convex-test";
+
+const NOW = Date.parse("2026-01-08T12:00:00.000Z");
+
+/** Builds a Convex test instance with production popularity triggers enabled. */
+function createPopularityConvexTest() {
+  const target = convexTest(schema, convexModules);
+  registerLearningPopularityAggregate(target);
+  return target;
+}
+
+/** Adds one expired counter so pagination must delete it during refresh. */
+async function insertExpiredCounter(ctx: MutationCtx, index: number) {
+  const graph = testMaterialGraph(
+    "vector",
+    `section-${index}`,
+    "en",
+    "mathematics"
+  );
+  const id = await ctx.db.insert("learningPopularityCounters", {
+    ...graph,
+    content_id: graph.assetId,
+    contextKey: "canonical",
+    contextMode: "canonical",
+    locale: "en",
+    materialDomain: "mathematics",
+    route: `material/${index}`,
+    score: 1,
+    section: "material",
+    scopeMode: "global",
+    sourcePath: `material/${index}`,
+    title: `Material ${index}`,
+    updatedAt: NOW,
+    windowKey: "7d",
+  });
+  const counter = await ctx.db.get(id);
+  if (!counter) {
+    throw new Error("Expected the pagination counter to exist.");
+  }
+  await learningPopularityRankings.insert(ctx, counter);
+}
+
+describe("contents/metrics/refresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedules every finite window for both popularity scopes", async () => {
+    const target = createPopularityConvexTest();
+    const state = await target.mutation(async (ctx) => {
+      const result = await ctx.runMutation(
+        internal.contents.mutations.popularity
+          .scheduleLearningPopularityRefreshes,
+        {}
+      );
+      return {
+        jobs: await ctx.db.system.query("_scheduled_functions").collect(),
+        result,
+      };
+    });
+
+    expect(state.result).toEqual({ scheduledWindows: 14 });
+    expect(state.jobs).toHaveLength(14);
+    expect(
+      state.jobs.every(({ args }) => args[0]?.windowKey !== "lifetime")
+    ).toBe(true);
+  });
+
+  it("skips lifetime refreshes without writes or continuation jobs", async () => {
+    const target = createPopularityConvexTest();
+    const state = await target.mutation(async (ctx) => {
+      const result = await ctx.runMutation(
+        internal.contents.mutations.popularity
+          .refreshLearningPopularityWindowPage,
+        { scopeMode: "global", windowKey: "lifetime" }
+      );
+      return {
+        jobs: await ctx.db.system.query("_scheduled_functions").collect(),
+        metrics: await ctx.meta.getTransactionMetrics(),
+        result,
+      };
+    });
+
+    expect(state.result).toEqual({
+      continueCursor: "",
+      isDone: true,
+      refreshedCounters: 0,
+      removedCounters: 0,
+      skipped: true,
+    });
+    expect(state.metrics.documentsWritten.used).toBe(0);
+    expect(state.jobs).toEqual([]);
+  });
+
+  it("bounds each page and schedules the remaining counters", async () => {
+    const target = createPopularityConvexTest();
+    await target.mutation(async (ctx) => {
+      for (
+        let index = 0;
+        index < LEARNING_POPULARITY_REFRESH_BATCH_SIZE + 1;
+        index += 1
+      ) {
+        await insertExpiredCounter(ctx, index);
+      }
+    });
+
+    const state = await target.mutation(async (ctx) => {
+      const result = await ctx.runMutation(
+        internal.contents.mutations.popularity
+          .refreshLearningPopularityWindowPage,
+        { scopeMode: "global", windowKey: "7d" }
+      );
+      return {
+        jobs: await ctx.db.system.query("_scheduled_functions").collect(),
+        result,
+      };
+    });
+
+    expect(state.result).toEqual({
+      continueCursor: expect.any(String),
+      isDone: false,
+      refreshedCounters: 0,
+      removedCounters: LEARNING_POPULARITY_REFRESH_BATCH_SIZE,
+      skipped: false,
+    });
+    expect(state.jobs).toHaveLength(1);
+    expect(state.jobs[0]?.args[0]).toMatchObject({
+      scopeMode: "global",
+      windowKey: "7d",
+    });
+  });
+});

--- a/packages/backend/convex/contents/metrics/refresh.ts
+++ b/packages/backend/convex/contents/metrics/refresh.ts
@@ -20,6 +20,30 @@ import { Clock, Effect } from "effect";
 type PopularityCounter = Doc<"learningPopularityCounters">;
 type PopularitySignal = Doc<"learningPopularitySignals">;
 
+/** Rebuilt semantics; `updatedAt` advances only when one of these changes. */
+const refreshFields = [
+  "alignmentId",
+  "assetId",
+  "conceptId",
+  "contextMaterialKey",
+  "contextMode",
+  "contextNodeKey",
+  "contextParentPath",
+  "contextProgramKey",
+  "contextPublicPath",
+  "contextSourcePath",
+  "description",
+  "learningObjectId",
+  "lensId",
+  "materialDomain",
+  "route",
+  "score",
+  "sourcePath",
+  "title",
+] as const satisfies readonly (keyof PopularityCounter)[];
+
+type Refresh = Pick<PopularityCounter, (typeof refreshFields)[number]>;
+
 /** Generated internal mutation reference accepted by Convex refresh scheduling. */
 type RefreshLearningPopularityWindowPageReference = FunctionReference<
   "mutation",
@@ -91,6 +115,40 @@ const recomputePopularityCounter = Effect.fn(
   };
 });
 
+/** Projects the stored counter state produced by one authoritative rebuild. */
+function projectPopularityRefresh(
+  counter: PopularityCounter,
+  latestSignal: PopularitySignal | null,
+  score: number
+): Refresh {
+  return {
+    alignmentId: latestSignal?.alignmentId ?? counter.alignmentId,
+    assetId: latestSignal?.assetId ?? counter.assetId,
+    conceptId: latestSignal?.conceptId ?? counter.conceptId,
+    contextMaterialKey:
+      latestSignal?.contextMaterialKey ?? counter.contextMaterialKey,
+    contextMode: latestSignal?.contextMode ?? counter.contextMode,
+    contextNodeKey: latestSignal?.contextNodeKey ?? counter.contextNodeKey,
+    contextParentPath:
+      latestSignal?.contextParentPath ?? counter.contextParentPath,
+    contextProgramKey:
+      latestSignal?.contextProgramKey ?? counter.contextProgramKey,
+    contextPublicPath:
+      latestSignal?.contextPublicPath ?? counter.contextPublicPath,
+    contextSourcePath:
+      latestSignal?.contextSourcePath ?? counter.contextSourcePath,
+    description: latestSignal?.description ?? counter.description,
+    learningObjectId:
+      latestSignal?.learningObjectId ?? counter.learningObjectId,
+    lensId: latestSignal?.lensId ?? counter.lensId,
+    materialDomain: latestSignal?.materialDomain ?? counter.materialDomain,
+    route: latestSignal?.route ?? counter.route,
+    score,
+    sourcePath: latestSignal?.sourcePath ?? counter.sourcePath,
+    title: latestSignal?.title ?? counter.title,
+  };
+}
+
 /** Applies a recomputed finite-window score to one popularity counter row. */
 const refreshPopularityCounter = Effect.fn(
   "contents.metrics.refreshPopularityCounter"
@@ -109,35 +167,27 @@ const refreshPopularityCounter = Effect.fn(
     };
   }
 
-  const latestSignal = refresh.latestSignal;
+  const update = projectPopularityRefresh(
+    counter,
+    refresh.latestSignal,
+    refresh.score
+  );
+
+  const changed = refreshFields.some(
+    (field) => counter[field] !== update[field]
+  );
+
+  if (!changed) {
+    return {
+      removed: false,
+      refreshed: false,
+    };
+  }
 
   yield* Effect.tryPromise({
     try: () =>
       ctx.db.patch(counter._id, {
-        alignmentId: latestSignal?.alignmentId ?? counter.alignmentId,
-        assetId: latestSignal?.assetId ?? counter.assetId,
-        conceptId: latestSignal?.conceptId ?? counter.conceptId,
-        contextMaterialKey:
-          latestSignal?.contextMaterialKey ?? counter.contextMaterialKey,
-        contextMode: latestSignal?.contextMode ?? counter.contextMode,
-        contextNodeKey: latestSignal?.contextNodeKey ?? counter.contextNodeKey,
-        contextParentPath:
-          latestSignal?.contextParentPath ?? counter.contextParentPath,
-        contextProgramKey:
-          latestSignal?.contextProgramKey ?? counter.contextProgramKey,
-        contextPublicPath:
-          latestSignal?.contextPublicPath ?? counter.contextPublicPath,
-        contextSourcePath:
-          latestSignal?.contextSourcePath ?? counter.contextSourcePath,
-        description: latestSignal?.description ?? counter.description,
-        learningObjectId:
-          latestSignal?.learningObjectId ?? counter.learningObjectId,
-        lensId: latestSignal?.lensId ?? counter.lensId,
-        materialDomain: latestSignal?.materialDomain ?? counter.materialDomain,
-        route: latestSignal?.route ?? counter.route,
-        score: refresh.score,
-        sourcePath: latestSignal?.sourcePath ?? counter.sourcePath,
-        title: latestSignal?.title ?? counter.title,
+        ...update,
         updatedAt: timestamp,
       }),
     catch: toContentAnalyticsIoError,

--- a/packages/backend/convex/contents/metrics/refresh.ts
+++ b/packages/backend/convex/contents/metrics/refresh.ts
@@ -87,18 +87,16 @@ const loadPopularitySignals = Effect.fn(
 /** Recomputes one finite-window counter from durable daily signal rows. */
 const recomputePopularityCounter = Effect.fn(
   "contents.metrics.recomputePopularityCounter"
-)(function* (ctx: MutationCtx, counter: PopularityCounter, timestamp: number) {
-  if (!isFinitePopularityWindow(counter.windowKey)) {
-    return {
-      latestSignal: null,
-      score: counter.score,
-    };
-  }
-
+)(function* (
+  ctx: MutationCtx,
+  counter: PopularityCounter,
+  windowKey: Exclude<PopularityCounter["windowKey"], "lifetime">,
+  timestamp: number
+) {
   const signals = yield* loadPopularitySignals(
     ctx,
     counter,
-    counter.windowKey,
+    windowKey,
     timestamp
   );
   let latestSignal: PopularitySignal | null = null;
@@ -109,53 +107,55 @@ const recomputePopularityCounter = Effect.fn(
     latestSignal = signal;
   }
 
-  return {
-    latestSignal,
-    score,
-  };
+  return latestSignal === null
+    ? { kind: "empty" as const }
+    : { kind: "active" as const, latestSignal, score };
 });
 
 /** Projects the stored counter state produced by one authoritative rebuild. */
 function projectPopularityRefresh(
-  counter: PopularityCounter,
-  latestSignal: PopularitySignal | null,
+  latestSignal: PopularitySignal,
   score: number
 ): Refresh {
   return {
-    alignmentId: latestSignal?.alignmentId ?? counter.alignmentId,
-    assetId: latestSignal?.assetId ?? counter.assetId,
-    conceptId: latestSignal?.conceptId ?? counter.conceptId,
-    contextMaterialKey:
-      latestSignal?.contextMaterialKey ?? counter.contextMaterialKey,
-    contextMode: latestSignal?.contextMode ?? counter.contextMode,
-    contextNodeKey: latestSignal?.contextNodeKey ?? counter.contextNodeKey,
-    contextParentPath:
-      latestSignal?.contextParentPath ?? counter.contextParentPath,
-    contextProgramKey:
-      latestSignal?.contextProgramKey ?? counter.contextProgramKey,
-    contextPublicPath:
-      latestSignal?.contextPublicPath ?? counter.contextPublicPath,
-    contextSourcePath:
-      latestSignal?.contextSourcePath ?? counter.contextSourcePath,
-    description: latestSignal?.description ?? counter.description,
-    learningObjectId:
-      latestSignal?.learningObjectId ?? counter.learningObjectId,
-    lensId: latestSignal?.lensId ?? counter.lensId,
-    materialDomain: latestSignal?.materialDomain ?? counter.materialDomain,
-    route: latestSignal?.route ?? counter.route,
+    alignmentId: latestSignal.alignmentId,
+    assetId: latestSignal.assetId,
+    conceptId: latestSignal.conceptId,
+    contextMaterialKey: latestSignal.contextMaterialKey,
+    contextMode: latestSignal.contextMode,
+    contextNodeKey: latestSignal.contextNodeKey,
+    contextParentPath: latestSignal.contextParentPath,
+    contextProgramKey: latestSignal.contextProgramKey,
+    contextPublicPath: latestSignal.contextPublicPath,
+    contextSourcePath: latestSignal.contextSourcePath,
+    description: latestSignal.description,
+    learningObjectId: latestSignal.learningObjectId,
+    lensId: latestSignal.lensId,
+    materialDomain: latestSignal.materialDomain,
+    route: latestSignal.route,
     score,
-    sourcePath: latestSignal?.sourcePath ?? counter.sourcePath,
-    title: latestSignal?.title ?? counter.title,
+    sourcePath: latestSignal.sourcePath,
+    title: latestSignal.title,
   };
 }
 
 /** Applies a recomputed finite-window score to one popularity counter row. */
 const refreshPopularityCounter = Effect.fn(
   "contents.metrics.refreshPopularityCounter"
-)(function* (ctx: MutationCtx, counter: PopularityCounter, timestamp: number) {
-  const refresh = yield* recomputePopularityCounter(ctx, counter, timestamp);
+)(function* (
+  ctx: MutationCtx,
+  counter: PopularityCounter,
+  windowKey: Exclude<PopularityCounter["windowKey"], "lifetime">,
+  timestamp: number
+) {
+  const refresh = yield* recomputePopularityCounter(
+    ctx,
+    counter,
+    windowKey,
+    timestamp
+  );
 
-  if (refresh.score <= 0) {
+  if (refresh.kind === "empty" || refresh.score <= 0) {
     yield* Effect.tryPromise({
       try: () => ctx.db.delete(counter._id),
       catch: toContentAnalyticsIoError,
@@ -167,11 +167,7 @@ const refreshPopularityCounter = Effect.fn(
     };
   }
 
-  const update = projectPopularityRefresh(
-    counter,
-    refresh.latestSignal,
-    refresh.score
-  );
+  const update = projectPopularityRefresh(refresh.latestSignal, refresh.score);
 
   const changed = refreshFields.some(
     (field) => counter[field] !== update[field]
@@ -267,7 +263,12 @@ export const refreshLearningPopularityWindowPage = Effect.fn(
   let removedCounters = 0;
 
   for (const counter of page.page) {
-    const result = yield* refreshPopularityCounter(ctx, counter, timestamp);
+    const result = yield* refreshPopularityCounter(
+      ctx,
+      counter,
+      args.windowKey,
+      timestamp
+    );
 
     if (result.refreshed) {
       refreshedCounters += 1;

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -45,16 +45,27 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   const subjectCounterId = await ctx.db.insert("learningPopularityCounters", {
     ...subject,
-    contextKey: "canonical",
+    alignmentId: "stale-alignment",
+    assetId: "stale-asset",
+    conceptId: "stale-concept",
+    contextKey: "placement:mathematics:addition",
+    contextMaterialKey: "stale-material",
     contextMode: "canonical",
+    contextNodeKey: "stale-node",
+    contextParentPath: "stale/parent",
+    contextProgramKey: "stale-program",
+    contextPublicPath: "stale/public",
+    contextSourcePath: "stale/source",
     description: "Stale subject description",
+    learningObjectId: "stale-learning-object",
+    lensId: "stale-lens",
     locale: "en",
-    materialDomain: "mathematics",
-    route: SUBJECT_ROUTE,
-    score: 99,
+    materialDomain: "physics",
+    route: "stale/subject/route",
+    score: 2,
     section: "material",
     scopeMode: "global",
-    sourcePath: SUBJECT_ROUTE,
+    sourcePath: "stale/subject/source",
     title: "Stale Vector Addition",
     updatedAt: NOW - POPULARITY_DAY_MS,
     windowKey: "7d",
@@ -88,8 +99,14 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   await ctx.db.insert("learningPopularitySignals", {
     ...subject,
-    contextKey: "canonical",
-    contextMode: "canonical",
+    contextKey: "placement:mathematics:addition",
+    contextMaterialKey: "vector-addition",
+    contextMode: "placement",
+    contextNodeKey: "addition",
+    contextParentPath: "subjects/mathematics/vector",
+    contextProgramKey: "mathematics",
+    contextPublicPath: SUBJECT_ROUTE,
+    contextSourcePath: "material/lesson/mathematics/vector/addition",
     description: "Current subject description",
     locale: "en",
     materialDomain: "mathematics",
@@ -119,6 +136,44 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
   });
 }
 
+/** Reads stored counters and their aggregate ranking output together. */
+async function readPopularitySnapshot(
+  target: ReturnType<typeof createPopularityConvexTest>
+) {
+  return await target.query(async (ctx) => {
+    const counters = await ctx.db.query("learningPopularityCounters").collect();
+    const ranking = await learningPopularityRankings.paginate(ctx, {
+      namespace: ["material", "en", "global", "7d"],
+      order: "asc",
+      pageSize: 10,
+    });
+
+    return {
+      counters,
+      ranking: ranking.page,
+    };
+  });
+}
+
+/** Runs the registered refresh interface and exposes its transaction cost. */
+async function runRefresh(
+  target: ReturnType<typeof createPopularityConvexTest>
+) {
+  return await target.mutation(async (ctx) => {
+    const result = await ctx.runMutation(
+      internal.contents.mutations.popularity
+        .refreshLearningPopularityWindowPage,
+      {
+        scopeMode: "global",
+        windowKey: "7d",
+      }
+    );
+    const metrics = await ctx.meta.getTransactionMetrics();
+
+    return { metrics, result };
+  });
+}
+
 describe("contents/mutations/popularity", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -130,35 +185,72 @@ describe("contents/mutations/popularity", () => {
     vi.restoreAllMocks();
   });
 
-  it("rebuilds finite windows from daily signals and removes expired counters", async () => {
+  it("repairs finite windows from daily signals and removes expired counters", async () => {
     const t = createPopularityConvexTest();
 
     await t.mutation(insertPopularityRefreshRows);
 
-    const result = await t.mutation(
-      internal.contents.mutations.popularity
-        .refreshLearningPopularityWindowPage,
-      {
-        scopeMode: "global",
-        windowKey: "7d",
-      }
-    );
+    const refresh = await runRefresh(t);
     const counters = await t.query(
       async (ctx) => await ctx.db.query("learningPopularityCounters").collect()
     );
+    const subject = withContentId(
+      testMaterialGraph("vector", "addition", "en", "mathematics")
+    );
 
-    expect(result).toEqual({
+    expect(refresh.result).toEqual({
       continueCursor: expect.any(String),
       isDone: true,
       refreshedCounters: 1,
       removedCounters: 1,
       skipped: false,
     });
+    expect(refresh.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(counters).toHaveLength(1);
     expect(counters[0]).toMatchObject({
+      alignmentId: subject.alignmentId,
+      assetId: subject.assetId,
+      conceptId: subject.conceptId,
+      contextKey: "placement:mathematics:addition",
+      contextMaterialKey: "vector-addition",
+      contextMode: "placement",
+      contextNodeKey: "addition",
+      contextParentPath: "subjects/mathematics/vector",
+      contextProgramKey: "mathematics",
+      contextPublicPath: SUBJECT_ROUTE,
+      contextSourcePath: "material/lesson/mathematics/vector/addition",
+      description: "Current subject description",
+      learningObjectId: subject.learningObjectId,
+      lensId: subject.lensId,
+      materialDomain: "mathematics",
       route: SUBJECT_ROUTE,
       score: 2,
+      sourcePath: SUBJECT_ROUTE,
       title: "Current Vector Addition",
+      updatedAt: NOW,
     });
+  });
+
+  it("does not rewrite or rerank an unchanged rebuilt counter", async () => {
+    const t = createPopularityConvexTest();
+
+    await t.mutation(insertPopularityRefreshRows);
+    await runRefresh(t);
+    const before = await readPopularitySnapshot(t);
+
+    vi.setSystemTime(new Date(NOW + POPULARITY_DAY_MS / 2));
+    const replay = await runRefresh(t);
+    const after = await readPopularitySnapshot(t);
+
+    expect(replay.result).toEqual({
+      continueCursor: expect.any(String),
+      isDone: true,
+      refreshedCounters: 0,
+      removedCounters: 0,
+      skipped: false,
+    });
+    expect(replay.metrics.documentsWritten.used).toBe(0);
+    expect(after).toEqual(before);
+    expect(after.counters[0]?.updatedAt).toBe(NOW);
   });
 });

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -205,7 +205,6 @@ describe("contents/mutations/popularity", () => {
       removedCounters: 1,
       skipped: false,
     });
-    expect(refresh.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(counters).toHaveLength(1);
     expect(counters[0]).toMatchObject({
       alignmentId: subject.alignmentId,
@@ -235,13 +234,14 @@ describe("contents/mutations/popularity", () => {
     const t = createPopularityConvexTest();
 
     await t.mutation(insertPopularityRefreshRows);
-    await runRefresh(t);
+    const repair = await runRefresh(t);
     const before = await readPopularitySnapshot(t);
 
     vi.setSystemTime(new Date(NOW + POPULARITY_DAY_MS / 2));
     const replay = await runRefresh(t);
     const after = await readPopularitySnapshot(t);
 
+    expect(repair.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(replay.result).toEqual({
       continueCursor: expect.any(String),
       isDone: true,
@@ -251,6 +251,5 @@ describe("contents/mutations/popularity", () => {
     });
     expect(replay.metrics.documentsWritten.used).toBe(0);
     expect(after).toEqual(before);
-    expect(after.counters[0]?.updatedAt).toBe(NOW);
   });
 });

--- a/packages/backend/convex/contents/mutations/popularity.test.ts
+++ b/packages/backend/convex/contents/mutations/popularity.test.ts
@@ -45,27 +45,16 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   const subjectCounterId = await ctx.db.insert("learningPopularityCounters", {
     ...subject,
-    alignmentId: "stale-alignment",
-    assetId: "stale-asset",
-    conceptId: "stale-concept",
-    contextKey: "placement:mathematics:addition",
-    contextMaterialKey: "stale-material",
+    contextKey: "canonical",
     contextMode: "canonical",
-    contextNodeKey: "stale-node",
-    contextParentPath: "stale/parent",
-    contextProgramKey: "stale-program",
-    contextPublicPath: "stale/public",
-    contextSourcePath: "stale/source",
     description: "Stale subject description",
-    learningObjectId: "stale-learning-object",
-    lensId: "stale-lens",
     locale: "en",
-    materialDomain: "physics",
-    route: "stale/subject/route",
-    score: 2,
+    materialDomain: "mathematics",
+    route: SUBJECT_ROUTE,
+    score: 99,
     section: "material",
     scopeMode: "global",
-    sourcePath: "stale/subject/source",
+    sourcePath: SUBJECT_ROUTE,
     title: "Stale Vector Addition",
     updatedAt: NOW - POPULARITY_DAY_MS,
     windowKey: "7d",
@@ -99,14 +88,8 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
 
   await ctx.db.insert("learningPopularitySignals", {
     ...subject,
-    contextKey: "placement:mathematics:addition",
-    contextMaterialKey: "vector-addition",
-    contextMode: "placement",
-    contextNodeKey: "addition",
-    contextParentPath: "subjects/mathematics/vector",
-    contextProgramKey: "mathematics",
-    contextPublicPath: SUBJECT_ROUTE,
-    contextSourcePath: "material/lesson/mathematics/vector/addition",
+    contextKey: "canonical",
+    contextMode: "canonical",
     description: "Current subject description",
     locale: "en",
     materialDomain: "mathematics",
@@ -133,25 +116,6 @@ async function insertPopularityRefreshRows(ctx: MutationCtx) {
     title: "Old Dynastic Politics",
     updatedAt: NOW - 8 * POPULARITY_DAY_MS,
     viewCount: 5,
-  });
-}
-
-/** Reads stored counters and their aggregate ranking output together. */
-async function readPopularitySnapshot(
-  target: ReturnType<typeof createPopularityConvexTest>
-) {
-  return await target.query(async (ctx) => {
-    const counters = await ctx.db.query("learningPopularityCounters").collect();
-    const ranking = await learningPopularityRankings.paginate(ctx, {
-      namespace: ["material", "en", "global", "7d"],
-      order: "asc",
-      pageSize: 10,
-    });
-
-    return {
-      counters,
-      ranking: ranking.page,
-    };
   });
 }
 
@@ -185,7 +149,7 @@ describe("contents/mutations/popularity", () => {
     vi.restoreAllMocks();
   });
 
-  it("repairs finite windows from daily signals and removes expired counters", async () => {
+  it("rebuilds finite windows from daily signals and removes expired counters", async () => {
     const t = createPopularityConvexTest();
 
     await t.mutation(insertPopularityRefreshRows);
@@ -194,10 +158,6 @@ describe("contents/mutations/popularity", () => {
     const counters = await t.query(
       async (ctx) => await ctx.db.query("learningPopularityCounters").collect()
     );
-    const subject = withContentId(
-      testMaterialGraph("vector", "addition", "en", "mathematics")
-    );
-
     expect(refresh.result).toEqual({
       continueCursor: expect.any(String),
       isDone: true,
@@ -207,26 +167,9 @@ describe("contents/mutations/popularity", () => {
     });
     expect(counters).toHaveLength(1);
     expect(counters[0]).toMatchObject({
-      alignmentId: subject.alignmentId,
-      assetId: subject.assetId,
-      conceptId: subject.conceptId,
-      contextKey: "placement:mathematics:addition",
-      contextMaterialKey: "vector-addition",
-      contextMode: "placement",
-      contextNodeKey: "addition",
-      contextParentPath: "subjects/mathematics/vector",
-      contextProgramKey: "mathematics",
-      contextPublicPath: SUBJECT_ROUTE,
-      contextSourcePath: "material/lesson/mathematics/vector/addition",
-      description: "Current subject description",
-      learningObjectId: subject.learningObjectId,
-      lensId: subject.lensId,
-      materialDomain: "mathematics",
       route: SUBJECT_ROUTE,
       score: 2,
-      sourcePath: SUBJECT_ROUTE,
       title: "Current Vector Addition",
-      updatedAt: NOW,
     });
   });
 
@@ -235,11 +178,15 @@ describe("contents/mutations/popularity", () => {
 
     await t.mutation(insertPopularityRefreshRows);
     const repair = await runRefresh(t);
-    const before = await readPopularitySnapshot(t);
+    const before = await t.query(
+      async (ctx) => await ctx.db.query("learningPopularityCounters").collect()
+    );
 
     vi.setSystemTime(new Date(NOW + POPULARITY_DAY_MS / 2));
     const replay = await runRefresh(t);
-    const after = await readPopularitySnapshot(t);
+    const after = await t.query(
+      async (ctx) => await ctx.db.query("learningPopularityCounters").collect()
+    );
 
     expect(repair.metrics.documentsWritten.used).toBeGreaterThan(0);
     expect(replay.result).toEqual({


### PR DESCRIPTION
## Summary

- skip Convex counter and aggregate writes when a finite popularity rebuild is unchanged
- keep expired-counter deletion and changed-counter repair behavior intact
- verify the scheduler excludes lifetime counters and bounds each continuation page

## Cost evidence

- the first refresh repairs current state
- an identical second refresh reports zero written documents and preserves stored counters
- each worker handles at most 10 counters and schedules one continuation when rows remain
- the scheduler creates exactly 14 finite-window jobs across the two supported scopes

## Verification

- backend suite: 362 files and 1,656 tests passed
- touched coverage: 100% statements, branches, functions, and lines
- backend typecheck passed
- repository lint and test-ownership checks passed
- formatting and diff checks passed
