### PR TITLE
Keep reading content in the initial HTML

### DIFF
--- a/apps/www/e2e/content.browser.ts
+++ b/apps/www/e2e/content.browser.ts
@@ -8,6 +8,9 @@ import {
 
 const APP_ORIGIN = "https://nakafa.com";
 const CLASS_SEPARATOR_PATTERN = /\s+/;
+const DOCUMENT_TITLE_PATTERN = /<h1[\s>]/;
+const DOCUMENT_SECTION_PATTERN = /<h2[\s>]/;
+const STORED_DEVICE_PATTERN = /^".+"$/;
 type DateLabels = Readonly<{ published: string; updated: string }>;
 type JsonLdType = "Article" | "LearningResource";
 const dateLabels = {
@@ -238,7 +241,15 @@ const verifyContentRoute = Effect.fn("NakafaE2E.verifyContentRoute")(function* (
   const response = yield* Effect.promise(() =>
     page.goto(route.href, { waitUntil: "domcontentloaded" })
   );
-  yield* Effect.sync(() => expect(response?.status()).toBe(200));
+  if (!response) {
+    return yield* contentDateError(route.href, "document response");
+  }
+  const html = yield* Effect.promise(() => response.text());
+  yield* Effect.sync(() => {
+    expect(response.status()).toBe(200);
+    expect(html).toMatch(DOCUMENT_TITLE_PATTERN);
+    expect(html).toMatch(DOCUMENT_SECTION_PATTERN);
+  });
   yield* expectCanonicalAlternates(page, route, group.routes);
   yield* expectTruthfulDates(page, route, group.jsonLdTypes);
 
@@ -277,11 +288,26 @@ for (const group of contentRouteGroups) {
             const page = yield* Effect.promise(() => context.newPage());
             yield* withObservedPageErrors(
               page,
-              Effect.forEach(
-                group.routes,
-                (route) => verifyContentRoute(page, route, group),
-                { concurrency: 1, discard: true }
-              )
+              Effect.gen(function* () {
+                let firstDeviceId: string | null = null;
+                for (const route of group.routes) {
+                  yield* verifyContentRoute(page, route, group);
+                  const readDeviceId = () =>
+                    page.evaluate(() =>
+                      localStorage.getItem("nakafa-device-id")
+                    );
+                  yield* Effect.promise(() =>
+                    expect.poll(readDeviceId).toMatch(STORED_DEVICE_PATTERN)
+                  );
+                  const deviceId = yield* Effect.promise(readDeviceId);
+                  if (firstDeviceId !== null) {
+                    yield* Effect.sync(() =>
+                      expect(deviceId).toBe(firstDeviceId)
+                    );
+                  }
+                  firstDeviceId = deviceId;
+                }
+              })
             );
           })
       )

--- a/apps/www/lib/content/views/record.ts
+++ b/apps/www/lib/content/views/record.ts
@@ -1,6 +1,10 @@
 "use client";
 
-import { useDocumentVisibility, useLocalStorage } from "@mantine/hooks";
+import {
+  readLocalStorageValue,
+  useDocumentVisibility,
+  useLocalStorage,
+} from "@mantine/hooks";
 import { captureException } from "@repo/analytics/posthog/browser";
 import { api } from "@repo/backend/convex/_generated/api";
 import type { LearningContextInput } from "@repo/backend/convex/contents/context";
@@ -9,10 +13,12 @@ import type { Locale } from "@repo/backend/convex/lib/validators/contents";
 import { useConvexAuth, useMutation } from "convex/react";
 import { Effect } from "effect";
 import { nanoid } from "nanoid";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { createContentViewKey } from "@/lib/content/views/key";
 import { useContentViews } from "@/lib/context/use-content-views";
 import { useUser } from "@/lib/context/use-user";
+
+const DEVICE_STORAGE_KEY = "nakafa-device-id";
 
 /** Client-side graph content-view recording configuration. */
 interface UseRecordContentViewOptions {
@@ -62,10 +68,9 @@ export function useRecordContentView({
     context,
     signedInUserId,
   });
-  const [defaultDeviceId] = useState(() => `${Date.now()}-${nanoid(9)}`);
-  const [deviceId] = useLocalStorage({
-    key: "nakafa-device-id",
-    defaultValue: defaultDeviceId,
+  const [deviceId, setDeviceId] = useLocalStorage({
+    key: DEVICE_STORAGE_KEY,
+    defaultValue: "",
   });
 
   useEffect(() => {
@@ -86,6 +91,15 @@ export function useRecordContentView({
     }
 
     if (!isVisible) {
+      return;
+    }
+
+    // Browser identity must not make the surrounding reading page dynamic.
+    if (!deviceId) {
+      setDeviceId(
+        readLocalStorageValue<string>({ key: DEVICE_STORAGE_KEY }) ||
+          `${Date.now()}-${nanoid(9)}`
+      );
       return;
     }
 
@@ -134,6 +148,7 @@ export function useRecordContentView({
     publicPath,
     recordView,
     section,
+    setDeviceId,
     signedInUserId,
     viewKey,
   ]);


### PR DESCRIPTION
Article titles and lesson sections were missing from the initial HTML because the content-view hook generated a timestamped random device ID during prerendering. Create that identity in the browser effect and read persisted storage before generating it, preserving the same device identity across page loads.

The existing EN/ID/DE content acceptance checks now require real h1/h2 elements in each document response and verify persistent browser identity alongside canonical URLs, structured dates, and lazy-loaded graphs.

Validation: production build generated all 233 pages; article and material browser checks passed across all three locales; 1,743 web tests passed with 100% statements, branches, functions, and lines; formatting, lint, web typecheck, and React Doctor 100/100 passed. Live before-fix responses had no article headings, while the corrected local production responses include them.