### PR TITLE
Disable persistent cache for cold web builds

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -197,9 +197,6 @@ const nextConfig = {
   // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/output
   // `process.cwd()` resolves to the app directory (`apps/www`) during Next.js
   // config loading, so walking up two levels targets the monorepo root.
-  outputFileTracingExcludes: {
-    "/*": ["../../.cache/runtime/**"],
-  },
   outputFileTracingRoot: path.join(process.cwd(), "../.."),
   serverExternalPackages: [
     ...(config.serverExternalPackages ?? []),
@@ -210,6 +207,10 @@ const nextConfig = {
   headers: createAppHeaders,
   experimental: {
     ...config.experimental,
+    // Cold builds must fit the 8 GB production builder without retaining the
+    // persistent compiler graph for disk-cache serialization.
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
+    turbopackFileSystemCacheForBuild: false,
     ...(configEnv.NEXT_EXPOSE_TESTING_API === "true"
       ? { exposeTestingApiInProductionBuild: true }
       : {}),


### PR DESCRIPTION
Cold web builds are under memory pressure on the four CPU, 8 GB production builder. The deployment for `49a75e5` compiled in 5.3 minutes, then made no visible TypeScript progress for 16 minutes before cancellation.

Disable Turbopack's persistent build cache using the [documented Next.js option](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache). Next 16.3 enables this cache by default, and the installed build pipeline starts TypeScript before awaiting compiler shutdown and cache serialization. Full typechecking stays enabled. The production machine size, static generation settings, and application caches keep their existing configuration.

Remove the tracing exclusion for `.cache/runtime`, whose snapshot source and readers were retired in #593.

Validation:
- `pnpm format`, `pnpm lint`, and `pnpm --filter www typecheck` passed.
- A fresh signed local acceptance build passed: compilation 44 seconds, TypeScript 9.7 seconds, and all 233 pages generated in 5.1 seconds. The complete build lifecycle took 83.4 seconds; its temporary database was cleaned up.
- An 8 GB Linux test with a co-located native database and watcher saturated memory, so it cannot isolate the production web budget. A web-only four CPU, 8 GB build with a separate isolated signed database is a required pre-merge check.
- Exact-head CI, review, protected merge, and the resulting production deployment and live acceptance remain release gates.