### PR TITLE
Reuse article bibliography sidebar for Quran

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -11,7 +11,6 @@ import type { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { type ReactNode, Suspense } from "react";
 import { DeferredAiSheetOpen } from "@/components/ai/deferred-sheet-open";
-import { FooterContent } from "@/components/shared/footer-content";
 import { HeaderContent } from "@/components/shared/header-content";
 import { LayoutContent } from "@/components/shared/layout-content";
 import { LayoutMaterialContent } from "@/components/shared/material/content";
@@ -25,7 +24,6 @@ import {
 } from "@/components/shared/quran/interpretation/button";
 import { QuranInterpretationControls } from "@/components/shared/quran/interpretation/controls";
 import { QuranVerseList } from "@/components/shared/quran/verses/list";
-import { RefContent } from "@/components/shared/ref-content";
 import {
   getPublishedQuranCatalog,
   getPublishedQuranView,
@@ -284,9 +282,6 @@ async function CachedSurahShell({
             )}
           </LayoutContent>
           <PaginationContent pagination={pagination} />
-          <FooterContent>
-            <RefContent references={references} title={title} />
-          </FooterContent>
           {toolbar}
         </LayoutMaterialContent>
         <LayoutMaterialToc
@@ -300,6 +295,7 @@ async function CachedSurahShell({
             description,
             descriptionLanguage,
           }}
+          references={{ title, data: references }}
         />
       </VirtualProvider>
     </>

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/page.tsx
@@ -6,10 +6,8 @@ import type { Metadata } from "next";
 import { locale as rootLocale } from "next/root-params";
 import { type Locale, useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { FooterContent } from "@/components/shared/footer-content";
 import { HeaderContent } from "@/components/shared/header-content";
 import { LayoutContent } from "@/components/shared/layout-content";
-import { RefContent } from "@/components/shared/ref-content";
 import { getPublishedQuranCatalog } from "@/lib/content/quran/publication";
 import { getLocaleOrThrow } from "@/lib/i18n/params";
 import { getAppSocialArtwork } from "@/lib/og/app-artwork";
@@ -117,9 +115,6 @@ function PageContent({
           })}
         </div>
       </LayoutContent>
-      <FooterContent>
-        <RefContent />
-      </FooterContent>
     </>
   );
 }

--- a/apps/www/components/shared/ref-content.tsx
+++ b/apps/www/components/shared/ref-content.tsx
@@ -1,303 +1,125 @@
 "use client";
 
 import {
-  Book03Icon,
-  BookOpen02Icon,
-  Calendar03Icon,
   DiscordIcon,
   GithubIcon,
-  Globe02Icon,
-  LayerIcon,
-  QuillWrite01Icon,
   YoutubeIcon,
 } from "@hugeicons/core-free-icons";
-import { useDisclosure } from "@mantine/hooks";
-import type { Reference } from "@repo/contents/_types/content";
 import { Button } from "@repo/design-system/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@repo/design-system/components/ui/card";
 import { HugeIcons } from "@repo/design-system/components/ui/huge-icons";
-import { ScrollArea } from "@repo/design-system/components/ui/scroll-area";
-import { Separator } from "@repo/design-system/components/ui/separator";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@repo/design-system/components/ui/sheet";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@repo/design-system/components/ui/tooltip";
-import { cleanupUrl, formatUrl } from "@repo/design-system/lib/routing/url";
 import { cn } from "@repo/design-system/lib/utils";
 import { COMPANY_SOCIAL_PROFILES } from "@repo/seo/company-profiles";
 import { useTranslations } from "next-intl";
-import { useLayoutEffect } from "react";
 
 interface Props {
-  /** The className of the references. */
   className?: string;
-  /** The URL of the GitHub repository. */
   githubUrl?: string;
-  /** The references to display (sheet content) */
-  references?: Reference[];
-  /** The title of the references (sheet title) */
-  title?: string;
 }
 
-/**
- * Renders reference actions for learn pages.
- *
- * The bibliography sheet is transient UI, so it resets closed when Next hides
- * the page through Cache Components state preservation.
- *
- * References:
- * - Next.js preserving UI state with Cache Components:
- *   `apps/www/node_modules/next/dist/docs/01-app/02-guides/preserving-ui-state.md`
- * - Mantine `useDisclosure`:
- *   https://mantine.dev/hooks/use-disclosure/
- */
-export function RefContent({ title, references, githubUrl, className }: Props) {
+/** Renders source and community links for learn page catalogs. */
+export function RefContent({ githubUrl, className }: Props) {
   const t = useTranslations("Common");
-  const [open, { close, set, toggle }] = useDisclosure(false);
-  const referenceList = references ?? [];
-  const showSheet = Boolean(referenceList.length && title);
-
-  useLayoutEffect(() => close, [close]);
 
   return (
-    <>
-      <section
-        aria-labelledby={t("references")}
-        className={cn("space-y-4", className)}
+    <section
+      aria-labelledby={t("references")}
+      className={cn("space-y-4", className)}
+    >
+      <h2
+        className="scroll-mt-28 font-medium text-2xl leading-tight tracking-tight"
+        id={t("references")}
       >
-        <h2
-          className="scroll-mt-28 font-medium text-2xl leading-tight tracking-tight"
-          id={t("references")}
-        >
-          {t("references")}
-        </h2>
+        {t("references")}
+      </h2>
 
-        <nav
-          aria-label="Reference actions"
-          className="flex flex-wrap items-center gap-2"
-        >
-          {showSheet ? (
-            <Tooltip>
-              <TooltipTrigger
+      <nav
+        aria-label="Reference actions"
+        className="flex flex-wrap items-center gap-2"
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("source-code")}
+                nativeButton={false}
                 render={
-                  <Button
-                    aria-label={t("bibliography")}
-                    onClick={toggle}
-                    size="icon"
-                    variant="outline"
+                  <a
+                    href={githubUrl ?? "https://github.com/nakafaai/nakafa.com"}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title={t("source-code")}
                   >
-                    <span className="sr-only">{t("bibliography")}</span>
-                    <HugeIcons className="size-4" icon={LayerIcon} />
-                  </Button>
+                    <span className="sr-only">{t("source-code")}</span>
+                    <HugeIcons className="size-4" icon={GithubIcon} />
+                  </a>
                 }
+                size="icon"
+                variant="outline"
               />
-              <TooltipContent side="bottom">
-                <p>{t("bibliography")}</p>
-              </TooltipContent>
-            </Tooltip>
-          ) : null}
+            }
+          />
+          <TooltipContent side="bottom">
+            <p>{t("source-code")}</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  aria-label={t("source-code")}
-                  nativeButton={false}
-                  render={
-                    <a
-                      href={
-                        githubUrl ?? "https://github.com/nakafaai/nakafa.com"
-                      }
-                      rel="noopener noreferrer"
-                      target="_blank"
-                      title={t("source-code")}
-                    >
-                      <span className="sr-only">{t("source-code")}</span>
-                      <HugeIcons className="size-4" icon={GithubIcon} />
-                    </a>
-                  }
-                  size="icon"
-                  variant="outline"
-                />
-              }
-            />
-            <TooltipContent side="bottom">
-              <p>{t("source-code")}</p>
-            </TooltipContent>
-          </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                nativeButton={false}
+                render={
+                  <a
+                    href={COMPANY_SOCIAL_PROFILES.youtube}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title={t("videos")}
+                  >
+                    <span className="sr-only">{t("videos")}</span>
+                    <HugeIcons className="size-4" icon={YoutubeIcon} />
+                  </a>
+                }
+                size="icon"
+                variant="outline"
+              />
+            }
+          />
+          <TooltipContent side="bottom">
+            <p>{t("videos")}</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  nativeButton={false}
-                  render={
-                    <a
-                      href={COMPANY_SOCIAL_PROFILES.youtube}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                      title={t("videos")}
-                    >
-                      <span className="sr-only">{t("videos")}</span>
-                      <HugeIcons className="size-4" icon={YoutubeIcon} />
-                    </a>
-                  }
-                  size="icon"
-                  variant="outline"
-                />
-              }
-            />
-            <TooltipContent side="bottom">
-              <p>{t("videos")}</p>
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  nativeButton={false}
-                  render={
-                    <a
-                      href={COMPANY_SOCIAL_PROFILES.discord}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                      title={t("community")}
-                    >
-                      <span className="sr-only">{t("community")}</span>
-                      <HugeIcons className="size-4" icon={DiscordIcon} />
-                    </a>
-                  }
-                  size="icon"
-                  variant="outline"
-                />
-              }
-            />
-            <TooltipContent side="bottom">
-              <p>{t("community")}</p>
-            </TooltipContent>
-          </Tooltip>
-        </nav>
-      </section>
-
-      {showSheet ? (
-        <Sheet modal={false} onOpenChange={set} open={open}>
-          <SheetContent className="w-full sm:max-w-xl">
-            <div className="flex h-full flex-col">
-              <SheetHeader>
-                <SheetTitle className="text-xl">
-                  {referenceList.length} {t("references")}
-                </SheetTitle>
-                <SheetDescription>{title}</SheetDescription>
-              </SheetHeader>
-
-              <Separator />
-
-              <div className="flex flex-1 flex-col overflow-hidden">
-                <ScrollArea className="h-full px-4">
-                  <div className="flex flex-col gap-4 py-4">
-                    {referenceList.map((reference) => {
-                      const url = reference.url
-                        ? formatUrl(reference.url)
-                        : t("no-website");
-                      const cleanUrl = cleanupUrl(url).split("/")[0];
-
-                      return (
-                        <Card key={reference.title}>
-                          <CardHeader>
-                            <CardTitle
-                              className="line-clamp-1 capitalize"
-                              title={reference.title}
-                            >
-                              {reference.title.toLowerCase()}
-                            </CardTitle>
-                            <CardDescription className="flex items-center gap-1">
-                              <HugeIcons
-                                className="size-4 shrink-0"
-                                icon={Globe02Icon}
-                              />
-                              {reference.url ? (
-                                <a
-                                  className="underline-offset-4 hover:underline"
-                                  href={reference.url}
-                                  rel="noopener noreferrer"
-                                  target="_blank"
-                                >
-                                  {cleanUrl}
-                                </a>
-                              ) : (
-                                <span>{t("no-website")}</span>
-                              )}
-                            </CardDescription>
-                          </CardHeader>
-
-                          <CardContent className="space-y-2">
-                            <div className="flex items-center gap-1">
-                              <HugeIcons
-                                className="size-4 shrink-0"
-                                icon={QuillWrite01Icon}
-                              />
-                              <span className="line-clamp-1 text-sm">
-                                {reference.authors}
-                              </span>
-                            </div>
-
-                            <div className="flex items-center gap-1">
-                              <HugeIcons
-                                className="size-4 shrink-0"
-                                icon={Calendar03Icon}
-                              />
-                              <span className="text-sm">{reference.year}</span>
-                            </div>
-
-                            {!!reference.publication && (
-                              <div className="flex items-center gap-1">
-                                <HugeIcons
-                                  className="size-4 shrink-0"
-                                  icon={BookOpen02Icon}
-                                />
-                                <span className="line-clamp-1 text-sm">
-                                  {reference.publication}
-                                </span>
-                              </div>
-                            )}
-
-                            {!!reference.details && (
-                              <div className="flex items-center gap-1">
-                                <HugeIcons
-                                  className="size-4 shrink-0"
-                                  icon={Book03Icon}
-                                />
-                                <span className="text-sm">
-                                  {reference.details}
-                                </span>
-                              </div>
-                            )}
-                          </CardContent>
-                        </Card>
-                      );
-                    })}
-                  </div>
-                </ScrollArea>
-              </div>
-            </div>
-          </SheetContent>
-        </Sheet>
-      ) : null}
-    </>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                nativeButton={false}
+                render={
+                  <a
+                    href={COMPANY_SOCIAL_PROFILES.discord}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title={t("community")}
+                  >
+                    <span className="sr-only">{t("community")}</span>
+                    <HugeIcons className="size-4" icon={DiscordIcon} />
+                  </a>
+                }
+                size="icon"
+                variant="outline"
+              />
+            }
+          />
+          <TooltipContent side="bottom">
+            <p>{t("community")}</p>
+          </TooltipContent>
+        </Tooltip>
+      </nav>
+    </section>
   );
 }

--- a/apps/www/components/sidebar/reference-button.tsx
+++ b/apps/www/components/sidebar/reference-button.tsx
@@ -157,7 +157,7 @@ export function ReferenceButton({ references, title }: Props) {
                                   className="size-4 shrink-0"
                                   icon={Book03Icon}
                                 />
-                                <span className="min-w-0 truncate text-sm">
+                                <span className="wrap-anywhere min-w-0 text-sm">
                                   {reference.details}
                                 </span>
                               </div>

--- a/apps/www/e2e/quran.browser.ts
+++ b/apps/www/e2e/quran.browser.ts
@@ -12,6 +12,7 @@ const quranTranslationNoteHrefPattern = /^#.+-translation-note-\d+$/u;
 const rawTranslationNotePattern = /\[\d+\]/u;
 
 interface QuranLocaleContract {
+  readonly bibliographyLabel: string;
   readonly hasEmbeddedTafsir: boolean;
   readonly hasTranslationNotes: boolean;
   readonly meanings: readonly [QuranMeaningContract, ...QuranMeaningContract[]];
@@ -31,6 +32,7 @@ type QuranLocaleContracts = {
 
 const quranLocaleContracts = {
   de: {
+    bibliographyLabel: "Literaturverzeichnis",
     hasEmbeddedTafsir: false,
     hasTranslationNotes: false,
     locale: "de",
@@ -41,6 +43,7 @@ const quranLocaleContracts = {
     translationNotesLabel: "Anmerkungen zur Übersetzung",
   },
   en: {
+    bibliographyLabel: "Bibliography",
     hasEmbeddedTafsir: false,
     hasTranslationNotes: true,
     locale: "en",
@@ -48,6 +51,7 @@ const quranLocaleContracts = {
     translationNotesLabel: "Translation notes",
   },
   id: {
+    bibliographyLabel: "Daftar pustaka",
     hasEmbeddedTafsir: true,
     hasTranslationNotes: true,
     locale: "id",
@@ -305,7 +309,15 @@ const verifyQuranLocaleCoverage = Effect.fn(
     readinessTimeoutMilliseconds
   );
 
-  const bibliography = page.locator("footer button").first();
+  yield* Effect.promise(() => expect(page.locator("footer")).toHaveCount(0));
+  const outline = page
+    .locator('button[data-slot="sidebar-trigger"].fixed')
+    .filter({ visible: true });
+  yield* Effect.promise(() => outline.click());
+  const bibliography = page.getByRole("button", {
+    exact: true,
+    name: contract.bibliographyLabel,
+  });
   yield* Effect.promise(() => expect(bibliography).toBeVisible());
   yield* Effect.promise(() => bibliography.click());
   const bibliographySheet = page.locator('[data-slot="sheet-popup"]');

--- a/apps/www/e2e/reference-sheet.browser.ts
+++ b/apps/www/e2e/reference-sheet.browser.ts
@@ -4,36 +4,32 @@ import { withObservedPageErrors } from "@/e2e/support/browser-context";
 import { seedDeniedAnalyticsConsent } from "@/e2e/support/consent";
 import { waitForCommittedAppRouter } from "@/e2e/support/navigation/readiness";
 
-const articleHref = "/id/articles/politics/regional-elections-turmoil";
 const readinessTimeoutMilliseconds = 15_000;
 
 const verifyCompactReferenceSheet = Effect.fn(
   "NakafaE2E.verifyCompactReferenceSheet"
-)(function* (page: Page) {
+)(function* (page: Page, href: string, width: number) {
   yield* seedDeniedAnalyticsConsent(page);
   const response = yield* Effect.promise(() =>
-    page.goto(articleHref, { waitUntil: "domcontentloaded" })
+    page.goto(href, { waitUntil: "domcontentloaded" })
   );
   yield* Effect.sync(() => expect(response?.ok()).toBe(true));
   yield* waitForCommittedAppRouter(
     page,
-    articleHref,
-    articleHref,
+    href,
+    href,
     readinessTimeoutMilliseconds
   );
 
-  const sidebarTrigger = page.getByRole("button", {
-    exact: true,
-    name: "Pada halaman ini",
-  });
-  yield* Effect.promise(() => expect(sidebarTrigger).toBeVisible());
-  yield* Effect.promise(() => sidebarTrigger.click());
-
-  const mobileSidebar = page
-    .locator('[role="dialog"][data-sidebar="sidebar"]')
+  const sidebarTrigger = page
+    .getByRole("button", { exact: true, name: "Pada halaman ini" })
+    .or(page.locator('button[data-slot="sidebar-trigger"].fixed'))
     .filter({ visible: true });
-  yield* Effect.promise(() => expect(mobileSidebar).toBeVisible());
-  const trigger = mobileSidebar.getByRole("button", {
+  if (width < 1280) {
+    yield* Effect.promise(() => sidebarTrigger.click());
+  }
+
+  const trigger = page.getByRole("button", {
     exact: true,
     name: "Daftar pustaka",
   });
@@ -76,7 +72,7 @@ const verifyCompactReferenceSheet = Effect.fn(
           ? `${contentStyle.paddingLeft} ${contentStyle.paddingRight}`
           : null,
         dividerWidth: separator?.getBoundingClientRect().width,
-        itemHeight: item.getBoundingClientRect().height,
+        hasOverflow: item.scrollWidth > item.clientWidth,
         itemPaddingTop: itemStyle.paddingTop,
         listWidth: list?.getBoundingClientRect().width,
         metadataGap: metadata ? getComputedStyle(metadata).gap : null,
@@ -88,6 +84,7 @@ const verifyCompactReferenceSheet = Effect.fn(
   );
   yield* Effect.sync(() => {
     expect(metrics).toMatchObject({
+      hasOverflow: false,
       contentGap: "16px",
       contentOverflowX: "hidden",
       contentPaddingInline: "16px 16px",
@@ -98,7 +95,6 @@ const verifyCompactReferenceSheet = Effect.fn(
       urlOverflowX: "hidden",
       urlTextOverflow: "ellipsis",
     });
-    expect(metrics.itemHeight).toBeLessThanOrEqual(232);
   });
 
   yield* Effect.promise(() => page.keyboard.press("Escape"));
@@ -106,12 +102,24 @@ const verifyCompactReferenceSheet = Effect.fn(
   yield* Effect.promise(() => expect(trigger).toBeFocused());
 });
 
-test.describe("article bibliography", () => {
-  test.use({ viewport: { height: 957, width: 665 } });
+for (const width of [390, 665, 1440]) {
+  test.describe(`bibliography at ${width}px`, () => {
+    test.use({ viewport: { height: 957, width } });
 
-  test("presents references as a compact divided list", async ({ page }) => {
-    await Effect.runPromise(
-      withObservedPageErrors(page, verifyCompactReferenceSheet(page))
-    );
+    for (const href of [
+      "/id/articles/politics/regional-elections-turmoil",
+      "/id/quran/1",
+    ]) {
+      test(`presents ${href} references as a divided list`, async ({
+        page,
+      }) => {
+        await Effect.runPromise(
+          withObservedPageErrors(
+            page,
+            verifyCompactReferenceSheet(page, href, width)
+          )
+        );
+      });
+    }
   });
-});
+}


### PR DESCRIPTION
Quran references used a separate card-based footer sheet, unlike the article bibliography. Pass the existing Quran reference projection to the shared outline sidebar so both pages use the same bibliography action and divided list. Remove the Quran index and surah footers and delete the now-unused bibliography props, state, trigger, and duplicate sheet from RefContent.

Allow reference details to wrap so complete signed Quran source notices, versions, terms, and update URLs remain readable. No new components, data contracts, dependencies, or backend changes.

Validation:
- Full local production build passed, including all 233 generated pages.
- Format, lint, workspace boundaries, and web typecheck passed.
- Quran reference tests: 4 passed with 100% coverage.
- React Doctor: 100/100, no findings.
- Production browser acceptance: 10 passed, covering article and Quran sheets at 390, 665, and 1440 pixels, all three Quran locales, tafsir behavior, links, divider layout, overflow, and keyboard dismissal/focus.
- Inspected the actual local production Quran sheet visually.

Production deployment remains behind protected merge to main.