### PR TITLE
Reduce production static worker memory

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -228,12 +228,12 @@ const nextConfig = {
     instantInsights: {
       validationLevel: "warning",
     },
-    // Anonymous Convex and Vercel builds run with bounded memory. Limit page
-    // analysis and generation to two isolated workers, with one export per
-    // worker. Next otherwise batches eight exports into each worker heap.
+    // Anonymous Convex and Vercel builds share bounded host memory. One static
+    // worker avoids duplicating page modules and caches across worker heaps.
+    // Export pages sequentially within that worker.
     // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration
     ...(runtime.agent === "anonymous" || runtime.vercel === "1"
-      ? { cpus: 2, staticGenerationMaxConcurrency: 1 }
+      ? { cpus: 1, staticGenerationMaxConcurrency: 1 }
       : {}),
     // The anonymous runner also shares one local backend. Retry one complete
     // page after an intermittent response. Repeated failures still fail.


### PR DESCRIPTION
Vercel's 4-core, 8 GB production build completed compilation but exhausted memory after generating 1,443 of 1,925 pages with two static workers. Use one worker for bounded anonymous and Vercel builds so page modules and caches occupy one worker heap. Keep sequential page exports, the normal Next build, prerendering, typechecks, and finalization.

Validation: formatting, full lint, app typecheck, and a complete production-configured Next 16.3.4 build passed for all 1,925 pages. In the local full-build comparison, process-family peak after compilation fell from 7.63 GiB to 7.08 GiB; elapsed build time increased from 234.95 to 353.39 seconds. These macOS measurements include the isolated fixture backend and are not Vercel memory-limit proof. Compilation peaks varied and are not improved by this change. Exact-head CI and the protected production deployment remain required.

Source review confirmed that the worker count controls page analysis and generation, retains all routes and both PPR phases, and does not turn total build duration into a per-page timeout. Source-map disabling did not improve the local comparison, so it is unchanged. Reference: [Next static generation configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/staticGeneration).
