### PR TITLE
Fix cold Turbopack production builds

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -217,6 +217,10 @@ const nextConfig = {
   headers: createAppHeaders,
   experimental: {
     ...config.experimental,
+    // Persistent caching also retains Turbopack's dependency graph. Cold Linux
+    // builds exceed the bounded host memory while emitting this app's assets.
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
+    turbopackFileSystemCacheForBuild: false,
     ...(configEnv.NEXT_EXPOSE_TESTING_API === "true"
       ? { exposeTestingApiInProductionBuild: true }
       : {}),


### PR DESCRIPTION
Cold Vercel builds stall during Turbopack compilation until the 45-minute build limit. Disable the web app's persistent build cache: in the installed Next.js implementation, this also removes dependency tracking when no deferred entries exist. The controlled Linux build repeatedly exhausted its 7 GiB limit with the cache enabled and completed with it disabled.

Validation: `pnpm format`, `pnpm lint`, the web and backend typechecks, and the full local production build with all 1,925 pages pass. Cold Linux AMD64 compilation passes with both two and four loader workers under a 7 GiB limit, with no OOM event. These Linux measurements used emulation on macOS; the protected Vercel production deployment remains the final hosted verification.

The setting follows [Next.js's build-cache configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache). No dependency or runtime behavior changes are included.
