### PR TITLE
fix(tryouts): guard exact unanswered attempt retirement

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12985,6 +12985,250 @@ export declare const internal: {
       >;
     };
   };
+  retirement: {
+    internal: {
+      emptyAttempt: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          plan: {
+            active: {
+              manifestHash: string;
+              releaseId: string;
+              sequence: number;
+            };
+            attempt: {
+              _creationTime: number;
+              _id: Id<"tryoutAttempts">;
+              accessCampaignId?: Id<"tryoutAccessCampaigns">;
+              accessEndsAt: number;
+              accessGrantId?: Id<"tryoutAccessGrants">;
+              accessSourceKind:
+                "free" | "competition" | "access-pass" | "subscription";
+              accessSubscriptionId?: string;
+              appLocale: "en" | "id" | "de";
+              attemptNumber: number;
+              completedAt: number | null;
+              completedSectionKeys: Array<string>;
+              countryKey: string;
+              countsForCompetition: boolean;
+              endReason: "submitted" | "time-expired" | null;
+              examKey: string;
+              expiresAt: number;
+              lastActivityAt: number;
+              scaleVersionId?: Id<"irtScaleVersions">;
+              scoreStatus: "provisional" | "official";
+              scoringStrategy: "irt" | "raw" | "weighted";
+              sectionSnapshots: Array<{
+                publicPath?: string;
+                questionCount: number;
+                questionSourcePath: string;
+                sectionIdentity: string;
+                sectionKey: string;
+                sectionOrder: number;
+                sectionRowHash: string;
+                sourceRevision: string;
+                timeLimitSeconds: number;
+              }>;
+              setIdentity: string;
+              setKey: string;
+              setPublicPath: string;
+              snapshotReleaseId: string;
+              startedAt: number;
+              status: "in-progress" | "completed" | "expired";
+              theta?: number;
+              thetaSE?: number;
+              totalCorrect: number;
+              totalQuestions: number;
+              trackKey: string;
+              tryoutBundleHash: string;
+              tryoutBundleId: Id<"tryoutRuntimeBundles">;
+              tryoutSnapshotId: string;
+              userId: Id<"users">;
+            };
+            newSnapshotId: string;
+            previous: {
+              _creationTime: number;
+              _id: Id<"tryoutAttempts">;
+              accessCampaignId?: Id<"tryoutAccessCampaigns">;
+              accessEndsAt: number;
+              accessGrantId?: Id<"tryoutAccessGrants">;
+              accessSourceKind:
+                "free" | "competition" | "access-pass" | "subscription";
+              accessSubscriptionId?: string;
+              appLocale: "en" | "id" | "de";
+              attemptNumber: number;
+              completedAt: number | null;
+              completedSectionKeys: Array<string>;
+              countryKey: string;
+              countsForCompetition: boolean;
+              endReason: "submitted" | "time-expired" | null;
+              examKey: string;
+              expiresAt: number;
+              lastActivityAt: number;
+              scaleVersionId?: Id<"irtScaleVersions">;
+              scoreStatus: "provisional" | "official";
+              scoringStrategy: "irt" | "raw" | "weighted";
+              sectionSnapshots: Array<{
+                publicPath?: string;
+                questionCount: number;
+                questionSourcePath: string;
+                sectionIdentity: string;
+                sectionKey: string;
+                sectionOrder: number;
+                sectionRowHash: string;
+                sourceRevision: string;
+                timeLimitSeconds: number;
+              }>;
+              setIdentity: string;
+              setKey: string;
+              setPublicPath: string;
+              snapshotReleaseId: string;
+              startedAt: number;
+              status: "in-progress" | "completed" | "expired";
+              theta?: number;
+              thetaSE?: number;
+              totalCorrect: number;
+              totalQuestions: number;
+              trackKey: string;
+              tryoutBundleHash: string;
+              tryoutBundleId: Id<"tryoutRuntimeBundles">;
+              tryoutSnapshotId: string;
+              userId: Id<"users">;
+            };
+            previousScore: {
+              _creationTime: number;
+              _id: Id<"tryoutScores">;
+              finalizedAt: number;
+              publishedScore: number;
+              rawScore: number;
+              scaleVersionId?: Id<"irtScaleVersions">;
+              scoreStatus: "provisional" | "official";
+              scoringStrategy: "irt" | "raw" | "weighted";
+              setIdentity: string;
+              theta?: number;
+              thetaSE?: number;
+              totalCorrect: number;
+              totalQuestions: number;
+              tryoutAttemptId: Id<"tryoutAttempts">;
+              tryoutSnapshotId: string;
+              userId: Id<"users">;
+            };
+            progress: {
+              _creationTime: number;
+              _id: Id<"tryoutSetProgress">;
+              appLocale: "en" | "id" | "de";
+              attemptNumber: number;
+              countryKey: string;
+              examKey: string;
+              latestAttemptId: Id<"tryoutAttempts">;
+              publishedScore: number | null;
+              setIdentity: string;
+              setKey: string;
+              status: "in-progress" | "completed" | "expired";
+              statusRank: 1 | 2 | 3;
+              trackKey: string;
+              updatedAt: number;
+              userId: Id<"users">;
+            };
+            scale: {
+              _creationTime: number;
+              _id: Id<"irtScaleVersions">;
+              history?: true;
+              model: "2pl";
+              publishedAt: number;
+              questionCount: number;
+              setIdentity: string;
+              status: "provisional" | "official";
+              tryoutSnapshotId: string;
+            };
+            section: {
+              _creationTime: number;
+              _id: Id<"tryoutSectionAttempts">;
+              answeredCount: number;
+              completedAt: number | null;
+              correctAnswers: number;
+              endReason: "submitted" | "time-expired" | null;
+              expiresAt: number;
+              lastActivityAt: number;
+              score?: {
+                publishedScore: number;
+                rawScore: number;
+                scoreStatus: "provisional" | "official";
+                scoringStrategy: "irt" | "raw" | "weighted";
+                theta?: number;
+                thetaSE?: number;
+              };
+              sectionIdentity: string;
+              sectionKey: string;
+              sectionOrder: number;
+              startedAt: number;
+              status: "in-progress" | "completed" | "expired";
+              totalQuestions: number;
+              tryoutAttemptId: Id<"tryoutAttempts">;
+            };
+            sharedAttempts: Array<{
+              _creationTime: number;
+              _id: Id<"tryoutAttempts">;
+              accessCampaignId?: Id<"tryoutAccessCampaigns">;
+              accessEndsAt: number;
+              accessGrantId?: Id<"tryoutAccessGrants">;
+              accessSourceKind:
+                "free" | "competition" | "access-pass" | "subscription";
+              accessSubscriptionId?: string;
+              appLocale: "en" | "id" | "de";
+              attemptNumber: number;
+              completedAt: number | null;
+              completedSectionKeys: Array<string>;
+              countryKey: string;
+              countsForCompetition: boolean;
+              endReason: "submitted" | "time-expired" | null;
+              examKey: string;
+              expiresAt: number;
+              lastActivityAt: number;
+              scaleVersionId?: Id<"irtScaleVersions">;
+              scoreStatus: "provisional" | "official";
+              scoringStrategy: "irt" | "raw" | "weighted";
+              sectionSnapshots: Array<{
+                publicPath?: string;
+                questionCount: number;
+                questionSourcePath: string;
+                sectionIdentity: string;
+                sectionKey: string;
+                sectionOrder: number;
+                sectionRowHash: string;
+                sourceRevision: string;
+                timeLimitSeconds: number;
+              }>;
+              setIdentity: string;
+              setKey: string;
+              setPublicPath: string;
+              snapshotReleaseId: string;
+              startedAt: number;
+              status: "in-progress" | "completed" | "expired";
+              theta?: number;
+              thetaSE?: number;
+              totalCorrect: number;
+              totalQuestions: number;
+              trackKey: string;
+              tryoutBundleHash: string;
+              tryoutBundleId: Id<"tryoutRuntimeBundles">;
+              tryoutSnapshotId: string;
+              userId: Id<"users">;
+            }>;
+          };
+        },
+        {
+          alreadyRetired: boolean;
+          removedPlacements: number;
+          removedSections: number;
+          restoredAttemptId: Id<"tryoutAttempts">;
+          restoredProgressId: Id<"tryoutSetProgress">;
+          retiredAttemptId: Id<"tryoutAttempts">;
+        }
+      >;
+    };
+  };
   subscriptions: {
     mutations: {
       createSubscription: FunctionReference<

--- a/packages/backend/convex/retirement/impl.test.ts
+++ b/packages/backend/convex/retirement/impl.test.ts
@@ -385,6 +385,8 @@ describe("retirement empty attempt", () => {
     "partial-footprint",
     "changed-history",
     "changed-shared",
+    "missing-bundle",
+    "changed-bundle",
   ] as const) {
     it.effect(`refuses an incomplete or changed retry: ${mode}`, () =>
       fixture().pipe(
@@ -407,6 +409,12 @@ describe("retirement empty attempt", () => {
                 await ctx.db.patch(plan.previousScore._id, {
                   publishedScore: 101,
                 });
+              } else if (mode === "missing-bundle") {
+                await ctx.db.delete(plan.attempt.tryoutBundleId);
+              } else if (mode === "changed-bundle") {
+                await ctx.db.patch(plan.attempt.tryoutBundleId, {
+                  bundleHash: testTextHash("changed-shared-bundle"),
+                });
               } else {
                 const shared = plan.sharedAttempts[0];
                 assert.ok(shared);
@@ -419,7 +427,11 @@ describe("retirement empty attempt", () => {
             await expect(
               t.mutation((ctx) => runConvexProgram(retireAttempt(ctx, plan)))
             ).rejects.toMatchObject({
-              data: { code: "TRYOUT_EMPTY_RETIREMENT_REFUSED" },
+              data: {
+                code: mode.endsWith("bundle")
+                  ? "TRYOUT_SELECTOR_INTEGRITY"
+                  : "TRYOUT_EMPTY_RETIREMENT_REFUSED",
+              },
             });
             expect(await t.query(stored)).toEqual(before);
           })

--- a/packages/backend/convex/retirement/impl.test.ts
+++ b/packages/backend/convex/retirement/impl.test.ts
@@ -1,0 +1,459 @@
+import { afterEach, assert, describe, expect, it } from "@effect/vitest";
+import type { Doc } from "@repo/backend/convex/_generated/dataModel";
+import type {
+  MutationCtx,
+  QueryCtx,
+} from "@repo/backend/convex/_generated/server";
+import { cleanupAttemptRuntime } from "@repo/backend/convex/auth/cleanup/tryouts";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { retireAttempt } from "@repo/backend/convex/retirement/impl";
+import type { Plan } from "@repo/backend/convex/retirement/spec";
+import { createConvexTestWithBetterAuth } from "@repo/backend/convex/test.helpers";
+import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
+import { makeActivationRuntime } from "@repo/backend/test/activation/fixture";
+import { testTextHash } from "@repo/backend/test/content/release";
+import { insertZeroRelease } from "@repo/backend/test/content/state";
+import { storeRuntimeFixture } from "@repo/backend/test/runtime/bundle";
+import { seedTryoutContentAccessState } from "@repo/backend/test/tryout/runtime";
+import { makeFunctionReference } from "convex/server";
+import { Effect } from "effect";
+
+// Convex Test has a different ID codec from the native deployment. Bind only the
+// fixed reviewed ID to its generated fixture; all document guards remain real.
+const reviewed = vi.hoisted(() => ({ id: "wn7d0a14z2wscs0kpmgx7k7psh8e0x0t" }));
+vi.mock("@repo/backend/convex/retirement/spec", async (original) => ({
+  ...(await original<typeof import("@repo/backend/convex/retirement/spec")>()),
+  get REVIEWED_ATTEMPT_ID() {
+    return reviewed.id;
+  },
+}));
+const endpoint = makeFunctionReference<"mutation", { plan: Plan }>(
+  "retirement/internal:emptyAttempt"
+);
+
+vi.mock("@repo/backend/convex/auth/cleanup/tryouts", { spy: true });
+
+/** Builds two real signed runtimes with the reviewed bounded attempt shape. */
+const fixture = Effect.fn("test.retirement.fixture")(function* () {
+  const t = createConvexTestWithBetterAuth();
+  const runtime = yield* Effect.promise(() =>
+    t.mutation((ctx) =>
+      seedTryoutContentAccessState(ctx, {
+        attemptStatus: "in-progress",
+        sectionStatus: "in-progress",
+        suffix: "retirement",
+      })
+    )
+  );
+  const replacement = yield* makeActivationRuntime();
+  yield* storeRuntimeFixture(t, replacement);
+  const plan = yield* Effect.promise(() =>
+    t.mutation(async (ctx) => {
+      const original = await ctx.db.get("tryoutAttempts", runtime.attemptId);
+      const frozen = await ctx.db.get(
+        "tryoutAttemptPlacements",
+        runtime.placementId
+      );
+      const state = await ctx.db.query("contentState").unique();
+      assert.ok(original && frozen && state);
+      const scaleId = await ctx.db.insert("irtScaleVersions", {
+        model: "2pl",
+        publishedAt: 1,
+        questionCount: 160,
+        setIdentity: original.setIdentity,
+        status: "provisional",
+        tryoutSnapshotId: original.tryoutSnapshotId,
+      });
+      await ctx.db.patch("tryoutAttempts", original._id, {
+        accessSourceKind: "subscription",
+        attemptNumber: 5,
+        completedSectionKeys: ["general-reasoning"],
+        scaleVersionId: scaleId,
+        totalQuestions: 160,
+      });
+      await ctx.db.patch("tryoutSectionAttempts", runtime.sectionAttemptId, {
+        completedAt: original.lastActivityAt,
+        endReason: "time-expired",
+        sectionKey: "general-reasoning",
+        score: {
+          publishedScore: 100,
+          rawScore: 0,
+          scoreStatus: "provisional",
+          scoringStrategy: "irt",
+          theta: -4,
+          thetaSE: 1.373_759_630_503_494_7,
+        },
+        status: "expired",
+      });
+      const attempt = await ctx.db.get("tryoutAttempts", original._id);
+      assert.ok(attempt);
+      const {
+        _id: originalId,
+        _creationTime: originalCreatedAt,
+        ...attemptFields
+      } = attempt;
+      const previousId = await ctx.db.insert("tryoutAttempts", {
+        ...attemptFields,
+        attemptNumber: 4,
+        completedAt: original.startedAt - 1,
+        endReason: "submitted",
+        startedAt: original.startedAt - 100,
+        lastActivityAt: original.startedAt - 1,
+        status: "completed",
+      });
+      const previousScoreId = await ctx.db.insert("tryoutScores", {
+        finalizedAt: original.startedAt - 1,
+        publishedScore: 100,
+        rawScore: 100,
+        scaleVersionId: scaleId,
+        scoreStatus: "provisional",
+        scoringStrategy: "irt",
+        setIdentity: original.setIdentity,
+        totalCorrect: 10,
+        totalQuestions: 160,
+        tryoutAttemptId: previousId,
+        tryoutSnapshotId: original.tryoutSnapshotId,
+        userId: original.userId,
+      });
+      const sharedAttempts: Doc<"tryoutAttempts">[] = [];
+      for (let index = 0; index < 3; index += 1) {
+        const sharedId = await ctx.db.insert("tryoutAttempts", {
+          ...attemptFields,
+          examKey: "tka",
+          setIdentity: `tka-shared-${index}`,
+          startedAt: original.startedAt - 200,
+          completedAt: original.startedAt - 100,
+          endReason: "submitted",
+          status: "completed",
+        });
+        const shared = await ctx.db.get("tryoutAttempts", sharedId);
+        assert.ok(shared);
+        sharedAttempts.push(shared);
+      }
+      const {
+        _id: frozenId,
+        _creationTime: frozenCreatedAt,
+        ...placementFields
+      } = frozen;
+      for (let order = 2; order <= 160; order += 1) {
+        await ctx.db.insert("tryoutAttemptPlacements", {
+          ...placementFields,
+          questionOrder: order,
+        });
+      }
+      const progressId = await runConvexProgram(
+        writeTryoutSetProgress(ctx, {
+          attempt,
+          publishedScore: null,
+          status: "in-progress",
+          updatedAt: attempt.lastActivityAt,
+        })
+      );
+      const active = {
+        releaseId: "retirement-replacement",
+        manifestHash: testTextHash("retirement-replacement"),
+        sequence: 2,
+      };
+      await insertZeroRelease(ctx, {
+        ...active,
+        ownership: { base: [], result: [] },
+        role: "candidate",
+        status: "completed",
+        snapshots: replacement.release.manifest.snapshots,
+      });
+      await ctx.db.patch("contentState", state._id, {
+        activeReleaseId: active.releaseId,
+        activeManifestHash: active.manifestHash,
+        activeSequence: active.sequence,
+      });
+      const section = await ctx.db.get(
+        "tryoutSectionAttempts",
+        runtime.sectionAttemptId
+      );
+      const progress = await ctx.db.get("tryoutSetProgress", progressId);
+      const previous = await ctx.db.get("tryoutAttempts", previousId);
+      const previousScore = await ctx.db.get("tryoutScores", previousScoreId);
+      const scale = await ctx.db.get("irtScaleVersions", scaleId);
+      assert.ok(section && progress && previous && previousScore && scale);
+      return {
+        active,
+        newSnapshotId: replacement.snapshot.snapshotId,
+        attempt,
+        section,
+        progress,
+        previous,
+        previousScore,
+        scale,
+        sharedAttempts,
+      } satisfies Plan;
+    })
+  );
+  return { t, plan };
+});
+
+/** Retains the complete domain state needed to prove transactional refusal. */
+async function stored(ctx: Pick<QueryCtx, "db">) {
+  return {
+    attempts: await ctx.db.query("tryoutAttempts").collect(),
+    sections: await ctx.db.query("tryoutSectionAttempts").collect(),
+    placements: await ctx.db.query("tryoutAttemptPlacements").collect(),
+    responses: await ctx.db.query("tryoutResponses").collect(),
+    scores: await ctx.db.query("tryoutScores").collect(),
+    progress: await ctx.db.query("tryoutSetProgress").collect(),
+    scales: await ctx.db.query("irtScaleVersions").collect(),
+    bundles: await ctx.db.query("tryoutRuntimeBundles").collect(),
+  };
+}
+
+afterEach(() => {
+  reviewed.id = "wn7d0a14z2wscs0kpmgx7k7psh8e0x0t";
+  vi.mocked(cleanupAttemptRuntime).mockRestore();
+});
+
+describe("retirement empty attempt", () => {
+  it.effect(
+    "removes only the empty attempt and restores its completed predecessor",
+    () =>
+      fixture().pipe(
+        Effect.flatMap(({ t, plan }) =>
+          Effect.promise(async () => {
+            const before = await t.query(stored);
+            reviewed.id = plan.attempt._id;
+            const result = await t.mutation(endpoint, { plan });
+            const after = await t.query(stored);
+            expect(result).toMatchObject({
+              retiredAttemptId: plan.attempt._id,
+              restoredAttemptId: plan.previous._id,
+              removedSections: 1,
+              removedPlacements: 160,
+            });
+            expect(after.attempts).toEqual(
+              before.attempts.filter((row) => row._id !== plan.attempt._id)
+            );
+            expect(after.sections).toEqual([]);
+            expect(after.placements).toEqual([]);
+            expect(after.responses).toEqual(before.responses);
+            expect(after.scores).toEqual(before.scores);
+            expect(after.scales).toEqual(before.scales);
+            expect(after.bundles).toEqual(before.bundles);
+            expect(after.progress).toHaveLength(1);
+            expect(await t.mutation(endpoint, { plan })).toMatchObject({
+              alreadyRetired: true,
+              restoredProgressId: result.restoredProgressId,
+              removedSections: 0,
+              removedPlacements: 0,
+            });
+            expect(await t.query(stored)).toEqual(after);
+            expect(after.progress[0]).toMatchObject({
+              latestAttemptId: plan.previous._id,
+              attemptNumber: 4,
+              status: "completed",
+              publishedScore: 100,
+            });
+          })
+        )
+      )
+  );
+
+  it.effect(
+    "refuses a different attempt at the internal boundary before writes",
+    () =>
+      fixture().pipe(
+        Effect.flatMap(({ t, plan }) =>
+          Effect.promise(async () => {
+            const before = await t.query(stored);
+            await expect(t.mutation(endpoint, { plan })).rejects.toMatchObject({
+              data: { code: "TRYOUT_EMPTY_RETIREMENT_REFUSED" },
+            });
+            expect(await t.query(stored)).toEqual(before);
+          })
+        )
+      )
+  );
+
+  const changes = [
+    {
+      name: "publication changed",
+      apply: async (ctx: MutationCtx, plan: Plan) => {
+        const state = await ctx.db.query("contentState").unique();
+        assert.ok(state);
+        await ctx.db.patch(state._id, {
+          activeSequence: plan.active.sequence + 1,
+        });
+      },
+    },
+    {
+      name: "attempt activity changed",
+      apply: (ctx: MutationCtx, plan: Plan) =>
+        ctx.db.patch(plan.attempt._id, {
+          lastActivityAt: plan.attempt.lastActivityAt + 1,
+        }),
+    },
+    {
+      name: "section activity changed",
+      apply: (ctx: MutationCtx, plan: Plan) =>
+        ctx.db.patch(plan.section._id, { answeredCount: 1 }),
+    },
+    {
+      name: "frozen placement removed",
+      apply: async (ctx: MutationCtx) => {
+        const row = await ctx.db.query("tryoutAttemptPlacements").first();
+        assert.ok(row);
+        await ctx.db.delete(row._id);
+      },
+    },
+    {
+      name: "progress changed",
+      apply: (ctx: MutationCtx, plan: Plan) =>
+        ctx.db.patch(plan.progress._id, {
+          updatedAt: plan.progress.updatedAt + 1,
+        }),
+    },
+    {
+      name: "predecessor score changed",
+      apply: (ctx: MutationCtx, plan: Plan) =>
+        ctx.db.patch(plan.previousScore._id, { publishedScore: 101 }),
+    },
+    {
+      name: "scale ownership changed",
+      apply: (ctx: MutationCtx, plan: Plan) =>
+        ctx.db.patch(plan.scale._id, { history: true }),
+    },
+    {
+      name: "shared history changed",
+      apply: async (ctx: MutationCtx, plan: Plan) => {
+        const shared = plan.sharedAttempts[0];
+        assert.ok(shared);
+        await ctx.db.patch(shared._id, {
+          lastActivityAt: shared.lastActivityAt + 1,
+        });
+      },
+    },
+    {
+      name: "new response",
+      apply: async (ctx: MutationCtx, plan: Plan) => {
+        const placement = await ctx.db.query("tryoutAttemptPlacements").first();
+        assert.ok(placement);
+        await ctx.db.insert("tryoutResponses", {
+          answeredAt: 1,
+          isComplete: true,
+          isCorrect: true,
+          placementId: placement._id,
+          selection: { kind: "single-choice", optionKey: "option-1" },
+          timeSpent: 1,
+          tryoutAttemptId: plan.attempt._id,
+          tryoutSectionAttemptId: plan.section._id,
+          updatedAt: 1,
+        });
+      },
+    },
+    {
+      name: "new score",
+      apply: async (ctx: MutationCtx, plan: Plan) => {
+        const { _id, _creationTime, ...score } = plan.previousScore;
+        await ctx.db.insert("tryoutScores", {
+          ...score,
+          tryoutAttemptId: plan.attempt._id,
+        });
+      },
+    },
+  ];
+  for (const change of changes) {
+    it.effect(
+      `refuses ${change.name} without changing any retained state`,
+      () =>
+        fixture().pipe(
+          Effect.flatMap(({ t, plan }) =>
+            Effect.promise(async () => {
+              await t.mutation((ctx) => change.apply(ctx, plan));
+              const before = await t.query(stored);
+              await expect(
+                t.mutation((ctx) => runConvexProgram(retireAttempt(ctx, plan)))
+              ).rejects.toMatchObject({
+                data: { code: "TRYOUT_EMPTY_RETIREMENT_REFUSED" },
+              });
+              expect(await t.query(stored)).toEqual(before);
+            })
+          )
+        )
+    );
+  }
+
+  for (const mode of [
+    "missing-progress",
+    "changed-progress",
+    "partial-footprint",
+    "changed-history",
+    "changed-shared",
+  ] as const) {
+    it.effect(`refuses an incomplete or changed retry: ${mode}`, () =>
+      fixture().pipe(
+        Effect.flatMap(({ t, plan }) =>
+          Effect.promise(async () => {
+            await t.mutation((ctx) =>
+              runConvexProgram(retireAttempt(ctx, plan))
+            );
+            await t.mutation(async (ctx) => {
+              const progress = await ctx.db.query("tryoutSetProgress").unique();
+              assert.ok(progress);
+              if (mode === "missing-progress") {
+                await ctx.db.delete(progress._id);
+              } else if (mode === "changed-progress") {
+                await ctx.db.patch(progress._id, { publishedScore: 101 });
+              } else if (mode === "partial-footprint") {
+                const { _id, _creationTime, ...section } = plan.section;
+                await ctx.db.insert("tryoutSectionAttempts", section);
+              } else if (mode === "changed-history") {
+                await ctx.db.patch(plan.previousScore._id, {
+                  publishedScore: 101,
+                });
+              } else {
+                const shared = plan.sharedAttempts[0];
+                assert.ok(shared);
+                await ctx.db.patch(shared._id, {
+                  lastActivityAt: shared.lastActivityAt + 1,
+                });
+              }
+            });
+            const before = await t.query(stored);
+            await expect(
+              t.mutation((ctx) => runConvexProgram(retireAttempt(ctx, plan)))
+            ).rejects.toMatchObject({
+              data: { code: "TRYOUT_EMPTY_RETIREMENT_REFUSED" },
+            });
+            expect(await t.query(stored)).toEqual(before);
+          })
+        )
+      )
+    );
+  }
+
+  it.effect(
+    "rolls back a completed deletion phase if activity changes before the next phase",
+    () =>
+      fixture().pipe(
+        Effect.flatMap(({ t, plan }) =>
+          Effect.promise(async () => {
+            const before = await t.query(stored);
+            vi.mocked(cleanupAttemptRuntime).mockImplementationOnce(
+              Effect.fn("test.retirement.activity")(function* (ctx, attempt) {
+                yield* Effect.promise(() => ctx.db.delete(plan.section._id));
+                yield* Effect.promise(() =>
+                  ctx.db.patch(attempt._id, {
+                    lastActivityAt: attempt.lastActivityAt + 1,
+                  })
+                );
+                return true;
+              })
+            );
+            await expect(
+              t.mutation((ctx) => runConvexProgram(retireAttempt(ctx, plan)))
+            ).rejects.toMatchObject({
+              data: { code: "TRYOUT_EMPTY_RETIREMENT_REFUSED" },
+            });
+            expect(await t.query(stored)).toEqual(before);
+          })
+        )
+      )
+  );
+});

--- a/packages/backend/convex/retirement/impl.ts
+++ b/packages/backend/convex/retirement/impl.ts
@@ -1,0 +1,62 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import { cleanupAttemptRuntime } from "@repo/backend/convex/auth/cleanup/tryouts";
+import {
+  inspectRetirement,
+  readCompletedRetirement,
+  requireEmptyAttempt,
+} from "@repo/backend/convex/retirement/proof";
+import { type Plan, requireProof } from "@repo/backend/convex/retirement/spec";
+import { writeTryoutSetProgress } from "@repo/backend/convex/tryouts/progress/write";
+import { Effect, Option } from "effect";
+
+/** Deletes only the reviewed empty attempt and restores its unchanged predecessor. */
+export const retireAttempt = Effect.fn("retirement.retireAttempt")(function* (
+  ctx: MutationCtx,
+  plan: Plan
+) {
+  const completed = yield* readCompletedRetirement(ctx, plan);
+  if (Option.isSome(completed)) {
+    return {
+      alreadyRetired: true,
+      retiredAttemptId: plan.attempt._id,
+      restoredAttemptId: plan.previous._id,
+      restoredProgressId: completed.value,
+      removedSections: 0,
+      removedPlacements: 0,
+    };
+  }
+  yield* inspectRetirement(ctx, plan);
+  let removed = false;
+  for (let phase = 0; phase < 8; phase += 1) {
+    yield* requireEmptyAttempt(ctx, plan);
+    yield* cleanupAttemptRuntime(ctx, plan.attempt);
+    const remaining = yield* Effect.promise(() =>
+      ctx.db.get("tryoutAttempts", plan.attempt._id)
+    );
+    if (remaining === null) {
+      removed = true;
+      break;
+    }
+  }
+  yield* requireProof(
+    removed,
+    "The reviewed cleanup exceeded its atomic phase bound."
+  );
+  yield* Effect.promise(() =>
+    ctx.db.delete("tryoutSetProgress", plan.progress._id)
+  );
+  const restoredProgressId = yield* writeTryoutSetProgress(ctx, {
+    attempt: plan.previous,
+    publishedScore: plan.previousScore.publishedScore,
+    status: plan.previous.status,
+    updatedAt: plan.previous.lastActivityAt,
+  });
+  return {
+    alreadyRetired: false,
+    retiredAttemptId: plan.attempt._id,
+    restoredAttemptId: plan.previous._id,
+    restoredProgressId,
+    removedSections: 1,
+    removedPlacements: 160,
+  };
+});

--- a/packages/backend/convex/retirement/internal.ts
+++ b/packages/backend/convex/retirement/internal.ts
@@ -1,0 +1,33 @@
+import { internalMutation } from "@repo/backend/convex/functions";
+import { runConvexProgram } from "@repo/backend/convex/lib/effect";
+import { retireAttempt } from "@repo/backend/convex/retirement/impl";
+import {
+  planValidator,
+  REVIEWED_ATTEMPT_ID,
+  requireProof,
+} from "@repo/backend/convex/retirement/spec";
+import { v } from "convex/values";
+import { Effect } from "effect";
+
+/** Temporary internal operation, removed immediately after the reviewed retirement. */
+export const emptyAttempt = internalMutation({
+  args: { plan: planValidator },
+  returns: v.object({
+    alreadyRetired: v.boolean(),
+    retiredAttemptId: v.id("tryoutAttempts"),
+    restoredAttemptId: v.id("tryoutAttempts"),
+    restoredProgressId: v.id("tryoutSetProgress"),
+    removedSections: v.number(),
+    removedPlacements: v.number(),
+  }),
+  handler: (ctx, { plan }) =>
+    runConvexProgram(
+      Effect.gen(function* () {
+        yield* requireProof(
+          plan.attempt._id === REVIEWED_ATTEMPT_ID,
+          "Only the reviewed production attempt may be retired."
+        );
+        return yield* retireAttempt(ctx, plan);
+      })
+    ),
+});

--- a/packages/backend/convex/retirement/proof.ts
+++ b/packages/backend/convex/retirement/proof.ts
@@ -1,0 +1,367 @@
+import type { MutationCtx } from "@repo/backend/convex/_generated/server";
+import {
+  loadRelease,
+  loadState,
+} from "@repo/backend/convex/contentRelease/model";
+import { decodeReleaseJson } from "@repo/backend/convex/contentRelease/parse";
+import { loadReleaseTryoutRuntime } from "@repo/backend/convex/contentRelease/tryout/runtime";
+import {
+  EmptyAttemptRetirementError,
+  type Plan,
+  requireProof,
+  sameDocument,
+} from "@repo/backend/convex/retirement/spec";
+import { getTryoutStatusRank } from "@repo/backend/convex/tryouts/status";
+import { Effect, Option } from "effect";
+
+/** Pins the already verified publication and its newly selectable runtime. */
+const requirePublication = Effect.fn("retirement.requirePublication")(
+  function* (ctx: MutationCtx, plan: Plan) {
+    const state = yield* loadState(ctx);
+    yield* requireProof(
+      state?.activeReleaseId === plan.active.releaseId &&
+        state.activeManifestHash === plan.active.manifestHash &&
+        state.activeSequence === plan.active.sequence,
+      "The reviewed Question publication is no longer active."
+    );
+    const release = yield* loadRelease(ctx, plan.active.releaseId);
+    const signed = yield* decodeReleaseJson(release.releaseJson);
+    yield* requireProof(
+      release.status === "completed" &&
+        release.sequence === plan.active.sequence &&
+        signed.manifestHash === plan.active.manifestHash &&
+        signed.manifest.snapshots.tryout.resultSnapshotId ===
+          plan.newSnapshotId &&
+        plan.newSnapshotId !== plan.attempt.tryoutSnapshotId,
+      "The replacement signed try-out snapshot is not the reviewed active result."
+    );
+    const runtime = yield* loadReleaseTryoutRuntime(ctx, signed);
+    yield* requireProof(
+      runtime.result !== null &&
+        runtime.result.stored.snapshotId === plan.newSnapshotId,
+      "The replacement try-out runtime is unavailable."
+    );
+  }
+);
+
+/** Rechecks identity, activity and empty response/score indexes before each phase. */
+export const requireEmptyAttempt = Effect.fn("retirement.requireEmptyAttempt")(
+  function* (ctx: MutationCtx, plan: Plan) {
+    const [attempt, response, score] = yield* Effect.all([
+      Effect.promise(() => ctx.db.get("tryoutAttempts", plan.attempt._id)),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutResponses")
+          .withIndex("by_tryoutAttemptId_and_answeredAt", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutScores")
+          .withIndex("by_tryoutAttemptId", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+    ]);
+    yield* requireProof(
+      attempt !== null && sameDocument(attempt, plan.attempt),
+      "The reviewed attempt identity or activity changed."
+    );
+    yield* requireProof(
+      response === null && score === null,
+      "The reviewed attempt has a response or score."
+    );
+  }
+);
+
+/** Proves the exact bounded footprint and its completed predecessor before writes. */
+export const inspectRetirement = Effect.fn("retirement.inspect")(function* (
+  ctx: MutationCtx,
+  plan: Plan
+) {
+  const attempt = plan.attempt;
+  yield* requirePublication(ctx, plan);
+  yield* requireEmptyAttempt(ctx, plan);
+  yield* requireProof(
+    attempt.countryKey === "indonesia" &&
+      attempt.examKey === "snbt" &&
+      attempt.trackKey === "2027" &&
+      attempt.setKey === "set-1" &&
+      attempt.appLocale === "id" &&
+      attempt.attemptNumber === 5 &&
+      attempt.status === "in-progress" &&
+      attempt.totalQuestions === 160 &&
+      attempt.totalCorrect === 0 &&
+      sameDocument(attempt.completedSectionKeys, ["general-reasoning"]) &&
+      attempt.completedAt === null &&
+      attempt.endReason === null &&
+      attempt.accessSourceKind === "subscription",
+    "This is not the reviewed empty SNBT attempt."
+  );
+  const [sections, placements, progress, latest, previousScore, scale] =
+    yield* Effect.all([
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutSectionAttempts")
+          .withIndex("by_tryoutAttemptId_and_sectionOrder", (q) =>
+            q.eq("tryoutAttemptId", attempt._id)
+          )
+          .take(2)
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutAttemptPlacements")
+          .withIndex("by_tryoutAttemptId_and_questionOrder", (q) =>
+            q.eq("tryoutAttemptId", attempt._id)
+          )
+          .take(161)
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutSetProgress")
+          .withIndex("by_userId_and_setIdentity", (q) =>
+            q
+              .eq("userId", attempt.userId)
+              .eq("setIdentity", attempt.setIdentity)
+          )
+          .unique()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutAttempts")
+          .withIndex("by_userId_and_setIdentity_and_startedAt", (q) =>
+            q
+              .eq("userId", attempt.userId)
+              .eq("setIdentity", attempt.setIdentity)
+          )
+          .order("desc")
+          .take(2)
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutScores")
+          .withIndex("by_tryoutAttemptId", (q) =>
+            q.eq("tryoutAttemptId", plan.previous._id)
+          )
+          .unique()
+      ),
+      Effect.promise(() => ctx.db.get("irtScaleVersions", plan.scale._id)),
+    ]);
+  yield* requireProof(
+    sections.length === 1 &&
+      sameDocument(sections, [plan.section]) &&
+      plan.section.status === "expired" &&
+      plan.section.sectionKey === "general-reasoning" &&
+      plan.section.answeredCount === 0 &&
+      plan.section.correctAnswers === 0 &&
+      plan.section.completedAt === attempt.lastActivityAt &&
+      plan.section.endReason === "time-expired" &&
+      plan.section.score?.rawScore === 0 &&
+      plan.section.score.publishedScore === 100 &&
+      plan.section.score.scoreStatus === "provisional",
+    "The reviewed empty section changed."
+  );
+  yield* requireProof(
+    placements.length === 160,
+    "The reviewed frozen placement bound changed."
+  );
+  const sectionResponse = yield* Effect.promise(() =>
+    ctx.db
+      .query("tryoutResponses")
+      .withIndex("by_tryoutSectionAttemptId_and_answeredAt", (q) =>
+        q.eq("tryoutSectionAttemptId", plan.section._id)
+      )
+      .first()
+  );
+  yield* requireProof(
+    sectionResponse === null,
+    "The reviewed section has a response."
+  );
+  for (const placement of placements) {
+    const response = yield* Effect.promise(() =>
+      ctx.db
+        .query("tryoutResponses")
+        .withIndex("by_placementId", (q) => q.eq("placementId", placement._id))
+        .first()
+    );
+    yield* requireProof(
+      response === null,
+      "A response still references a reviewed frozen placement."
+    );
+  }
+  yield* requireProof(
+    progress !== null &&
+      sameDocument(progress, plan.progress) &&
+      plan.progress.latestAttemptId === attempt._id &&
+      plan.progress.status === "in-progress" &&
+      plan.progress.publishedScore === null,
+    "The reviewed latest progress changed."
+  );
+  yield* requireProof(
+    sameDocument(latest, [attempt, plan.previous]) &&
+      plan.previous.attemptNumber === 4 &&
+      plan.previous.status === "completed",
+    "The reviewed completed predecessor changed."
+  );
+  yield* requireProof(
+    previousScore !== null &&
+      sameDocument(previousScore, plan.previousScore) &&
+      plan.previousScore.publishedScore === 100 &&
+      plan.previousScore.userId === attempt.userId &&
+      plan.previousScore.tryoutSnapshotId === plan.previous.tryoutSnapshotId &&
+      plan.previousScore.setIdentity === attempt.setIdentity,
+    "The reviewed predecessor score changed."
+  );
+  yield* requireProof(
+    attempt.scaleVersionId === plan.scale._id &&
+      scale !== null &&
+      sameDocument(scale, plan.scale) &&
+      plan.scale.history !== true &&
+      plan.scale.status === "provisional" &&
+      plan.scale.tryoutSnapshotId === attempt.tryoutSnapshotId &&
+      plan.scale.setIdentity === attempt.setIdentity &&
+      plan.scale.questionCount === 160,
+    "The canonical scale retention proof changed."
+  );
+  yield* requireProof(
+    plan.sharedAttempts.length === 3 &&
+      new Set(plan.sharedAttempts.map((shared) => shared._id)).size === 3,
+    "Three distinct completed shared TKA histories must remain protected."
+  );
+  for (const shared of plan.sharedAttempts) {
+    const row = yield* Effect.promise(() =>
+      ctx.db.get("tryoutAttempts", shared._id)
+    );
+    yield* requireProof(
+      shared._id !== attempt._id &&
+        shared.status === "completed" &&
+        shared.examKey === "tka" &&
+        shared.tryoutBundleId === attempt.tryoutBundleId &&
+        shared.tryoutSnapshotId === attempt.tryoutSnapshotId &&
+        row !== null &&
+        sameDocument(row, shared),
+      "A protected shared TKA history changed."
+    );
+  }
+});
+
+/** Recognizes only the fully completed and still preserved retirement result. */
+export const readCompletedRetirement = Effect.fn("retirement.readCompleted")(
+  function* (ctx: MutationCtx, plan: Plan) {
+    const attempt = yield* Effect.promise(() =>
+      ctx.db.get("tryoutAttempts", plan.attempt._id)
+    );
+    if (attempt !== null) {
+      return Option.none();
+    }
+    yield* requirePublication(ctx, plan);
+    const [
+      section,
+      placement,
+      response,
+      score,
+      oldProgress,
+      progress,
+      previous,
+      previousScore,
+      scale,
+    ] = yield* Effect.all([
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutSectionAttempts")
+          .withIndex("by_tryoutAttemptId_and_sectionOrder", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutAttemptPlacements")
+          .withIndex("by_tryoutAttemptId_and_questionOrder", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutResponses")
+          .withIndex("by_tryoutAttemptId_and_answeredAt", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutScores")
+          .withIndex("by_tryoutAttemptId", (q) =>
+            q.eq("tryoutAttemptId", plan.attempt._id)
+          )
+          .first()
+      ),
+      Effect.promise(() => ctx.db.get("tryoutSetProgress", plan.progress._id)),
+      Effect.promise(() =>
+        ctx.db
+          .query("tryoutSetProgress")
+          .withIndex("by_userId_and_setIdentity", (q) =>
+            q
+              .eq("userId", plan.attempt.userId)
+              .eq("setIdentity", plan.attempt.setIdentity)
+          )
+          .unique()
+      ),
+      Effect.promise(() => ctx.db.get("tryoutAttempts", plan.previous._id)),
+      Effect.promise(() => ctx.db.get("tryoutScores", plan.previousScore._id)),
+      Effect.promise(() => ctx.db.get("irtScaleVersions", plan.scale._id)),
+    ]);
+    yield* requireProof(
+      section === null &&
+        placement === null &&
+        response === null &&
+        score === null &&
+        oldProgress === null,
+      "The prior retirement left an incomplete attempt footprint."
+    );
+    yield* requireProof(
+      previous !== null &&
+        sameDocument(previous, plan.previous) &&
+        previousScore !== null &&
+        sameDocument(previousScore, plan.previousScore) &&
+        scale !== null &&
+        sameDocument(scale, plan.scale),
+      "The previously preserved predecessor or canonical scale changed."
+    );
+    for (const shared of plan.sharedAttempts) {
+      const row = yield* Effect.promise(() =>
+        ctx.db.get("tryoutAttempts", shared._id)
+      );
+      yield* requireProof(
+        row !== null && sameDocument(row, shared),
+        "A previously preserved shared history changed."
+      );
+    }
+    if (progress === null) {
+      return yield* new EmptyAttemptRetirementError({
+        code: "TRYOUT_EMPTY_RETIREMENT_REFUSED",
+        message: "The prior retirement has no restored progress.",
+      });
+    }
+    yield* requireProof(
+      sameDocument(progress, {
+        ...plan.progress,
+        _id: progress._id,
+        _creationTime: progress._creationTime,
+        attemptNumber: plan.previous.attemptNumber,
+        latestAttemptId: plan.previous._id,
+        publishedScore: plan.previousScore.publishedScore,
+        status: plan.previous.status,
+        statusRank: getTryoutStatusRank(plan.previous.status),
+        updatedAt: plan.previous.lastActivityAt,
+      }),
+      "The prior retirement progress changed."
+    );
+    return Option.some(progress._id);
+  }
+);

--- a/packages/backend/convex/retirement/proof.ts
+++ b/packages/backend/convex/retirement/proof.ts
@@ -11,6 +11,7 @@ import {
   requireProof,
   sameDocument,
 } from "@repo/backend/convex/retirement/spec";
+import { loadAttemptRuntimeBundle } from "@repo/backend/convex/tryouts/runtime/attempt/source";
 import { getTryoutStatusRank } from "@repo/backend/convex/tryouts/status";
 import { Effect, Option } from "effect";
 
@@ -245,6 +246,7 @@ export const inspectRetirement = Effect.fn("retirement.inspect")(function* (
         sameDocument(row, shared),
       "A protected shared TKA history changed."
     );
+    yield* loadAttemptRuntimeBundle(ctx, shared);
   }
 });
 
@@ -341,6 +343,7 @@ export const readCompletedRetirement = Effect.fn("retirement.readCompleted")(
         row !== null && sameDocument(row, shared),
         "A previously preserved shared history changed."
       );
+      yield* loadAttemptRuntimeBundle(ctx, shared);
     }
     if (progress === null) {
       return yield* new EmptyAttemptRetirementError({

--- a/packages/backend/convex/retirement/spec.ts
+++ b/packages/backend/convex/retirement/spec.ts
@@ -1,0 +1,52 @@
+import schema from "@repo/backend/convex/schema";
+import { convexToJson, type Infer, type Value, v } from "convex/values";
+import { Effect, Schema } from "effect";
+
+export const REVIEWED_ATTEMPT_ID = "wn7d0a14z2wscs0kpmgx7k7psh8e0x0t";
+
+export const planValidator = v.object({
+  active: v.object({
+    releaseId: v.string(),
+    manifestHash: v.string(),
+    sequence: v.number(),
+  }),
+  newSnapshotId: v.string(),
+  attempt: schema.doc("tryoutAttempts"),
+  section: schema.doc("tryoutSectionAttempts"),
+  progress: schema.doc("tryoutSetProgress"),
+  previous: schema.doc("tryoutAttempts"),
+  previousScore: schema.doc("tryoutScores"),
+  scale: schema.doc("irtScaleVersions"),
+  sharedAttempts: v.array(schema.doc("tryoutAttempts")),
+});
+export type Plan = Infer<typeof planValidator>;
+
+/** Refuses retirement when the reviewed empty-attempt proof no longer holds. */
+export class EmptyAttemptRetirementError extends Schema.TaggedError<EmptyAttemptRetirementError>()(
+  "EmptyAttemptRetirementError",
+  {
+    code: Schema.Literal("TRYOUT_EMPTY_RETIREMENT_REFUSED"),
+    message: Schema.String,
+  }
+) {}
+
+/** Compares validated Convex documents through its canonical sorted-key codec. */
+export function sameDocument(actual: Value, expected: Value) {
+  return (
+    JSON.stringify(convexToJson(actual)) ===
+    JSON.stringify(convexToJson(expected))
+  );
+}
+
+/** Keeps every reviewed precondition in the typed retirement failure channel. */
+export const requireProof = Effect.fn("retirement.requireProof")(function* (
+  condition: boolean,
+  message: string
+) {
+  if (!condition) {
+    return yield* new EmptyAttemptRetirementError({
+      code: "TRYOUT_EMPTY_RETIREMENT_REFUSED",
+      message,
+    });
+  }
+});


### PR DESCRIPTION
## Description

One unanswered SNBT attempt retains Question diagrams from the predecessor snapshot. Add a temporary internal mutation that can retire only that reviewed attempt after a verified replacement Question publication becomes active, then restore its completed predecessor in set progress.

The transaction pins full attempt, section, progress, predecessor, score, scale and shared-history documents. It requires zero response rows and zero persisted attempt scores, rechecks activity before every native cleanup phase, and refuses any changed proof. The reviewed section expired without answers and has only its automatic provisional section score. Canonical IRT data and three completed TKA histories sharing the old snapshot remain preserved. Repeating a completed operation verifies preservation and performs no writes. Both initial preservation and retry use the native attempt runtime loader to reject a missing bundle or mismatched bundle hash or snapshot identity.

## Type

- Bug fix

## Testing

- Backend suite: 416 files, 2,075 tests passed with 100% per-file coverage. The nearest 20 tests include missing or changed retained-bundle rejection on retry.
- Backend native TypeScript typecheck and root lint passed.
- Native isolated Convex codegen passed.
- A native preserved-ID rehearsal imported the audited production rows into an anonymous local backend. It removed only one attempt, one section and 160 placements, restored predecessor progress, and preserved all other imported rows, including 27 attempts, 227 responses, 27 persisted scores, five canonical scales, 760 scale items and 35 calibration runs. An exact retry made zero writes.
- No dependency changes or frontend changes. No production mutation has run.

## Additional Context

Deployment and execution are separate. Before execution, verify the new signed active Question release and snapshot, audit the complete current attempt inventory again, and compare every reviewed document to its pinned value. Any new activity aborts retirement. Remove this temporary capability and its tests in the following strict-renderer release after production preservation and history checks succeed.
