### PR TITLE
Bound production static page generation

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -229,18 +229,16 @@ const nextConfig = {
       validationLevel: "warning",
     },
     // Anonymous Convex and Vercel builds run with bounded memory. Limit page
-    // analysis and generation to two isolated worker heaps instead of deriving
-    // the worker count from the build host.
+    // analysis and generation to two isolated workers, with one export per
+    // worker. Next otherwise batches eight exports into each worker heap.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(runtime.agent === "anonymous" || runtime.vercel === "1"
-      ? { cpus: 2 }
+      ? { cpus: 2, staticGenerationMaxConcurrency: 1 }
       : {}),
-    // The anonymous runner also shares one local backend. Let each worker
-    // process one page at a time and retry one complete page after an
-    // intermittent response. Repeated or deterministic failures still fail.
+    // The anonymous runner also shares one local backend. Retry one complete
+    // page after an intermittent response. Repeated failures still fail.
     ...(runtime.agent === "anonymous"
       ? {
-          staticGenerationMaxConcurrency: 1,
           staticGenerationRetryCount: 2,
         }
       : {}),


### PR DESCRIPTION
Production compilation now completes, but Next's partial page-shell exports time out while Vercel runs up to eight exports in each of two worker heaps. Limit each Vercel worker to one page export, matching the existing local and CI scheduling. Production prerender source maps remain enabled.

Next.js 16.3.4's installed export worker uses this option only to set the `Promise.all` batch width. Route selection and rendering behavior are unchanged. The [official static-generation reference](https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration) documents the same per-worker limit.

Validation:

- Repository formatting and lint passed.
- Full isolated production build passed all 1,925 pages, including both typecheck phases.
- A separate complete static-generation run with the Vercel configuration, source maps enabled, two workers, one export per worker, and the retained local content fixture passed all 1,925 pages in 3.8 minutes with no timeout. The resulting build manifest confirmed those effective settings.

Production verification remains required after the protected merge. The earlier Vercel run was canceled from the dashboard after partial-shell timeouts; its logs do not provide a heap profile.
