### PR TITLE
fix(analytics): name operational exceptions after their origin

### DIFF
--- a/.changeset/olive-pandas-shake.md
+++ b/.changeset/olive-pandas-shake.md
@@ -1,0 +1,5 @@
+---
+"@repo/analytics": patch
+---
+
+Name operational exceptions after their admitted origin so error tracking groups by call site instead of minified frames. `createOperationalException` derives `OperationalError(source)` (or `source.operation`) from the already-decoded properties; messages, causes, and payloads stay redacted and only developer-authored constants enter the name.

--- a/packages/analytics/posthog/browser.test.ts
+++ b/packages/analytics/posthog/browser.test.ts
@@ -422,7 +422,7 @@ describe("two-tier PostHog browser runtime", () => {
       expect(client.captureException).toHaveBeenCalledWith(
         expect.objectContaining({
           message: "Operational exception",
-          name: "OperationalError",
+          name: "OperationalError(browser-test)",
         }),
         { source: "browser-test" }
       );

--- a/packages/analytics/posthog/browser.ts
+++ b/packages/analytics/posthog/browser.ts
@@ -351,7 +351,7 @@ export function captureException(
     return;
   }
   MutableRef.get(analyticsClient)?.captureException(
-    createOperationalException(error),
+    createOperationalException(error, decodedProperties.value),
     decodedProperties.value
   );
 }

--- a/packages/analytics/posthog/exception.test.ts
+++ b/packages/analytics/posthog/exception.test.ts
@@ -13,26 +13,43 @@ describe("operational exception privacy", () => {
       "    at submit (/app/chunk.js:10:5)",
     ].join("\n");
 
-    const operational = createOperationalException(input);
+    const operational = createOperationalException(input, {
+      source: "chat-api",
+    });
 
-    expect(operational.name).toBe("OperationalError");
+    expect(operational.name).toBe("OperationalError(chat-api)");
     expect(operational.message).toBe("Operational exception");
     expect(operational.stack).toBe(
-      "OperationalError: Operational exception\n    at submit (/app/chunk.js:10:5)"
+      "OperationalError(chat-api): Operational exception\n    at submit (/app/chunk.js:10:5)"
     );
     expect(JSON.stringify(operational)).not.toContain("user@example.com");
   });
 
   it("does not serialize arbitrary non-error payloads", () => {
-    const operational = createOperationalException({
-      message: "secret user@example.com",
-    });
+    const operational = createOperationalException(
+      { message: "secret user@example.com" },
+      { source: "chat-api" }
+    );
 
     expect(operational).toMatchObject({
       message: "Operational exception",
-      name: "OperationalError",
+      name: "OperationalError(chat-api)",
     });
     expect(JSON.stringify(operational)).not.toContain("user@example.com");
+  });
+
+  it("names the exception after its origin so grouping is stable", () => {
+    expect(
+      createOperationalException(new Error("boom"), {
+        source: "next-on-request-error",
+      }).name
+    ).toBe("OperationalError(next-on-request-error)");
+    expect(
+      createOperationalException(new Error("boom"), {
+        operation: "save-message",
+        source: "chat-api",
+      }).name
+    ).toBe("OperationalError(chat-api.save-message)");
   });
 
   it("accepts only exact bounded operational context", () => {

--- a/packages/analytics/posthog/exception.ts
+++ b/packages/analytics/posthog/exception.ts
@@ -56,10 +56,30 @@ const operationalExceptionMessage = "Operational exception";
 const operationalExceptionName = "OperationalError";
 const stackFramePattern = /^\s*at\s/;
 
+/**
+ * Builds a stable exception name from the admitted origin so error tracking
+ * groups events by their source instead of by minified stack frames.
+ *
+ * Only the developer-authored `source` and `operation` constants enter the
+ * name, so the redaction of the message, cause, and payload still holds.
+ */
+function deriveOperationalExceptionName(
+  properties: OperationalExceptionProperties
+) {
+  const scope = properties.operation
+    ? `${properties.source}.${properties.operation}`
+    : properties.source;
+  return `${operationalExceptionName}(${scope})`;
+}
+
 /** Removes messages, causes, and arbitrary payloads while retaining code frames. */
-export function createOperationalException(error: unknown) {
+export function createOperationalException(
+  error: unknown,
+  properties: OperationalExceptionProperties
+) {
+  const name = deriveOperationalExceptionName(properties);
   const operationalError = new Error(operationalExceptionMessage);
-  operationalError.name = operationalExceptionName;
+  operationalError.name = name;
 
   if (!(Predicate.isError(error) && error.stack)) {
     return operationalError;
@@ -69,7 +89,7 @@ export function createOperationalException(error: unknown) {
     .split("\n")
     .filter((line) => stackFramePattern.test(line));
   operationalError.stack = [
-    `${operationalExceptionName}: ${operationalExceptionMessage}`,
+    `${name}: ${operationalExceptionMessage}`,
     ...frames,
   ].join("\n");
   return operationalError;

--- a/packages/analytics/posthog/server.test.ts
+++ b/packages/analytics/posthog/server.test.ts
@@ -103,7 +103,7 @@ describe("PostHog server reporting", () => {
         1,
         expect.objectContaining({
           message: "Operational exception",
-          name: "OperationalError",
+          name: "OperationalError(request)",
         }),
         undefined,
         properties

--- a/packages/analytics/posthog/server.ts
+++ b/packages/analytics/posthog/server.ts
@@ -94,7 +94,7 @@ export const captureServerException = Effect.fn(
   yield* Effect.tryPromise({
     try: () =>
       analytics.captureExceptionImmediate(
-        createOperationalException(error),
+        createOperationalException(error, decodedProperties.value),
         undefined,
         decodedProperties.value
       ),


### PR DESCRIPTION
## Description

Every operational exception reached PostHog as the identical `OperationalError: Operational exception`, so unrelated failures merged into one untriageable issue and single origins scattered across minified-frame fragments. `createOperationalException` now derives the exception name from the admitted origin (`OperationalError(source)`, refined to `source.operation` when present) and both capture seams pass their already-decoded properties through.

Privacy is unchanged: the message, cause, and arbitrary payloads stay stripped, and only developer-authored `source`/`operation` constants (verified hardcoded at every call site) enter the name. `route_path` and digests stay event properties for filtering, not grouping, so one origin cannot scatter across issues.

Supersedes the PostHog bot draft #620 with the same direction, rebased onto current main (including #617's `Predicate.isError` guard) under owner authorship so the production gate can run. Rejects #619's `distinctId = source` (corrupts identity semantics) and #622's digest-in-fingerprint plus unverified source-map upload.

## Type

- Bug fix

## Testing

- `pnpm --filter @repo/analytics test`: 63 passed, 100% statement/branch/function/line
- `pnpm --filter @repo/analytics typecheck`: clean
- `pnpm exec ultracite check` on all touched files: clean
- `node scripts/check/tests.ts`: passes
- www consumers unaffected (`createOperationalException` is package-internal; `lib/analytics/server.test.ts` + `sitemap.xml/route.test.ts` pass)
- No dependency or lockfile changes: `pnpm security:audit` not affected
- Manual testing (desktop/mobile): not applicable, server/browser capture seams verified by unit tests
- Contribution terms reviewed: `LICENSE`, `CONTENT_LICENSE.md`, and `TRADEMARKS.md`

## Related Issues

Supersedes #620. Follow-up to #617 (stacks cleanly on its merged gate work).

## Additional Context

New grouping applies to exceptions ingested from now on. The existing merged issue keeps its name; per the bot note, `$issue_name` labels only the event that creates each new issue. Source-map upload remains a separate follow-up requiring build secrets and preview validation.