### PR TITLE
Keep number-line sign labels on one line

### DIFF
--- a/packages/design-system/components/contents/mathematics/number-line.tsx
+++ b/packages/design-system/components/contents/mathematics/number-line.tsx
@@ -199,7 +199,7 @@ export function NumberLine({
               >
                 {!!segment.label && (
                   <div
-                    className="absolute top-0 -translate-x-1/2 font-medium text-sm"
+                    className="absolute top-0 -translate-x-1/2 whitespace-nowrap font-medium text-sm"
                     style={{ left: `${segment.startPos + segment.width / 2}%` }}
                   >
                     {segment.label}


### PR DESCRIPTION
At phone widths, the right `+++` sign-chart label wraps onto two lines and puts its last sign on the number-line axis. Prevent wrapping on the segment-label container, matching the existing endpoint-label behavior.

Verified the actual Q10 Q8 question explanation through the official signed Aksara preview at 390px and 1440px in light and dark themes. All three sign labels are now 47.06 × 20px; the phone label was previously 33.88 × 40.31px. Both open boundaries, positions and shaded intervals remain unchanged, with no runtime, HTTP or KaTeX errors.

Validation: full `pnpm lint`, design-system typecheck, focused formatting and React Doctor on the changed component (complete, 100/100, no diagnostics or skipped checks). The change adds one existing CSS utility class and changes no dependencies or renderer contracts.
