### PR TITLE
Run web typechecking before compilation

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -175,6 +175,12 @@ const nextConfig = {
     : undefined,
   cacheComponents: true,
   partialPrefetching: true,
+  typescript: {
+    // pnpm build runs next typegen and the full two-checker tsc gate first.
+    // Keep that check outside the resident web compiler's memory footprint.
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/typescript
+    ignoreBuildErrors: true,
+  },
   env: {
     NEXT_PUBLIC_AKSARA_PREVIEW_CHILD: `${isAksaraPreviewChild}`,
   },

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "analyze": "next experimental-analyze",
-    "build": "pnpm verify:featured-renderer && next build",
+    "build": "pnpm typecheck && pnpm verify:featured-renderer && next build",
     "build:vercel": "pnpm --dir ../../packages/backend exec convex deploy --yes --typecheck enable && pnpm --dir ../.. run build --filter=www",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "portless run --name nakafa next dev",


### PR DESCRIPTION
The web build now runs its existing `next typegen` and full native TypeScript check with two checkers before starting Next.js compilation. This releases the typechecker before the web compiler becomes resident and disables the duplicate internal Next.js check, following the documented external-typecheck build pattern. Both CI and Vercel run this gated package build.

The latest unpromoted Vercel build compiled successfully, then remained silent in TypeScript for over 20 minutes and was canceled. Vercel did not report a confirmed OOM. In an isolated 4-vCPU, 8-GiB Linux VM, the default four-checker command plus 2.8 GiB of simulated resident compiler memory triggered a kernel OOM. The existing two-checker command passed in 23 seconds with over 1 GiB available. Moving the check before compilation also removes that overlap, without a larger builder or an added memory cap.

Validation: `pnpm format` and `pnpm lint` passed. A deliberate TS2322 error caused the actual `pnpm acceptance:build` to exit before compilation; the probe was removed. A clean production build then passed the full typecheck, compiled in 51 seconds, and generated all 233 pages in 6.3 seconds. Production-mode article and lesson acceptance passed across EN, ID, and DE. No dependencies or application behavior changed.