### PR TITLE
Clean backend Effect diagnostics and shallow checkout scope logs

### DIFF
--- a/packages/backend/client/content/transport.test.ts
+++ b/packages/backend/client/content/transport.test.ts
@@ -132,9 +132,11 @@ describe("content runtime transport", () => {
       );
       const cyclic: { self?: unknown } = {};
       cyclic.self = cyclic;
-      expect(
-        yield* encodeContentRequest(cyclic, 1024).pipe(Effect.flip)
-      ).toMatchObject({ reason: "request" });
+      for (const input of [cyclic, undefined]) {
+        expect(
+          yield* encodeContentRequest(input, 1024).pipe(Effect.flip)
+        ).toMatchObject({ reason: "request" });
+      }
       expect(
         yield* encodeContentRequest({ value: "x".repeat(1024) }, 10).pipe(
           Effect.flip
@@ -426,6 +428,7 @@ describe("content runtime transport", () => {
           "response-unmarked",
         ],
         [createResponse("{", 200), "json-syntax"],
+        [createResponse(new Uint8Array([0xc3, 0x28]), 200), "body"],
         [createResponse("x".repeat(20), 200), "response-size"],
       ];
       for (const [response, reason] of invalid) {
@@ -442,7 +445,9 @@ describe("content runtime transport", () => {
         [{ kind: "found" }, 200],
         [{ kind: "missing" }, 404],
         [{ code: "CONTENT_RUNTIME_UNAUTHORIZED", kind: "failure" }, 401],
+        [{ code: "CONTENT_RUNTIME_INVALID", kind: "failure" }, 400],
         [{ code: "CONTENT_RUNTIME_INVALID", kind: "failure" }, 413],
+        [{ code: "CONTENT_RUNTIME_INVALID", kind: "failure" }, 415],
         [{ code: "CONTENT_RUNTIME_INTERNAL", kind: "failure" }, 500],
         [{ code: "CONTENT_RUNTIME_RESPONSE_TOO_LARGE", kind: "failure" }, 500],
       ] as const) {
@@ -450,11 +455,19 @@ describe("content runtime transport", () => {
           yield* validateContentRuntimeStatus(response, status)
         ).toBeUndefined();
       }
-      expect(
-        yield* validateContentRuntimeStatus({ kind: "missing" }, 200).pipe(
-          Effect.flip
-        )
-      ).toMatchObject({ reason: "status" });
+      for (const [response, status] of [
+        [{ kind: "missing" }, 200],
+        [{ code: "CONTENT_RUNTIME_UNAUTHORIZED", kind: "failure" }, 403],
+        [{ code: "CONTENT_RUNTIME_INVALID", kind: "failure" }, 422],
+        [{ code: "CONTENT_RUNTIME_INTERNAL", kind: "failure" }, 503],
+        [{ code: "CONTENT_RUNTIME_RESPONSE_TOO_LARGE", kind: "failure" }, 413],
+      ] as const) {
+        expect(
+          yield* validateContentRuntimeStatus(response, status).pipe(
+            Effect.flip
+          )
+        ).toMatchObject({ reason: "status" });
+      }
     })
   );
 });

--- a/packages/backend/client/content/transport.ts
+++ b/packages/backend/client/content/transport.ts
@@ -83,10 +83,7 @@ function isRetryableContentResponse(response: Response, endpoint: string) {
  * @see https://github.com/nodejs/undici/blob/v7.29.0/README.md#garbage-collection
  */
 const cancelRetryResponse = Effect.fn("NakafaContent.cancelRetryResponse")(
-  function* (failure: ContentRequestFailure) {
-    if (failure._tag !== "RetryableContentResponse") {
-      return;
-    }
+  function* (failure: RetryableContentResponse) {
     const body = failure.response.body;
     if (body === null) {
       return;
@@ -269,12 +266,10 @@ export const requestContentResponse = Effect.fn(
           signal: AbortSignal.timeout(CONTENT_TIMEOUT_MILLISECONDS),
         }),
     }).pipe(
-      Effect.flatMap((response) => {
-        if (!isRetryableContentResponse(response, input.endpoint)) {
-          return Effect.succeed(response);
-        }
-        return Effect.fail(new RetryableContentResponse({ response }));
-      })
+      Effect.filterOrFail(
+        (response) => !isRetryableContentResponse(response, input.endpoint),
+        (response) => new RetryableContentResponse({ response })
+      )
     );
     const value = yield* read(response, input.endpoint).pipe(
       Effect.mapError(classifyContentBodyFailure)

--- a/packages/backend/client/nakafa/markdown.test.ts
+++ b/packages/backend/client/nakafa/markdown.test.ts
@@ -56,11 +56,9 @@ describe("readNakafaMarkdown", () => {
     (ref) =>
       Effect.gen(function* () {
         runtimeMocks.resolveNakafaContentRef.mockReturnValue(
-          Effect.succeed(Option.some(ref))
+          Effect.succeedSome(ref)
         );
-        runtimeMocks.readPublishedMarkdown.mockReturnValue(
-          Effect.succeed(Option.none())
-        );
+        runtimeMocks.readPublishedMarkdown.mockReturnValue(Effect.succeedNone);
 
         yield* readNakafaMarkdown(
           "https://example.convex.cloud",
@@ -78,11 +76,9 @@ describe("readNakafaMarkdown", () => {
   it.effect("dispatches Quran through its signed snapshot reader", () =>
     Effect.gen(function* () {
       runtimeMocks.resolveNakafaContentRef.mockReturnValue(
-        Effect.succeed(Option.some(quranRef))
+        Effect.succeedSome(quranRef)
       );
-      runtimeMocks.readQuranMarkdown.mockReturnValue(
-        Effect.succeed(Option.none())
-      );
+      runtimeMocks.readQuranMarkdown.mockReturnValue(Effect.succeedNone);
 
       yield* readNakafaMarkdown(
         "https://example.convex.cloud",

--- a/packages/backend/content/publication/snapshot.ts
+++ b/packages/backend/content/publication/snapshot.ts
@@ -106,7 +106,7 @@ export const snapshotPublicationLayer = (tables: PublicationSnapshot) =>
         }
       );
       return PublicationSource.of({
-        state: Effect.succeed(Option.some(state)),
+        state: Effect.succeedSome(state),
         release: Effect.fn("publication.snapshot.release")(
           function* (releaseId) {
             const release = releases.get(releaseId);

--- a/packages/backend/convex/auth/deletion.test.ts
+++ b/packages/backend/convex/auth/deletion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { api, internal } from "@repo/backend/convex/_generated/api";
 import {
+  ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE,
   ACCOUNT_DELETION_CANCELLATION_UNPROVEN_CODE,
   ACCOUNT_DELETION_TRANSACTION_BATCH_SIZE,
 } from "@repo/backend/convex/auth/deletion/constants";
@@ -88,7 +89,7 @@ describe("auth/deletion", () => {
     ).resolves.toBe(accountDeletionAttemptStatus.unknown);
   });
 
-  it("lets an opaque browser attempt cancel while its auth user exists", async () => {
+  it("cancels a live browser attempt and ignores its obsolete commit", async () => {
     const t = createConvexTestWithBetterAuth();
     const identity = await t.mutation((ctx) =>
       seedAuthenticatedUser(ctx, {
@@ -96,11 +97,11 @@ describe("auth/deletion", () => {
         suffix: "cancel-current-deletion",
       })
     );
-    await t.mutation(async (ctx) => {
+    const preparationId = await t.mutation(async (ctx) => {
       await ctx.db.patch("users", identity.userId, {
         deletionPreparedAt: NOW,
       });
-      await ctx.db.insert("accountDeletionPreparations", {
+      return await ctx.db.insert("accountDeletionPreparations", {
         attemptId: ATTEMPT_ID,
         authId: identity.authUserId,
         recoveryGeneration: 0,
@@ -113,6 +114,16 @@ describe("auth/deletion", () => {
         attemptId: ATTEMPT_ID,
       })
     ).resolves.toBe(accountDeletionCancellationOutcome.complete);
+    await expect(
+      t.mutation(internal.auth.deletion.continueAccountDeletionCommit, {
+        authId: identity.authUserId,
+        expectedPreparation: {
+          attemptId: ATTEMPT_ID,
+          preparationId,
+          recoveryGeneration: 0,
+        },
+      })
+    ).resolves.toBe(false);
 
     const state = await t.query(async (ctx) => ({
       cancellation: await ctx.db
@@ -265,4 +276,67 @@ describe("auth/deletion", () => {
       }),
     ]);
   });
+
+  it.each(["cancellations", "receipts"])(
+    "continues expired %s cleanup until both retention tables are drained",
+    async (kind) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      const t = createConvexTestWithBetterAuth();
+      await t.mutation(async (ctx) => {
+        for (
+          let index = 0;
+          index <= ACCOUNT_DELETION_ATTEMPT_SWEEP_BATCH_SIZE;
+          index += 1
+        ) {
+          const attemptId = `expired-${index}`;
+          if (kind === "cancellations") {
+            await ctx.db.insert("accountDeletionAttemptCancellations", {
+              attemptId,
+              canceledAt: 0,
+            });
+          } else {
+            await ctx.db.insert("accountDeletionReceipts", {
+              attemptId,
+              committedAt: 0,
+            });
+          }
+        }
+        await ctx.db.insert("accountDeletionAttemptCancellations", {
+          attemptId: "retained-cancellation",
+          canceledAt: NOW,
+        });
+        await ctx.db.insert("accountDeletionReceipts", {
+          attemptId: "retained-receipt",
+          committedAt: NOW,
+        });
+      });
+
+      await expect(
+        t.mutation(internal.auth.deletion.sweepAccountDeletionRetention, {})
+      ).resolves.toBeNull();
+      const pending = await t.query((ctx) =>
+        ctx.db.system.query("_scheduled_functions").take(2)
+      );
+      expect(pending).toMatchObject([
+        {
+          args: [{}],
+          name: "auth/deletion:sweepAccountDeletionRetention",
+          state: { kind: "pending" },
+        },
+      ]);
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const remaining = await t.query(async (ctx) => ({
+        cancellations: await ctx.db
+          .query("accountDeletionAttemptCancellations")
+          .take(2),
+        receipts: await ctx.db.query("accountDeletionReceipts").take(2),
+      }));
+      expect(remaining).toMatchObject({
+        cancellations: [{ attemptId: "retained-cancellation" }],
+        receipts: [{ attemptId: "retained-receipt" }],
+      });
+    }
+  );
 });

--- a/packages/backend/convex/auth/deletion.ts
+++ b/packages/backend/convex/auth/deletion.ts
@@ -105,15 +105,13 @@ export const cancelAccountDeletionAttempt = mutation({
         async (authId) =>
           (await authReader.getAnyUserById(ctx, authId)) !== null
       ).pipe(
-        Effect.flatMap((outcome) =>
-          outcome === null
-            ? Effect.fail(
-                new AccountDeletionCancellationUnprovenError({
-                  code: ACCOUNT_DELETION_CANCELLATION_UNPROVEN_CODE,
-                  message: "Account deletion cancellation could not be proven.",
-                })
-              )
-            : Effect.succeed(outcome)
+        Effect.filterOrFail(
+          (outcome) => outcome !== null,
+          () =>
+            new AccountDeletionCancellationUnprovenError({
+              code: ACCOUNT_DELETION_CANCELLATION_UNPROVEN_CODE,
+              message: "Account deletion cancellation could not be proven.",
+            })
         )
       )
     ),

--- a/packages/backend/convex/contentRelease/search/verify.test.ts
+++ b/packages/backend/convex/contentRelease/search/verify.test.ts
@@ -5,6 +5,12 @@ import { resolveSearchProjection } from "@repo/backend/convex/contentRelease/sea
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
 import {
+  insertTestPage,
+  TEST_PAGE_KEY,
+  TEST_PAGE_PATH,
+} from "@repo/backend/test/content/page";
+import { testTextHash } from "@repo/backend/test/content/release";
+import {
   insertRuntimeArticles,
   testArticleProjection,
 } from "@repo/backend/test/content/runtime";
@@ -28,19 +34,29 @@ describe("search result publication integrity", () => {
         searchSequence: TEST_RUNTIME_RELEASE.sequence,
       });
     });
-    const read = () =>
+    const owner = await t.query((ctx) =>
+      runConvexProgram(loadSearchOwner(ctx))
+    );
+    if (!owner) {
+      return expect.fail("Expected one active search owner.");
+    }
+    const read = (selectedOwner = owner) =>
       t.query(async (ctx) => {
-        const owner = await runConvexProgram(loadSearchOwner(ctx));
         const row = await ctx.db.query("contentIndex").unique();
-        if (!(owner && row)) {
+        if (!row) {
           return expect.fail("Expected one active search hit.");
         }
-        return runConvexProgram(resolveSearchProjection(ctx, row, owner));
+        return runConvexProgram(
+          resolveSearchProjection(ctx, row, selectedOwner)
+        );
       });
     expect(await read()).toMatchObject({
       contentKey: projection.contentKey,
       publicPath: projection.publicPath,
       projection,
+    });
+    await expect(read({ ...owner, families: [] })).rejects.toMatchObject({
+      data: { code: "CONTENT_RELEASE_INTEGRITY" },
     });
     const original = await t.query((ctx) =>
       ctx.db.query("contentIndex").unique()
@@ -48,26 +64,59 @@ describe("search result publication integrity", () => {
     if (!original) {
       return expect.fail("Expected one active search hit.");
     }
+    const identity = {
+      appLocale: original.appLocale,
+      contentKey: original.contentKey,
+      family: original.family,
+      projectionHash: original.projectionHash,
+      publicPath: original.publicPath,
+      releaseId: original.releaseId,
+      sequence: original.sequence,
+      slot: original.slot,
+    };
     const patches: readonly Partial<Doc<"contentIndex">>[] = [
       { slot: "green" },
       { family: "material" },
+      { appLocale: "id" },
       { projectionHash: `sha256:${"f".repeat(64)}` },
+      { publicPath: "articles/politics/other-route" },
+      { releaseId: "different-release" },
+      { sequence: original.sequence + 1 },
     ];
     for (const patch of patches) {
       await t.mutation((ctx) =>
         ctx.db.patch(original._id, {
-          family: original.family,
-          projectionHash: original.projectionHash,
-          slot: original.slot,
+          ...identity,
           ...patch,
         })
       );
       await expect(read()).rejects.toMatchObject({
         data: {
           code: "CONTENT_RELEASE_INTEGRITY",
-          message: `Active search entry ${projection.contentKey}/en is stale.`,
+          message: `Active search entry ${projection.contentKey}/${patch.appLocale ?? original.appLocale} is stale.`,
         },
       });
     }
+
+    await t.mutation(async (ctx) => {
+      const page = await insertTestPage(
+        ctx,
+        "en",
+        "terms-of-service",
+        TEST_PAGE_PATH
+      );
+      await ctx.db.patch(original._id, {
+        ...identity,
+        contentKey: TEST_PAGE_KEY,
+        projectionHash: testTextHash(page),
+        publicPath: TEST_PAGE_PATH,
+      });
+    });
+    await expect(read()).rejects.toMatchObject({
+      data: {
+        code: "CONTENT_RELEASE_INTEGRITY",
+        message: `Active search entry ${TEST_PAGE_KEY}/en is stale.`,
+      },
+    });
   });
 });

--- a/packages/backend/convex/contentRelease/search/verify.ts
+++ b/packages/backend/convex/contentRelease/search/verify.ts
@@ -21,9 +21,14 @@ export const resolveSearchProjection = Effect.fn(
     row.appLocale,
     owner.sequence
   ).pipe(Effect.provide(convexPublicationLayer(ctx)));
+  if (!resolved) {
+    return yield* staleSearchRow(row);
+  }
+  const projection = resolved.projection;
+  if (projection.kind !== "article" && projection.kind !== "subject-lesson") {
+    return yield* staleSearchRow(row);
+  }
   if (
-    !resolved ||
-    resolved.appLocale !== row.appLocale ||
     resolved.family !== row.family ||
     resolved.projectionHash !== row.projectionHash ||
     resolved.publicPath !== row.publicPath ||
@@ -32,7 +37,7 @@ export const resolveSearchProjection = Effect.fn(
   ) {
     return yield* staleSearchRow(row);
   }
-  return resolved;
+  return { ...resolved, projection };
 });
 /** Creates one typed integrity failure for a stale release-owned search row. */
 function staleSearchRow(

--- a/packages/backend/convex/contents/helpers/search/published.test.ts
+++ b/packages/backend/convex/contents/helpers/search/published.test.ts
@@ -66,11 +66,9 @@ describe("readPublishedSearchDocuments", () => {
   it("keeps smaller pages stable across empty and overlapping queries", async () => {
     const t = createConvexTestWithBetterAuth();
     const queries = ["missing", "alpha", "beta", "gamma"];
-    const texts = [
-      "alpha beta bounded search",
-      "beta bounded search",
-      "gamma bounded search",
-    ];
+    const texts = Array.from({ length: 20 }, (_, index) =>
+      index < 10 ? "alpha beta bounded search" : "gamma bounded search"
+    );
 
     await t.mutation(async (ctx) => {
       await insertRuntimeArticles(ctx, texts.length);

--- a/packages/backend/convex/contents/helpers/search/published.ts
+++ b/packages/backend/convex/contents/helpers/search/published.ts
@@ -1,8 +1,6 @@
 import type { Doc } from "@repo/backend/convex/_generated/dataModel";
 import type { QueryCtx } from "@repo/backend/convex/_generated/server";
-import { releaseFail } from "@repo/backend/convex/contentRelease/error";
 import type { ModelSlot } from "@repo/backend/convex/contentRelease/models/slot";
-import { decodeProjectionJson } from "@repo/backend/convex/contentRelease/parse";
 import type { loadSearchOwner } from "@repo/backend/convex/contentRelease/search/owner";
 import { resolveSearchProjection } from "@repo/backend/convex/contentRelease/search/verify";
 import { buildContentSearchDocument } from "@repo/backend/convex/contents/helpers/search/documents";
@@ -57,16 +55,16 @@ export const readPublishedSearchDocuments = Effect.fn(
   families: readonly PublishedFamily[]
 ) {
   if (queryTexts.length === 0) {
-    const groups = yield* Effect.all(
-      families.map((family) =>
+    const groups = yield* Effect.forEach(
+      families,
+      (family) =>
         browseFamily(
           ctx,
           owner.slot,
           args.locale,
           family,
           NAKAFA_AGENT_SEARCH_WINDOW
-        )
-      ),
+        ),
       { concurrency: "unbounded" }
     );
     const rows = interleaveSearchGroups(
@@ -74,16 +72,12 @@ export const readPublishedSearchDocuments = Effect.fn(
       NAKAFA_AGENT_SEARCH_WINDOW,
       (row) => row._id
     );
-    const authenticated = yield* authenticateSearchRows(
-      ctx,
-      rows,
-      owner,
-      args.locale
-    );
+    const authenticated = yield* authenticateSearchRows(ctx, rows, owner);
     return authenticated.map(({ document }) => document).slice(0, scanLimit);
   }
-  const groups = yield* Effect.all(
-    queryTexts.map((queryText) =>
+  const groups = yield* Effect.forEach(
+    queryTexts,
+    (queryText) =>
       searchQuery(
         ctx,
         owner.slot,
@@ -91,8 +85,7 @@ export const readPublishedSearchDocuments = Effect.fn(
         families,
         queryText,
         NAKAFA_AGENT_SEARCH_WINDOW
-      ).pipe(Effect.map((rows) => ({ queryText, rows })))
-    ),
+      ).pipe(Effect.map((rows) => ({ queryText, rows }))),
     { concurrency: "unbounded" }
   );
   const rows = interleaveSearchGroups(
@@ -100,12 +93,7 @@ export const readPublishedSearchDocuments = Effect.fn(
     NAKAFA_AGENT_SEARCH_WINDOW,
     (row) => row._id
   );
-  const authenticated = yield* authenticateSearchRows(
-    ctx,
-    rows,
-    owner,
-    args.locale
-  );
+  const authenticated = yield* authenticateSearchRows(ctx, rows, owner);
   const documentsByRow = new Map(
     authenticated.map(({ document, row }) => [row._id, document])
   );
@@ -136,10 +124,10 @@ const searchQuery = Effect.fn("contents.search.searchPublishedQuery")(
     scanLimit: number
   ) {
     const route = getExactRouteQuery(locale, queryText);
-    const groups = yield* Effect.all(
-      families.map((family) =>
-        searchFamily(ctx, slot, locale, family, route, queryText, scanLimit)
-      ),
+    const groups = yield* Effect.forEach(
+      families,
+      (family) =>
+        searchFamily(ctx, slot, locale, family, route, queryText, scanLimit),
       { concurrency: "unbounded" }
     );
     return interleaveSearchGroups(groups, scanLimit, (row) => row._id);
@@ -156,9 +144,6 @@ const searchFamily = Effect.fn("contents.search.searchPublishedFamily")(
     queryText: string,
     scanLimit: number
   ) {
-    if (scanLimit <= 0) {
-      return [];
-    }
     const exact = route
       ? yield* Effect.promise(() =>
           ctx.db
@@ -204,9 +189,6 @@ const browseFamily = Effect.fn("contents.search.browsePublishedFamily")(
     family: PublishedFamily,
     scanLimit: number
   ) {
-    if (scanLimit <= 0) {
-      return [];
-    }
     const rows = yield* Effect.promise(() =>
       ctx.db
         .query("contentIndex")
@@ -222,17 +204,16 @@ const browseFamily = Effect.fn("contents.search.browsePublishedFamily")(
 function authenticateSearchRows(
   ctx: QueryCtx,
   rows: readonly Doc<"contentIndex">[],
-  owner: PublishedSearchOwner,
-  locale: ContentSearchInput["locale"]
+  owner: PublishedSearchOwner
 ) {
   return Effect.forEach(
     rows,
     (row) =>
-      authenticateSearchRow(ctx, row, owner, locale).pipe(
-        Effect.map((document) => (document ? { document, row } : null))
+      authenticateSearchRow(ctx, row, owner).pipe(
+        Effect.map((document) => ({ document, row }))
       ),
     { concurrency: "unbounded" }
-  ).pipe(Effect.map((results) => results.filter((result) => result !== null)));
+  );
 }
 /** Verifies one search hit against its active immutable projection. */
 const authenticateSearchRow = Effect.fn(
@@ -240,33 +221,17 @@ const authenticateSearchRow = Effect.fn(
 )(function* (
   ctx: QueryCtx,
   row: Doc<"contentIndex">,
-  owner: PublishedSearchOwner,
-  locale: ContentSearchInput["locale"]
+  owner: PublishedSearchOwner
 ) {
-  if (row.appLocale !== locale) {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `Active search entry ${row.contentKey}/${row.appLocale} escaped the requested locale.`
-    );
-  }
   const resolved = yield* resolveSearchProjection(ctx, row, owner);
-  if (!resolved) {
-    return null;
-  }
-  const projection = yield* decodeProjectionJson(resolved.projectionJson);
-  if (projection.kind !== "article" && projection.kind !== "subject-lesson") {
-    return yield* releaseFail(
-      "CONTENT_RELEASE_INTEGRITY",
-      `Active search entry ${row.contentKey}/${row.appLocale} exposes a non-search projection.`
-    );
-  }
+  const projection = resolved.projection;
   const section = projection.kind === "article" ? "articles" : "material";
   return buildContentSearchDocument({
     ...projection.graph,
     contentHash: row.projectionHash,
     description: projection.metadata.description,
     hasMarkdownSource: true,
-    locale,
+    locale: projection.appLocale,
     route: projection.publicPath,
     section,
     sourcePath: resolved.sourcePath,

--- a/packages/backend/convex/routes/agent/mcp/input.test.ts
+++ b/packages/backend/convex/routes/agent/mcp/input.test.ts
@@ -83,8 +83,8 @@ describe("MCP request input", () => {
             contentType
           )
       );
-      const results = yield* Effect.all(
-        requests.map((request) => readMcpRequest(request).pipe(Effect.result))
+      const results = yield* Effect.forEach(requests, (request) =>
+        readMcpRequest(request).pipe(Effect.result)
       );
 
       for (const result of results) {
@@ -164,10 +164,9 @@ describe("MCP request input", () => {
           },
           method: "POST",
         });
-        const results = yield* Effect.all(
-          [invalidLength, failed, malformedUtf8, absent].map((request) =>
-            readMcpRequest(request).pipe(Effect.result)
-          )
+        const results = yield* Effect.forEach(
+          [invalidLength, failed, malformedUtf8, absent],
+          (request) => readMcpRequest(request).pipe(Effect.result)
         );
 
         for (const result of results) {

--- a/packages/backend/convex/routes/agent/security.test.ts
+++ b/packages/backend/convex/routes/agent/security.test.ts
@@ -8,6 +8,7 @@ import { Effect, Result } from "effect";
 const SECRET_NAME = NAKAFA_API_EDGE_CONTRACT.secretEnvironment;
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 
@@ -55,6 +56,26 @@ describe("agent edge security", () => {
           NAKAFA_API_EDGE_CONTRACT
         )
       ).toBe(false);
+    })
+  );
+
+  it.effect("fails closed when digest computation is unavailable", () =>
+    Effect.gen(function* () {
+      vi.stubEnv(SECRET_NAME, "current-secret");
+      vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
+        new Error("digest unavailable")
+      );
+
+      expect(
+        yield* hasValidEdgeSecret(
+          requestWithSecret("current-secret"),
+          NAKAFA_API_EDGE_CONTRACT
+        ).pipe(Effect.flip)
+      ).toMatchObject({
+        _tag: "NakafaAgentDataReadError",
+        cause: "digest unavailable",
+        message: "The public agent edge boundary is unavailable.",
+      });
     })
   );
 

--- a/packages/backend/convex/routes/agent/security.ts
+++ b/packages/backend/convex/routes/agent/security.ts
@@ -33,8 +33,8 @@ export const hasValidEdgeSecret = Effect.fn("agent.hasValidEdgeSecret")(
       return false;
     }
 
-    const comparisons = yield* Effect.all(
-      acceptedSecrets.map((expected) => constantTimeEqual(expected, supplied))
+    const comparisons = yield* Effect.forEach(acceptedSecrets, (expected) =>
+      constantTimeEqual(expected, supplied)
     );
     return comparisons.some(Boolean);
   }
@@ -57,11 +57,11 @@ const constantTimeEqual = Effect.fn("agent.constantTimeEqual")(function* (
         crypto.subtle.digest("SHA-256", new TextEncoder().encode(supplied)),
       ]),
   });
-  const left = new Uint8Array(expectedDigest);
-  const right = new Uint8Array(suppliedDigest);
+  const left = new DataView(expectedDigest);
+  const right = new DataView(suppliedDigest);
   let difference = 0;
-  for (let index = 0; index < left.length; index += 1) {
-    difference += Math.abs((left[index] ?? 0) - (right[index] ?? 0));
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference += Math.abs(left.getUint8(index) - right.getUint8(index));
   }
   return difference === 0;
 });

--- a/scripts/vercel/scope.sh
+++ b/scripts/vercel/scope.sh
@@ -20,6 +20,11 @@ fi
 
 repository_root=$(git rev-parse --show-toplevel) || exit 1
 
+# Vercel's shallow checkout may omit the previous deployment's commit.
+# Build whenever a shared history cannot be proven.
+git -C "$repository_root" merge-base "$base_revision" "$head_revision" \
+  >/dev/null 2>&1 || exit 1
+
 git -C "$repository_root" diff --quiet "$base_revision...$head_revision" --
 change_status=$?
 case "$change_status" in

--- a/scripts/vercel/scope.test.ts
+++ b/scripts/vercel/scope.test.ts
@@ -157,7 +157,6 @@ const runScope = Effect.fn("VercelScopeTest.runScope")(function* (
         VERCEL_GIT_COMMIT_SHA: options.head,
         VERCEL_GIT_PREVIOUS_SHA: options.base,
       },
-      stderr: "ignore",
       stdout: "ignore",
     }
   ).pipe(
@@ -165,14 +164,33 @@ const runScope = Effect.fn("VercelScopeTest.runScope")(function* (
       () => new ScopeFixtureError({ message: "Unable to start scope script." })
     )
   );
-  return yield* command.exitCode.pipe(
+  const [exitCode, stderr] = yield* Effect.all(
+    [command.exitCode, Stream.mkString(Stream.decodeText(command.stderr))],
+    { concurrency: 2 }
+  ).pipe(
     Effect.mapError(
       () => new ScopeFixtureError({ message: "Unable to finish scope script." })
     )
   );
+  expect(stderr).toBe("");
+  return exitCode;
 });
 
 describe("Vercel production scope", () => {
+  it.effect("builds quietly when the previous Git commit is unavailable", () =>
+    Effect.gen(function* () {
+      const repository = yield* makeRepository();
+      const head = yield* readRevision(repository);
+      expect(
+        yield* runScope(repository, {
+          base: "0".repeat(40),
+          head,
+          turboExit: 0,
+        })
+      ).toBe(1);
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+
   it.effect("skips only verified non-production or test-only work", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;


### PR DESCRIPTION
## Description

Native backend typechecking emitted 13 Effect suggestions. Use `filterOrFail`, `succeedSome`/`succeedNone`, and `forEach` while preserving typed failures, result order, and each traversal's concurrency. Authenticate search projection kinds at the shared verification boundary and reuse the validated projection. Remove unreachable retry and search branches, and compare the complete SHA-256 digest without impossible byte fallbacks.

Vercel shallow checkouts can omit the previous deployment's commit. Check for shared Git history before comparing revisions so the scope hook conservatively starts a build without emitting a fatal Git diagnostic.

## Type

- Bug fix
- Refactoring

## Testing

- `pnpm --filter @repo/backend typecheck`: passes with zero Effect suggestions.
- `pnpm --filter @repo/backend test --maxWorkers=1`: 424 files and 2,163 tests pass; every changed backend source file reaches 100% statements, branches, functions, and lines.
- `pnpm test:scripts`: native script typecheck and all 54 tests pass.
- `pnpm format`, `pnpm lint`, and `git diff --check`: pass.
- Effect source parity matches `effect@4.0.0-rc.112`.

Regression coverage exercises transport body/status failures, cancellation and scheduled retention cleanup, stale or invalid search projection identities, stable bounded search pages, digest failures, and unavailable Git revisions.

## Related Issues

None.

## Additional Context

The backend suite uses one worker for local resource contention while retaining the existing timeout and coverage configuration. Dependencies and public Convex signatures are unchanged.
