### PR TITLE
Retire obsolete signed history through guarded internal operations

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12000,6 +12000,45 @@ export declare const internal: {
         >;
       };
     };
+    retire: {
+      attempt: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          plan: {
+            attemptId: Id<"tryoutAttempts">;
+            bundleHash: string;
+            runtimeId: Id<"tryoutRuntimeBundles">;
+            source: {
+              manifestHash: string;
+              releaseId: string;
+              sequence: number;
+            };
+            startedAt: number;
+          };
+        },
+        { complete: boolean }
+      >;
+      history: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          plan: {
+            active: {
+              manifestHash: string;
+              releaseId: string;
+              sequence: number;
+            };
+            releases: Array<{
+              manifestHash: string;
+              releaseId: string;
+              sequence: number;
+            }>;
+          };
+        },
+        { complete: boolean; floor: number }
+      >;
+    };
     rollback: {
       prepareRollback: FunctionReference<
         "query",

--- a/packages/backend/convex/auth/cleanup/tryouts.test.ts
+++ b/packages/backend/convex/auth/cleanup/tryouts.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, it } from "@effect/vitest";
 import { cleanupUserTryouts } from "@repo/backend/convex/auth/cleanup/tryouts";
 import { runConvexProgram } from "@repo/backend/convex/lib/effect";
 import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
 import { seedTryoutContentAccessState } from "@repo/backend/test/tryout/runtime";
 import { Effect } from "effect";
 
@@ -52,6 +53,41 @@ describe("auth/cleanup/tryouts", () => {
           await ctx.db.patch("tryoutAttempts", runtime.attemptId, {
             scaleVersionId,
           });
+          const attempt = await ctx.db.get("tryoutAttempts", runtime.attemptId);
+          assert.ok(attempt);
+          await runConvexProgram(
+            writeTryoutSetProgress(ctx, {
+              attempt,
+              publishedScore: 100,
+              status: "completed",
+              updatedAt: attempt.lastActivityAt,
+            })
+          );
+          await ctx.db.insert("tryoutResponses", {
+            answeredAt: 1,
+            isComplete: true,
+            isCorrect: true,
+            placementId: runtime.placementId,
+            selection: { kind: "single-choice", optionKey: "option-1" },
+            timeSpent: 1,
+            tryoutAttemptId: attempt._id,
+            tryoutSectionAttemptId: runtime.sectionAttemptId,
+            updatedAt: 1,
+          });
+          await ctx.db.insert("tryoutScores", {
+            finalizedAt: 1,
+            publishedScore: 100,
+            rawScore: 1,
+            scaleVersionId,
+            scoreStatus: "official",
+            scoringStrategy: "irt",
+            setIdentity: attempt.setIdentity,
+            totalCorrect: 1,
+            totalQuestions: 1,
+            tryoutAttemptId: attempt._id,
+            tryoutSnapshotId: attempt.tryoutSnapshotId,
+            userId: attempt.userId,
+          });
           return {
             attemptId: runtime.attemptId,
             scaleVersionId,
@@ -85,4 +121,69 @@ describe("auth/cleanup/tryouts", () => {
       });
     })
   );
+
+  it("removes a deleted user's entitlement and grant without deleting shared campaign access", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const fixture = await t.mutation(async (ctx) => {
+      const runtime = await seedTryoutContentAccessState(ctx, {
+        attemptStatus: "completed",
+        sectionStatus: "completed",
+        suffix: "cleanup-access",
+      });
+      const campaignId = await ctx.db.insert("tryoutAccessCampaigns", {
+        campaignKind: "access-pass",
+        enabled: true,
+        endsAt: 100,
+        firstRedeemedAt: 1,
+        name: "Technical cleanup access",
+        redeemStatus: "active",
+        resultsFinalizedAt: null,
+        resultsStatus: "pending",
+        slug: "test-cleanup-access",
+        startsAt: 1,
+      });
+      const linkId = await ctx.db.insert("tryoutAccessLinks", {
+        campaignId,
+        code: "test-cleanup-link",
+        enabled: true,
+        label: "Technical cleanup link",
+      });
+      const grantId = await ctx.db.insert("tryoutAccessGrants", {
+        campaignId,
+        linkId,
+        userId: runtime.identity.userId,
+        endsAt: 100,
+        redeemedAt: 1,
+        status: "active",
+      });
+      await ctx.db.insert("tryoutEntitlements", {
+        accessCampaignId: campaignId,
+        accessGrantId: grantId,
+        countryKey: "indonesia",
+        examKey: "snbt",
+        endsAt: 100,
+        sourceKind: "access-pass",
+        startsAt: 1,
+        userId: runtime.identity.userId,
+      });
+      return { campaignId, linkId, userId: runtime.identity.userId };
+    });
+    let progressed = true;
+    for (let page = 0; page < 16 && progressed; page += 1) {
+      progressed = await t.mutation((ctx) =>
+        runConvexProgram(cleanupUserTryouts(ctx, fixture.userId))
+      );
+    }
+    expect(progressed).toBe(false);
+    const remaining = await t.query(async (ctx) => ({
+      campaign: await ctx.db.get("tryoutAccessCampaigns", fixture.campaignId),
+      link: await ctx.db.get("tryoutAccessLinks", fixture.linkId),
+      entitlements: await ctx.db.query("tryoutEntitlements").collect(),
+      grants: await ctx.db.query("tryoutAccessGrants").collect(),
+    }));
+    expect(remaining.entitlements).toEqual([]);
+    expect(remaining.grants).toEqual([]);
+    expect(remaining.campaign?._id).toBe(fixture.campaignId);
+    expect(remaining.link?._id).toBe(fixture.linkId);
+  });
 });

--- a/packages/backend/convex/auth/cleanup/tryouts.ts
+++ b/packages/backend/convex/auth/cleanup/tryouts.ts
@@ -188,3 +188,6 @@ export const cleanupUserTryouts = Effect.fn("auth.cleanup.cleanupUserTryouts")(
     return false;
   }
 );
+
+/** Temporary retirement seam; remove after predecessor history is absent. */
+export { cleanupAttemptRuntime };

--- a/packages/backend/convex/contentRelease/compact/state.ts
+++ b/packages/backend/convex/contentRelease/compact/state.ts
@@ -294,3 +294,6 @@ export const ensureCompaction = Effect.fn("contentRelease.ensureCompaction")(
     } as const;
   }
 );
+
+/** Temporary retirement seam; remove after predecessor history is absent. */
+export { protectedFloor };

--- a/packages/backend/convex/contentRelease/retire.ts
+++ b/packages/backend/convex/contentRelease/retire.ts
@@ -1,0 +1,24 @@
+import { internalMutation } from "@repo/backend/convex/_generated/server";
+import { retireAttemptPage } from "@repo/backend/convex/contentRelease/retire/attempt";
+import { beginHistoryRetirement } from "@repo/backend/convex/contentRelease/retire/history";
+import {
+  retirementAttemptValidator,
+  retirementHistoryValidator,
+} from "@repo/backend/convex/contentRelease/retire/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { v } from "convex/values";
+
+/** Temporary exact-identity retirement; remove after prod and dev zero proof. */
+export const attempt = internalMutation({
+  args: { plan: retirementAttemptValidator },
+  returns: v.object({ complete: v.boolean() }),
+  handler: (ctx, { plan }) => runConvexProgram(retireAttemptPage(ctx, plan)),
+});
+
+/** Temporary compaction admission; remove with the predecessor scope decoder. */
+export const history = internalMutation({
+  args: { plan: retirementHistoryValidator },
+  returns: v.object({ complete: v.boolean(), floor: v.number() }),
+  handler: (ctx, { plan }) =>
+    runConvexProgram(beginHistoryRetirement(ctx, plan)),
+});

--- a/packages/backend/convex/contentRelease/retire/attempt.test.ts
+++ b/packages/backend/convex/contentRelease/retire/attempt.test.ts
@@ -1,0 +1,157 @@
+import { assert, describe, expect, it } from "@effect/vitest";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import { retireAttemptPage } from "@repo/backend/convex/contentRelease/retire/attempt";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { seedRetirementAttempt } from "@repo/backend/test/content/retire";
+import { makeFunctionReference } from "convex/server";
+
+describe("contentRelease/retire/attempt", () => {
+  it("deletes one reviewed attempt in bounded pages while preserving the user and publication", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementAttempt);
+    let complete = false;
+    for (let page = 0; page < 16 && !complete; page += 1) {
+      ({ complete } = await t.mutation(
+        makeFunctionReference<"mutation">("contentRelease/retire:attempt"),
+        { plan }
+      ));
+    }
+    expect(complete).toBe(true);
+    await expect(
+      t.mutation((ctx) => runConvexProgram(retireAttemptPage(ctx, plan)))
+    ).resolves.toEqual({ complete: true });
+    const remaining = await t.query(async (ctx) => ({
+      attempts: await ctx.db.query("tryoutAttempts").collect(),
+      placements: await ctx.db.query("tryoutAttemptPlacements").collect(),
+      progress: await ctx.db.query("tryoutSetProgress").collect(),
+      runtime: await ctx.db.get("tryoutRuntimeBundles", plan.runtimeId),
+      sections: await ctx.db.query("tryoutSectionAttempts").collect(),
+      state: await ctx.db.query("contentState").unique(),
+      users: await ctx.db.query("users").collect(),
+    }));
+    expect(remaining).toMatchObject({
+      attempts: [],
+      placements: [],
+      progress: [],
+      runtime: null,
+      sections: [],
+      state: { activeSequence: 5 },
+    });
+    expect(remaining.users).toHaveLength(1);
+  });
+
+  it("rejects changed identity, paid access, and active attempts before deleting children", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementAttempt);
+    for (const patch of [
+      { status: "in-progress" as const },
+      {
+        status: "completed" as const,
+        accessSubscriptionId: "paid-subscription",
+      },
+      {
+        accessSubscriptionId: undefined,
+        accessSourceKind: "subscription" as const,
+      },
+      { accessSourceKind: "free" as const, countsForCompetition: true },
+      { countsForCompetition: false, accessSourceKind: "competition" as const },
+      { accessSourceKind: "free" as const, startedAt: plan.startedAt + 1 },
+    ]) {
+      await t.mutation((ctx) =>
+        ctx.db.patch("tryoutAttempts", plan.attemptId, patch)
+      );
+      await expect(
+        t.mutation((ctx) => runConvexProgram(retireAttemptPage(ctx, plan)))
+      ).rejects.toThrow("completed unpaid snapshot");
+    }
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          retireAttemptPage(ctx, { ...plan, bundleHash: "changed" })
+        )
+      )
+    ).rejects.toThrow("runtime changed identity");
+    expect(
+      await t.query((ctx) => ctx.db.query("tryoutAttemptPlacements").collect())
+    ).toHaveLength(1);
+  });
+
+  it("preserves another attempt sharing the runtime and its compact progress", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementAttempt);
+    await t.mutation(async (ctx) => {
+      const attempt = await ctx.db.get("tryoutAttempts", plan.attemptId);
+      assert.ok(attempt);
+      const { _creationTime, _id, ...values } = attempt;
+      await ctx.db.insert("tryoutAttempts", { ...values, attemptNumber: 2 });
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(retireAttemptPage(ctx, plan)))
+    ).rejects.toThrow("Another try-out attempt");
+    expect(
+      await t.query((ctx) => ctx.db.query("tryoutSetProgress").collect())
+    ).toHaveLength(1);
+  });
+
+  it("preserves progress shared with another runtime and refuses a slot-owned snapshot", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementAttempt);
+    await t.mutation(async (ctx) => {
+      const attempt = await ctx.db.get("tryoutAttempts", plan.attemptId);
+      const runtime = await ctx.db.get("tryoutRuntimeBundles", plan.runtimeId);
+      assert.ok(attempt && runtime);
+      const {
+        _creationTime: runtimeCreated,
+        _id: runtimeId,
+        ...runtimeValues
+      } = runtime;
+      const otherRuntimeId = await ctx.db.insert("tryoutRuntimeBundles", {
+        ...runtimeValues,
+        bundleHash: "another-bundle",
+      });
+      const { _creationTime, _id, ...values } = attempt;
+      await ctx.db.insert("tryoutAttempts", {
+        ...values,
+        tryoutBundleId: otherRuntimeId,
+        attemptNumber: 2,
+      });
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(retireAttemptPage(ctx, plan)))
+    ).rejects.toThrow("progress shared");
+    await t.mutation(async (ctx) => {
+      const active = await ctx.db
+        .query("contentReleases")
+        .withIndex("by_sequence", (q) => q.eq("sequence", 5))
+        .unique();
+      const runtime = await ctx.db.get("tryoutRuntimeBundles", plan.runtimeId);
+      assert.ok(active && runtime);
+      const release = await runConvexProgram(
+        decodeReleaseJson(active.releaseJson)
+      );
+      await ctx.db.patch("tryoutRuntimeBundles", runtime._id, {
+        rendererManifestHash: release.manifest.rendererManifestHash,
+      });
+      await ctx.db.patch("contentReleases", active._id, {
+        releaseJson: JSON.stringify({
+          ...release,
+          manifest: {
+            ...release.manifest,
+            snapshots: {
+              ...release.manifest.snapshots,
+              tryout: {
+                ...release.manifest.snapshots.tryout,
+                baseSnapshotId: runtime.snapshotId,
+                resultSnapshotId: runtime.snapshotId,
+              },
+            },
+          },
+        }),
+      });
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(retireAttemptPage(ctx, plan)))
+    ).rejects.toThrow("publication slot");
+  });
+});

--- a/packages/backend/convex/contentRelease/retire/attempt.ts
+++ b/packages/backend/convex/contentRelease/retire/attempt.ts
@@ -1,0 +1,109 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { cleanupAttemptRuntime } from "@repo/backend/convex/auth/cleanup/tryouts";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import { loadRetiredRelease } from "@repo/backend/convex/contentRelease/retire/history";
+import type { retirementAttemptValidator } from "@repo/backend/convex/contentRelease/retire/spec";
+import { readTryoutRuntimeRetention } from "@repo/backend/convex/contentRelease/tryout/runtime";
+import type { Infer } from "convex/values";
+import { Effect } from "effect";
+
+/** Deletes one bounded page belonging only to an exact reviewed unpaid attempt. */
+export const retireAttemptPage = Effect.fn("contentRelease.retireAttemptPage")(
+  function* (ctx: MutationCtx, plan: Infer<typeof retirementAttemptValidator>) {
+    const [runtime, attempt] = yield* Effect.all([
+      Effect.promise(() => ctx.db.get("tryoutRuntimeBundles", plan.runtimeId)),
+      Effect.promise(() => ctx.db.get("tryoutAttempts", plan.attemptId)),
+    ]);
+    if (!(runtime || attempt)) {
+      return { complete: true };
+    }
+    if (
+      !runtime ||
+      runtime.bundleHash !== plan.bundleHash ||
+      runtime.sourceReleaseId !== plan.source.releaseId ||
+      runtime.sourceManifestHash !== plan.source.manifestHash
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "The reviewed try-out runtime changed identity."
+      );
+    }
+    yield* loadRetiredRelease(ctx, plan.source);
+    const retention = yield* readTryoutRuntimeRetention(ctx, runtime);
+    if (retention.retainingReleaseId !== null) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_STATE",
+        "An active publication slot still owns the reviewed runtime."
+      );
+    }
+    const attempts = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutAttempts")
+        .withIndex("by_tryoutBundleId", (query) =>
+          query.eq("tryoutBundleId", runtime._id)
+        )
+        .take(2)
+    );
+    if (attempts.some((row) => row._id !== plan.attemptId)) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_CONFLICT",
+        "Another try-out attempt still owns the reviewed runtime."
+      );
+    }
+    if (!attempt) {
+      yield* Effect.promise(() =>
+        ctx.db.delete("tryoutRuntimeBundles", runtime._id)
+      );
+      return { complete: true };
+    }
+    if (
+      attempt.tryoutBundleId !== runtime._id ||
+      attempt.tryoutBundleHash !== plan.bundleHash ||
+      attempt.tryoutSnapshotId !== runtime.snapshotId ||
+      attempt.snapshotReleaseId !== plan.source.releaseId ||
+      attempt.status !== "completed" ||
+      attempt.startedAt !== plan.startedAt ||
+      attempt.accessSubscriptionId !== undefined ||
+      attempt.accessSourceKind !== "free" ||
+      attempt.countsForCompetition
+    ) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_INTEGRITY",
+        "The reviewed attempt is no longer the same completed unpaid snapshot."
+      );
+    }
+    const progress = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutSetProgress")
+        .withIndex("by_userId_and_setIdentity", (query) =>
+          query
+            .eq("userId", attempt.userId)
+            .eq("setIdentity", attempt.setIdentity)
+        )
+        .unique()
+    );
+    if (progress?.latestAttemptId === attempt._id) {
+      const siblings = yield* Effect.promise(() =>
+        ctx.db
+          .query("tryoutAttempts")
+          .withIndex("by_userId_and_setIdentity_and_startedAt", (query) =>
+            query
+              .eq("userId", attempt.userId)
+              .eq("setIdentity", attempt.setIdentity)
+          )
+          .take(2)
+      );
+      if (siblings.some((row) => row._id !== attempt._id)) {
+        return yield* releaseFail(
+          "CONTENT_RELEASE_STATE",
+          "The reviewed attempt still owns progress shared with another attempt."
+        );
+      }
+      yield* Effect.promise(() =>
+        ctx.db.delete("tryoutSetProgress", progress._id)
+      );
+    }
+    yield* cleanupAttemptRuntime(ctx, attempt);
+    return { complete: false };
+  }
+);

--- a/packages/backend/convex/contentRelease/retire/history.test.ts
+++ b/packages/backend/convex/contentRelease/retire/history.test.ts
@@ -1,0 +1,219 @@
+import { vWorkflowId } from "@convex-dev/workflow";
+import { assert, describe, expect, it } from "@effect/vitest";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import { runProgram } from "@repo/backend/convex/contentRelease/compact";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import {
+  beginHistoryRetirement,
+  loadRetiredRelease,
+} from "@repo/backend/convex/contentRelease/retire/history";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import {
+  seedRetirementAttempt,
+  seedRetirementHistory,
+} from "@repo/backend/test/content/retire";
+import { makeFunctionReference } from "convex/server";
+import { parse } from "convex-helpers/validators";
+import { Effect } from "effect";
+
+describe("contentRelease/retire/history", () => {
+  it("compacts only the reviewed predecessor range and resumes safely", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementHistory);
+    const begin = () =>
+      t.mutation(
+        makeFunctionReference<"mutation">("contentRelease/retire:history"),
+        {
+          plan,
+        }
+      );
+    await expect(begin()).resolves.toEqual({ complete: false, floor: 4 });
+    await expect(begin()).resolves.toEqual({ complete: false, floor: 4 });
+    await expect(
+      t.action((ctx) => runConvexProgram(runProgram(ctx)))
+    ).resolves.toMatchObject({ complete: true, floor: 4 });
+    await expect(begin()).resolves.toEqual({ complete: true, floor: 4 });
+    expect(
+      await t.query(async (ctx) =>
+        (await ctx.db.query("contentReleases").collect()).map(
+          ({ sequence }) => sequence
+        )
+      )
+    ).toEqual([4, 5]);
+  });
+
+  it("reports a typed failure for malformed or changed exact identities", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementHistory);
+    const first = plan.releases[0];
+    assert.ok(first);
+    const failure = await t.mutation((ctx) =>
+      runConvexProgram(
+        loadRetiredRelease(ctx, { ...first, manifestHash: "changed" }).pipe(
+          Effect.match({
+            onFailure: (error) => ({ code: error.code, tag: error._tag }),
+            onSuccess: () => null,
+          })
+        )
+      )
+    );
+    expect(failure).toEqual({
+      code: "CONTENT_RELEASE_INTEGRITY",
+      tag: "ReleaseError",
+    });
+    for (const releases of [
+      [],
+      [first, first],
+      [{ ...first, sequence: 0 }],
+      [{ ...first, sequence: 1.5 }],
+      Array.from({ length: 33 }, (_, index) => ({
+        ...first,
+        sequence: index + 1,
+      })),
+    ]) {
+      await expect(
+        t.mutation((ctx) =>
+          runConvexProgram(beginHistoryRetirement(ctx, { ...plan, releases }))
+        )
+      ).rejects.toThrow("bounded contiguous");
+    }
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          beginHistoryRetirement(ctx, {
+            ...plan,
+            active: { ...plan.active, manifestHash: "changed" },
+          })
+        )
+      )
+    ).rejects.toThrow("slots changed");
+  });
+
+  it("preserves modern and protected releases even if a plan names their hashes", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementHistory);
+    const modern = {
+      ...plan.active,
+      sequence: 4,
+      releaseId: "release-compact-4",
+    };
+    await expect(
+      t.mutation((ctx) =>
+        runConvexProgram(
+          beginHistoryRetirement(ctx, {
+            ...plan,
+            releases: [...plan.releases, modern],
+          })
+        )
+      )
+    ).rejects.toThrow("protected release");
+    await t.mutation(async (ctx) => {
+      const first = await ctx.db
+        .query("contentReleases")
+        .withIndex("by_sequence", (q) => q.eq("sequence", 1))
+        .unique();
+      if (!first) {
+        throw new Error("Missing retirement fixture.");
+      }
+      const parsed = await runConvexProgram(
+        decodeReleaseJson(first.releaseJson)
+      );
+      await ctx.db.patch("contentReleases", first._id, {
+        releaseJson: JSON.stringify({
+          ...parsed,
+          manifest: {
+            ...parsed.manifest,
+            scope: { families: ["material"], snapshots: [] },
+          },
+        }),
+      });
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(beginHistoryRetirement(ctx, plan)))
+    ).rejects.toThrow("reviewed retirement identity");
+  });
+
+  it("rejects stale singleton slots and a concurrent compaction owner", async () => {
+    const patches: Partial<Doc<"contentState">>[] = [
+      { activeReleaseId: "changed" },
+      { activeSequence: 6 },
+      { candidateReleaseId: "pending" },
+      { recoveryReleaseId: "retained" },
+      { compactedFloor: undefined },
+      { compactPhase: "heads", compactFloor: 3, compactFrom: 1 },
+      { compactPhase: "heads", compactFloor: 4, compactFrom: 0 },
+    ];
+    for (const patch of patches) {
+      const t = createConvexTestWithBetterAuth();
+      const plan = await t.mutation(seedRetirementHistory);
+      await t.mutation(async (ctx) => {
+        const state = await ctx.db.query("contentState").unique();
+        assert.ok(state);
+        await ctx.db.patch("contentState", state._id, patch);
+      });
+      await expect(
+        t.mutation((ctx) => runConvexProgram(beginHistoryRetirement(ctx, plan)))
+      ).rejects.toThrow("CONTENT_RELEASE_CONFLICT");
+    }
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementHistory);
+    await t.mutation(async (ctx) => {
+      const state = await ctx.db.query("contentState").unique();
+      assert.ok(state);
+      await ctx.db.delete("contentState", state._id);
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(beginHistoryRetirement(ctx, plan)))
+    ).rejects.toThrow("slots changed");
+  });
+
+  it("rejects duplicate sequences, ongoing proof, and a permanent runtime pin", async () => {
+    const t = createConvexTestWithBetterAuth();
+    const plan = await t.mutation(seedRetirementHistory);
+    const first = plan.releases[0];
+    assert.ok(first);
+    const duplicateId = await t.mutation(async (ctx) => {
+      const row = await ctx.db
+        .query("contentReleases")
+        .withIndex("by_sequence", (q) => q.eq("sequence", 1))
+        .unique();
+      assert.ok(row);
+      const { _creationTime, _id, ...values } = row;
+      return await ctx.db.insert("contentReleases", {
+        ...values,
+        releaseId: "duplicate-sequence",
+      });
+    });
+    await expect(
+      t.mutation((ctx) => runConvexProgram(beginHistoryRetirement(ctx, plan)))
+    ).rejects.toThrow("duplicate sequences");
+    await t.mutation((ctx) => ctx.db.delete("contentReleases", duplicateId));
+    for (const patch of [
+      { status: "verified" as const },
+      {
+        status: "aborted" as const,
+        proofWorkflowId: parse(vWorkflowId, "test-retirement-workflow"),
+      },
+    ]) {
+      await t.mutation(async (ctx) => {
+        const row = await ctx.db
+          .query("contentReleases")
+          .withIndex("by_sequence", (q) => q.eq("sequence", 1))
+          .unique();
+        assert.ok(row);
+        await ctx.db.patch("contentReleases", row._id, patch);
+      });
+      await expect(
+        t.mutation((ctx) => runConvexProgram(loadRetiredRelease(ctx, first)))
+      ).rejects.toThrow("reviewed retirement identity");
+    }
+    const runtimeTest = createConvexTestWithBetterAuth();
+    await runtimeTest.mutation(seedRetirementAttempt);
+    await expect(
+      runtimeTest.mutation((ctx) =>
+        runConvexProgram(beginHistoryRetirement(ctx, plan))
+      )
+    ).rejects.toThrow("permanent try-out runtime");
+  });
+});

--- a/packages/backend/convex/contentRelease/retire/history.ts
+++ b/packages/backend/convex/contentRelease/retire/history.ts
@@ -1,0 +1,140 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { protectedRuntimeFloor } from "@repo/backend/convex/contentRelease/compact/runtime";
+import { protectedFloor } from "@repo/backend/convex/contentRelease/compact/state";
+import { releaseFail } from "@repo/backend/convex/contentRelease/error";
+import {
+  loadRelease,
+  loadState,
+} from "@repo/backend/convex/contentRelease/model";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import type {
+  releaseIdentityValidator,
+  retirementHistoryValidator,
+} from "@repo/backend/convex/contentRelease/retire/spec";
+import type { Infer } from "convex/values";
+import { Effect } from "effect";
+
+/** Proves the exact empty predecessor scope before its retirement is allowed. */
+export const loadRetiredRelease = Effect.fn(
+  "contentRelease.loadRetiredRelease"
+)(function* (
+  ctx: MutationCtx,
+  identity: Infer<typeof releaseIdentityValidator>
+) {
+  const row = yield* loadRelease(ctx, identity.releaseId);
+  const signed = yield* decodeReleaseJson(row.releaseJson);
+  if (
+    row.sequence !== identity.sequence ||
+    signed.manifestHash !== identity.manifestHash ||
+    signed.manifest.releaseId !== identity.releaseId ||
+    signed.manifest.scope.content?.length !== 0 ||
+    (row.status !== "completed" && row.status !== "aborted") ||
+    row.proofWorkflowId !== undefined
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      `Release ${identity.releaseId} no longer matches the reviewed retirement identity.`
+    );
+  }
+  return row;
+});
+
+/** Starts only the reviewed predecessor range in the native durable compactor. */
+export const beginHistoryRetirement = Effect.fn(
+  "contentRelease.beginHistoryRetirement"
+)(function* (ctx: MutationCtx, plan: Infer<typeof retirementHistoryValidator>) {
+  const first = plan.releases[0];
+  const last = plan.releases.at(-1);
+  if (
+    !(first && last) ||
+    plan.releases.length > 32 ||
+    !Number.isSafeInteger(first.sequence) ||
+    first.sequence < 1 ||
+    plan.releases.some(
+      (release, index) => release.sequence !== first.sequence + index
+    )
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "Retirement requires one bounded contiguous release range."
+    );
+  }
+  const floor = last.sequence + 1;
+  const state = yield* loadState(ctx);
+  if (
+    !state ||
+    state.activeReleaseId !== plan.active.releaseId ||
+    state.activeManifestHash !== plan.active.manifestHash ||
+    state.activeSequence !== plan.active.sequence ||
+    state.candidateReleaseId !== undefined ||
+    state.recoveryReleaseId !== undefined
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_CONFLICT",
+      "Publication slots changed after retirement review."
+    );
+  }
+  if ((state.compactedFloor ?? 0) >= floor) {
+    return { complete: true, floor };
+  }
+  if (state.compactPhase !== undefined) {
+    if (state.compactFloor !== floor || state.compactFrom !== first.sequence) {
+      return yield* releaseFail(
+        "CONTENT_RELEASE_CONFLICT",
+        "Another history compaction already owns this deployment."
+      );
+    }
+    return { complete: false, floor };
+  }
+  if ((state.compactedFloor ?? 0) !== first.sequence) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_CONFLICT",
+      "The reviewed range does not start at the compacted floor."
+    );
+  }
+  const ceiling = yield* protectedFloor(ctx, state);
+  if (floor > ceiling) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "The retirement range contains protected release history."
+    );
+  }
+  const rows = yield* Effect.forEach(plan.releases, (identity) =>
+    loadRetiredRelease(ctx, identity)
+  );
+  const stored = yield* Effect.promise(() =>
+    ctx.db
+      .query("contentReleases")
+      .withIndex("by_sequence", (query) =>
+        query.gte("sequence", first.sequence).lt("sequence", floor)
+      )
+      .take(plan.releases.length + 1)
+  );
+  if (
+    stored.length !== rows.length ||
+    stored.some((row, index) => row._id !== rows[index]?._id)
+  ) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_INTEGRITY",
+      "The reviewed retirement range changed or contains duplicate sequences."
+    );
+  }
+  if ((yield* protectedRuntimeFloor(ctx, rows)) !== null) {
+    return yield* releaseFail(
+      "CONTENT_RELEASE_STATE",
+      "A permanent try-out runtime still owns the retirement range."
+    );
+  }
+  const now = Date.now();
+  yield* Effect.promise(() =>
+    ctx.db.patch("contentState", state._id, {
+      compactCursor: undefined,
+      compactFloor: floor,
+      compactFrom: first.sequence,
+      compactPhase: "heads",
+      compactStartedAt: now,
+      updatedAt: now,
+    })
+  );
+  return { complete: false, floor };
+});

--- a/packages/backend/convex/contentRelease/retire/spec.ts
+++ b/packages/backend/convex/contentRelease/retire/spec.ts
@@ -1,0 +1,20 @@
+import { v } from "convex/values";
+
+export const releaseIdentityValidator = v.object({
+  manifestHash: v.string(),
+  releaseId: v.string(),
+  sequence: v.number(),
+});
+
+export const retirementHistoryValidator = v.object({
+  active: releaseIdentityValidator,
+  releases: v.array(releaseIdentityValidator),
+});
+
+export const retirementAttemptValidator = v.object({
+  attemptId: v.id("tryoutAttempts"),
+  bundleHash: v.string(),
+  runtimeId: v.id("tryoutRuntimeBundles"),
+  source: releaseIdentityValidator,
+  startedAt: v.number(),
+});

--- a/packages/backend/test/content/retire.ts
+++ b/packages/backend/test/content/retire.ts
@@ -1,0 +1,98 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import type {
+  retirementAttemptValidator,
+  retirementHistoryValidator,
+} from "@repo/backend/convex/contentRelease/retire/spec";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
+import { compactionIdentity } from "@repo/backend/test/content/compact";
+import {
+  insertTestState,
+  insertZeroRelease,
+} from "@repo/backend/test/content/state";
+import { seedTryoutContentAccessState } from "@repo/backend/test/tryout/runtime";
+import type { Infer } from "convex/values";
+
+/** Seeds reviewed recent predecessor records below a modern active release. */
+export async function seedRetirementHistory(ctx: MutationCtx) {
+  const releases = Array.from({ length: 5 }, (_, index) =>
+    compactionIdentity(index + 1)
+  );
+  for (const [index, identity] of releases.entries()) {
+    await insertZeroRelease(ctx, {
+      ...identity,
+      base: releases[index - 1],
+      ownership: { base: [], result: ["material"] },
+      role: "candidate",
+      scope:
+        index < 3
+          ? { content: [], families: ["material"], snapshots: [] }
+          : { families: ["material"], snapshots: [] },
+      status: "completed",
+    });
+  }
+  const active = releases.at(-1);
+  if (!active) {
+    throw new Error("Expected the technical active release fixture.");
+  }
+  await insertTestState(ctx, { active, nextSequence: 6 });
+  const state = await ctx.db.query("contentState").unique();
+  if (!state) {
+    throw new Error("Expected the technical singleton fixture.");
+  }
+  await ctx.db.patch("contentState", state._id, { compactedFloor: 1 });
+  return { active, releases: releases.slice(0, 3) } satisfies Infer<
+    typeof retirementHistoryValidator
+  >;
+}
+
+/** Seeds one unpaid completed attempt isolated from current publication state. */
+export async function seedRetirementAttempt(ctx: MutationCtx) {
+  const fixture = await seedTryoutContentAccessState(ctx, {
+    attemptStatus: "completed",
+    sectionStatus: "completed",
+    suffix: "retirement",
+  });
+  const state = await ctx.db.query("contentState").unique();
+  if (state) {
+    const original = await ctx.db
+      .query("contentReleases")
+      .withIndex("by_releaseId", (q) =>
+        q.eq("releaseId", state.activeReleaseId ?? "")
+      )
+      .unique();
+    if (original) {
+      await ctx.db.delete("contentReleases", original._id);
+    }
+    await ctx.db.delete("contentState", state._id);
+  }
+  const history = await seedRetirementHistory(ctx);
+  const source = history.releases[0];
+  const attempt = await ctx.db.get("tryoutAttempts", fixture.attemptId);
+  if (!(source && attempt)) {
+    throw new Error("Expected the technical retirement source and attempt.");
+  }
+  await ctx.db.patch("tryoutRuntimeBundles", attempt.tryoutBundleId, {
+    cleanupReleaseId: undefined,
+    sourceManifestHash: source.manifestHash,
+    sourceReleaseId: source.releaseId,
+  });
+  await ctx.db.patch("tryoutAttempts", attempt._id, {
+    snapshotReleaseId: source.releaseId,
+  });
+  await runConvexProgram(
+    writeTryoutSetProgress(ctx, {
+      attempt,
+      publishedScore: 100,
+      status: "completed",
+      updatedAt: attempt.lastActivityAt,
+    })
+  );
+  return {
+    attemptId: attempt._id,
+    bundleHash: attempt.tryoutBundleHash,
+    runtimeId: attempt.tryoutBundleId,
+    source,
+    startedAt: attempt.startedAt,
+  } satisfies Infer<typeof retirementAttemptValidator>;
+}


### PR DESCRIPTION
Obsolete signed manifests still contain the predecessor `scope.content` field, and one completed free try-out attempt pins that history. Add temporary internal retirement mutations so the reviewed attempt and a bounded, exact-identity release range can be retired before removing the predecessor decoder.

Attempt retirement checks the runtime hash, source release, completion time identity, free access, competition status, publication slots, and other attempt owners before reusing bounded account-cleanup primitives. History retirement checks every release identity and the current publication slots, then hands the reviewed range to the existing durable compactor. Both operations are retryable and fail closed if their reviewed state changes.

Validation:

- Backend suite: 417 files and 2,058 tests passed; changed covered modules retain 100% statement, branch, function, and line coverage.
- Backend typecheck, repository lint, formatting, and full diff check passed.
- Native isolated Convex rehearsal drained the technical attempt in six bounded pages, deleted its children and unused runtime, preserved a current attempt byte-for-byte plus its user and free claim, then compacted only the three reviewed releases while retaining sequences 4 and 5.

These endpoints are transitional. After protected merge and deployment, refresh production and shared-development identity evidence, retire only the reviewed predecessor data, prove zero remaining predecessor manifests/runtime references, and delete these endpoints and temporary exports together with the predecessor contracts.
