### PR TITLE
Use official Quran spellings per locale, drop quran-short

### DIFF
--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -230,15 +230,15 @@ async function CachedSurahShell({
       <VirtualProvider>
         <SidebarRightProvider>
           <LayoutMaterialContent>
-          <QuranSurahHeader
-            arabic={surahData.name.arabic}
-            copySourceUrl={`https://nakafa.com/${locale}/quran/${surah}.md`}
-            meaning={description}
-            meaningLanguage={descriptionLanguage}
-            quranLabel={t("quran")}
-            slug={`/${locale}/quran/${surah}`}
-            title={title}
-          />
+            <QuranSurahHeader
+              arabic={surahData.name.arabic}
+              copySourceUrl={`https://nakafa.com/${locale}/quran/${surah}.md`}
+              meaning={description}
+              meaningLanguage={descriptionLanguage}
+              quranLabel={t("quran-short")}
+              slug={`/${locale}/quran/${surah}`}
+              title={title}
+            />
             <LayoutContent className="pt-6">
               {result.preBismillah === null ? null : (
                 <QuranBismillah

--- a/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
+++ b/apps/www/app/[locale]/(app)/(shared)/(main)/(learn)/quran/[surah]/page.tsx
@@ -235,7 +235,7 @@ async function CachedSurahShell({
               copySourceUrl={`https://nakafa.com/${locale}/quran/${surah}.md`}
               meaning={description}
               meaningLanguage={descriptionLanguage}
-              quranLabel={t("quran-short")}
+              quranLabel={t("quran")}
               slug={`/${locale}/quran/${surah}`}
               title={title}
             />

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -255,14 +255,13 @@
   },
   "Holy": {
     "holy": "Heilige Schriften",
-    "quran": "Quran",
-    "quran-short": "Quran",
-    "quran-description": "Lies den Quran mit einer Übersetzung Vers für Vers.",
+    "quran": "Koran",
+    "quran-description": "Lies den Koran mit einer Übersetzung Vers für Vers.",
     "verse": "Vers",
     "verse-count": "Vers {count}",
     "interpretation": "Tafsir",
     "interpretation-error": "Der Tafsir zu diesem Vers konnte nicht geladen werden. Versuche es erneut.",
-    "interpretation-refreshing": "Der Quran wurde aktualisiert. Die Seite wird neu geladen...",
+    "interpretation-refreshing": "Der Koran wurde aktualisiert. Die Seite wird neu geladen...",
     "meaning": "Namensbedeutung",
     "revelation": "Offenbarungsort",
     "revelation-place": "{place, select, Meccan {mekkanisch} Medinan {medinensisch} other {unbekannt}}",
@@ -272,10 +271,10 @@
     "translation": "Übersetzung",
     "translation-source": "Übersetzung",
     "translation-notes": "Anmerkungen zur Übersetzung",
-    "markdown-limit": "Dieses Markdown auf Seitenebene ist auf die Verse 1-{toVerse} von {numberOfVerses} begrenzt. Nutze das Nakafa-Quran-Nachschlagewerkzeug für genaue Versbereiche.",
+    "markdown-limit": "Dieses Markdown auf Seitenebene ist auf die Verse 1-{toVerse} von {numberOfVerses} begrenzt. Nutze das Nakafa-Koran-Nachschlagewerkzeug für genaue Versbereiche.",
     "surah-title": "Sure {number}: {name} - {quran}",
     "verses": "Verse",
-    "read-quran-description": "Lies den Quran auf Nakafa online mit einer Übersetzung Vers für Vers"
+    "read-quran-description": "Lies den Koran auf Nakafa online mit einer Übersetzung Vers für Vers"
   },
   "Exercises": {
     "exercises": "Übungen",
@@ -618,7 +617,7 @@
     "nakafa-search-empty": "Keine passenden Inhalte gefunden.",
     "nakafa-content": "Lernmaterial",
     "nakafa-exercise": "Übungen",
-    "nakafa-quran": "Quran",
+    "nakafa-quran": "Koran",
     "nakafa-quran-verse-count": "{count, plural, one {# Vers} other {# Verse}}",
     "question-number": "Aufgabe {number}",
     "nakafa-loading": "{kind} wird gelesen...",
@@ -1177,8 +1176,8 @@
     },
     "quran": {
       "title": "Sure {number}. {name} ({transliteration}){translation, select, __EMPTY__ {} other { - {translation}}} | Nakafa",
-      "description": "Lies die Sure {name} ({transliteration}) mit einer Übersetzung Vers für Vers. {numberOfVerses} Verse aus dem heiligen Quran.",
-      "keywords": "Sure {name}, Quran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}"
+      "description": "Lies die Sure {name} ({transliteration}) mit einer Übersetzung Vers für Vers. {numberOfVerses} Verse aus dem heiligen Koran.",
+      "keywords": "Sure {name}, Koran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}"
     }
   }
 }

--- a/packages/internationalization/dictionaries/de.json
+++ b/packages/internationalization/dictionaries/de.json
@@ -256,6 +256,7 @@
   "Holy": {
     "holy": "Heilige Schriften",
     "quran": "Quran",
+    "quran-short": "Quran",
     "quran-description": "Lies den Quran mit einer Übersetzung Vers für Vers.",
     "verse": "Vers",
     "verse-count": "Vers {count}",

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -256,7 +256,6 @@
   "Holy": {
     "holy": "Holy",
     "quran": "Quran",
-    "quran-short": "Quran",
     "quran-description": "Read the Quran with verse-by-verse translation.",
     "verse": "Verse",
     "verse-count": "Verse {count}",

--- a/packages/internationalization/dictionaries/en.json
+++ b/packages/internationalization/dictionaries/en.json
@@ -256,6 +256,7 @@
   "Holy": {
     "holy": "Holy",
     "quran": "Quran",
+    "quran-short": "Quran",
     "quran-description": "Read the Quran with verse-by-verse translation.",
     "verse": "Verse",
     "verse-count": "Verse {count}",

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -255,14 +255,13 @@
   },
   "Holy": {
     "holy": "Suci",
-    "quran": "Al Quran",
-    "quran-short": "Quran",
-    "quran-description": "Baca Al-Quran dengan terjemahan dan tafsir per ayat.",
+    "quran": "Al-Qur'an",
+    "quran-description": "Baca Al-Qur'an dengan terjemahan dan tafsir per ayat.",
     "verse": "Ayat",
     "verse-count": "Ayat {count}",
     "interpretation": "Tafsir",
     "interpretation-error": "Tafsir ayat ini belum dapat dimuat. Coba lagi.",
-    "interpretation-refreshing": "Al-Quran telah diperbarui. Memuat ulang halaman ini...",
+    "interpretation-refreshing": "Al-Qur'an telah diperbarui. Memuat ulang halaman ini...",
     "meaning": "Makna nama",
     "revelation": "Tempat turun",
     "revelation-place": "{place, select, Meccan {Makkiyah} Medinan {Madaniyah} other {Tidak diketahui}}",
@@ -272,10 +271,10 @@
     "translation": "Terjemahan",
     "translation-source": "Terjemahan",
     "translation-notes": "Catatan terjemahan",
-    "markdown-limit": "Markdown pada halaman ini dibatasi pada ayat 1-{toVerse} dari {numberOfVerses}. Gunakan alat rujukan Al-Quran Nakafa untuk rentang ayat yang tepat.",
+    "markdown-limit": "Markdown pada halaman ini dibatasi pada ayat 1-{toVerse} dari {numberOfVerses}. Gunakan alat rujukan Al-Qur'an Nakafa untuk rentang ayat yang tepat.",
     "surah-title": "Surat {number}: {name} - {quran}",
     "verses": "Ayat",
-    "read-quran-description": "Baca Al-Quran online dengan terjemahan dan tafsir per ayat di Nakafa"
+    "read-quran-description": "Baca Al-Qur'an online dengan terjemahan dan tafsir per ayat di Nakafa"
   },
   "Exercises": {
     "exercises": "Latihan",
@@ -1177,8 +1176,8 @@
     },
     "quran": {
       "title": "Surat {number}. {name} ({transliteration}){translation, select, __EMPTY__ {} other { - {translation}}} | Nakafa",
-      "description": "Baca Surat {name} ({transliteration}) dengan terjemahan dan tafsir. {numberOfVerses} ayat dari Al-Quran.",
-      "keywords": "Surat {name}, Al-Quran{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}, tafsir"
+      "description": "Baca Surat {name} ({transliteration}) dengan terjemahan dan tafsir. {numberOfVerses} ayat dari Al-Qur'an.",
+      "keywords": "Surat {name}, Al-Qur'an{translation, select, __EMPTY__ {} other {, {translation}}}, {revelation}, tafsir"
     }
   }
 }

--- a/packages/internationalization/dictionaries/id.json
+++ b/packages/internationalization/dictionaries/id.json
@@ -256,6 +256,7 @@
   "Holy": {
     "holy": "Suci",
     "quran": "Al Quran",
+    "quran-short": "Quran",
     "quran-description": "Baca Al-Quran dengan terjemahan dan tafsir per ayat.",
     "verse": "Ayat",
     "verse-count": "Ayat {count}",


### PR DESCRIPTION
Supersedes the quran-short approach: the short key duplicated en/de values, so the surah breadcrumb reuses the existing Holy.quran key instead.

Official-dictionary spelling fixes (researched against KBBI, Duden, Cambridge/Oxford/Merriam-Webster/Collins):
- id follows KBBI: Al Quran / Al-Quran -> Al-Qur'an (baku since 2019, Badan Bahasa over LPMQ Kemenag proposal; Kuran and Al-Quran are listed tidak baku)
- de follows Duden: Quran -> Koran (headword Koran, der; duden.de/rechtschreibung/Quran is 404, Quran is only a rare variant)
- en keeps Quran (Merriam-Webster/Collins headword; Oxford prefers Qur'an, Cambridge prefers Koran)

Files:
- apps/www/.../quran/[surah]/page.tsx: quranLabel back to t("quran")
- dictionaries de/id.json: label, descriptions, SEO metadata, Ai chip label (de)
- dictionaries en.json: drop quran-short only

Verification (local):
- pnpm format clean, ultracite check clean, check:tests passed
- @repo/internationalization tests pass (13)
- www full suite pass (225 files / 1746 tests, 100% coverage gates met)
- typecheck pass for @repo/internationalization and www