### PR TITLE
Fix outline truncation and simplify React composition

### DIFF
--- a/apps/www/components/home/explore.tsx
+++ b/apps/www/components/home/explore.tsx
@@ -11,6 +11,7 @@ import {
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
 import NavigationLink from "@repo/design-system/components/ui/navigation-link";
 import { useLocale, useTranslations } from "next-intl";
+import type { ComponentProps, ReactNode } from "react";
 import {
   getAppNavigationViewer,
   getForYouNavigationHref,
@@ -124,49 +125,47 @@ export function HomeExplore() {
         preferredTryoutHref,
       })
     : "/try-out";
-  const cards = [
-    {
-      href: subjectHref,
-      id: "subject",
-      title: tCommon("subject"),
-      visual: <SubjectIcon />,
-    },
-    {
-      href: tryoutHref,
-      id: "tryOut",
-      title: tCommon("try-out"),
-      visual: <TryoutIcon />,
-    },
-    {
-      href: "/chat",
-      id: "askNina",
-      title: tAi("ask-nina"),
-      visual: <NinaIcon />,
-    },
-  ] as const;
-
   return (
     <section className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 md:gap-6">
-        {cards.map((card) => {
-          if (!visibleCardIds.has(card.id)) {
-            return null;
-          }
-
-          return (
-            <NavigationLink
-              className="group flex flex-col items-center gap-2"
-              href={card.href}
-              key={card.id}
-            >
-              <div className="flex aspect-[1/0.95] w-full items-center justify-center rounded-xl border bg-card">
-                {card.visual}
-              </div>
-              <h2>{card.title}</h2>
-            </NavigationLink>
-          );
-        })}
+        {visibleCardIds.has("subject") && (
+          <ExploreCard href={subjectHref} title={tCommon("subject")}>
+            <SubjectIcon />
+          </ExploreCard>
+        )}
+        {visibleCardIds.has("tryOut") && (
+          <ExploreCard href={tryoutHref} title={tCommon("try-out")}>
+            <TryoutIcon />
+          </ExploreCard>
+        )}
+        {visibleCardIds.has("askNina") && (
+          <ExploreCard href="/chat" title={tAi("ask-nina")}>
+            <NinaIcon />
+          </ExploreCard>
+        )}
       </div>
     </section>
+  );
+}
+
+function ExploreCard({
+  children,
+  href,
+  title,
+}: {
+  children: ReactNode;
+  href: ComponentProps<typeof NavigationLink>["href"];
+  title: string;
+}) {
+  return (
+    <NavigationLink
+      className="group flex flex-col items-center gap-2"
+      href={href}
+    >
+      <div className="flex aspect-[1/0.95] w-full items-center justify-center rounded-xl border bg-card">
+        {children}
+      </div>
+      <h2>{title}</h2>
+    </NavigationLink>
   );
 }

--- a/apps/www/components/providers/app.tsx
+++ b/apps/www/components/providers/app.tsx
@@ -28,24 +28,26 @@ export function AppProviders({
   children: ReactNode;
   pageNavigation: PageNavigation | null;
 }) {
-  const content = pageNavigation ? (
-    <AnalyticsConsentProvider
-      isPreviewChild={env.NEXT_PUBLIC_AKSARA_PREVIEW_CHILD === "true"}
-    >
-      {children}
-      <AnalyticsConsentControls />
-    </AnalyticsConsentProvider>
-  ) : (
-    <AnalyticsUnavailableProvider>{children}</AnalyticsUnavailableProvider>
-  );
-
   return (
     <NuqsAdapter>
       <ReactQueryProviders>
         <ConvexProvider convexUrl={env.NEXT_PUBLIC_CONVEX_URL}>
           <UserContextProvider>
             <PageNavigationProvider navigation={pageNavigation}>
-              {content}
+              {pageNavigation ? (
+                <AnalyticsConsentProvider
+                  isPreviewChild={
+                    env.NEXT_PUBLIC_AKSARA_PREVIEW_CHILD === "true"
+                  }
+                >
+                  {children}
+                  <AnalyticsConsentControls />
+                </AnalyticsConsentProvider>
+              ) : (
+                <AnalyticsUnavailableProvider>
+                  {children}
+                </AnalyticsUnavailableProvider>
+              )}
             </PageNavigationProvider>
           </UserContextProvider>
         </ConvexProvider>

--- a/apps/www/components/shared/sidebar-tree.tsx
+++ b/apps/www/components/shared/sidebar-tree.tsx
@@ -29,6 +29,15 @@ interface Props {
   title?: string;
 }
 
+/** Keeps outline labels on one line while exposing their complete title. */
+function SidebarTreeLabel({ label }: Pick<ParsedHeading, "label">) {
+  return (
+    <span className="truncate" title={label}>
+      {label}
+    </span>
+  );
+}
+
 /**
  * Recursive component to render nested headings
  */
@@ -39,11 +48,6 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
   const id = slugify(heading.label);
   const virtualIndex = heading.index;
   const isActive = virtualIndex === undefined && activeHeadings.includes(id);
-  const label = (
-    <span className="truncate" title={heading.label}>
-      {heading.label}
-    </span>
-  );
 
   return (
     <SidebarMenuItem key={heading.href}>
@@ -57,7 +61,7 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
                   // In-page headings use native fragment navigation so an
                   // existing hash never enters the route prefetch cache.
                   <a href={heading.href} title={heading.label}>
-                    {label}
+                    <SidebarTreeLabel label={heading.label} />
                   </a>
                 ) : (
                   <button
@@ -67,7 +71,7 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
                     }}
                     type="button"
                   >
-                    {label}
+                    <SidebarTreeLabel label={heading.label} />
                   </button>
                 )
               }

--- a/apps/www/components/shared/sidebar-tree.tsx
+++ b/apps/www/components/shared/sidebar-tree.tsx
@@ -39,6 +39,11 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
   const id = slugify(heading.label);
   const virtualIndex = heading.index;
   const isActive = virtualIndex === undefined && activeHeadings.includes(id);
+  const label = (
+    <span className="truncate" title={heading.label}>
+      {heading.label}
+    </span>
+  );
 
   return (
     <SidebarMenuItem key={heading.href}>
@@ -52,7 +57,7 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
                   // In-page headings use native fragment navigation so an
                   // existing hash never enters the route prefetch cache.
                   <a href={heading.href} title={heading.label}>
-                    {heading.label}
+                    {label}
                   </a>
                 ) : (
                   <button
@@ -61,14 +66,12 @@ function SidebarTreeItem({ heading }: { heading: ParsedHeading }) {
                       scrollToIndex(virtualIndex);
                     }}
                     type="button"
-                  />
+                  >
+                    {label}
+                  </button>
                 )
               }
-            >
-              <span className="truncate" title={heading.label}>
-                {heading.label}
-              </span>
-            </SidebarMenuButton>
+            />
           }
         />
         <TooltipContent

--- a/packages/design-system/components/contents/physics/kinematics/acceleration/lab.tsx
+++ b/packages/design-system/components/contents/physics/kinematics/acceleration/lab.tsx
@@ -45,33 +45,23 @@ export function AccelerationLab({
     {
       id: "initial-velocity",
       label: labels.factLabels.initialVelocity,
-      value: (
-        <InlineMath
-          math={`v_0=${formatMeterPerSecondMath(motion.scenario.v0)}`}
-        />
-      ),
+      math: `v_0=${formatMeterPerSecondMath(motion.scenario.v0)}`,
     },
     {
       id: "acceleration",
       indicatorColor: motion.scenario.color,
       label: labels.factLabels.acceleration,
-      value: (
-        <InlineMath math={`a=${formatAccelerationMath(motion.acceleration)}`} />
-      ),
+      math: `a=${formatAccelerationMath(motion.acceleration)}`,
     },
     {
       id: "final-velocity",
       label: labels.factLabels.finalVelocity,
-      value: (
-        <InlineMath
-          math={`v_t=${formatMeterPerSecondMath(motion.scenario.v1)}`}
-        />
-      ),
+      math: `v_t=${formatMeterPerSecondMath(motion.scenario.v1)}`,
     },
     {
       id: "time-step",
       label: labels.factLabels.timeStep,
-      value: <InlineMath math={`\\Delta t=${formatSecondMath(1)}`} />,
+      math: `\\Delta t=${formatSecondMath(1)}`,
     },
   ];
 
@@ -151,7 +141,7 @@ export function AccelerationLab({
               }
               key={fact.id}
               label={fact.label}
-              value={fact.value}
+              value={<InlineMath math={fact.math} />}
             />
           ))}
         </dl>

--- a/packages/design-system/components/contents/physics/kinematics/parabolic-movement-analysis/lab.tsx
+++ b/packages/design-system/components/contents/physics/kinematics/parabolic-movement-analysis/lab.tsx
@@ -55,66 +55,42 @@ export function ParabolicMovementAnalysisLab({
     {
       id: "horizontal-component",
       label: labels.factLabels.horizontalComponent,
-      value: (
-        <InlineMath
-          math={`v_{0x}=${formatSpeedMath(
-            motion.horizontalVelocity,
-            decimalSeparator
-          )}`}
-        />
-      ),
+      math: `v_{0x}=${formatSpeedMath(
+        motion.horizontalVelocity,
+        decimalSeparator
+      )}`,
     },
     {
       id: "vertical-component",
       label: labels.factLabels.verticalComponent,
-      value: (
-        <InlineMath
-          math={`v_{0y}=${formatSpeedMath(
-            motion.verticalVelocity,
-            decimalSeparator
-          )}`}
-        />
-      ),
+      math: `v_{0y}=${formatSpeedMath(
+        motion.verticalVelocity,
+        decimalSeparator
+      )}`,
     },
     {
       id: "peak-time",
       label: labels.factLabels.peakTime,
-      value: (
-        <InlineMath
-          math={`t=${formatSecondMath(motion.peakTime, decimalSeparator)}`}
-        />
-      ),
+      math: `t=${formatSecondMath(motion.peakTime, decimalSeparator)}`,
     },
     {
       id: "flight-time",
       label: labels.factLabels.flightTime,
-      value: (
-        <InlineMath
-          math={`T=${formatSecondMath(motion.flightTime, decimalSeparator)}`}
-        />
-      ),
+      math: `T=${formatSecondMath(motion.flightTime, decimalSeparator)}`,
     },
     {
       id: "range",
       label: labels.factLabels.range,
-      value: (
-        <InlineMath
-          math={`R=${formatMeterMath(motion.range, decimalSeparator)}`}
-        />
-      ),
+      math: `R=${formatMeterMath(motion.range, decimalSeparator)}`,
     },
     {
       id: "instantaneous-velocity",
       label: labels.factLabels.instantaneousVelocity,
-      value: (
-        <InlineMath
-          math={`\\vec{v}=${formatVelocityVectorMath(
-            instantVelocity.horizontalVelocity,
-            instantVelocity.verticalVelocity,
-            decimalSeparator
-          )}`}
-        />
-      ),
+      math: `\\vec{v}=${formatVelocityVectorMath(
+        instantVelocity.horizontalVelocity,
+        instantVelocity.verticalVelocity,
+        decimalSeparator
+      )}`,
     },
   ];
 
@@ -194,7 +170,11 @@ export function ParabolicMovementAnalysisLab({
       <CardFooter className="border-t">
         <dl className="grid w-full grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
           {facts.map((fact) => (
-            <LabFact key={fact.id} label={fact.label} value={fact.value} />
+            <LabFact
+              key={fact.id}
+              label={fact.label}
+              value={<InlineMath math={fact.math} />}
+            />
           ))}
         </dl>
       </CardFooter>

--- a/packages/design-system/components/contents/physics/kinematics/parabolic-movement/lab.tsx
+++ b/packages/design-system/components/contents/physics/kinematics/parabolic-movement/lab.tsx
@@ -47,44 +47,25 @@ export function ParabolicMovementLab({
     {
       id: "initial-speed",
       label: labels.factLabels.initialSpeed,
-      value: (
-        <InlineMath
-          math={`v_0=${formatSpeedMath(
-            motion.scenario.initialSpeed,
-            decimalSeparator
-          )}`}
-        />
-      ),
+      math: `v_0=${formatSpeedMath(
+        motion.scenario.initialSpeed,
+        decimalSeparator
+      )}`,
     },
     {
       id: "flight-time",
       label: labels.factLabels.flightTime,
-      value: (
-        <InlineMath
-          math={`T=${formatSecondMath(motion.flightTime, decimalSeparator)}`}
-        />
-      ),
+      math: `T=${formatSecondMath(motion.flightTime, decimalSeparator)}`,
     },
     {
       id: "range",
       label: labels.factLabels.range,
-      value: (
-        <InlineMath
-          math={`R=${formatMeterMath(motion.range, decimalSeparator)}`}
-        />
-      ),
+      math: `R=${formatMeterMath(motion.range, decimalSeparator)}`,
     },
     {
       id: "peak-height",
       label: labels.factLabels.peakHeight,
-      value: (
-        <InlineMath
-          math={`h_{\\max}=${formatMeterMath(
-            motion.peakHeight,
-            decimalSeparator
-          )}`}
-        />
-      ),
+      math: `h_{\\max}=${formatMeterMath(motion.peakHeight, decimalSeparator)}`,
     },
   ];
 
@@ -159,7 +140,11 @@ export function ParabolicMovementLab({
       <CardFooter className="border-t">
         <dl className="grid w-full grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
           {facts.map((fact) => (
-            <LabFact key={fact.id} label={fact.label} value={fact.value} />
+            <LabFact
+              key={fact.id}
+              label={fact.label}
+              value={<InlineMath math={fact.math} />}
+            />
           ))}
         </dl>
       </CardFooter>

--- a/packages/design-system/components/contents/physics/kinematics/uniform-linear-motion/lab.tsx
+++ b/packages/design-system/components/contents/physics/kinematics/uniform-linear-motion/lab.tsx
@@ -54,23 +54,23 @@ export function UniformLinearMotionLab({
     {
       id: "speed",
       label: labels.speed,
-      value: <InlineMath math={formatSpeedMath(motion.speed)} />,
+      math: formatSpeedMath(motion.speed),
     },
     {
       id: "position-step",
       label: labels.positionStep,
-      value: <InlineMath math={formatSecondMath(motion.timeStep)} />,
+      math: formatSecondMath(motion.timeStep),
     },
     {
       id: "step-distance",
       indicatorColor: UNIFORM_LINEAR_MOTION_COLORS.positionMark,
       label: labels.stepDistance,
-      value: <InlineMath math={formatMeterMath(motion.stepDistance)} />,
+      math: formatMeterMath(motion.stepDistance),
     },
     {
       id: "duration",
       label: labels.duration,
-      value: <InlineMath math={formatSecondMath(motion.duration)} />,
+      math: formatSecondMath(motion.duration),
     },
   ];
 
@@ -162,7 +162,7 @@ export function UniformLinearMotionLab({
                 {fact.label}
               </dt>
               <dd className="wrap-break-word text-foreground tabular-nums">
-                {fact.value}
+                <InlineMath math={fact.math} />
               </dd>
             </div>
           ))}

--- a/packages/design-system/components/contents/snbt/quantitative/set-10/question-2.tsx
+++ b/packages/design-system/components/contents/snbt/quantitative/set-10/question-2.tsx
@@ -34,58 +34,56 @@ export function Graph(
     { x: -LENGTH * Math.cos(ANGLE), y: -LENGTH * Math.sin(ANGLE), z: 0 },
   ];
 
-  const refinedData: ComponentProps<typeof LineEquation>["data"] = [
-    {
-      points: horizontalPointsWithCenter,
-      color: getColor("INDIGO"),
-      showPoints: false,
-      smooth: false,
-      cone: { position: "both", size: 0.5 },
-    },
-    {
-      points: d1PointsWithCenter,
-      color: getColor("INDIGO"),
-      showPoints: false,
-      smooth: false,
-      cone: { position: "both", size: 0.5 },
-      labels: [
-        {
-          text: <InlineMath math="x^\circ" />,
-          at: 1, // Center point
-          offset: [-1.2, 0.4, 0], // Adjusted for x position
-          color: getColor("TEAL"),
-        },
-      ],
-    },
-    {
-      points: d2PointsWithCenter,
-      color: getColor("INDIGO"),
-      showPoints: false,
-      smooth: false,
-      cone: { position: "both", size: 0.5 },
-      labels: [
-        {
-          text: <InlineMath math="y^\circ" />,
-          at: 1, // Center point
-          offset: [1.2, 0.4, 0], // Adjusted for y position
-          fontSize: 0.6,
-          color: getColor("TEAL"),
-        },
-        {
-          text: <InlineMath math="z^\circ" />,
-          at: 1, // Center point
-          offset: [0, -0.8, 0], // Adjusted for z position
-          fontSize: 0.6,
-          color: getColor("TEAL"),
-        },
-      ],
-    },
-  ];
-
   return (
     <LineEquation
       cameraPosition={[0, 0, 10]}
-      data={refinedData}
+      data={[
+        {
+          points: horizontalPointsWithCenter,
+          color: getColor("INDIGO"),
+          showPoints: false,
+          smooth: false,
+          cone: { position: "both", size: 0.5 },
+        },
+        {
+          points: d1PointsWithCenter,
+          color: getColor("INDIGO"),
+          showPoints: false,
+          smooth: false,
+          cone: { position: "both", size: 0.5 },
+          labels: [
+            {
+              text: <InlineMath math="x^\circ" />,
+              at: 1, // Center point
+              offset: [-1.2, 0.4, 0], // Adjusted for x position
+              color: getColor("TEAL"),
+            },
+          ],
+        },
+        {
+          points: d2PointsWithCenter,
+          color: getColor("INDIGO"),
+          showPoints: false,
+          smooth: false,
+          cone: { position: "both", size: 0.5 },
+          labels: [
+            {
+              text: <InlineMath math="y^\circ" />,
+              at: 1, // Center point
+              offset: [1.2, 0.4, 0], // Adjusted for y position
+              fontSize: 0.6,
+              color: getColor("TEAL"),
+            },
+            {
+              text: <InlineMath math="z^\circ" />,
+              at: 1, // Center point
+              offset: [0, -0.8, 0], // Adjusted for z position
+              fontSize: 0.6,
+              color: getColor("TEAL"),
+            },
+          ],
+        },
+      ]}
       showZAxis={false}
       {...props}
     />

--- a/packages/design-system/components/evilcharts/charts/area/series.tsx
+++ b/packages/design-system/components/evilcharts/charts/area/series.tsx
@@ -31,8 +31,6 @@ import { Area as RechartsArea } from "recharts";
 
 const STROKE_WIDTH = 0.8;
 const STACK_ID = "evil-stacked";
-type AreaDotProp = ComponentProps<typeof RechartsArea>["dot"];
-type AreaActiveDotProp = ComponentProps<typeof RechartsArea>["activeDot"];
 type StrokeVariant = "solid" | "dashed" | "animated-dashed";
 
 interface AreaProps {
@@ -99,13 +97,7 @@ export function Area({
   const showUnselected = hasSelection && !isSelected;
   const colorsCount = getColorsCount(config[dataKey] ?? {});
 
-  const { dot, activeDot } = resolveDots(
-    children,
-    id,
-    dataKey,
-    opacity.dot,
-    maskId
-  );
+  const { dot, activeDot } = resolveDots(children);
 
   const isAnimatedDashed =
     !shouldReduceMotion && strokeVariant === "animated-dashed";
@@ -114,10 +106,33 @@ export function Area({
   return (
     <>
       <RechartsArea
-        activeDot={activeDot}
+        activeDot={
+          activeDot ? (
+            <ChartDot
+              chartId={id}
+              dataKey={dataKey}
+              fillOpacity={opacity.dot}
+              type={activeDot.variant}
+            />
+          ) : (
+            false
+          )
+        }
         connectNulls={connectNulls}
         dataKey={dataKey}
-        dot={dot}
+        dot={
+          dot ? (
+            <ChartDot
+              chartId={id}
+              dataKey={dataKey}
+              fillOpacity={opacity.dot}
+              maskId={maskId}
+              type={dot.variant}
+            />
+          ) : (
+            false
+          )
+        }
         fill={getFillPattern(variant, showUnselected, id)}
         fillOpacity={opacity.fill}
         // Recharts' built-in area animation is permanently disabled ; it drew
@@ -200,19 +215,10 @@ const getFillPattern = (
   return `url(#${id}-${variant})`;
 };
 
-// Pulls <Dot /> and <ActiveDot /> out of an area's children into Recharts dot slots.
-// When a `maskId` is given the resting dot is wired to the intro reveal mask so it
-// wipes in with the line; the active dot is always left unmasked since it only
-// appears on hover, after the intro has finished.
-const resolveDots = (
-  children: ReactNode,
-  id: string,
-  dataKey: string,
-  dotOpacity: number,
-  maskId: string | undefined
-): { dot: AreaDotProp; activeDot: AreaActiveDotProp } => {
-  let dot: AreaDotProp = false;
-  let activeDot: AreaActiveDotProp = false;
+// Reads marker configuration; the series owns the Recharts rendering slots.
+const resolveDots = (children: ReactNode) => {
+  let dot: DotProps | undefined;
+  let activeDot: DotProps | undefined;
 
   Children.forEach(children, (child) => {
     if (!isValidElement<DotProps>(child)) {
@@ -220,28 +226,11 @@ const resolveDots = (
     }
 
     if (child.type === Dot) {
-      const { variant } = child.props;
-      dot = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          maskId={maskId}
-          type={variant}
-        />
-      );
+      dot = child.props;
     }
 
     if (child.type === ActiveDot) {
-      const { variant } = child.props;
-      activeDot = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          type={variant}
-        />
-      );
+      activeDot = child.props;
     }
   });
 

--- a/packages/design-system/components/evilcharts/charts/bar/shape.tsx
+++ b/packages/design-system/components/evilcharts/charts/bar/shape.tsx
@@ -6,13 +6,15 @@ import {
   getChartColorVariable,
   getChartSeriesId,
 } from "@repo/design-system/components/evilcharts/ui/chart-config";
-import { REVEAL_EASE } from "@repo/design-system/components/evilcharts/ui/reveal";
+import {
+  REVEAL_EASE,
+  RevealGroup,
+} from "@repo/design-system/components/evilcharts/ui/reveal";
 import {
   BAR_REVEAL_DURATION_MS,
   BAR_REVEAL_STAGGER_MS,
   getOrderedRevealStep,
 } from "@repo/design-system/components/evilcharts/ui/reveal-animation";
-import { m } from "motion/react";
 import type { KeyboardEvent } from "react";
 import { Rectangle } from "recharts";
 import type { RectRadius } from "recharts/types/shape/Rectangle";
@@ -117,37 +119,6 @@ export const CustomBar = (props: CustomBarProps) => {
     ? [barRadius, barRadius, 0, 0]
     : barRadius;
 
-  // The visible, painted bar, plus the stripped variant's solid top strip
-  const visibleBar = (
-    <>
-      <Rectangle
-        fill={fill}
-        filter={filter}
-        height={Math.max(0, height - 3)}
-        opacity={fillOpacity}
-        radius={radius}
-        stroke={
-          isLastBar
-            ? `url(#${getChartSeriesId(id, "colors", dataKey)})`
-            : undefined
-        }
-        strokeWidth={isLastBar ? 1 : undefined}
-        width={width}
-        x={x}
-        y={y}
-      />
-      {isStripped && (
-        <Rectangle
-          fill={`url(#${getChartSeriesId(id, "colors", dataKey)})`}
-          height={2}
-          radius={1}
-          width={width}
-          x={x}
-          y={y - 4}
-        />
-      )}
-    </>
-  );
   const interactiveProps = onClick
     ? {
         onClick,
@@ -169,17 +140,34 @@ export const CustomBar = (props: CustomBarProps) => {
       {/* Full-height invisible rect keeps the whole column hoverable/clickable */}
       <Rectangle {...props} fill="transparent" />
       {/* The painted bar grows in from its baseline; the hit rect above stays put */}
-      {grow ? (
-        <m.g
-          animate={grow.animate}
-          style={grow.style}
-          transition={grow.transition}
-        >
-          {visibleBar}
-        </m.g>
-      ) : (
-        visibleBar
-      )}
+      <RevealGroup animation={grow}>
+        <Rectangle
+          fill={fill}
+          filter={filter}
+          height={Math.max(0, height - 3)}
+          opacity={fillOpacity}
+          radius={radius}
+          stroke={
+            isLastBar
+              ? `url(#${getChartSeriesId(id, "colors", dataKey)})`
+              : undefined
+          }
+          strokeWidth={isLastBar ? 1 : undefined}
+          width={width}
+          x={x}
+          y={y}
+        />
+        {isStripped && (
+          <Rectangle
+            fill={`url(#${getChartSeriesId(id, "colors", dataKey)})`}
+            height={2}
+            radius={1}
+            width={width}
+            x={x}
+            y={y - 4}
+          />
+        )}
+      </RevealGroup>
     </g>
   );
 };

--- a/packages/design-system/components/evilcharts/charts/composed/line.tsx
+++ b/packages/design-system/components/evilcharts/charts/composed/line.tsx
@@ -32,10 +32,6 @@ import {
 } from "react";
 import { Line as RechartsLine } from "recharts";
 
-type LineDotProp = ComponentProps<typeof RechartsLine>["dot"];
-
-type LineActiveDotProp = ComponentProps<typeof RechartsLine>["activeDot"];
-
 type StrokeVariant = "solid" | "dashed" | "animated-dashed";
 
 interface LineProps {
@@ -99,13 +95,7 @@ export function Line({
   const filter = glow ? `url(#${id}-glow)` : undefined;
   const colorsCount = getColorsCount(config[dataKey] ?? {});
 
-  const { dot, activeDot } = resolveDots(
-    children,
-    id,
-    dataKey,
-    opacity.dot,
-    maskId
-  );
+  const { dot, activeDot } = resolveDots(children);
 
   const isAnimatedDashed =
     !shouldReduceMotion && strokeVariant === "animated-dashed";
@@ -137,10 +127,33 @@ export function Line({
         />
       )}
       <RechartsLine
-        activeDot={activeDot}
+        activeDot={
+          activeDot ? (
+            <ChartDot
+              chartId={`${id}-line`}
+              dataKey={dataKey}
+              fillOpacity={opacity.dot}
+              type={activeDot.variant}
+            />
+          ) : (
+            false
+          )
+        }
         connectNulls={connectNulls}
         dataKey={dataKey}
-        dot={dot}
+        dot={
+          dot ? (
+            <ChartDot
+              chartId={`${id}-line`}
+              dataKey={dataKey}
+              fillOpacity={opacity.dot}
+              maskId={maskId}
+              type={dot.variant}
+            />
+          ) : (
+            false
+          )
+        }
         filter={filter}
         // Recharts' built-in line animation is permanently disabled, the
         // motion.dev reveal mask drives the intro, wiping stroke and dots in together.
@@ -184,19 +197,10 @@ export const Dot: FC<DotProps> = () => null;
  */
 export const ActiveDot: FC<DotProps> = () => null;
 
-// Pulls <Dot /> and <ActiveDot /> out of a line's children into Recharts dot slots.
-// When a `maskId` is given the resting dot is wired to the intro reveal mask so it
-// wipes in with the line; the active dot is always left unmasked since it only
-// appears on hover, after the intro has finished.
-const resolveDots = (
-  children: ReactNode,
-  id: string,
-  dataKey: string,
-  dotOpacity: number,
-  maskId: string | undefined
-): { dot: LineDotProp; activeDot: LineActiveDotProp } => {
-  let dot: LineDotProp = false;
-  let activeDot: LineActiveDotProp = false;
+// Reads marker configuration; the series owns the Recharts rendering slots.
+const resolveDots = (children: ReactNode) => {
+  let dot: DotProps | undefined;
+  let activeDot: DotProps | undefined;
 
   Children.forEach(children, (child) => {
     if (!isValidElement<DotProps>(child)) {
@@ -204,28 +208,11 @@ const resolveDots = (
     }
 
     if (child.type === Dot) {
-      const { variant } = child.props;
-      dot = (
-        <ChartDot
-          chartId={`${id}-line`}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          maskId={maskId}
-          type={variant}
-        />
-      );
+      dot = child.props;
     }
 
     if (child.type === ActiveDot) {
-      const { variant } = child.props;
-      activeDot = (
-        <ChartDot
-          chartId={`${id}-line`}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          type={variant}
-        />
-      );
+      activeDot = child.props;
     }
   });
 

--- a/packages/design-system/components/evilcharts/charts/composed/scatter.tsx
+++ b/packages/design-system/components/evilcharts/charts/composed/scatter.tsx
@@ -26,12 +26,6 @@ import {
 } from "react";
 import { Scatter as RechartsScatter } from "recharts";
 
-type ScatterShapeProp = ComponentProps<typeof RechartsScatter>["shape"];
-
-type ScatterActiveShapeProp = ComponentProps<
-  typeof RechartsScatter
->["activeShape"];
-
 interface ScatterProps
   extends Omit<
     ComponentProps<typeof RechartsScatter>,
@@ -56,22 +50,31 @@ export function Scatter({ dataKey, children, ...scatterProps }: ScatterProps) {
 
   const opacity = getOpacity(selectedDataKey, dataKey);
   const chartId = `${id}-scatter`;
-  const { shape, activeShape } = resolveScatterShapes(
-    children,
-    chartId,
-    dataKey,
-    opacity.dot
-  );
+  const { shape, activeShape } = resolveScatterShapes(children);
 
   return (
     <>
       <RechartsScatter
-        activeShape={activeShape}
+        activeShape={
+          <ChartDot
+            chartId={chartId}
+            dataKey={dataKey}
+            fillOpacity={opacity.dot}
+            type={activeShape.variant}
+          />
+        }
         fill={`url(#${getChartSeriesId(chartId, "colors", dataKey)})`}
         isAnimationActive={false}
         legendType="circle"
         name={dataKey}
-        shape={shape}
+        shape={
+          <ChartDot
+            chartId={chartId}
+            dataKey={dataKey}
+            fillOpacity={opacity.dot}
+            type={shape.variant}
+          />
+        }
         {...scatterProps}
       />
       <defs>
@@ -81,29 +84,10 @@ export function Scatter({ dataKey, children, ...scatterProps }: ScatterProps) {
   );
 }
 
-// Pulls <Dot /> and <ActiveDot /> into Recharts Scatter shape slots.
-const resolveScatterShapes = (
-  children: ReactNode,
-  id: string,
-  dataKey: string,
-  dotOpacity: number
-): { shape: ScatterShapeProp; activeShape: ScatterActiveShapeProp } => {
-  let shape: ScatterShapeProp = (
-    <ChartDot
-      chartId={id}
-      dataKey={dataKey}
-      fillOpacity={dotOpacity}
-      type="default"
-    />
-  );
-  let activeShape: ScatterActiveShapeProp = (
-    <ChartDot
-      chartId={id}
-      dataKey={dataKey}
-      fillOpacity={dotOpacity}
-      type="colored-border"
-    />
-  );
+// Reads marker configuration while preserving Scatter's default point styles.
+const resolveScatterShapes = (children: ReactNode) => {
+  let shape: DotProps = { variant: "default" };
+  let activeShape: DotProps = { variant: "colored-border" };
 
   Children.forEach(children, (child) => {
     if (!isValidElement<DotProps>(child)) {
@@ -111,27 +95,11 @@ const resolveScatterShapes = (
     }
 
     if (child.type === Dot) {
-      const { variant } = child.props;
-      shape = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          type={variant}
-        />
-      );
+      shape = child.props;
     }
 
     if (child.type === ActiveDot) {
-      const { variant } = child.props;
-      activeShape = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          type={variant}
-        />
-      );
+      activeShape = child.props;
     }
   });
 

--- a/packages/design-system/components/evilcharts/charts/composed/shape.tsx
+++ b/packages/design-system/components/evilcharts/charts/composed/shape.tsx
@@ -3,13 +3,15 @@
 import type { BarVariant } from "@repo/design-system/components/evilcharts/charts/composed/bars";
 import type { ComposedAnimationType } from "@repo/design-system/components/evilcharts/charts/composed-chart";
 import { getChartColorVariable } from "@repo/design-system/components/evilcharts/ui/chart-config";
-import { REVEAL_EASE } from "@repo/design-system/components/evilcharts/ui/reveal";
+import {
+  REVEAL_EASE,
+  RevealGroup,
+} from "@repo/design-system/components/evilcharts/ui/reveal";
 import {
   BAR_REVEAL_DURATION_MS,
   BAR_REVEAL_STAGGER_MS,
   getOrderedRevealStep,
 } from "@repo/design-system/components/evilcharts/ui/reveal-animation";
-import { m } from "motion/react";
 import type { KeyboardEvent } from "react";
 
 // Custom bar shape
@@ -118,16 +120,6 @@ export const CustomBar = ({
     }
   };
 
-  // Full-height invisible rect, keeps the column hoverable even mid grow-in
-  const hitArea = enableHoverHighlight ? (
-    <rect
-      fill="transparent"
-      height={hitAreaHeight}
-      width={hitAreaWidth}
-      x={hitAreaX}
-      y={hitAreaY}
-    />
-  ) : null;
   const interactiveProps = onClick
     ? {
         onClick,
@@ -144,76 +136,50 @@ export const CustomBar = ({
       }
     : {};
 
-  if (variant === "stripped") {
-    const strippedBar = (
-      <>
-        <rect fill={getFill()} height={height} width={width} x={x} y={y} />
-        <rect
-          fill={`url(#${id}-bar-colors)`}
-          height={2}
-          width={width}
-          x={x}
-          y={y}
-        />
-      </>
-    );
-
-    return (
-      <g {...interactiveProps} style={cursorStyle}>
-        {grow ? (
-          <m.g
-            animate={grow.animate}
-            className="transition-opacity duration-200"
-            filter={filter}
-            opacity={fillOpacity}
-            style={grow.style}
-            transition={grow.transition}
-          >
-            {strippedBar}
-          </m.g>
-        ) : (
-          <g
-            className="transition-opacity duration-200"
-            filter={filter}
-            opacity={fillOpacity}
-          >
-            {strippedBar}
-          </g>
-        )}
-        {hitArea}
-      </g>
-    );
-  }
-
-  const bar = (
-    <rect
-      className="transition-opacity duration-200"
-      fill={getFill()}
-      filter={filter}
-      height={height}
-      opacity={fillOpacity}
-      rx={barRadius}
-      ry={barRadius}
-      width={width}
-      x={x}
-      y={y}
-    />
-  );
-
   return (
     <g {...interactiveProps} style={cursorStyle}>
-      {grow ? (
-        <m.g
-          animate={grow.animate}
-          style={grow.style}
-          transition={grow.transition}
+      {variant === "stripped" ? (
+        <RevealGroup
+          animation={grow}
+          className="transition-opacity duration-200"
+          filter={filter}
+          opacity={fillOpacity}
         >
-          {bar}
-        </m.g>
+          <rect fill={getFill()} height={height} width={width} x={x} y={y} />
+          <rect
+            fill={`url(#${id}-bar-colors)`}
+            height={2}
+            width={width}
+            x={x}
+            y={y}
+          />
+        </RevealGroup>
       ) : (
-        bar
+        <RevealGroup animation={grow}>
+          <rect
+            className="transition-opacity duration-200"
+            fill={getFill()}
+            filter={filter}
+            height={height}
+            opacity={fillOpacity}
+            rx={barRadius}
+            ry={barRadius}
+            width={width}
+            x={x}
+            y={y}
+          />
+        </RevealGroup>
       )}
-      {hitArea}
+      {/* The hit area stays fixed while the visible bar grows. */}
+      {enableHoverHighlight && (
+        <rect
+          fill="transparent"
+          height={hitAreaHeight}
+          width={hitAreaWidth}
+          x={hitAreaX}
+          y={hitAreaY}
+        />
+      )}
     </g>
   );
 };

--- a/packages/design-system/components/evilcharts/charts/line/series.tsx
+++ b/packages/design-system/components/evilcharts/charts/line/series.tsx
@@ -33,10 +33,6 @@ import {
 } from "react";
 import { Line as RechartsLine } from "recharts";
 
-type LineDotProp = ComponentProps<typeof RechartsLine>["dot"];
-
-type LineActiveDotProp = ComponentProps<typeof RechartsLine>["activeDot"];
-
 type StrokeVariant = "solid" | "dashed" | "animated-dashed";
 
 // Composible parts
@@ -104,13 +100,7 @@ export function Line({
   const opacity = getOpacity(selectedDataKey, dataKey);
   const colorsCount = getColorsCount(config[dataKey] ?? {});
 
-  const { dot, activeDot } = resolveDots(
-    children,
-    id,
-    dataKey,
-    opacity.dot,
-    maskId
-  );
+  const { dot, activeDot } = resolveDots(children);
 
   const isAnimatedDashed =
     !shouldReduceMotion && strokeVariant === "animated-dashed";
@@ -136,10 +126,33 @@ export function Line({
           />
         )}
         <RechartsLine
-          activeDot={activeDot}
+          activeDot={
+            activeDot ? (
+              <ChartDot
+                chartId={id}
+                dataKey={dataKey}
+                fillOpacity={opacity.dot}
+                type={activeDot.variant}
+              />
+            ) : (
+              false
+            )
+          }
           connectNulls={connectNulls}
           dataKey={dataKey}
-          dot={dot}
+          dot={
+            dot ? (
+              <ChartDot
+                chartId={id}
+                dataKey={dataKey}
+                fillOpacity={opacity.dot}
+                maskId={maskId}
+                type={dot.variant}
+              />
+            ) : (
+              false
+            )
+          }
           filter={
             glowing
               ? `url(#${getChartSeriesId(id, "glow", dataKey)})`
@@ -219,19 +232,10 @@ const getStrokeDasharray = (enableBufferLine: boolean, isDashed: boolean) => {
   return isDashed ? "5 5" : undefined;
 };
 
-// Pulls <Dot /> and <ActiveDot /> out of a line's children into Recharts dot slots.
-// When a `maskId` is given the resting dot is wired to the intro reveal mask so it
-// wipes in with the line; the active dot is always left unmasked since it only
-// appears on hover, after the intro has finished.
-const resolveDots = (
-  children: ReactNode,
-  id: string,
-  dataKey: string,
-  dotOpacity: number,
-  maskId: string | undefined
-): { dot: LineDotProp; activeDot: LineActiveDotProp } => {
-  let dot: LineDotProp = false;
-  let activeDot: LineActiveDotProp = false;
+// Reads marker configuration; the series owns the Recharts rendering slots.
+const resolveDots = (children: ReactNode) => {
+  let dot: DotProps | undefined;
+  let activeDot: DotProps | undefined;
 
   Children.forEach(children, (child) => {
     if (!isValidElement<DotProps>(child)) {
@@ -239,28 +243,11 @@ const resolveDots = (
     }
 
     if (child.type === Dot) {
-      const { variant } = child.props;
-      dot = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          maskId={maskId}
-          type={variant}
-        />
-      );
+      dot = child.props;
     }
 
     if (child.type === ActiveDot) {
-      const { variant } = child.props;
-      activeDot = (
-        <ChartDot
-          chartId={id}
-          dataKey={dataKey}
-          fillOpacity={dotOpacity}
-          type={variant}
-        />
-      );
+      activeDot = child.props;
     }
   });
 

--- a/packages/design-system/components/evilcharts/ui/reveal.tsx
+++ b/packages/design-system/components/evilcharts/ui/reveal.tsx
@@ -2,6 +2,7 @@
 
 import type { OrderedRevealAnimation } from "@repo/design-system/components/evilcharts/ui/reveal-animation";
 import { m } from "motion/react";
+import type { ComponentProps, ReactNode } from "react";
 
 const REVEAL_DURATION = 1;
 
@@ -20,6 +21,29 @@ const SINGLE_REVEAL_ORIGIN: Record<
   "right-to-left": 1,
   "center-out": 0.5,
 };
+
+/** Keeps painted geometry together while its reveal is active or static. */
+export function RevealGroup({
+  animation,
+  children,
+  ...props
+}: Pick<ComponentProps<"g">, "className" | "filter" | "opacity"> & {
+  animation: Pick<
+    ComponentProps<typeof m.g>,
+    "animate" | "style" | "transition"
+  > | null;
+  children: ReactNode;
+}) {
+  if (!animation) {
+    return <g {...props}>{children}</g>;
+  }
+
+  return (
+    <m.g {...animation} {...props}>
+      {children}
+    </m.g>
+  );
+}
 
 export const RevealMask = ({
   id,


### PR DESCRIPTION
Outline labels wrapped because Base UI gives the render element's children precedence over the trigger's children. The truncation span therefore disappeared from the actual anchor. Render a module-level `SidebarTreeLabel` directly inside each anchor or virtual heading button so narrow drawers keep one-line labels, full accessible names, and native fragment navigation.

Trace the same composition pattern across the authored TypeScript codebase. Home cards and providers now compose their children directly; lab fact arrays contain math strings; chart marker resolution returns configuration instead of JSX. A shared `RevealGroup` owns the static SVG or animated SVG boundary, preserving bar paint, hit areas, selection opacity, and reveal timing. The quantitative graph composes its existing labels at the `LineEquation` boundary.

Validation:

- Parsed 3,171 authored TypeScript files with no parse errors. No component-local JSX variables or nested component definitions remain in the audit. The Base UI `useRender` hook result and email rendering input are intentional non-matches.
- Format, lint, design-system typecheck, and the full production build, including web typechecking, pass. React Doctor reports 100/100 with no issues.
- All 419 design-system tests pass with 100% per-file coverage.
- All 31 relevant existing browser tests pass. The outline acceptance covers 24 WebKit and Chromium cases at 320, 390, 1024, and 1440 pixels in Indonesian, English, and German, including real touch navigation.
- Production-mode browser checks cover changing all four lab controls and rendered area, bar, line, and scatter charts in WebKit and Chromium at 390 and 1440 pixels. No browser JavaScript errors were observed.

The audit required no new component unit tests, API changes, dependency changes, or lint suppressions. Vercel production deployment remains behind the protected merge to main.
