### PR TITLE
Deploy Convex functions before web prerendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,15 @@ repeat preparation. Update the pinned Aksara revision deliberately when the
 acceptance contract needs new reviewed examples.
 
 CI runs the same isolated acceptance commands with `PORTLESS=0`. Protected
-Vercel builds run only after a protected main merge through `convex deploy
---cmd`. They query bounded real published samples from the production backend
-and verify the signed content with the current renderer. App builds do not
-export or import production tables or release history. Full corpus validation
-remains in Aksara's publication and renderer compatibility checks.
+Vercel builds run only after a protected main merge. The web build command
+deploys Convex functions before building Next.js because prerendering queries
+those functions. Vercel supplies `NEXT_PUBLIC_CONVEX_URL`, which the runtime
+guard verifies against the protected production deployment. Convex's `--cmd`
+runs before the backend deployment and cannot be used for this ordering.
+Builds query bounded real published samples and verify the signed content with
+the current renderer. App builds do not export or import production tables or
+release history. Full corpus validation remains in Aksara's publication and
+renderer compatibility checks.
 
 ## Repository layout
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "pnpm verify:featured-renderer && next build",
-    "build:vercel": "pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck enable --cmd 'pnpm --dir ../.. run build --filter=www' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
+    "build:vercel": "pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck enable && pnpm --dir ../.. run build --filter=www",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "portless run --name nakafa next dev",
     "doctor": "pnpm dlx react-doctor@0.9.13",


### PR DESCRIPTION
## Description

The production build for #593 failed when prerendering called the new article delivery query before Convex had deployed it. Convex runs `--cmd` before pushing functions, so the failed build also prevented the backend deployment.

Deploy Convex first, then build the web app only when that succeeds. Keep Vercel's configured production URL and the existing runtime guard. Update the deployment documentation to explain the required order.

## Type

- Bug fix
- Documentation

## Testing

- `pnpm format`, `pnpm lint`, and `git diff --check` passed.
- Executed the actual package command against a temporary command boundary: success runs deployment before build; deployment failure exits with the same code and never starts the build.
- Verified Vercel's configured query and HTTP URLs match the protected production backend.
- Confirmed the missing production query with a read-only invocation and matched it to the Vercel prerender failure. Exact-head CI and the next protected Git deployment will provide the remaining build and hosted validation.

## Related Issues

Follow-up to #593.

## Additional Context

[Convex documents the CLI ordering](https://docs.convex.dev/cli/reference/deploy). The backend changes in #593 preserve existing public client functions, and the release preflight requires idle publication/model builders. [Failed production build](https://vercel.com/nakafa/www/A1Cc1yR9r4C2JySBrC57X6m1CLfg).