### PR TITLE
Keep reading headings and formulas within narrow screens

### DIFF
--- a/apps/www/components/content/title.tsx
+++ b/apps/www/components/content/title.tsx
@@ -9,7 +9,7 @@ export function ContentTitle({
   return (
     <header className="relative py-20">
       <div className="mx-auto max-w-3xl space-y-6 px-6 text-center">
-        <h1 className="text-balance font-normal font-serif text-5xl leading-tight tracking-tight">
+        <h1 className="wrap-anywhere hyphens-auto text-balance font-normal font-serif text-5xl leading-tight tracking-tight">
           {title}
         </h1>
         {description && (

--- a/apps/www/components/shared/layout-content.tsx
+++ b/apps/www/components/shared/layout-content.tsx
@@ -9,7 +9,7 @@ interface Props {
 /** Renders the shared article-width content surface. */
 export function LayoutContent({ children, className }: Props) {
   return (
-    <article className={cn("mx-auto max-w-3xl px-6", className)}>
+    <article className={cn("wrap-anywhere mx-auto max-w-3xl px-6", className)}>
       {children}
     </article>
   );

--- a/packages/design-system/components/markdown/heading.tsx
+++ b/packages/design-system/components/markdown/heading.tsx
@@ -62,7 +62,9 @@ export function Heading({
         id={id}
         {...props}
       >
-        <span className="text-pretty">{props.children}</span>
+        <span className="wrap-anywhere hyphens-auto text-pretty">
+          {props.children}
+        </span>
       </Tag>
     );
   }
@@ -78,12 +80,14 @@ export function Heading({
     >
       <a
         aria-label={`Link to ${props.children}`}
-        className="group/heading inline-flex items-center gap-4"
+        className="group/heading inline-flex min-w-0 items-center gap-4"
         href={`#${id}`}
         title={props.children?.toString()}
       >
-        <span className="text-pretty">{props.children}</span>
-        <div className="rounded-sm border p-2 opacity-0 transition-opacity ease-out group-hover/heading:opacity-100">
+        <span className="wrap-anywhere hyphens-auto text-pretty">
+          {props.children}
+        </span>
+        <div className="shrink-0 rounded-sm border p-2 opacity-0 transition-opacity ease-out group-hover/heading:opacity-100">
           <HugeIcons
             className="size-4 shrink-0 text-muted-foreground"
             icon={Link05Icon}

--- a/packages/design-system/components/markdown/math.tsx
+++ b/packages/design-system/components/markdown/math.tsx
@@ -176,7 +176,10 @@ export function BlockMath({
  */
 export function InlineMath(props: MathComponentProps) {
   return (
-    <span data-markdown-ignore="">
+    <span
+      className="inline-block max-w-full overflow-x-auto align-middle"
+      data-markdown-ignore=""
+    >
       <KatexMarkup displayMode={false} {...props} />
     </span>
   );


### PR DESCRIPTION
Long German headings and wide inline formulas overflowed narrow reading pages. Reading titles and heading text now wrap with native hyphenation, heading links can shrink, and wide inline formulas scroll inside their own width. The existing title remains 48 px.

Validation: lint, design-system typecheck, 419 tests with 100% coverage, React Doctor 100/100, and the local production build passed. All 609 revised lesson pages passed heading and document-width checks at 390 px; 18 WebKit cases passed at 320 and 1440 px. Chromium and WebKit also verified heading anchors, native horizontal scrolling, and preserved MathML. One separate prefetch 404 exposed two old authored German links, corrected in Aksara PR #310.
