### PR TITLE
Resolve curriculum artwork by reviewed course identity

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/root.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/curricula/[curriculum]/[[...path]]/root.tsx
@@ -143,9 +143,8 @@ export function CurriculumChildCards({
       {routes.map((route, index) => {
         const imageSrc = resolveCurriculumCatalogArtwork(locale, {
           nodeKey: route.nodeKey,
-          iconKey: route.iconKey,
+          programKey: route.programKey,
           kind: "route",
-          materialDomain: route.materialDomain,
         });
 
         return (

--- a/apps/www/lib/curriculum/artwork.test.ts
+++ b/apps/www/lib/curriculum/artwork.test.ts
@@ -2,7 +2,6 @@
 
 import { describe, expect, it } from "@effect/vitest";
 import { PublicPathSchema } from "@nakafa/aksara-contracts/ids";
-import { MaterialDomainSchema } from "@nakafa/aksara-contracts/material/domain";
 import { LearningProgramKeySchema } from "@nakafa/aksara-contracts/program/spec";
 import {
   getCurriculumIndexSocialImage,
@@ -33,60 +32,116 @@ describe("curriculum artwork", () => {
     ).toBe("/open-graph/curriculum/en-united-states.png");
   });
 
-  it("maps signed grade and material identities to reviewed artwork", () => {
-    expect(
-      resolveCurriculumCatalogArtwork("de", {
-        nodeKey: "class-10",
-        iconKey: "grade-10",
-        kind: "route",
-      })
-    ).toBe("/open-graph/grade/de-10.png");
-    expect(
-      resolveCurriculumCatalogArtwork("de", {
-        nodeKey: "economics",
-        iconKey: "mathematics",
-        kind: "route",
-        materialDomain: MaterialDomainSchema.make("economy"),
-      })
-    ).toBe("/open-graph/subject/de-economics.png");
-  });
-
   it.each(["en", "id", "de"] as const)(
-    "resolves stage artwork by identity in %s",
+    "distinguishes Mathematics from courses and topics sharing its domain in %s",
     (locale) => {
-      for (const nodeKey of ["secondary", "upper-secondary"]) {
-        expect(
-          resolveCurriculumCatalogArtwork(locale, {
-            kind: "route",
-            nodeKey,
-            iconKey: "school",
-          })
-        ).toBe(
-          `/open-graph/grade/${locale === "id" ? "en" : locale}-${nodeKey}.png`
-        );
-      }
+      const programKey = LearningProgramKeySchema.make("singapore-moe");
       expect(
         resolveCurriculumCatalogArtwork(locale, {
           kind: "route",
-          nodeKey: "lower-secondary",
-          iconKey: "middle-school",
+          programKey,
+          nodeKey: "secondary-mathematics",
         })
-      ).toBeUndefined();
+      ).toBe(`/open-graph/subject/${locale}-mathematics.png`);
+
+      for (const nodeKey of [
+        "secondary-additional-mathematics",
+        "secondary-mathematics-number-algebra",
+        "secondary-additional-mathematics-functions-calculus",
+      ]) {
+        expect(
+          resolveCurriculumCatalogArtwork(locale, {
+            kind: "route",
+            programKey,
+            nodeKey,
+          })
+        ).toBeUndefined();
+      }
     }
   );
 
-  it("keeps unknown catalog identities on card gradients", () => {
+  it.each([
+    ["merdeka", "class-11-mathematics"],
+    ["cambridge-international", "mathematics-0580"],
+    ["united-states", "high-school-mathematics"],
+  ])("preserves reviewed Mathematics artwork for %s", (program, nodeKey) => {
+    expect(
+      resolveCurriculumCatalogArtwork("de", {
+        kind: "route",
+        programKey: LearningProgramKeySchema.make(program),
+        nodeKey,
+      })
+    ).toBe("/open-graph/subject/de-mathematics.png");
+  });
+
+  it("preserves reviewed discipline artwork within the combined science course", () => {
+    const programKey = LearningProgramKeySchema.make("singapore-moe");
+    expect(
+      resolveCurriculumCatalogArtwork("id", {
+        kind: "route",
+        programKey,
+        nodeKey: "secondary-science-physics",
+      })
+    ).toBe("/open-graph/subject/id-physics.png");
+    expect(
+      resolveCurriculumCatalogArtwork("id", {
+        kind: "route",
+        programKey,
+        nodeKey: "secondary-science",
+      })
+    ).toBeUndefined();
+  });
+
+  it.each(["en", "id", "de"] as const)(
+    "preserves reviewed stage and grade artwork in %s",
+    (locale) => {
+      expect(
+        resolveCurriculumCatalogArtwork(locale, {
+          kind: "route",
+          programKey: LearningProgramKeySchema.make("merdeka"),
+          nodeKey: "class-10",
+        })
+      ).toBe(`/open-graph/grade/${locale}-10.png`);
+      expect(
+        resolveCurriculumCatalogArtwork(locale, {
+          kind: "route",
+          programKey: LearningProgramKeySchema.make("cambridge-international"),
+          nodeKey: "upper-secondary",
+        })
+      ).toBe(
+        `/open-graph/grade/${locale === "id" ? "en" : locale}-upper-secondary.png`
+      );
+      expect(
+        resolveCurriculumCatalogArtwork(locale, {
+          kind: "route",
+          programKey: LearningProgramKeySchema.make("singapore-moe"),
+          nodeKey: "secondary",
+        })
+      ).toBe(
+        `/open-graph/grade/${locale === "id" ? "en" : locale}-secondary.png`
+      );
+    }
+  );
+
+  it("does not infer artwork from another program or a shared school icon", () => {
+    for (const nodeKey of [
+      "secondary",
+      "secondary-mathematics",
+      "lower-secondary",
+      "class-10",
+    ]) {
+      expect(
+        resolveCurriculumCatalogArtwork("en", {
+          kind: "route",
+          programKey: LearningProgramKeySchema.make("cambridge-international"),
+          nodeKey,
+        })
+      ).toBeUndefined();
+    }
     expect(
       resolveCurriculumCatalogArtwork("en", {
         kind: "program",
         programKey: LearningProgramKeySchema.make("future"),
-      })
-    ).toBeUndefined();
-    expect(
-      resolveCurriculumCatalogArtwork("en", {
-        nodeKey: "future",
-        iconKey: "science",
-        kind: "route",
       })
     ).toBeUndefined();
   });

--- a/apps/www/lib/curriculum/artwork.ts
+++ b/apps/www/lib/curriculum/artwork.ts
@@ -1,4 +1,3 @@
-import { MaterialDomainSchema } from "@nakafa/aksara-contracts/material/domain";
 import type { CurriculumRoute } from "@nakafa/aksara-contracts/program/curriculum";
 import type { LearningProgramKey } from "@nakafa/aksara-contracts/program/spec";
 import type { Locale } from "next-intl";
@@ -9,58 +8,38 @@ import {
 } from "@/lib/og/artwork";
 import { getOgUrl } from "@/lib/utils/metadata";
 
-const STAGE_ARTWORK_BY_NODE_KEY = new Map<
-  CurriculumRoute["nodeKey"],
-  ArtworkIdentity
->([
-  ["secondary", "grade/secondary"],
-  ["upper-secondary", "grade/upper-secondary"],
-]);
-
-const GRADE_ARTWORK_BY_ICON_KEY = new Map<
-  CurriculumRoute["iconKey"],
-  ArtworkIdentity
->([
-  ["grade-9", "grade/9"],
-  ["grade-10", "grade/10"],
-  ["grade-11", "grade/11"],
-  ["grade-12", "grade/12"],
-]);
-
-const SUBJECT_ARTWORK_BY_MATERIAL_DOMAIN = new Map<
-  NonNullable<CurriculumRoute["materialDomain"]>,
-  ArtworkIdentity
->([
-  [MaterialDomainSchema.make("ai-ds"), "subject/ai-ds"],
-  [MaterialDomainSchema.make("biology"), "subject/biology"],
-  [MaterialDomainSchema.make("chemistry"), "subject/chemistry"],
-  [MaterialDomainSchema.make("computer-science"), "subject/computer-science"],
-  [MaterialDomainSchema.make("economy"), "subject/economics"],
-  [MaterialDomainSchema.make("english-language"), "subject/english-language"],
-  [MaterialDomainSchema.make("general-reasoning"), "subject/general-reasoning"],
-  [MaterialDomainSchema.make("geography"), "subject/geography"],
-  [MaterialDomainSchema.make("geospatial"), "subject/geospatial"],
-  [MaterialDomainSchema.make("history"), "subject/history"],
-  [
-    MaterialDomainSchema.make("indonesian-language"),
-    "subject/indonesian-language",
-  ],
-  [MaterialDomainSchema.make("informatics"), "subject/informatics"],
-  [
-    MaterialDomainSchema.make("mathematical-reasoning"),
-    "subject/mathematical-reasoning",
-  ],
-  [MaterialDomainSchema.make("mathematics"), "subject/mathematics"],
-  [MaterialDomainSchema.make("physics"), "subject/physics"],
-  [
-    MaterialDomainSchema.make("quantitative-knowledge"),
-    "subject/quantitative-knowledge",
-  ],
-  [MaterialDomainSchema.make("sociology"), "subject/sociology"],
-  [
-    MaterialDomainSchema.make("technology-electro-medical"),
-    "subject/technology-electro-medical",
-  ],
+/**
+ * Reviewed artwork for exact signed program and node identities.
+ * Material domains and icons describe shared content, not course identity.
+ * Add a node only when its own title matches reviewed public artwork.
+ */
+const CURRICULUM_ARTWORK_BY_IDENTITY = new Map<string, ArtworkIdentity>([
+  ["cambridge-international", "curriculum/cambridge-international"],
+  ["cambridge-international/upper-secondary", "grade/upper-secondary"],
+  ["cambridge-international/mathematics-0580", "subject/mathematics"],
+  ["cambridge-international/biology-0610", "subject/biology"],
+  ["cambridge-international/chemistry-0620", "subject/chemistry"],
+  ["cambridge-international/physics-0625", "subject/physics"],
+  ["merdeka", "curriculum/merdeka"],
+  ["merdeka/class-9", "grade/9"],
+  ["merdeka/class-10", "grade/10"],
+  ["merdeka/class-11", "grade/11"],
+  ["merdeka/class-12", "grade/12"],
+  ["merdeka/class-10-biology", "subject/biology"],
+  ["merdeka/class-10-chemistry", "subject/chemistry"],
+  ["merdeka/class-10-mathematics", "subject/mathematics"],
+  ["merdeka/class-10-physics", "subject/physics"],
+  ["merdeka/class-11-mathematics", "subject/mathematics"],
+  ["merdeka/class-11-physics", "subject/physics"],
+  ["merdeka/class-12-mathematics", "subject/mathematics"],
+  ["singapore-moe", "curriculum/singapore-moe"],
+  ["singapore-moe/secondary", "grade/secondary"],
+  ["singapore-moe/secondary-mathematics", "subject/mathematics"],
+  ["singapore-moe/secondary-science-physics", "subject/physics"],
+  ["singapore-moe/secondary-science-chemistry", "subject/chemistry"],
+  ["singapore-moe/secondary-science-biology", "subject/biology"],
+  ["united-states", "curriculum/united-states"],
+  ["united-states/high-school-mathematics", "subject/mathematics"],
 ]);
 
 type CurriculumSocialImageRoute = Pick<CurriculumRoute, "level" | "publicPath">;
@@ -72,23 +51,19 @@ type CurriculumCatalogArtworkSource =
     }
   | ({
       readonly kind: "route";
-    } & Pick<CurriculumRoute, "nodeKey" | "iconKey" | "materialDomain">);
+    } & Pick<CurriculumRoute, "programKey" | "nodeKey">);
 
 /** Resolves reviewed card artwork from one signed curriculum identity. */
 export function resolveCurriculumCatalogArtwork(
   locale: Locale,
   source: CurriculumCatalogArtworkSource
 ) {
-  const identity =
+  const key =
     source.kind === "program"
-      ? getCurriculumArtworkIdentity(source.programKey)
-      : (STAGE_ARTWORK_BY_NODE_KEY.get(source.nodeKey) ??
-        GRADE_ARTWORK_BY_ICON_KEY.get(source.iconKey) ??
-        (source.materialDomain
-          ? SUBJECT_ARTWORK_BY_MATERIAL_DOMAIN.get(source.materialDomain)
-          : undefined));
+      ? source.programKey
+      : `${source.programKey}/${source.nodeKey}`;
 
-  return identity ? resolveStaticArtwork(identity, locale) : undefined;
+  return resolveStaticArtwork(CURRICULUM_ARTWORK_BY_IDENTITY.get(key), locale);
 }
 
 /** Keeps the curriculum index on its localized generated social artwork. */
@@ -112,27 +87,9 @@ export function getCurriculumRouteSocialImage(
     return getOgUrl(locale, route.publicPath);
   }
 
-  const identity = getCurriculumArtworkIdentity(programKey);
   return resolveSocialArtwork({
-    identity,
+    identity: CURRICULUM_ARTWORK_BY_IDENTITY.get(programKey),
     locale,
     publicPath: route.publicPath,
   });
-}
-
-function getCurriculumArtworkIdentity(
-  programKey: LearningProgramKey
-): ArtworkIdentity | undefined {
-  switch (programKey) {
-    case "cambridge-international":
-      return "curriculum/cambridge-international";
-    case "merdeka":
-      return "curriculum/merdeka";
-    case "singapore-moe":
-      return "curriculum/singapore-moe";
-    case "united-states":
-      return "curriculum/united-states";
-    default:
-      return;
-  }
 }


### PR DESCRIPTION
Additional Mathematics incorrectly displayed Mathematics artwork because both courses share the same inherited material domain. Resolve card artwork through one explicit registry of reviewed program and node identities. Additional Mathematics and unreviewed topics now use the existing gradient; reviewed course, grade, stage, and program artwork remains available.

This removes the domain/icon inference maps and program switch, narrows the caller to program and node identity, and preserves generated social images for deeper routes. The resolver remains a pure lookup with no added Effect runtime or IO.

Validation: 1,755 web tests pass with 100% per-file coverage; lint, web typecheck, boundaries, and local production build pass. Browser inspection confirms distinct Mathematics and Additional Mathematics cards. React Doctor reports 93/100 with one pre-existing duplicate JSX warning in the unchanged header. Independent strict architecture review found no blockers.